### PR TITLE
Reworks the pipe system to be simpler

### DIFF
--- a/packages/berry-core/sources/scriptUtils.ts
+++ b/packages/berry-core/sources/scriptUtils.ts
@@ -1,5 +1,5 @@
 import {CwdFS, ZipOpenFS, xfs}           from '@berry/fslib';
-import {runShell}                        from '@berry/shell';
+import {execute}                         from '@berry/shell';
 import {delimiter, posix}                from 'path';
 import {PassThrough, Readable, Writable} from 'stream';
 import {dirSync}                         from 'tmp';
@@ -120,7 +120,7 @@ export async function executePackageScript(locator: Locator, scriptName: string,
       return;
 
     try {
-      return await runShell(script, args, {cwd, env, stdin, stdout, stderr});
+      return await execute(script, args, {cwd, env, stdin, stdout, stderr});
     } finally {
       await xfs.removePromise(binFolder);
     }

--- a/packages/berry-core/sources/scriptUtils.ts
+++ b/packages/berry-core/sources/scriptUtils.ts
@@ -120,7 +120,7 @@ export async function executePackageScript(locator: Locator, scriptName: string,
       return;
 
     try {
-      return await runShell(script, {args, cwd, env, stdin, stdout, stderr});
+      return await runShell(script, args, {cwd, env, stdin, stdout, stderr});
     } finally {
       await xfs.removePromise(binFolder);
     }

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -16,7 +16,7 @@ const bufferResult = async (command: string, args: Array<string> = []) => {
     stderrChunks.push(chunk);
   });
 
-  const exitCode = await runShell(command, {args, stdout, stderr});
+  const exitCode = await runShell(command, args, {stdout, stderr});
 
   return {
     exitCode,
@@ -114,11 +114,6 @@ describe(`Simple shell features`, () => {
 
     await expect(bufferResult(`echo hello && exit 0 && echo world`)).resolves.toMatchObject({
       exitCode: 0,
-      stdout: `hello\n`,
-    });
-
-    await expect(bufferResult(`(echo hello; exit 1); echo world`)).resolves.toMatchObject({
-      exitCode: 1,
       stdout: `hello\n`,
     });
   });

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -1,4 +1,4 @@
-import {runShell}    from '@berry/shell';
+import {execute}     from '@berry/shell';
 import {PassThrough} from 'stream';
 
 const bufferResult = async (command: string, args: Array<string> = []) => {
@@ -16,7 +16,7 @@ const bufferResult = async (command: string, args: Array<string> = []) => {
     stderrChunks.push(chunk);
   });
 
-  const exitCode = await runShell(command, args, {stdout, stderr});
+  const exitCode = await execute(command, args, {stdout, stderr});
 
   return {
     exitCode,


### PR DESCRIPTION
The shell is fairly complex by essence, so I'm trying to move things around in an effort to simplify it.

Two notes:

- It should improve performances, as I'm removing closures and stream indirections.
- It should hopefully solve in the process a CI error triggered on Node 8. I'm not 100% sure unfortunately, as Node has relatively complicated pipe sequences.
