### PR TITLE
Implement `--json` and `-v,--verbose` for `yarn workspaces`

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/list.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/list.test.js
@@ -1,0 +1,133 @@
+const {
+  fs: {writeFile, writeJson},
+} = require('pkg-tests-core');
+
+describe(`Commands`, () => {
+  describe(`workspace list -v,--verbose --json`, () => {
+    test(
+      `no workspace dependency between a and b`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`]
+        },
+        async ({path, run}) => {
+          await writeJson(`${path}/packages/workspace-a/package.json`, {
+            name: `workspace-a`,
+            version: `1.0.0`
+          });
+  
+          await writeFile(
+            `${path}/packages/workspace-a/index.js`,
+            `
+              module.exports = 42;
+            `,
+          );
+  
+          await writeJson(`${path}/packages/workspace-b/package.json`, {
+            name: `workspace-b`,
+            version: `1.0.0`
+          });
+  
+          await writeFile(
+            `${path}/packages/workspace-b/index.js`,
+            `
+              module.exports = 24;
+            `,
+          );
+          
+          await expect(run(`workspaces`, `list`, `-v`, `--json`)).resolves.toMatchObject({
+            stdout: `{"location":"packages/workspace-a","name":"workspace-a","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[]}\n{"location":"packages/workspace-b","name":"workspace-b","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[]}\n`,
+          });
+        }
+      )
+    );
+
+    test(
+      `workspace-a requires workspace-b, workspace-b requires workspace-a`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`]
+        },
+        async ({path, run}) => {
+          await writeJson(`${path}/packages/workspace-a/package.json`, {
+            name: `workspace-a`,
+            version: `1.0.0`,
+            dependencies: {
+              [`workspace-b`]: `1.0.0`,
+            },
+          });
+  
+          await writeFile(
+            `${path}/packages/workspace-a/index.js`,
+            `
+              module.exports = require('workspace-b/package.json');
+            `,
+          );
+  
+          await writeJson(`${path}/packages/workspace-b/package.json`, {
+            name: `workspace-b`,
+            version: `1.0.0`,
+            dependencies: {
+              [`workspace-a`]: `1.0.0`,
+            },
+          });
+  
+          await writeFile(
+            `${path}/packages/workspace-b/index.js`,
+            `
+              module.exports = require('workspace-a/package.json');
+            `,
+          );
+          
+          await expect(run(`workspaces`, `list`, `--verbose`, `--json`)).resolves.toMatchObject({
+            stdout: `{"location":"packages/workspace-a","name":"workspace-a","workspaceDependencies":["packages/workspace-b"],"mismatchedWorkspaceDependencies":[]}\n{"location":"packages/workspace-b","name":"workspace-b","workspaceDependencies":["packages/workspace-a"],"mismatchedWorkspaceDependencies":[]}\n`,
+          });
+        }
+      )
+    );
+
+    test(
+      `workspace-a requires mismatched version of workspace-b`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`]
+        },
+        async ({path, run}) => {
+          await writeJson(`${path}/packages/workspace-a/package.json`, {
+            name: `workspace-a`,
+            version: `1.0.0`,
+            dependencies: {
+              [`workspace-b`]: `2.0.0`,
+            },
+          });
+  
+          await writeFile(
+            `${path}/packages/workspace-a/index.js`,
+            `
+              module.exports = require('workspace-b/package.json');
+            `,
+          );
+  
+          await writeJson(`${path}/packages/workspace-b/package.json`, {
+            name: `workspace-b`,
+            version: `1.0.0`
+          });
+  
+          await writeFile(
+            `${path}/packages/workspace-b/index.js`,
+            `
+              module.exports = 53;
+            `,
+          );
+          
+          await expect(run(`workspaces`, `list`, `-v`, `--json`)).resolves.toMatchObject({
+            stdout: `{"location":"packages/workspace-a","name":"workspace-a","workspaceDependencies":[],"mismatchedWorkspaceDependencies":["workspace-b@2.0.0"]}\n{"location":"packages/workspace-b","name":"workspace-b","workspaceDependencies":[],"mismatchedWorkspaceDependencies":[]}\n`,
+          });
+        }
+      )
+    );
+  });
+});

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -3,14 +3,6 @@ import {Writable}                                                               
 
 const DEPENDENCY_TYPES = ['devDependencies', 'dependencies'];
 
-interface JsonOutput {
-  [key: string]: {
-    location: string,
-    workspaceDependencies: string [],
-    mismatchedWorkspaceDependencies: string []
-  }
-};
-
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
 

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -1,20 +1,67 @@
-import {Configuration, PluginConfiguration, Project} from '@berry/core';
-import {Writable}                                    from 'stream';
+import {Configuration, PluginConfiguration, Project, Workspace, Descriptor, structUtils} from '@berry/core';
+import {Writable}                                                                        from 'stream';
 
+const DEPENDENCY_TYPES = ['devDependencies', 'dependencies'];
+
+interface JsonOutput {
+  [key: string]: {
+    location: string,
+    workspaceDependencies: string [],
+    mismatchedWorkspaceDependencies: string []
+  }
+};
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
 
-  .command(`workspaces list`)
+  .command(`workspaces list [-v,--verbose] [--json]`)
 
   .categorize(`Workspace commands`)
   .describe(`list all available workspaces`)
 
-  .action(async ({cwd, stdout}: {cwd: string, stdout: Writable}) => {
+  .action(async ({cwd, stdout, verbose, json}: {cwd: string, stdout: Writable, verbose: boolean, json: boolean}) => {
     const configuration = await Configuration.find(cwd, pluginConfiguration);
     const {project} = await Project.find(configuration, cwd);
 
-    for (const cwd of project.workspacesByCwd.keys())
-      stdout.write(`${cwd}\n`);
-
+    if (verbose && json) {
+      const jsonOutput = project.workspaces.reduce((results: JsonOutput, workspace: Workspace) => {
+        const { manifest } = workspace;
+        if (manifest.name) {
+          const workspaceDependencies = new Set();
+          const mismatchedWorkspaceDependencies = new Set();
+          for(const dependencyType of DEPENDENCY_TYPES) {
+            const dependencies = manifest.getForScope(dependencyType);
+            dependencies.forEach((descriptor: Descriptor) => {
+              const candidateWorkspaces = project.workspacesByIdent.get(descriptor.identHash);
+              if (candidateWorkspaces && candidateWorkspaces.length) {
+                candidateWorkspaces.forEach((curr: Workspace) => {
+                  if (workspace.accepts(descriptor.range)) {
+                    if (curr.manifest.name) {
+                      workspaceDependencies.add(structUtils.stringifyIdent(curr.manifest.name))
+                    }
+                  }
+                  else {
+                    if (curr.manifest.name) {
+                      mismatchedWorkspaceDependencies.add(structUtils.stringifyIdent(curr.manifest.name));
+                    }
+                  }
+                });
+              }
+            });
+          }
+          results[structUtils.stringifyIdent(manifest.name)] = {
+            location: workspace.relativeCwd,
+            workspaceDependencies: Array.from(workspaceDependencies),
+            mismatchedWorkspaceDependencies: Array.from(mismatchedWorkspaceDependencies),
+          };
+        }
+        return results;
+      }, {});
+      stdout.write(`${JSON.stringify(jsonOutput, null, 2)}\n`);
+    }
+    else {
+      for (const cwd of project.workspacesByCwd.keys()) {
+        stdout.write(`${cwd}\n`);
+      }
+    }
     return 0;
   });


### PR DESCRIPTION
Bring v1 `yarn workspaces info` to v2 by using `yarn workspaces list -v --json`

Todo:
- [x] write tests