### PR TITLE
Adds support for enableGlobalCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
 
   - Running `yarn policies set-resolution <package> <resolution>` will force the resolver to use a specific resolution for the given package descriptor. Note that the descriptor passed as parameter must be exactly the same as the one you want to override. This command is a handy tool to manually optimize some ranges that could benefit from overlapping.
 
+  - Running `yarn up <package>` will upgrade `<package>` in all of your workspaces at once (only if they already use the specified package - those that don't won't see it being added). Adding the `-i` flag will also cause Yarn to ask you to confirm for each workspace.
+
+  - Running `yarn config --why` will tell you the source for each value in your configuration. We recommend using it when you're not sure to understand why Yarn would have a particular settings.
+
 ### Miscellaneous
 
   - A new protocol is now supported, `portal:`. Portals are very much like `link:` in that they directly point to a location on the disk, but unlike links they also take into account the dependencies of the target location (whereas links don't care about these). To give you a better idea, portals are what you use when you want to target a *package*, whereas links are what you use when you want to target a non-package folder (for example your `src` directory, or similar).

--- a/packages/berry-core/sources/Configuration.ts
+++ b/packages/berry-core/sources/Configuration.ts
@@ -143,6 +143,11 @@ export const coreDefinitions = {
     type: SettingsType.STRING,
     default: getRcFilename(),
   },
+  enableGlobalCache: {
+    description: `If true, the system-wide cache folder will be used regardless of \`cache-folder\``,
+    type: SettingsType.BOOLEAN,
+    default: false,
+  },
 
   // Settings related to the output style
   enableColors: {
@@ -391,6 +396,11 @@ export class Configuration {
     for (const {path, cwd, data} of rcFiles)
       configuration.useWithSource(path, data, cwd);
 
+    if (configuration.get(`enableGlobalCache`)) {
+      configuration.values.set(`cacheFolder`, `${configuration.get(`globalFolder`)}/cache`);
+      configuration.sources.set(`cacheFolder`, `<internal>`);
+    }
+
     return configuration;
   }
 
@@ -531,7 +541,7 @@ export class Configuration {
       if (Array.isArray(value)) {
         if (!definition.isArray && !Array.isArray(definition.default)) {
           throw new Error(`Non-array configuration settings "${name}" cannot be an array`);
-        } else {
+        } else {  
           value = value.map(sub => parseValue(sub, definition.type, folder));
         }
       } else {

--- a/packages/plugin-essentials/sources/commands/config.ts
+++ b/packages/plugin-essentials/sources/commands/config.ts
@@ -12,11 +12,15 @@ function fromEntries(iterable: Iterable<[any, any] | {0: any, 1: any}>): {[key: 
 
 export default (concierge: any, pluginConfiguration: PluginConfiguration) => concierge
 
-  .command(`config [-v,--verbose] [--json]`)
+  .command(`config [-v,--verbose] [--why] [--json]`)
   .describe(`display the current configuration`)
 
   .detail(`
-    This command prints the current active configuration settings. When used together with the \`-v,--verbose\` option, the output will contain the settings description on top of the regular key/value information.
+    This command prints the current active configuration settings.
+    
+    When used together with the \`-v,--verbose\` option, the output will contain the settings description on top of the regular key/value information.
+
+    When used together with the \`--why\` flag, the output will also contain the reason why a settings is set a particular way.
   `)
 
   .example(
@@ -24,7 +28,7 @@ export default (concierge: any, pluginConfiguration: PluginConfiguration) => con
     `yarn config`,
   )
 
-  .action(async ({cwd, stdout, verbose, json}: {cwd: string, stdout: Writable, verbose: boolean, json: boolean}) => {
+  .action(async ({cwd, stdout, verbose, why, json}: {cwd: string, stdout: Writable, verbose: boolean, why: boolean, json: boolean}) => {
     const configuration = await Configuration.find(cwd, pluginConfiguration);
 
     const keys = miscUtils.sortMap(configuration.settings.keys(), key => key);
@@ -33,8 +37,10 @@ export default (concierge: any, pluginConfiguration: PluginConfiguration) => con
     if (json) {
       const data = fromEntries(configuration.settings.entries());
 
-      for (const key of Object.keys(data))
-        data[key].effective = configuration.get(key);
+      for (const key of Object.keys(data)) {
+        data[key].effective = configuration.values.get(key);
+        data[key].source = configuration.sources.get(key);
+      }
 
       return JsonReport.send({stdout}, data);
     } else {
@@ -43,15 +49,19 @@ export default (concierge: any, pluginConfiguration: PluginConfiguration) => con
         colors: configuration.get(`enableColors`),
         maxArrayLength: 2,
       };
-  
-      if (verbose) {
+
+      if (why || verbose) {
         const keysAndDescriptions = keys.map(key => {
           const settings = configuration.settings.get(key);
 
           if (!settings)
             throw new Error(`Assertion failed: This settings ("${key}") should have been registered`);
 
-          return [key, settings.description] as [string, string];
+          const description = why
+            ? configuration.sources.get(key) || `<default>`
+            : settings.description;
+
+          return [key, description] as [string, string];
         });
 
         const maxDescriptionLength = keysAndDescriptions.reduce((max, [, description]) => {


### PR DESCRIPTION
This PR adds a new settings, `enableGlobalCache`, disabled by default, which instructs Yarn to use a global folder to keep its cache rather than the one defined in `cache-folder`.

Another option was to add variable support within the configuration values, but it felt too complex and slow for the purpose. Additionally, a separate flag provides semantic information that can be used with functions such as `yarn cache clean`.