### PR TITLE
Disables the CI w/ Node 8 on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,8 @@ jobs:
 
   strategy:
     matrix:
-      "Node 8.x":
-        node_version: 8.x
+#      "Node 8.x":
+#        node_version: 8.x
       "Node 10.x":
         node_version: 10.x
 


### PR DESCRIPTION
This diff disables the CI build for Node 8 on Windows as it never passes - without even running the tests. It's not clear what happens, and I can't reproduce it locally. Tracked over at #78 - hopefully someone can come up with an idea 🙁 