### PR TITLE
Enables backticks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "arca/import-align": 2,
     "arca/import-ordering": 2,
     "arca/newline-after-import-section": 2,
-    "arca/no-default-export": 2
+    "arca/no-default-export": 2,
+    "quotes": [2, "backtick"]
   }
 }

--- a/packages/berry-core/sources/Configuration.ts
+++ b/packages/berry-core/sources/Configuration.ts
@@ -72,11 +72,11 @@ export const ENVIRONMENT_PREFIX = `yarn_`;
 export const DEFAULT_RC_FILENAME = `.yarnrc`;
 
 export enum SettingsType {
-  BOOLEAN = 'BOOLEAN',
-  ABSOLUTE_PATH = 'ABSOLUTE_PATH',
-  LOCATOR = 'LOCATOR',
-  LOCATOR_LOOSE = 'LOCATOR_LOOSE',
-  STRING = 'STRING',
+  BOOLEAN = `BOOLEAN`,
+  ABSOLUTE_PATH = `ABSOLUTE_PATH`,
+  LOCATOR = `LOCATOR`,
+  LOCATOR_LOOSE = `LOCATOR_LOOSE`,
+  STRING = `STRING`,
 };
 
 export type SettingsDefinition = {
@@ -256,10 +256,10 @@ function parseValue(value: unknown, type: SettingsType, folder: string) {
 
 function getDefaultGlobalFolder() {
   if (process.platform === `win32`) {
-    const folder = NodeFS.toPortablePath(process.env.LOCALAPPDATA || win32.join(homedir(), 'AppData', 'Local'));
+    const folder = NodeFS.toPortablePath(process.env.LOCALAPPDATA || win32.join(homedir(), `AppData`, `Local`));
     return posix.resolve(folder);
   } else if (process.env.XDG_DATA_HOME) {
-    return posix.resolve(process.env.XDG_DATA_HOME, 'yarn/modern');
+    return posix.resolve(process.env.XDG_DATA_HOME, `yarn/modern`);
   } else {
     return posix.resolve(homedir(), `.local/share/yarn/modern`);
   }

--- a/packages/berry-core/sources/Manifest.ts
+++ b/packages/berry-core/sources/Manifest.ts
@@ -25,7 +25,7 @@ export class Manifest {
   public name: Ident | null = null;
   public version: string | null = null;
 
-  public ["private"]: boolean = false;
+  public [`private`]: boolean = false;
   public license: string | null = null;
 
   public languageName: string | null = null;
@@ -120,7 +120,7 @@ export class Manifest {
 
     if (typeof data.dependencies === `object` && data.dependencies !== null) {
       for (const [name, range] of Object.entries(data.dependencies)) {
-        if (typeof range !== 'string') {
+        if (typeof range !== `string`) {
           errors.push(new Error(`Invalid dependency range for '${name}'`));
           continue;
         }
@@ -140,7 +140,7 @@ export class Manifest {
 
     if (typeof data.devDependencies === `object` && data.devDependencies !== null) {
       for (const [name, range] of Object.entries(data.devDependencies)) {
-        if (typeof range !== 'string') {
+        if (typeof range !== `string`) {
           errors.push(new Error(`Invalid dependency range for '${name}'`));
           continue;
         }
@@ -160,7 +160,7 @@ export class Manifest {
 
     if (typeof data.peerDependencies === `object` && data.peerDependencies !== null) {
       for (const [name, range] of Object.entries(data.peerDependencies)) {
-        if (typeof range !== 'string') {
+        if (typeof range !== `string`) {
           errors.push(new Error(`Invalid dependency range for '${name}'`));
           continue;
         }

--- a/packages/berry-core/sources/Workspace.ts
+++ b/packages/berry-core/sources/Workspace.ts
@@ -13,7 +13,7 @@ import {IdentHash}             from './types';
 import {Descriptor, Locator}   from './types';
 
 function hashWorkspaceCwd(cwd: string) {
-  return createHmac('sha256', 'berry').update(cwd).digest('hex').substr(0, 6);
+  return createHmac(`sha256`, `berry`).update(cwd).digest(`hex`).substr(0, 6);
 }
 
 export class Workspace {

--- a/packages/berry-core/sources/miscUtils.ts
+++ b/packages/berry-core/sources/miscUtils.ts
@@ -41,7 +41,7 @@ export function prettifySyncErrors<T>(fn: () => T, update: (message: string) => 
 
 export function dynamicRequire(path: string) {
   // @ts-ignore
-  if (typeof __webpack_require__ !== 'undefined') {
+  if (typeof __webpack_require__ !== `undefined`) {
     // @ts-ignore
     return __non_webpack_require__(path);
   } else {

--- a/packages/berry-core/sources/nodeUtils.ts
+++ b/packages/berry-core/sources/nodeUtils.ts
@@ -12,5 +12,5 @@ export function dynamicRequire(request: string): any {
 
 export function builtinModules(): Set<string> {
   // @ts-ignore
-  return new Set(Module.builtinModules || Object.keys(process.binding('natives')));
+  return new Set(Module.builtinModules || Object.keys(process.binding(`natives`)));
 }

--- a/packages/berry-core/sources/types.ts
+++ b/packages/berry-core/sources/types.ts
@@ -22,7 +22,7 @@ export interface Locator extends Ident {
   reference: string,
 };
 
-export enum LinkType { HARD = 'hard', SOFT = 'soft' };
+export enum LinkType { HARD = `hard`, SOFT = `soft` };
 
 export interface Package extends Locator {
   version: string | null,

--- a/packages/berry-fslib/sources/AliasFS.ts
+++ b/packages/berry-fslib/sources/AliasFS.ts
@@ -163,7 +163,7 @@ export class AliasFS extends FakeFS {
     return this.baseFs.symlinkSync(target, p);
   }
 
-  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
@@ -175,7 +175,7 @@ export class AliasFS extends FakeFS {
     }
   }
 
-  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)

--- a/packages/berry-fslib/sources/CwdFS.ts
+++ b/packages/berry-fslib/sources/CwdFS.ts
@@ -173,7 +173,7 @@ export class CwdFS extends FakeFS {
     return this.baseFs.symlinkSync(target, this.fromCwdPath(p));
   }
 
-  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
@@ -185,7 +185,7 @@ export class CwdFS extends FakeFS {
     }
   }
 
-  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)

--- a/packages/berry-fslib/sources/FakeFS.ts
+++ b/packages/berry-fslib/sources/FakeFS.ts
@@ -76,10 +76,10 @@ export abstract class FakeFS {
   abstract utimesPromise(p: string, atime: Date | string | number, mtime: Date | string | number): Promise<void>;
   abstract utimesSync(p: string, atime: Date | string | number, mtime: Date | string | number): void;
 
-  abstract readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  abstract readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   abstract readFilePromise(p: string, encoding?: string): Promise<Buffer>;
 
-  abstract readFileSync(p: string, encoding: 'utf8'): string;
+  abstract readFileSync(p: string, encoding: `utf8`): string;
   abstract readFileSync(p: string, encoding?: string): Buffer;
 
   abstract readlinkPromise(p: string): Promise<string>;

--- a/packages/berry-fslib/sources/JailFS.ts
+++ b/packages/berry-fslib/sources/JailFS.ts
@@ -169,7 +169,7 @@ export class JailFS extends FakeFS {
     return this.baseFs.symlinkSync(target, this.fromJailedPath(p));
   }
 
-  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
@@ -181,7 +181,7 @@ export class JailFS extends FakeFS {
     }
   }
 
-  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)

--- a/packages/berry-fslib/sources/NodeFS.ts
+++ b/packages/berry-fslib/sources/NodeFS.ts
@@ -190,7 +190,7 @@ export class NodeFS extends FakeFS {
   }
 
   async symlinkPromise(target: string, p: string) {
-    const type: 'dir' | 'file' = target.endsWith(`/`) ? `dir` : `file`;
+    const type: `dir` | `file` = target.endsWith(`/`) ? `dir` : `file`;
 
     return await new Promise<void>((resolve, reject) => {
       this.realFs.symlink(NodeFS.fromPortablePath(target.replace(/\/+$/, ``)), NodeFS.fromPortablePath(p), type, this.makeCallback(resolve, reject));
@@ -198,12 +198,12 @@ export class NodeFS extends FakeFS {
   }
 
   symlinkSync(target: string, p: string) {
-    const type: 'dir' | 'file' = target.endsWith(`/`) ? `dir` : `file`;
+    const type: `dir` | `file` = target.endsWith(`/`) ? `dir` : `file`;
 
     return this.realFs.symlinkSync(NodeFS.fromPortablePath(target.replace(/\/+$/, ``)), NodeFS.fromPortablePath(p), type);
   }
 
-  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     return await new Promise<any>((resolve, reject) => {
@@ -211,7 +211,7 @@ export class NodeFS extends FakeFS {
     });
   }
 
-  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     return this.realFs.readFileSync(NodeFS.fromPortablePath(p), encoding);
@@ -260,8 +260,8 @@ export class NodeFS extends FakeFS {
     if (!match)
       return p;
 
-    const [, drive, pathWithoutPrefix = ''] = match;
-    const windowsPath = pathWithoutPrefix.replace(/\//g, '\\');
+    const [, drive, pathWithoutPrefix = ``] = match;
+    const windowsPath = pathWithoutPrefix.replace(/\//g, `\\`);
 
     return `${drive.toUpperCase()}:\\${windowsPath}`;
   }
@@ -281,11 +281,11 @@ export class NodeFS extends FakeFS {
 
     // If relative path, just replace win32 slashes by posix slashes
     if (!root)
-      return p.replace(/\\/g, '/');
+      return p.replace(/\\/g, `/`);
 
     const driveLetter = root[0].toLowerCase();
     const pathWithoutRoot = p.substr(root.length);
-    const posixPath = pathWithoutRoot.replace(/\\/g, '/');
+    const posixPath = pathWithoutRoot.replace(/\\/g, `/`);
 
     return `${PORTABLE_PATH_PREFIX}${driveLetter}/${posixPath}`;
   }

--- a/packages/berry-fslib/sources/PosixFS.ts
+++ b/packages/berry-fslib/sources/PosixFS.ts
@@ -153,7 +153,7 @@ export class PosixFS extends FakeFS {
     return this.baseFs.symlinkSync(target, NodeFS.toPortablePath(p));
   }
 
-  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
@@ -165,7 +165,7 @@ export class PosixFS extends FakeFS {
     }
   }
 
-  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)

--- a/packages/berry-fslib/sources/ZipFS.ts
+++ b/packages/berry-fslib/sources/ZipFS.ts
@@ -59,7 +59,7 @@ export type Options = {
 };
 
 function toUnixTimestamp(time: Date | string | number) {
-  if (typeof time === 'string' && String(+time) === time)
+  if (typeof time === `string` && String(+time) === time)
     return +time;
 
   // @ts-ignore
@@ -151,7 +151,7 @@ export class ZipFS extends FakeFS {
 
       // If the raw path is a directory, register it
       // to prevent empty folder being skipped
-      if (raw.endsWith('/')) {
+      if (raw.endsWith(`/`)) {
         this.registerListing(p);
       }
     }
@@ -726,7 +726,7 @@ export class ZipFS extends FakeFS {
     }
   }
 
-  readFilePromise(p: string, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
@@ -738,7 +738,7 @@ export class ZipFS extends FakeFS {
     }
   }
 
-  readFileSync(p: string, encoding: 'utf8'): string;
+  readFileSync(p: string, encoding: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     // This is messed up regarding the TS signatures

--- a/packages/berry-fslib/sources/ZipOpenFS.ts
+++ b/packages/berry-fslib/sources/ZipOpenFS.ts
@@ -419,7 +419,7 @@ export class ZipOpenFS extends FakeFS {
     });
   }
 
-  readFilePromise(p: string, encoding?: 'utf8'): Promise<string>;
+  readFilePromise(p: string, encoding?: `utf8`): Promise<string>;
   readFilePromise(p: string, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: string, encoding?: string) {
     return this.makeCallPromise(p, async () => {
@@ -435,7 +435,7 @@ export class ZipOpenFS extends FakeFS {
     });
   }
 
-  readFileSync(p: string, encoding?: 'utf8'): string;
+  readFileSync(p: string, encoding?: `utf8`): string;
   readFileSync(p: string, encoding?: string): Buffer;
   readFileSync(p: string, encoding?: string) {
     return this.makeCallSync(p, () => {

--- a/packages/berry-shell/sources/index.ts
+++ b/packages/berry-shell/sources/index.ts
@@ -121,7 +121,7 @@ async function interpolateArguments(commandArgs: Array<Array<CommandSegment>>, o
   for (const commandArg of commandArgs) {
     for (const segment of commandArg) {
 
-      if (typeof segment === 'string') {
+      if (typeof segment === `string`) {
 
         push(segment);
 
@@ -389,7 +389,7 @@ function locateArgsVariable(node: ShellLine): boolean {
           case `command`: {
             hasArgs = chain.args.some(arg => {
               return arg.some(segment => {
-                if (typeof segment === 'string')
+                if (typeof segment === `string`)
                   return false;
 
                 switch (segment.type) {

--- a/packages/berry-ui/sources/Div.ts
+++ b/packages/berry-ui/sources/Div.ts
@@ -3,12 +3,12 @@ import React         from 'react';
 import {NodeElement} from './NodeElement';
 
 export enum StylePositionEnum {
-  Absolute = 'absolute',
+  Absolute = `absolute`,
 }
 
 export enum StyleFlexDirectionEnum {
-  Column = 'column',
-  Row = 'row',
+  Column = `column`,
+  Row = `row`,
 }
 
 export type StyleProp = Partial<{

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -8,23 +8,23 @@ export type Suggestion = {
 };
 
 export enum Target {
-  REGULAR = 'dependencies',
-  DEVELOPMENT = 'devDependencies',
-  PEER = 'peerDependencies',
+  REGULAR = `dependencies`,
+  DEVELOPMENT = `devDependencies`,
+  PEER = `peerDependencies`,
 };
 
 export enum Modifier {
-  CARET = '^',
-  TILDE = '~',
-  EXACT = '',
+  CARET = `^`,
+  TILDE = `~`,
+  EXACT = ``,
 };
 
 export enum Strategy {
-  KEEP = 'keep',
-  REUSE = 'reuse',
-  PROJECT = 'project',
-  LATEST = 'latest',
-  CACHE = 'cache',
+  KEEP = `keep`,
+  REUSE = `reuse`,
+  PROJECT = `project`,
+  LATEST = `latest`,
+  CACHE = `cache`,
 };
 
 export function applyModifier(descriptor: Descriptor, modifier: Modifier) {

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -235,7 +235,7 @@ class PnpInstaller implements Installer {
     if (!relativeFolder.match(/^\.{0,2}\//))
       relativeFolder = `./${relativeFolder}`;
 
-    return relativeFolder.replace(/\/?$/, '/');
+    return relativeFolder.replace(/\/?$/, `/`);
   }
 
   private async getBuildScripts(fetchResult: FetchResult) {

--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -15,15 +15,15 @@ function mount(uri: vscode.Uri) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  context.subscriptions.push(vscode.workspace.registerFileSystemProvider('zip', new ZipFSProvider(), {
+  context.subscriptions.push(vscode.workspace.registerFileSystemProvider(`zip`, new ZipFSProvider(), {
     isCaseSensitive: true,
   }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('zipfs.mountZipFile', (uri: vscode.Uri) => {
+  context.subscriptions.push(vscode.commands.registerCommand(`zipfs.mountZipFile`, (uri: vscode.Uri) => {
     mount(uri);
   }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('zipfs.mountZipEditor', () => {
+  context.subscriptions.push(vscode.commands.registerCommand(`zipfs.mountZipEditor`, () => {
     mount(vscode.window.activeTextEditor!.document.uri);
   }));
 }


### PR DESCRIPTION
This diff enforces a consistent use of backticks across all files.

I favor backticks over other quotes since they lead to easier refactorings when variables are added/removed, rarely cause issues because of their content (like adding or removing a quote within a string), and shouldn't have any measurable impact on the runtime performances.