### PR TITLE
Implements a lazy cache

### DIFF
--- a/packages/berry-fslib/sources/LazyFS.ts
+++ b/packages/berry-fslib/sources/LazyFS.ts
@@ -1,0 +1,205 @@
+import {CreateReadStreamOptions, CreateWriteStreamOptions} from './FakeFS';
+import {FakeFS, WriteFileOptions}                          from './FakeFS';
+
+export type LazyFSFactory = () => FakeFS;
+
+export class LazyFS extends FakeFS {
+  private readonly factory: LazyFSFactory;
+
+  private baseFs: FakeFS | null = null;
+
+  constructor(factory: LazyFSFactory) {
+    super();
+
+    this.factory = factory;
+  }
+
+  getRealPath() {
+    return this.prepareFs().getRealPath();
+  }
+
+  async openPromise(p: string, flags: string, mode?: number) {
+    return await this.prepareFs().openPromise(p, flags, mode);
+  }
+
+  openSync(p: string, flags: string, mode?: number) {
+    return this.prepareFs().openSync(p, flags, mode);
+  }
+
+  async closePromise(fd: number) {
+    await this.prepareFs().closePromise(fd);
+  }
+
+  closeSync(fd: number) {
+    this.prepareFs().closeSync(fd);
+  }
+
+  createReadStream(p: string, opts?: CreateReadStreamOptions) {
+    return this.prepareFs().createReadStream(p, opts);
+  }
+
+  createWriteStream(p: string, opts?: CreateWriteStreamOptions) {
+    return this.prepareFs().createWriteStream(p, opts);
+  }
+
+  async realpathPromise(p: string) {
+    return await this.prepareFs().realpathPromise(p);
+  }
+
+  realpathSync(p: string) {
+    return this.prepareFs().realpathSync(p);
+  }
+
+  async existsPromise(p: string) {
+    return await this.prepareFs().existsPromise(p);
+  }
+
+  existsSync(p: string) {
+    return this.prepareFs().existsSync(p);
+  }
+
+  async accessPromise(p: string, mode?: number) {
+    return await this.prepareFs().accessPromise(p, mode);
+  }
+
+  accessSync(p: string, mode?: number) {
+    return this.prepareFs().accessSync(p, mode);
+  }
+
+  async statPromise(p: string) {
+    return await this.prepareFs().statPromise(p);
+  }
+
+  statSync(p: string) {
+    return this.prepareFs().statSync(p);
+  }
+
+  async lstatPromise(p: string) {
+    return await this.prepareFs().lstatPromise(p);
+  }
+
+  lstatSync(p: string) {
+    return this.prepareFs().lstatSync(p);
+  }
+
+  async chmodPromise(p: string, mask: number) {
+    return await this.prepareFs().chmodPromise(p, mask);
+  }
+
+  chmodSync(p: string, mask: number) {
+    return this.prepareFs().chmodSync(p, mask);
+  }
+
+  async renamePromise(oldP: string, newP: string) {
+    return await this.prepareFs().renamePromise(oldP, newP);
+  }
+
+  renameSync(oldP: string, newP: string) {
+    return this.prepareFs().renameSync(oldP, newP);
+  }
+
+  async copyFilePromise(sourceP: string, destP: string, flags?: number) {
+    return await this.prepareFs().copyFilePromise(sourceP, destP, flags);
+  }
+
+  copyFileSync(sourceP: string, destP: string, flags?: number) {
+    return this.prepareFs().copyFileSync(sourceP, destP, flags);
+  }
+
+  async writeFilePromise(p: string, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return await this.prepareFs().writeFilePromise(p, content, opts);
+  }
+
+  writeFileSync(p: string, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.prepareFs().writeFileSync(p, content, opts);
+  }
+
+  async unlinkPromise(p: string) {
+    return await this.prepareFs().unlinkPromise(p);
+  }
+
+  unlinkSync(p: string) {
+    return this.prepareFs().unlinkSync(p);
+  }
+
+  async utimesPromise(p: string, atime: Date | string | number, mtime: Date | string | number) {
+    return await this.prepareFs().utimesPromise(p, atime, mtime);
+  }
+
+  utimesSync(p: string, atime: Date | string | number, mtime: Date | string | number) {
+    return this.prepareFs().utimesSync(p, atime, mtime);
+  }
+
+  async mkdirPromise(p: string) {
+    return await this.prepareFs().mkdirPromise(p);
+  }
+
+  mkdirSync(p: string) {
+    return this.prepareFs().mkdirSync(p);
+  }
+
+  async rmdirPromise(p: string) {
+    return await this.prepareFs().rmdirPromise(p);
+  }
+
+  rmdirSync(p: string) {
+    return this.prepareFs().rmdirSync(p);
+  }
+
+  async symlinkPromise(target: string, p: string) {
+    return await this.prepareFs().symlinkPromise(target, p);
+  }
+
+  symlinkSync(target: string, p: string) {
+    return this.prepareFs().symlinkSync(target, p);
+  }
+
+  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding?: string): Promise<Buffer>;
+  async readFilePromise(p: string, encoding?: string) {
+    // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
+    switch (encoding) {
+      case `utf8`:
+        return await this.prepareFs().readFilePromise(p, encoding);
+      default:
+        return await this.prepareFs().readFilePromise(p, encoding);
+    }
+  }
+
+  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding?: string): Buffer;
+  readFileSync(p: string, encoding?: string) {
+    // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
+    switch (encoding) {
+      case `utf8`:
+        return this.prepareFs().readFileSync(p, encoding);
+      default:
+        return this.prepareFs().readFileSync(p, encoding);
+    }
+  }
+
+  async readdirPromise(p: string) {
+    return await this.prepareFs().readdirPromise(p);
+  }
+
+  readdirSync(p: string) {
+    return this.prepareFs().readdirSync(p);
+  }
+
+  async readlinkPromise(p: string) {
+    return await this.prepareFs().readlinkPromise(p);
+  }
+
+  readlinkSync(p: string) {
+    return this.prepareFs().readlinkSync(p);
+  }
+
+  private prepareFs() {
+    let baseFs = this.baseFs;
+
+    if (baseFs === null)
+      baseFs = this.baseFs = this.factory();
+
+    return baseFs;
+  }
+}

--- a/packages/berry-fslib/sources/index.ts
+++ b/packages/berry-fslib/sources/index.ts
@@ -7,6 +7,7 @@ export {AliasFS}   from './AliasFS';
 export {FakeFS}    from './FakeFS';
 export {CwdFS}     from './CwdFS';
 export {JailFS}    from './JailFS';
+export {LazyFS}    from './LazyFS';
 export {NodeFS}    from './NodeFS';
 export {PosixFS}   from './PosixFS';
 export {ZipFS}     from './ZipFS';

--- a/packages/plugin-file/sources/FileFetcher.ts
+++ b/packages/plugin-file/sources/FileFetcher.ts
@@ -33,7 +33,7 @@ export class FileFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, checksum] = await opts.cache.fetchPackageFromCache(
+    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(
       locator,
       expectedChecksum,
       async () => {
@@ -44,7 +44,7 @@ export class FileFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs: () => packageFs.discardAndClose(),
+      releaseFs,
       prefixPath: `/sources`,
       localPath: this.getLocalPath(locator, opts),
       checksum,

--- a/packages/plugin-file/sources/TarballFileFetcher.ts
+++ b/packages/plugin-file/sources/TarballFileFetcher.ts
@@ -27,7 +27,7 @@ export class TarballFileFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, checksum] = await opts.cache.fetchPackageFromCache(
+    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(
       locator,
       expectedChecksum,
       async () => {
@@ -38,7 +38,7 @@ export class TarballFileFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs: () => packageFs.discardAndClose(),
+      releaseFs,
       prefixPath: `/sources`,
       checksum,
     };

--- a/packages/plugin-github/sources/GithubFetcher.ts
+++ b/packages/plugin-github/sources/GithubFetcher.ts
@@ -19,7 +19,7 @@ export class GithubFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, checksum] = await opts.cache.fetchPackageFromCache(
+    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(
       locator,
       expectedChecksum,
       async () => {
@@ -30,7 +30,7 @@ export class GithubFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs: () => packageFs.discardAndClose(),
+      releaseFs,
       prefixPath: `/sources`,
       checksum,
     };

--- a/packages/plugin-http/sources/TarballHttpFetcher.ts
+++ b/packages/plugin-http/sources/TarballHttpFetcher.ts
@@ -22,7 +22,7 @@ export class TarballHttpFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, checksum] = await opts.cache.fetchPackageFromCache(
+    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(
       locator,
       expectedChecksum,
       async () => {
@@ -33,7 +33,7 @@ export class TarballHttpFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs: () => packageFs.discardAndClose(),
+      releaseFs,
       prefixPath: `/sources`,
       checksum,
     };

--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -23,7 +23,7 @@ export class NpmFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, checksum] = await opts.cache.fetchPackageFromCache(
+    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(
       locator,
       expectedChecksum,
       async () => {
@@ -34,7 +34,7 @@ export class NpmFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs: () => packageFs.discardAndClose(),
+      releaseFs,
       prefixPath: this.getPrefixPath(locator),
       checksum,
     };


### PR DESCRIPTION
This diff implements `LazyFS` - an fs layer that only instantiates its underlying target when one of its methods gets called. Since the fetch step doesn't actually uses the resulting fs (we only do this at link-time), it trims off a fair amount of time (from ~2.45s on the Yarn repo with a warm cache to ~1s).