### PR TITLE
Fixes piping

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -9914,6 +9914,14 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                   "workspace:packages/berry-parsers"
                 ],
                 [
+                  "@types/cross-spawn",
+                  "npm:6.0.0"
+                ],
+                [
+                  "cross-spawn",
+                  "npm:6.0.5"
+                ],
+                [
                   "execa",
                   "npm:1.0.0"
                 ],

--- a/packages/berry-shell/package.json
+++ b/packages/berry-shell/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@berry/fslib": "workspace:*",
     "@berry/parsers": "workspace:*",
+    "@types/cross-spawn": "6.0.0",
+    "cross-spawn": "^6.0.5",
     "execa": "^1.0.0",
     "stream-buffers": "^3.0.2"
   },

--- a/packages/berry-shell/sources/index.ts
+++ b/packages/berry-shell/sources/index.ts
@@ -1,11 +1,12 @@
 import {xfs, NodeFS}                                                      from '@berry/fslib';
 import {CommandSegment, CommandChain, CommandLine, ShellLine, parseShell} from '@berry/parsers';
-import crossSpawn                                                         from 'cross-spawn';
 import {posix}                                                            from 'path';
 import {PassThrough, Readable, Stream, Writable}                          from 'stream';
 
+import {Handle, ProtectedStream, Stdio, start, makeBuiltin, makeProcess}  from './pipe';
+
 export type UserOptions = {
-  builtins: {[key: string]: UserBuiltin},
+  builtins: {[key: string]: ShellBuiltin},
   cwd: string,
   env: {[key: string]: string | undefined},
   stdin: Readable,
@@ -14,21 +15,11 @@ export type UserOptions = {
   variables: {[key: string]: string},
 };
 
-export type UserBuiltin = (
-  args: Array<string>,
-  opts: ShellOptions,
-  state: ShellState,
-) => Promise<number>;
-
 export type ShellBuiltin = (
   args: Array<string>,
   opts: ShellOptions,
   state: ShellState,
-  leftMost: boolean,
-) => Promise<{
-  stdin: Writable | null,
-  promise: Promise<number>,
-}>;
+) => Promise<number>;
 
 export type ShellOptions = {
   args: Array<string>,
@@ -48,41 +39,6 @@ export type ShellState = {
   variables: {[key: string]: string},
 };
 
-function makeBuiltin(builtin: (args: Array<string>, opts: ShellOptions, state: ShellState) => Promise<number>): ShellBuiltin {
-  return async (args: Array<string>, opts: ShellOptions, state: ShellState, leftMost: boolean) => {
-    const stdin = !leftMost
-      ? new PassThrough()
-      : null;
-
-    if (stdin !== null)
-      state = {... state, stdin};
-
-    const close = () => {
-      if (state.stdin !== opts.initialStdin) {
-        // @ts-ignore
-        state.stdin.end();
-      }
-
-      if (state.stdout !== opts.initialStdout)
-        state.stdout.end();
-      if (state.stderr !== opts.initialStderr) {
-        state.stderr.end();
-      }
-    };
-
-    return {
-      stdin,
-      promise: builtin(args, opts, state).then(result => {
-        close();
-        return result;
-      }, error => {
-        close();
-        throw error;
-      }),
-    };
-  };
-}
-
 function cloneState(state: ShellState, mergeWith: Partial<ShellState> = {}) {
   const newState = {... state, ... mergeWith};
 
@@ -93,7 +49,7 @@ function cloneState(state: ShellState, mergeWith: Partial<ShellState> = {}) {
 }
 
 const BUILTINS = new Map<string, ShellBuiltin>([
-  [`cd`, makeBuiltin(async ([target, ... rest]: Array<string>, opts: ShellOptions, state: ShellState) => {
+  [`cd`, async ([target, ... rest]: Array<string>, opts: ShellOptions, state: ShellState) => {
     const resolvedTarget = posix.resolve(state.cwd, NodeFS.toPortablePath(target));
     const stat = await xfs.statPromise(resolvedTarget);
 
@@ -104,86 +60,28 @@ const BUILTINS = new Map<string, ShellBuiltin>([
       state.cwd = target;
       return 0;
     }
-  })],
+  }],
 
-  [`pwd`, makeBuiltin(async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
+  [`pwd`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
     state.stdout.write(`${NodeFS.fromPortablePath(state.cwd)}\n`);
     return 0;
-  })],
+  }],
 
-  [`true`, makeBuiltin(async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
+  [`true`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
     return 0;
-  })],
+  }],
 
-  [`false`, makeBuiltin(async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
+  [`false`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
     return 1;
-  })],
+  }],
 
-  [`exit`, makeBuiltin(async ([code, ... rest]: Array<string>, opts: ShellOptions, state: ShellState) => {
+  [`exit`, async ([code, ... rest]: Array<string>, opts: ShellOptions, state: ShellState) => {
     return state.exitCode = parseInt(code, 10);
-  })],
+  }],
 
-  [`echo`, makeBuiltin(async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
+  [`echo`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
     state.stdout.write(`${args.join(` `)}\n`);
     return 0;
-  })],
-
-  [`command`, async ([ident, ... rest]: Array<string>, opts: ShellOptions, state: ShellState, leftMost: boolean) => {
-    if (typeof ident === `undefined`)
-      return makeBuiltin(async () => 0)([], opts, state, leftMost);
-
-    const stdio: Array<any> = [state.stdin, state.stdout, state.stderr];
-    const isUserStream = (stream: Stream) => stream instanceof PassThrough;
-
-    if (isUserStream(state.stdin) || !leftMost)
-      stdio[0] = `pipe`;
-    if (isUserStream(state.stdout))
-      stdio[1] = `pipe`;
-    if (isUserStream(state.stderr))
-      stdio[2] = `pipe`;
-
-    const subprocess = crossSpawn(ident, rest, {
-      cwd: NodeFS.fromPortablePath(state.cwd),
-      env: state.environment,
-      stdio,
-    });
-
-    if (isUserStream(state.stdin) && !leftMost)
-      state.stdin.pipe(subprocess.stdin);
-    if (isUserStream(state.stdout))
-      subprocess.stdout.pipe(state.stdout);
-    if (isUserStream(state.stderr))
-      subprocess.stderr.pipe(state.stderr);
-
-    return {
-      stdin: subprocess.stdin,
-      promise: new Promise(resolve => {
-        subprocess.on(`error`, error => {
-          // @ts-ignore
-          switch (error.code) {
-            case `ENOENT`: {
-              state.stderr.write(`command not found: ${ident}\n`);
-              resolve(127);
-            } break;
-            case `EACCESS`: {
-              state.stderr.write(`permission denied: ${ident}\n`);
-              resolve(128);
-            } break;
-            default: {
-              state.stderr.write(`uncaught error: ${error.message}\n`);
-              resolve(1);
-            } break;
-          }
-        });
-        subprocess.on(`exit`, code => {
-          if (code !== null) {
-            resolve(code);
-          } else {
-            resolve(129);
-          }
-        });
-      }),
-    };
   }],
 ]);
 
@@ -306,110 +204,108 @@ async function interpolateArguments(commandArgs: Array<Array<CommandSegment>>, o
  * $ cat hello | grep world | grep -v foobar
  */
 
-function makeCommandAction(args: Array<string>, opts: ShellOptions) {
+function makeCommandAction(args: Array<string>, opts: ShellOptions, state: ShellState) {
   if (!opts.builtins.has(args[0]))
     args = [`command`, ... args];
 
   const [name, ... rest] = args;
+  if (name === `command`) {
+    return makeProcess(rest[0], rest.slice(1), {
+      cwd: NodeFS.fromPortablePath(state.cwd),
+      env: state.environment,
+    });
+  }
 
   const builtin = opts.builtins.get(name);
   if (typeof builtin === `undefined`)
     throw new Error(`Assertion failed: A builtin should exist for "${name}"`)
 
-  return async (state: ShellState, leftMost: boolean) => {
-    const {stdin, promise} = await builtin(rest, opts, state, leftMost);
-    return {stdin, promise};
-  };
+  return makeBuiltin(async ({stdin, stdout, stderr}) => {
+    state.stdin = stdin;
+    state.stdout = stdout;
+    state.stderr = stderr;
+
+    return await builtin(rest, opts, state);
+  });
 }
 
-function makeSubshellAction(ast: ShellLine, opts: ShellOptions) {
-  return async (state: ShellState, mustPipe: boolean) => {
+function makeSubshellAction(ast: ShellLine, opts: ShellOptions, state: ShellState) {
+  return (stdio: Stdio) => {
     const stdin = new PassThrough();
     const promise = executeShellLine(ast, opts, cloneState(state, {stdin}));
 
-    return {stdin: stdin as Writable, promise};
+    return {stdin, promise};
   };
 }
 
 async function executeCommandChain(node: CommandChain, opts: ShellOptions, state: ShellState) {
   const parts = [];
 
-  // leftMost we interpolate all the commands (we don't interpolate subshells
-  // because they operate in their own contexts and are allowed to define
-  // new internal variables)
-
   let current: CommandChain | null = node;
   let pipeType = null;
 
-  while (current) {
-    let action;
+  let execution: Handle | null = null;
 
+  while (current) {
+    // Only the final segment is allowed to modify the shell state; all the
+    // other ones are isolated
+    const activeState = current.then
+      ? {... state}
+      : state;
+
+    let action;
     switch (current.type) {
       case `command`: {
-        action = makeCommandAction(await interpolateArguments(current.args, opts, state), opts);
+        action = makeCommandAction(await interpolateArguments(current.args, opts, state), opts, activeState);
       } break;
 
       case `subshell`: {
-        action = makeSubshellAction(current.subshell, opts);
+        // We don't interpolate the subshell because it will be recursively
+        // interpolated within its own context
+        action = makeSubshellAction(current.subshell, opts, activeState);
       } break;
     }
 
     if (typeof action === `undefined`)
       throw new Error(`Assertion failed: An action should have been generated`);
 
-    parts.push({action, pipeType});
+    if (pipeType === null) {
+      // If we're processing the left-most segment of the command, we start a
+      // new execution pipeline
+      execution = start(action, {
+        stdin: new ProtectedStream<Readable>(activeState.stdin),
+        stdout: new ProtectedStream<Writable>(activeState.stdout),
+        stderr: new ProtectedStream<Writable>(activeState.stderr),
+      });
+    } else {
+      if (execution === null)
+        throw new Error(`The execution pipeline should have been setup`);
 
-    if (typeof current.then !== `undefined`) {
+      // Otherwise, depending on the exaxct pipe type, we either pipe stdout
+      // only or stdout and stderr
+      switch (pipeType) {
+        case `|`: {
+          execution = execution.pipeTo(action);
+        } break;
+
+        case `|&`: {
+          execution = execution.pipeTo(action);
+        } break;
+      }
+    }
+
+    if (current.then) {
       pipeType = current.then.type;
       current = current.then.chain;
     } else {
       current = null;
-      pipeType = null;
     }
   }
 
-  // Note that the execution starts from the right-most command and
-  // progressively moves towards the left-most command. We run them in this
-  // order because otherwise we would risk a race condition where (let's
-  // use A | B as example) A would start writing before B is ready, which
-  // could cause the pipe buffer to overflow and some writes to be lost.
+  if (execution === null)
+    throw new Error(`Assertion failed: The execution pipeline should have been setup`);
 
-  let stdout = state.stdout;
-  let stderr = state.stderr;
-
-  const promises = [];
-
-  for (let t = parts.length - 1; t >= 0; --t) {
-    const {action, pipeType} = parts[t];
-    const {stdin, promise} = await action(Object.assign(state, {stdout, stderr}), t === 0);
-
-    promises.push(promise);
-
-    switch (pipeType) {
-      case null: {
-        // no pipe!
-      } break;
-
-      case `|`: {
-        if (stdin === null)
-          throw new Error(`Assertion failed: The pipe is expected to return a writable stream`);
-
-        stdout = stdin;
-      } break;
-
-      case `|&`: {
-        if (stdin === null)
-          throw new Error(`Assertion failed: The pipe is expected to return a writable stream`);
-
-        stdout = stdin;
-        stderr = stdin;
-      } break;
-    }
-  }
-
-  const exitCodes = await Promise.all(promises);
-
-  return exitCodes[exitCodes.length - 1];
+  return await execution.run();
 }
 
 /**
@@ -542,8 +438,8 @@ export async function execute(command: string, args: Array<string> = [], {
       normalizedEnv[key] = value;
 
   const normalizedBuiltins = new Map(BUILTINS);
-  for (const [key, action] of Object.entries(builtins))
-    normalizedBuiltins.set(key, makeBuiltin(action));
+  for (const [key, builtin] of Object.entries(builtins))
+    normalizedBuiltins.set(key, builtin);
 
   const ast = parseShell(command);
 

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -70,9 +70,19 @@ describe(`Simple shell features`, () => {
     });
   });
 
-  it(`should pipe the result of a command into another`, async () => {
-    await expect(bufferResult(`echo hello world | wc -w | tr -d ' '`)).resolves.toMatchObject({
-      stdout: `2\n`,
+  it(`should pipe the result of a command into another (two commands)`, async () => {
+    await expect(bufferResult(`echo hello world | node -e 'process.stdin.on("data", data => process.stdout.write(data.toString().toUpperCase()))'`)).resolves.toMatchObject({
+      stdout: `HELLO WORLD\n`,
+    });
+  });
+
+  it(`should pipe the result of a command into another (three commands)`, async () => {
+    await expect(bufferResult([
+      `echo hello world`,
+      `node -e 'process.stdin.on("data", data => process.stdout.write(data.toString().toUpperCase()))'`,
+      `node -e 'process.stdin.on("data", data => process.stdout.write(data.toString().replace(/./g, $0 => \`{\${$0}}\`)))'`
+    ].join(` | `))).resolves.toMatchObject({
+      stdout: `{H}{E}{L}{L}{O}{ }{W}{O}{R}{L}{D}\n`,
     });
   });
 

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -90,6 +90,16 @@ describe(`Simple shell features`, () => {
     });
   });
 
+  it(`should pipe the result of a command into another (no builtins)`, async () => {
+    await expect(bufferResult([
+      `node -e 'process.stdout.write("hello world\\\\n")'`,
+      `node -e 'process.stdin.on("data", data => process.stdout.write(data.toString().toUpperCase()))'`,
+      `node -e 'process.stdin.on("data", data => process.stdout.write(data.toString().replace(/./g, $0 => \`{\${$0}}\`)))'`
+    ].join(` | `))).resolves.toMatchObject({
+      stdout: `{H}{E}{L}{L}{O}{ }{W}{O}{R}{L}{D}\n`,
+    });
+  });
+
   it(`should shortcut the right branch of a '||' when the left branch succeeds`, async () => {
     await expect(bufferResult(`true || echo failed`)).resolves.toMatchObject({
       stdout: ``,

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -1,6 +1,10 @@
 import {execute}     from '@berry/shell';
 import {PassThrough} from 'stream';
 
+const ifNotWin32It = process.platform !== `win32`
+  ? it
+  : it.skip;
+
 const bufferResult = async (command: string, args: Array<string> = []) => {
   const stdout = new PassThrough();
   const stderr = new PassThrough();
@@ -53,7 +57,7 @@ describe(`Simple shell features`, () => {
     });
   });
 
-  it(`should throw an error when a command doesn't exist`, async () => {
+  ifNotWin32It(`should throw an error when a command doesn't exist`, async () => {
     await expect(bufferResult(`this-command-doesnt-exist-sorry`)).resolves.toMatchObject({
       exitCode: 127,
       stderr: `command not found: this-command-doesnt-exist-sorry\n`,

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -91,12 +91,21 @@ describe(`Simple shell features`, () => {
     });
   });
 
-  it(`should pipe the result of a command into another (two commands)`, async () => {
+  it(`should pipe the result of a command into another (two commands, builtin into native)`, async () => {
     await expect(bufferResult([
       `echo hello world`,
       `node -e 'process.stdin.on("data", data => process.stdout.write(data.toString().toUpperCase()))'`,
     ].join(` | `))).resolves.toMatchObject({
       stdout: `HELLO WORLD\n`,
+    });
+  });
+
+  it(`should pipe the result of a command into another (two commands, native into pipe)`, async () => {
+    await expect(bufferResult([
+      `node -e 'process.stdout.write("abcdefgh\\\\n");'`,
+      `test-builtin`,
+    ].join(` | `))).resolves.toMatchObject({
+      stdout: `aceg\n`,
     });
   });
 

--- a/scripts/azure-run-tests.yml
+++ b/scripts/azure-run-tests.yml
@@ -6,6 +6,7 @@ steps:
   displayName: 'Install Node.js'
 
 - bash: |
+    node --version
     node ./scripts/run-yarn.js build:cli
     node ./scripts/run-yarn.js build:plugin-pack
     node ./scripts/run-yarn.js build:plugin-stage

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,6 +1951,8 @@ __metadata:
   dependencies:
     "@berry/fslib": "workspace:*"
     "@berry/parsers": "workspace:*"
+    "@types/cross-spawn": "npm:6.0.0"
+    cross-spawn: "npm:^6.0.5"
     execa: "npm:^1.0.0"
     stream-buffers: "npm:^3.0.2"
   languageName: unknown


### PR DESCRIPTION
There was a timing issue in the way the piping was handled: we were closing the output streams too soon, and that was causing weird race conditions (in Jest it could lead to timeouts, tests reported finished before they actually did, or validation errors within the Node internals). This diff should fix the logic behind it by:

- Ensuring that the builtin commands always close their stdout/stderr after they're done writing, except if they're the right-most command (because then they might close the real stdout, which would throw an exception).

- Ensuring that the builtin commands always close their stdin after they're done reading, except if they're the left-most command (for a similar reason but this time with the real stdin).