### PR TITLE
Implements yarn unplug

### DIFF
--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -109,7 +109,6 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
       return checkReport.exitCode();
 
     let askedQuestions = false;
-    let hasChanged = false;
 
     const afterWorkspaceDependencyAdditionList: Array<[
       Workspace,
@@ -172,37 +171,33 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
             selected,
           ]);
         }
-
-        hasChanged = true;
       }
     }
 
-    if (hasChanged) {
-      await configuration.triggerMultipleHooks(
-        (hooks: Hooks) => hooks.afterWorkspaceDependencyAddition,
-        afterWorkspaceDependencyAdditionList,
-      );
+    await configuration.triggerMultipleHooks(
+      (hooks: Hooks) => hooks.afterWorkspaceDependencyAddition,
+      afterWorkspaceDependencyAdditionList,
+    );
 
-      await configuration.triggerMultipleHooks(
-        (hooks: Hooks) => hooks.afterWorkspaceDependencyReplacement,
-        afterWorkspaceDependencyReplacementList,
-      );
+    await configuration.triggerMultipleHooks(
+      (hooks: Hooks) => hooks.afterWorkspaceDependencyReplacement,
+      afterWorkspaceDependencyReplacementList,
+    );
 
-      if (askedQuestions)
-        stdout.write(`\n`);
+    if (askedQuestions)
+      stdout.write(`\n`);
 
-      let installReport;
-      
-      if (quiet) {
-        installReport = await LightReport.start({configuration, stdout}, async report => {
-          await project.install({cache, report});
-        });
-      } else {
-        installReport = await StreamReport.start({configuration, stdout}, async report => {
-          await project.install({cache, report});
-        });
-      }
-
-      return installReport.exitCode();
+    let installReport;
+    
+    if (quiet) {
+      installReport = await LightReport.start({configuration, stdout}, async report => {
+        await project.install({cache, report});
+      });
+    } else {
+      installReport = await StreamReport.start({configuration, stdout}, async report => {
+        await project.install({cache, report});
+      });
     }
+
+    return installReport.exitCode();
   });

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -1,0 +1,56 @@
+import {WorkspaceRequiredError}                                           from '@berry/cli';
+import {Cache, Configuration, PluginConfiguration, Project, StreamReport} from '@berry/core';
+import {structUtils}                                                      from '@berry/core';
+import {Writable}                                                         from 'stream';
+
+// eslint-disable-next-line arca/no-default-export
+export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
+
+  .command(`unplug [... patterns]`)
+  .describe(`force the unpacking of a list of packages`)
+
+  .detail(`
+    This command will add the specified selectors to the list of packages that must be unplugged when installed.
+
+    A package being unplugged means that instead of being referenced directly through its archive, it will be unpacked at install time in the directory configured via \`virtualFolder\`.
+
+    Unpacking a package isn't advised as a general tool because it makes it harder to store your packages within the repository. However, it's a good approach to quickly and safely debug some packages, and can even sometimes be required depending on the context (for example when the package contains shellscripts).
+
+    The unplug command sets a flag that's persisted in your top-level \`package.json\` through the \`dependenciesMeta\` field. As such, to undo its effects, just revert the changes made to the manifest and run \`yarn install\`.
+  `)
+
+  .example(
+    `Unplug lodash`,
+    `yarn unplug lodash`
+  )
+
+  .example(
+    `Unplug one specific version of lodash`,
+    `yarn unplug lodash@1.2.3`,
+  )
+
+  .action(async ({cwd, patterns, stdout}: {cwd: string, patterns: string, stdout: Writable}) => {
+    const configuration = await Configuration.find(cwd, pluginConfiguration);
+    const {project, workspace} = await Project.find(configuration, cwd);
+    const cache = await Cache.find(configuration);
+
+    if (!workspace)
+      throw new WorkspaceRequiredError(cwd);
+
+    const topLevelWorkspace = project.topLevelWorkspace;
+
+    for (const pattern of patterns) {
+      const descriptor = structUtils.parseDescriptor(pattern);
+      const dependencyMeta = topLevelWorkspace.manifest.ensureDependencyMeta(descriptor);
+
+      dependencyMeta.unplugged = true;0
+    }
+
+    await topLevelWorkspace.persistManifest();
+
+    const report = await StreamReport.start({configuration, stdout}, async report => {
+      await project.install({cache, report});
+    });
+
+    return report.exitCode();
+  });

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -3,6 +3,7 @@ import {NodeFS, xfs}                                       from '@berry/fslib';
 import {Hooks as StageHooks}                               from '@berry/plugin-stage';
 
 import {PnpLinker}                                         from './PnpLinker';
+import unplug                                              from './commands/unplug';
 
 async function setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>) {
   const pnpPath = NodeFS.fromPortablePath(project.configuration.get(`pnpPath`));
@@ -66,6 +67,9 @@ const plugin: Plugin = {
   },
   linkers: [
     PnpLinker,
+  ],
+  commands: [
+    unplug,
   ],
 };
 


### PR DESCRIPTION
This diff reimplements the `yarn unplug` command that disappeared when moving from the v1 to the v2.