### PR TITLE
Fixes sibling peer dependencies

### DIFF
--- a/packages/berry-core/sources/RunInstallPleaseResolver.ts
+++ b/packages/berry-core/sources/RunInstallPleaseResolver.ts
@@ -22,7 +22,7 @@ export class RunInstallPleaseResolver implements Resolver {
   }
 
   bindDescriptor(descriptor: Descriptor, fromLocator: Locator, opts: MinimalResolveOptions): never {
-    throw new Error(`Unreachable`);
+    throw new ReportError(MessageName.MISSING_LOCKFILE_ENTRY, `A dependency cannot be retrieved from the lockfile; try to make an install to update your resolutions`);
   }
 
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions): Promise<never> {


### PR DESCRIPTION
There was a problem in the way the virtual links were generated: the tree recursion was done one dependency after another, but before they had all been virtualized. It caused the recursions to not see that the parent package was still referencing entries that would later get virtualized, and in response to virtualize them themselves.

This diff adds a two-pass processing: first we virtualize all the dependencies of the current package, and only then we update the dependencies and recurse within them.
