### PR TITLE
Fixes policies set-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,5 @@ junit.xml
 
 /.yarn/build-state.yml
 
-/packages/*/bin/*
 /packages/*/bundles/*
-
 !/packages/berry-pnp/bundles/hook.js

--- a/packages/berry-builder/sources/build-bundle.js
+++ b/packages/berry-builder/sources/build-bundle.js
@@ -27,7 +27,7 @@ concierge
 
       output: {
         filename: `berry.js`,
-        path: path.resolve(basedir, `bin`),
+        path: `${basedir}/bundles`,
       },
 
       module: {

--- a/packages/berry-builder/sources/build-plugin.js
+++ b/packages/berry-builder/sources/build-plugin.js
@@ -38,7 +38,7 @@ concierge
 
       output: {
         filename: `${pluginName}.js`,
-        path: `${pluginPath}/bin`,
+        path: `${pluginPath}/bundles`,
         libraryTarget: `var`,
         library: `plugin`,
       },
@@ -64,9 +64,9 @@ concierge
                 for (const file of chunk.files) {
                   compilation.assets[file] = new RawSource(`
                     module.exports = {};
-                    
+
                     module.exports.factory = function (require) {
-                      ${compilation.assets[file].source()}                    
+                      ${compilation.assets[file].source()}
                       return plugin;
                     };
 

--- a/packages/plugin-pack/bin/@berry/plugin-pack.js
+++ b/packages/plugin-pack/bin/@berry/plugin-pack.js
@@ -1,6 +1,6 @@
 
                     module.exports = {};
-                    
+
                     module.exports.factory = function (require) {
                       var plugin =
 /******/ (function(modules) { // webpackBootstrap
@@ -95,53 +95,44 @@
 
 "use strict";
 
-Object.defineProperty(exports, "__esModule", { value: true });
-const core_1 = __webpack_require__(1);
-const core_2 = __webpack_require__(1);
-const plugin_essentials_1 = __webpack_require__(2);
-const afterWorkspaceDependencyAddition = async (workspace, dependencyTarget, descriptor) => {
-    if (descriptor.scope === `types`)
-        return;
-    const project = workspace.project;
-    const configuration = project.configuration;
-    const cache = await core_1.Cache.find(configuration);
-    const typesName = descriptor.scope
-        ? `${descriptor.scope}__${descriptor.name}`
-        : `${descriptor.name}`;
-    const target = plugin_essentials_1.suggestUtils.Target.REGULAR;
-    const modifier = plugin_essentials_1.suggestUtils.Modifier.EXACT;
-    const strategies = [plugin_essentials_1.suggestUtils.Strategy.LATEST];
-    const request = core_2.structUtils.makeDescriptor(core_2.structUtils.makeIdent(`types`, typesName), `unknown`);
-    const suggestions = await plugin_essentials_1.suggestUtils.getSuggestedDescriptors(request, null, { project, cache, target, modifier, strategies });
-    if (suggestions.length === 0)
-        return;
-    const selected = suggestions[0].descriptor;
-    workspace.manifest[target].set(selected.identHash, selected);
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 };
+Object.defineProperty(exports, "__esModule", { value: true });
+const pack_1 = __importDefault(__webpack_require__(1));
 const plugin = {
-    hooks: {
-        afterWorkspaceDependencyAddition,
-    },
+    commands: [
+        pack_1.default,
+    ],
 };
 exports.default = plugin;
 
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-module.exports = require("@berry/core");
+"use strict";
 
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = (concierge, pluginConfiguration) => concierge
+    .command(`pack [--filename]`)
+    .describe(`Creates a compressed gzip archive of package dependencies.`)
+    .detail(`
+    This command will create a new compressed gzip archive of package dependencies in your local directory.
 
-module.exports = require("@berry/plugin-essentials");
+    \`--filename\` parameter names the archive of package as given filename.
+  `)
+    .example(`Creates a compressed gzip archive of the package dependencies.`, `yarn pack`)
+    .example(`Creates a compressed gzip archive of package dependencies with the given filename.`, `yarn pack --filename`)
+    .action(() => {
+});
+
 
 /***/ })
-/******/ ]);                    
+/******/ ]);
                       return plugin;
                     };
 
-                    module.exports.name = "@berry/plugin-typescript";
+                    module.exports.name = "@berry/plugin-pack";
                   

--- a/packages/plugin-typescript/bin/@berry/plugin-typescript.js
+++ b/packages/plugin-typescript/bin/@berry/plugin-typescript.js
@@ -1,6 +1,6 @@
 
                     module.exports = {};
-                    
+
                     module.exports.factory = function (require) {
                       var plugin =
 /******/ (function(modules) { // webpackBootstrap
@@ -95,44 +95,53 @@
 
 "use strict";
 
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const pack_1 = __importDefault(__webpack_require__(1));
+const core_1 = __webpack_require__(1);
+const core_2 = __webpack_require__(1);
+const plugin_essentials_1 = __webpack_require__(2);
+const afterWorkspaceDependencyAddition = async (workspace, dependencyTarget, descriptor) => {
+    if (descriptor.scope === `types`)
+        return;
+    const project = workspace.project;
+    const configuration = project.configuration;
+    const cache = await core_1.Cache.find(configuration);
+    const typesName = descriptor.scope
+        ? `${descriptor.scope}__${descriptor.name}`
+        : `${descriptor.name}`;
+    const target = plugin_essentials_1.suggestUtils.Target.REGULAR;
+    const modifier = plugin_essentials_1.suggestUtils.Modifier.EXACT;
+    const strategies = [plugin_essentials_1.suggestUtils.Strategy.LATEST];
+    const request = core_2.structUtils.makeDescriptor(core_2.structUtils.makeIdent(`types`, typesName), `unknown`);
+    const suggestions = await plugin_essentials_1.suggestUtils.getSuggestedDescriptors(request, null, { project, cache, target, modifier, strategies });
+    if (suggestions.length === 0)
+        return;
+    const selected = suggestions[0].descriptor;
+    workspace.manifest[target].set(selected.identHash, selected);
+};
 const plugin = {
-    commands: [
-        pack_1.default,
-    ],
+    hooks: {
+        afterWorkspaceDependencyAddition,
+    },
 };
 exports.default = plugin;
 
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-"use strict";
+module.exports = require("@berry/core");
 
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = (concierge, pluginConfiguration) => concierge
-    .command(`pack [--filename]`)
-    .describe(`Creates a compressed gzip archive of package dependencies.`)
-    .detail(`
-    This command will create a new compressed gzip archive of package dependencies in your local directory.
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
 
-    \`--filename\` parameter names the archive of package as given filename.
-  `)
-    .example(`Creates a compressed gzip archive of the package dependencies.`, `yarn pack`)
-    .example(`Creates a compressed gzip archive of package dependencies with the given filename.`, `yarn pack --filename`)
-    .action(() => {
-});
-
+module.exports = require("@berry/plugin-essentials");
 
 /***/ })
-/******/ ]);                    
+/******/ ]);
                       return plugin;
                     };
 
-                    module.exports.name = "@berry/plugin-pack";
+                    module.exports.name = "@berry/plugin-typescript";
                   

--- a/scripts/plugin-pack.js
+++ b/scripts/plugin-pack.js
@@ -1,7 +1,7 @@
 const {existsSync} = require(`fs`);
 
-if (existsSync(`${__dirname}/../packages/plugin-pack/bin/@berry/plugin-pack.js`)) {
-  module.exports = require(`${__dirname}/../packages/plugin-pack/bin/@berry/plugin-pack.js`);
+if (existsSync(`${__dirname}/../packages/plugin-pack/bundles/@berry/plugin-pack.js`)) {
+  module.exports = require(`${__dirname}/../packages/plugin-pack/bundles/@berry/plugin-pack.js`);
 } else {
-  module.exports = require(`${__dirname}/local/berry-plugin-pack.js`);
+  module.exports = require(`${__dirname}/../packages/plugin-pack/bin/@berry/plugin-pack.js`);
 }

--- a/scripts/plugin-typescript.js
+++ b/scripts/plugin-typescript.js
@@ -1,7 +1,7 @@
 const {existsSync} = require(`fs`);
 
-if (existsSync(`${__dirname}/../typescriptages/plugin-typescript/bin/@berry/plugin-typescript.js`)) {
-  module.exports = require(`${__dirname}/../typescriptages/plugin-typescript/bin/@berry/plugin-typescript.js`);
+if (existsSync(`${__dirname}/../packages/plugin-typescript/bundles/@berry/plugin-typescript.js`)) {
+  module.exports = require(`${__dirname}/../packages/plugin-typescript/bundles/@berry/plugin-typescript.js`);
 } else {
-  module.exports = require(`${__dirname}/local/berry-plugin-typescript.js`);
+  module.exports = require(`${__dirname}/../packages/plugin-typescript/bin/@berry/plugin-typescript.js`);
 }

--- a/scripts/run-yarn.js
+++ b/scripts/run-yarn.js
@@ -1,7 +1,7 @@
 const {existsSync} = require(`fs`);
 
-if (existsSync(`${__dirname}/../packages/berry-cli/bin/berry.js`)) {
-  require(`${__dirname}/../packages/berry-cli/bin/berry.js`);
+if (existsSync(`${__dirname}/../packages/berry-cli/bundles/berry.js`)) {
+  require(`${__dirname}/../packages/berry-cli/bundles/berry.js`);
 } else {
-  require(`${__dirname}/local/berry.js`);
+  require(`${__dirname}/../packages/berry-cli/bin/berry.js`);
 }

--- a/scripts/update-local.sh
+++ b/scripts/update-local.sh
@@ -5,11 +5,16 @@ set -e
 THIS_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 mkdir -p "$THIS_DIR"/local
 
-yarn build:cli
-cp "$THIS_DIR"/../packages/berry-cli/bin/berry.js "$THIS_DIR"/local/berry.js
+make_build() {
+  yarn "$1"
 
-yarn build:plugin-pack
-cp "$THIS_DIR"/../packages/plugin-pack/bin/@berry/plugin-pack.js "$THIS_DIR"/local/berry-plugin-pack.js
+  local src="$THIS_DIR"/../packages/"$2"/bundles/"$3"
+  local dest="$THIS_DIR"/../packages/"$2"/bin/"$3"
 
-yarn build:plugin-typescript
-cp "$THIS_DIR"/../packages/plugin-typescript/bin/@berry/plugin-typescript.js "$THIS_DIR"/local/berry-plugin-typescript.js
+  mkdir -p $(dirname "$dest")
+  cp "$src" "$dest"
+}
+
+make_build build:cli berry-cli berry.js
+make_build build:plugin-pack plugin-pack @berry/plugin-pack.js
+make_build build:plugin-typescript plugin-typescript @berry/plugin-typescript.js


### PR DESCRIPTION
I moved files around in order to prevent conflicts between files, but unfortunately forgot that the nightly build of Yarn is directly fetched from the version stored on Github.

This diff will put back the Yarn build at its previous location, which should restore the broken feature. A followup diff will add a test to make sure someone else doesn't make the same mistake 🙂 

Fixes #19 
