### PR TITLE
Runs the postinstall scripts on workspaces

### DIFF
--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -75,7 +75,7 @@ class PnpInstaller implements Installer {
       buildScripts.length = 0;
     }
 
-    if (buildScripts.length > 0 && pkg.linkType !== LinkType.HARD) {
+    if (buildScripts.length > 0 && pkg.linkType !== LinkType.HARD && !this.opts.project.tryWorkspaceByLocator(pkg)) {
       this.opts.report.reportWarning(MessageName.SOFT_LINK_BUILD, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but is referenced through a soft link. Soft links don't support build scripts, so they'll be ignored.`);
       buildScripts.length = 0;
     }


### PR DESCRIPTION
Since the workspaces are installed through soft links, and since we disable postinstall scripts on soft links (because we don't want to run the postinstall scripts for packages depended upon via `portal:`), the postinstall scripts never ran on workspaces.

This diff ensures that postinstall scripts are always allowed on workspaces.