### PR TITLE
Introduce workspace_field/3 predicate to expose workspace manifest information

### DIFF
--- a/packages/berry-core/sources/Manifest.ts
+++ b/packages/berry-core/sources/Manifest.ts
@@ -46,6 +46,8 @@ export class Manifest {
 
   public files: Set<String> = new Set();
 
+  public raw: object | null = null;
+
   static async find(path: string, {baseFs = new NodeFS()}: {baseFs?: FakeFS} = {}) {
     return await Manifest.fromFile(posix.join(path, `package.json`), {baseFs});
   }
@@ -68,6 +70,7 @@ export class Manifest {
     if (typeof data !== `object` || data === null)
       throw new Error(`Utterly invalid manifest data (${data})`);
 
+    this.raw = data;
     const errors: Array<Error> = [];
 
     if (typeof data.name === `string`) {

--- a/packages/plugin-constraints/sources/Constraints.ts
+++ b/packages/plugin-constraints/sources/Constraints.ts
@@ -1,8 +1,9 @@
 import {Ident, Locator, Project, Workspace} from '@berry/core';
 import {miscUtils, structUtils}             from '@berry/core';
 import {xfs}                                from '@berry/fslib';
-// @ts-ignore
 import pl                                   from 'tau-prolog';
+
+import {linkProjectToSession}               from './tauModule';
 
 export type DependencyMismatch = {
   packageLocator: Locator,
@@ -65,6 +66,8 @@ export class Constraints {
 
   async process() {
     const session = pl.create();
+    linkProjectToSession(session, this.project);
+
     session.consult(this.fullSource);
 
     let enforcedDependencyRanges: Array<{

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -1,0 +1,68 @@
+import {Project} from '@berry/core';
+import pl        from 'tau-prolog';
+
+const {is_atom} = pl.type;
+
+function prependGoals(
+    thread: pl.type.Thread, point: pl.type.State,
+    goals: pl.type.Term<number, string>[]): void {
+  thread.prepend(goals.map(
+      goal => new pl.type.State(
+          point.goal.replace(goal), point.substitution, point)));
+}
+
+const projects = new WeakMap<pl.type.Session, Project>();
+
+function getProject(thread: pl.type.Thread): Project {
+  const project = projects.get(thread.session);
+
+  if (project == null) {
+    throw new Error(`No project registered for the active session`);
+  }
+
+  return project;
+}
+
+const tauModule = new pl.type.Module(
+    `constraints`, {
+      'workspace_field/3': (thread, point, atom) => {
+        const [workspaceCwd, fieldName, fieldValue] = atom.args;
+
+        if (!is_atom(workspaceCwd) || !is_atom(fieldName)) {
+          thread.throw_error(pl.error.instantiation(atom.indicator));
+          return;
+        }
+
+        const workspace =
+            getProject(thread).tryWorkspaceByCwd(workspaceCwd.id);
+
+        if (workspace == null) {
+          // Workspace not found => this predicate can never match
+          // We might want to throw here? We can be pretty sure the user did
+          // something wrong at this point
+          return;
+        }
+
+        const manifest: {[key: string]: any} = {};
+        workspace.manifest.exportTo(manifest);
+
+        if (!(fieldName.id in manifest)) {
+          // Field is not present => this predicate can never match
+          return;
+        }
+
+        prependGoals(thread, point, [new pl.type.Term('=', [
+                       fieldValue,
+                       new pl.type.Term(String((manifest)[fieldName.id])),
+                     ])]);
+      },
+    },
+    [
+      `workspace_field/3`,
+    ]);
+
+export function linkProjectToSession(session: pl.type.Session, project: Project) {
+  projects.set(session, project);
+
+  session.consult(`:- use_module(library(${tauModule.id})).`);
+}

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -16,9 +16,8 @@ const projects = new WeakMap<pl.type.Session, Project>();
 function getProject(thread: pl.type.Thread): Project {
   const project = projects.get(thread.session);
 
-  if (project == null) {
+  if (project == null)
     throw new Error(`Assertion failed: A project should have been registered for the active session`);
-  }
 
   return project;
 }
@@ -36,19 +35,17 @@ const tauModule = new pl.type.Module(
         const workspace =
             getProject(thread).tryWorkspaceByCwd(workspaceCwd.id);
 
-        if (workspace == null) {
+        if (workspace == null)
           // Workspace not found => this predicate can never match
           // We might want to throw here? We can be pretty sure the user did
           // something wrong at this point
           return;
-        }
 
         const manifest: {[key: string]: any} = workspace.manifest.raw!;
 
-        if (!(fieldName.id in manifest)) {
+        if (!(fieldName.id in manifest))
           // Field is not present => this predicate can never match
           return;
-        }
 
         prependGoals(thread, point, [new pl.type.Term('=', [
                        fieldValue,

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -3,12 +3,14 @@ import pl        from 'tau-prolog';
 
 const {is_atom} = pl.type;
 
-function prependGoals(
-    thread: pl.type.Thread, point: pl.type.State,
-    goals: pl.type.Term<number, string>[]): void {
+function prependGoals(thread: pl.type.Thread, point: pl.type.State, goals: pl.type.Term<number, string>[]): void {
   thread.prepend(goals.map(
-      goal => new pl.type.State(
-          point.goal.replace(goal), point.substitution, point)));
+    goal => new pl.type.State(
+      point.goal.replace(goal),
+      point.substitution,
+      point,
+    ),
+  ));
 }
 
 const projects = new WeakMap<pl.type.Session, Project>();
@@ -22,40 +24,38 @@ function getProject(thread: pl.type.Thread): Project {
   return project;
 }
 
-const tauModule = new pl.type.Module(
-    `constraints`, {
-      'workspace_field/3': (thread, point, atom) => {
-        const [workspaceCwd, fieldName, fieldValue] = atom.args;
+const tauModule = new pl.type.Module(`constraints`, {
+  [`workspace_field/3`]: (thread, point, atom) => {
+    const [workspaceCwd, fieldName, fieldValue] = atom.args;
 
-        if (!is_atom(workspaceCwd) || !is_atom(fieldName)) {
-          thread.throwError(pl.error.instantiation(atom.indicator));
-          return;
-        }
+    if (!is_atom(workspaceCwd) || !is_atom(fieldName)) {
+      thread.throwError(pl.error.instantiation(atom.indicator));
+      return;
+    }
 
-        const workspace =
-            getProject(thread).tryWorkspaceByCwd(workspaceCwd.id);
+    const project = getProject(thread);
+    const workspace = project.tryWorkspaceByCwd(workspaceCwd.id);
 
-        if (workspace == null)
-          // Workspace not found => this predicate can never match
-          // We might want to throw here? We can be pretty sure the user did
-          // something wrong at this point
-          return;
+    // Workspace not found => this predicate can never match
+    // We might want to throw here? We can be pretty sure the user did
+    // something wrong at this point
+    if (workspace == null)
+      return;
 
-        const manifest: {[key: string]: any} = workspace.manifest.raw!;
+    const manifest: {[key: string]: any} = workspace.manifest.raw!;
 
-        if (!(fieldName.id in manifest))
-          // Field is not present => this predicate can never match
-          return;
+    // Field is not present => this predicate can never match
+    if (!(fieldName.id in manifest))
+      return;
 
-        prependGoals(thread, point, [new pl.type.Term('=', [
-                       fieldValue,
-                       new pl.type.Term(String((manifest)[fieldName.id])),
-                     ])]);
-      },
-    },
-    [
-      `workspace_field/3`,
-    ]);
+    prependGoals(thread, point, [new pl.type.Term('=', [
+      fieldValue,
+      new pl.type.Term(String((manifest)[fieldName.id])),
+    ])]);
+  },
+}, [
+  `workspace_field/3`,
+]);
 
 export function linkProjectToSession(session: pl.type.Session, project: Project) {
   projects.set(session, project);

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -29,7 +29,7 @@ const tauModule = new pl.type.Module(
         const [workspaceCwd, fieldName, fieldValue] = atom.args;
 
         if (!is_atom(workspaceCwd) || !is_atom(fieldName)) {
-          thread.throw_error(pl.error.instantiation(atom.indicator));
+          thread.throwError(pl.error.instantiation(atom.indicator));
           return;
         }
 

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -43,8 +43,7 @@ const tauModule = new pl.type.Module(
           return;
         }
 
-        const manifest: {[key: string]: any} = {};
-        workspace.manifest.exportTo(manifest);
+        const manifest: {[key: string]: any} = workspace.manifest.raw!;
 
         if (!(fieldName.id in manifest)) {
           // Field is not present => this predicate can never match

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -17,7 +17,7 @@ function getProject(thread: pl.type.Thread): Project {
   const project = projects.get(thread.session);
 
   if (project == null) {
-    throw new Error(`No project registered for the active session`);
+    throw new Error(`Assertion failed: A project should have been registered for the active session`);
   }
 
   return project;

--- a/packages/plugin-constraints/sources/types/tau-prolog.d.ts
+++ b/packages/plugin-constraints/sources/types/tau-prolog.d.ts
@@ -1,0 +1,275 @@
+declare module 'tau-prolog' {
+  namespace tau {
+    namespace type {
+      type _Value = Var|Num|Term<number, string>|Substitution|State|Rule;
+      type Value = Var|Num|Term<number, string>;
+
+      class Var {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly id: string;
+
+        public constructor(id: string);
+
+        public unify(obj: _Value, occurs_check: boolean): Substitution|null;
+
+        public clone(): this;
+
+        public equals(obj: _Value): boolean;
+
+        public rename(thread: Thread): this;
+
+        public variables(): string[];
+
+        public apply(subs: Substitution): this;
+
+        public compare(other: this): -1|0|1;
+      }
+
+      class Num {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly is_float: boolean;
+
+        public readonly value: number;
+
+        public constructor(value: number, is_float?: boolean);
+
+        public unify(obj: _Value, occurs_check: boolean): Substitution|null;
+
+        public clone(): this;
+
+        public equals(obj: _Value): boolean;
+
+        public rename(thread: Thread): this;
+
+        public variables(): string[];
+
+        public apply(subs: Substitution): this;
+
+        public compare(other: this): -1|0|1;
+      }
+
+      class Term<Arity extends number, Indicator extends string> {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly indicator: Indicator;
+
+        public readonly id: string;
+
+        public readonly args: Value[]&{length: Arity};
+
+        public constructor(id: string, args?: Value[], ref?: number);
+
+        public unify(obj: _Value, occurs_check: boolean): Substitution|null;
+
+        public clone(): this;
+
+        public equals(obj: _Value): boolean;
+
+        public rename(thread: Thread): this;
+
+        public variables(): string[];
+
+        public apply(subs: Substitution): this;
+
+        public select(): Term<number, string>;
+
+        public replace(term: Term<number, string>): Term<number, string>;
+
+        public search(expr: Term<number, string>): boolean;
+
+        public compare(other: this): -1|0|1;
+      }
+
+      class Substitution {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly links: {};
+
+        public constructor(links?: {});
+
+        public clone(): this;
+
+        public equals(obj: _Value): boolean;
+
+        public apply(subs: Substitution): this;
+      }
+
+      class State {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly goal: Term<number, string>;
+
+        public readonly substitution: Substitution;
+
+        public readonly parent: State|null;
+
+        public constructor(goal?: Term<number, string>, subs?: Substitution, parent?: State);
+
+        public clone(): this;
+
+        public equals(obj: _Value): boolean;
+      }
+
+      class Rule {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly head: Term<number, string>;
+
+        public readonly body: Term<number, string>|null;
+
+        public readonly dynamic: boolean;
+
+        public constructor(
+            head: Term<number, string>, body: Term<number, string>|null, dynamic?: boolean);
+
+        public clone(): this;
+
+        public equals(obj: _Value): boolean;
+
+        public rename(thread: Thread): this;
+
+        public variables(): string[];
+
+        public apply(subs: Substitution): this;
+      }
+
+      class Session {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly rules: Record<string, Rule>;
+
+        public readonly modules: string[];
+
+        public readonly threads: Thread[];
+
+        public readonly total_threads: number;
+
+        public constructor(limit?: number);
+
+        public consult(program: string): void;
+
+        public query(query: string): void;
+
+        public answer(callback: (answer: Answer) => void): void;
+
+        public answers(callback: (answer: Answer) => void, maxCount?: number, after?: () => void):
+            void;
+
+        public add_rule(rule: Rule, options?: {from?: string}): true;
+
+        public prepend(states: State[]): void;
+
+        public throw_error(error: Term<1, 'error'>): void;
+
+        public success(state: State, parent?: State): void;
+      }
+
+      class Thread {
+        // private property to ensure types don't overlap
+        private _uniqueProperty;
+
+        public readonly epoch: number;
+        public readonly session: Session;
+        public readonly total_steps: Number;
+        public readonly cpu_time: Number;
+        public readonly cpu_time_last: Number;
+        public readonly points: [];
+        public readonly debugger: boolean;
+        public readonly debugger_states: [];
+        public readonly level: string;
+        public readonly current_limit: number;
+
+        public consult(program: string): void;
+
+        public query(query: string): void;
+
+        public answer(callback: (answer: Answer) => void): void;
+
+        public answers(callback: (answer: Answer) => void, maxCount?: number, after?: () => void):
+            void;
+
+        public add_rule(rule: Rule, options?: {from?: string}): true;
+
+        public prepend(states: State[]): void;
+
+        public throw_error(error: Term<1, 'error'>): void;
+
+        public success(state: State, parent?: State): void;
+      }
+
+      interface PredicateFn {
+        (thread: Thread, point: State, atom: Term<number, string>): void|true;
+      }
+
+      type Predicate = Rule[]|PredicateFn;
+
+      class Module {
+        public readonly id: string;
+
+        public readonly predicates: Record<string, Predicate>;
+
+        public readonly exports: string[];
+
+        public constructor(id: string, predicates: Record<string, Predicate>, exports: string[]);
+
+        public exports_predicate(indicator: string): boolean;
+      }
+
+      function is_variable(obj: any): obj is Var;
+
+      function is_atom(obj: any): obj is Term<0, string>;
+
+      function is_module(obj: any): obj is Term<1, 'module/1'>;
+
+      function is_error(obj: any): obj is Term<1, 'throw/1'>;
+    }
+
+    namespace error {
+      function existence(type: string, object: type.Term<number, string>|string, indicator: string):
+          type.Term<1, 'error'>;
+      function type(expected: string, found: type.Term<number, string>, indicator: string):
+          type.Term<1, 'error'>;
+      function instantiation(indicator: string): type.Term<1, 'error'>;
+      function domain(expected: string, found: type.Term<number, string>, indicator: string):
+          type.Term<1, 'error'>;
+      function representation(flag: string, indicator: string): type.Term<1, 'error'>;
+      function permission(
+          operation: string, type: string, found: type.Term<number, string>, indicator: string):
+          type.Term<1, 'error'>;
+      function evaluation(error: string, indicator: string): type.Term<1, 'error'>;
+      function syntax(
+          token: undefined|
+          {value: string, line: number, column: number, matches: string[], start: number},
+          expected: string,
+          last: boolean): type.Term<1, 'error'>;
+      function syntax_by_predicate(expected: string, indicator: string): type.Term<1, 'error'>;
+    }
+
+    interface Answer {
+      id: string;
+
+      links: Record<string, Link>;
+    }
+
+    interface Link {
+      id: string;
+
+      toJavaScript(): string|number|(string|number)[];
+    }
+
+    function format_answer(answer: Answer): string;
+
+    function create(limit?: number): type.Session;
+  }
+
+  export = tau;
+}

--- a/packages/plugin-constraints/sources/types/tau-prolog.d.ts
+++ b/packages/plugin-constraints/sources/types/tau-prolog.d.ts
@@ -201,7 +201,7 @@ declare module 'tau-prolog' {
 
         public prepend(states: State[]): void;
 
-        public throw_error(error: Term<1, 'error'>): void;
+        public throwError(error: Term<1, 'error'>): void;
 
         public success(state: State, parent?: State): void;
       }


### PR DESCRIPTION
Implements the `workspace_field/3` predicate proposed in #31.

Timings for the current constraints file in the berry repo on a 2017 MacBook Pro with 2.9 GHz i7:

- Before: mean 1.910s, deviation 0.230
- After: mean 1.845s, deviation 0.203

This is the average of five timings. It doesn't look like there's any speed impact at all for constraints files that don't use any predicate exposed in the javascript tau module.
