### PR TITLE
Adds a node-gyp plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     }
   },
   "scripts": {
-    "foo": "node-gyp --version",
     "test:unit": "jest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     }
   },
   "scripts": {
+    "foo": "node-gyp --version",
     "test:unit": "jest"
   }
 }

--- a/packages/berry-cli/package.json
+++ b/packages/berry-cli/package.json
@@ -28,6 +28,7 @@
     "@berry/plugin-hub": "workspace:*",
     "@berry/plugin-init": "workspace:*",
     "@berry/plugin-link": "workspace:*",
+    "@berry/plugin-node-gyp": "workspace:*",
     "@berry/plugin-npm": "workspace:*",
     "@berry/plugin-pnp": "workspace:*",
     "@berry/plugin-typescript": "workspace:*",
@@ -40,14 +41,15 @@
   "@berry/builder": {
     "bundles": {
       "standard": [
-        "@berry/plugin-dlx",
         "@berry/plugin-essentials",
-        "@berry/plugin-init",
         "@berry/plugin-constraints",
+        "@berry/plugin-dlx",
         "@berry/plugin-file",
         "@berry/plugin-github",
         "@berry/plugin-http",
+        "@berry/plugin-init",
         "@berry/plugin-link",
+        "@berry/plugin-node-gyp",
         "@berry/plugin-npm",
         "@berry/plugin-pnp"
       ]

--- a/packages/berry-core/sources/Plugin.ts
+++ b/packages/berry-core/sources/Plugin.ts
@@ -16,10 +16,26 @@ export interface ResolverPlugin {
   new(): Resolver;
 };
 
-// We keep this one an interface because we allow other plugins to extend it
-// with new hooks, cf TypeScript documentation on declaration merging
-export interface Hooks {
-  afterAllInstalled?: (project: Project) => void,
+export type Hooks = {
+  // Called before a script is executed. The hooks are allowed to modify the
+  // `env` object as they see fit, and any call to `makePathWrapper` will cause
+  // a binary of the given name to be injected somewhere within the PATH (we
+  // recommend you don't alter the PATH yourself unless required).
+  //
+  // The keys you get in the env are guaranteed to be uppercase. We strongly
+  // suggest you adopt this convention for any new key added to the env (we
+  // might enforce it later on).
+  setupScriptEnvironment?: (
+    project: Project,
+    env: {[key: string]: string},
+    makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>,
+  ) => Promise<void>,
+
+  // Called after the `install` method from the `Project` class successfully
+  // completed.
+  afterAllInstalled?: (
+    project: Project,
+  ) => void,
 };
 
 export type Plugin = {

--- a/packages/berry-core/sources/index.ts
+++ b/packages/berry-core/sources/index.ts
@@ -6,7 +6,7 @@ export {JsonReport}                                                           fr
 export {LightReport}                                                          from './LightReport';
 export {Linker, LinkOptions, MinimalLinkOptions}                              from './Linker';
 export {Manifest, DependencyMeta, PeerDependencyMeta}                         from './Manifest';
-export {Plugin}                                                               from './Plugin';
+export {Hooks, Plugin}                                                        from './Plugin';
 export {Project}                                                              from './Project';
 export {ReportError, Report, MessageName}                                     from './Report';
 export {Resolver, ResolveOptions, MinimalResolveOptions}                      from './Resolver';

--- a/packages/plugin-node-gyp/package.json
+++ b/packages/plugin-node-gyp/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@berry/plugin-node-gyp",
+  "private": true,
+  "main": "./sources/index.ts",
+  "dependencies": {
+    "@berry/core": "workspace:*"
+  }
+}

--- a/packages/plugin-node-gyp/sources/index.ts
+++ b/packages/plugin-node-gyp/sources/index.ts
@@ -1,0 +1,22 @@
+import {Hooks as CoreHooks, Plugin, Project, SettingsType} from '@berry/core';
+
+async function setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>) {
+  await makePathWrapper(`node-gyp`, process.execPath, [process.argv[1], `dlx`, `-q`, project.configuration.get(`nodeGypMagicLocator`)]);
+}
+
+const plugin: Plugin = {
+  hooks: {
+    setupScriptEnvironment,
+  } as (
+    CoreHooks
+  ),
+  configuration: {
+    nodeGypMagicLocator: {
+      description: `Package to use when node-gyp is omitted from the dependencies`,
+      type: SettingsType.LOCATOR_LOOSE,
+      default: `node-gyp`,
+    },
+  },
+};
+
+export default plugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,6 +1596,7 @@ __metadata:
     "@berry/plugin-hub": "workspace:*"
     "@berry/plugin-init": "workspace:*"
     "@berry/plugin-link": "workspace:*"
+    "@berry/plugin-node-gyp": "workspace:*"
     "@berry/plugin-npm": "workspace:*"
     "@berry/plugin-pnp": "workspace:*"
     "@berry/plugin-typescript": "workspace:*"
@@ -1861,6 +1862,14 @@ __metadata:
   dependencies:
     "@berry/core": "workspace:*"
     "@berry/fslib": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@berry/plugin-node-gyp@workspace:*, @berry/plugin-node-gyp@workspace:packages/plugin-node-gyp":
+  version: 0.0.0
+  resolution: "@berry/plugin-node-gyp@workspace:packages/plugin-node-gyp"
+  dependencies:
+    "@berry/core": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The `node-gyp` package is a bit magic in both Yarn and npm in that it is downloaded on-demand if the package requests it. It's a horrible thing to do because you have no way to guarantee which version of `node-gyp` will be used. Still, that's how the ecosystem currently works and there's some friction to change it so I'll have to live with it for now (https://github.com/lovell/sharp/pull/924).

This PR implements a plugin that causes `node-gyp` to be installed when called, unless overridden by an explicit dependency. There's one improvement over Yarn 1 and npm, though: you can enforce the version of `node-gyp` that gets used by using the new `node-gyp-magic-locator` settings:

```yaml
node-gyp-magic-locator: "node-gyp@3.8.0"
```
