### PR TITLE
Improves hooks

### DIFF
--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -23,11 +23,22 @@ import * as suggestUtils               from './suggestUtils';
 export {suggestUtils};
 
 export interface Hooks {
-  afterNewWorkspaceDependency?: (
+  afterWorkspaceDependencyAddition?: (
     workspace: Workspace,
     target: suggestUtils.Target,
     descriptor: Descriptor,
-  ) => void,
+  ) => Promise<void>,
+  afterWorkspaceDependencyReplacement?: (
+    workspace: Workspace,
+    target: suggestUtils.Target,
+    fromDescriptor: Descriptor,
+    toDescriptor: Descriptor,
+  ) => Promise<void>;
+  afterWorkspaceDependencyRemoval?: (
+    workspace: Workspace,
+    target: suggestUtils.Target,
+    descriptor: Descriptor,
+  ) => Promise<void>,
 };
 
 const plugin: Plugin = {

--- a/packages/plugin-typescript/bin/@berry/plugin-typescript.js
+++ b/packages/plugin-typescript/bin/@berry/plugin-typescript.js
@@ -99,7 +99,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core_1 = __webpack_require__(1);
 const core_2 = __webpack_require__(1);
 const plugin_essentials_1 = __webpack_require__(2);
-const afterNewWorkspaceDependency = async (workspace, dependencyTarget, descriptor) => {
+const afterWorkspaceDependencyAddition = async (workspace, dependencyTarget, descriptor) => {
     if (descriptor.scope === `types`)
         return;
     const project = workspace.project;
@@ -120,7 +120,7 @@ const afterNewWorkspaceDependency = async (workspace, dependencyTarget, descript
 };
 const plugin = {
     hooks: {
-        afterNewWorkspaceDependency,
+        afterWorkspaceDependencyAddition,
     },
 };
 exports.default = plugin;

--- a/packages/plugin-typescript/sources/index.ts
+++ b/packages/plugin-typescript/sources/index.ts
@@ -3,7 +3,7 @@ import {httpUtils, structUtils}               from '@berry/core';
 import {Hooks as EssentialsHooks}             from '@berry/plugin-essentials';
 import {suggestUtils}                         from '@berry/plugin-essentials';
 
-const afterNewWorkspaceDependency = async (
+const afterWorkspaceDependencyAddition = async (
   workspace: Workspace,
   dependencyTarget: suggestUtils.Target,
   descriptor: Descriptor,
@@ -39,7 +39,7 @@ const afterNewWorkspaceDependency = async (
 
 const plugin: Plugin = {
   hooks: {
-    afterNewWorkspaceDependency,
+    afterWorkspaceDependencyAddition,
   } as (
     EssentialsHooks
   ),


### PR DESCRIPTION
This PR improves the hook system by renaming `afterNewWorkspaceDependency` into `afterWorkspaceDependencyAddition`, which allows creating two other related hooks:

- `afterNewWorkspaceDependencyAddition`
- `afterNewWorkspaceDependencyReplacement`
- `afterNewWorkspaceDependencyDeletion`

Note that these hooks cannot run during `yarn install`. This is because Yarn doesn't keep a project state (except for the build artifacts), and as such cannot distinguish the dependencies that have always been listed but never installed versus those that have just been added into a manifest.