### PR TITLE
Implements enable-network

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/enableNetwork.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/enableNetwork.test.js
@@ -1,0 +1,12 @@
+describe(`Features`, () => {
+  describe(`enableNetwork`, () => {
+    test(
+      `it should prevent Yarn from accessing the network (yarn add)`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await expect((async () => {
+          await run(`add`, `no-deps`, {enableNetwork: false});
+        })()).rejects.toThrow();
+      }),
+    );
+  });
+});

--- a/packages/berry-core/sources/Configuration.ts
+++ b/packages/berry-core/sources/Configuration.ts
@@ -175,7 +175,12 @@ export const coreDefinitions = {
     default: `npm:`,
   },
 
-  // Settings related to network proxies
+  // Settings related to network access
+  enableNetwork: {
+    description: `If false, the package manager will refuse to use the network if required to`,
+    type: SettingsType.BOOLEAN,
+    default: true,
+  },
   httpProxy: {
     description: `URL of the http proxy that must be used for outgoing http requests`,
     type: SettingsType.STRING,

--- a/packages/berry-core/sources/LightReport.ts
+++ b/packages/berry-core/sources/LightReport.ts
@@ -7,6 +7,7 @@ import {Locator}             from './types';
 export type LightReportOptions = {
   configuration: Configuration,
   stdout: Writable,
+  suggestInstall?: boolean,
 };
 
 export class LightReport extends Report {
@@ -26,14 +27,16 @@ export class LightReport extends Report {
 
   private configuration: Configuration;
   private stdout: Writable;
+  private suggestInstall: boolean;
 
   private errorCount: number = 0;
 
-  constructor({configuration, stdout}: LightReportOptions) {
+  constructor({configuration, stdout, suggestInstall = true}: LightReportOptions) {
     super();
 
     this.configuration = configuration;
     this.stdout = stdout;
+    this.suggestInstall = suggestInstall;
   }
 
   hasErrors() {
@@ -76,7 +79,10 @@ export class LightReport extends Report {
   async finalize() {
     if (this.errorCount > 0) {
       this.stdout.write(`${this.configuration.format(`➤`, `redBright`)} Errors happened when preparing the environment required to run this command.\n`);
-      this.stdout.write(`${this.configuration.format(`➤`, `redBright`)} This might be caused by packages being missing from the lockfile, in which case running "berry install" might help.\n`);
+
+      if (this.suggestInstall) {
+        this.stdout.write(`${this.configuration.format(`➤`, `redBright`)} This might be caused by packages being missing from the lockfile, in which case running "berry install" might help.\n`);
+      }
     }
   }
 

--- a/packages/berry-core/sources/httpUtils.ts
+++ b/packages/berry-core/sources/httpUtils.ts
@@ -17,6 +17,9 @@ function parseProxy(specifier: string) {
 }
 
 async function getNoCache(target: string, configuration: Configuration): Promise<Buffer> {
+  if (!configuration.get(`enableNetwork`))
+    throw new Error(`Network access have been disabled by configuration (when querying ${target})`);
+
   const url = new URL(target);
   let agent;
 
@@ -32,7 +35,7 @@ async function getNoCache(target: string, configuration: Configuration): Promise
   const res = await got(target, {agent, encoding: null});
 
   if (res.statusCode !== 200)
-    throw new Error(`Server answered status code ${res.statusCode}`);
+    throw new Error(`The remote server answered with an HTTP ${res.statusCode} (when querying ${target})`);
 
   return await res.body;
 }

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -128,6 +128,9 @@ export async function getSuggestedDescriptors(request: Descriptor, previous: Des
         } else if (target === Target.PEER) {
           const reason = `Use * (catch-all peer dependency pattern)`;
           suggested.push({descriptor: structUtils.makeDescriptor(request, `*`), reason})
+        } else if (!project.configuration.get(`enableNetwork`)) {
+          const reason = `Resolve from latest ${project.configuration.format(`(unavailable because enableNetwork is toggled off)`, `grey`)}`;
+          suggested.push({descriptor: null, reason});
         } else {
           let latest;
           try {

--- a/packages/plugin-typescript/sources/index.ts
+++ b/packages/plugin-typescript/sources/index.ts
@@ -26,10 +26,13 @@ const afterWorkspaceDependencyAddition = async (
   const request = structUtils.makeDescriptor(structUtils.makeIdent(`types`, typesName), `unknown`);
   const suggestions = await suggestUtils.getSuggestedDescriptors(request, null, {project, cache, target, modifier, strategies});
 
-  if (suggestions.length === 0)
+  const nonNullSuggestions = suggestions.filter(suggestion => suggestion.descriptor !== null);
+  if (nonNullSuggestions.length === 0)
     return;
 
-  const selected = suggestions[0].descriptor;
+  const selected = nonNullSuggestions[0].descriptor;
+  if (selected === null)
+    return;
 
   workspace.manifest[target].set(
     selected.identHash,


### PR DESCRIPTION
This settings is identical to the `--offline` flag in the v1. It is meant to prevent Yarn from accessing the network, which is handy in two cases:

- To avoid unwanted internet access on sensitive machines
- To skip unwanted internet access when working offline (like in transports)