### PR TITLE
Support fetching private packages

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -247,15 +247,20 @@ exports.startPackageServer = function startPackageServer(): Promise<string> {
     },
   };
 
-  function processError(res: ServerResponse, statusCode: number, errorMessage: string): void {
-    console.error(errorMessage);
-
+  function sendError(res: ServerResponse, statusCode: number, errorMessage: string): void {
     res.writeHead(statusCode);
     res.end(errorMessage);
   }
 
+  function processError(res: ServerResponse, statusCode: number, errorMessage: string): void {
+    console.error(errorMessage);
+    sendError(res, statusCode, errorMessage);
+  }
+
   function parseRequest(url: string): Request|null {
     let match: RegExpMatchArray|null;
+
+    url = url.replace(/%2f/g, '/');
 
     if (match = url.match(/^\/(?:(@[^\/]+)\/)?([^@\/][^\/]*)$/)) {
       const [_, scope, localName] = match;
@@ -303,11 +308,11 @@ exports.startPackageServer = function startPackageServer(): Promise<string> {
             const {authorization} = req.headers;
             if (authorization != null) {
               if (!validAuthorizations.includes(authorization)) {
-                processError(res, 403, `Forbidden`);
+                sendError(res, 403, `Forbidden`);
                 return;
               }
             } else if (needsAuth(parsedRequest)) {
-              processError(res, 401, `Authentication required`);
+              sendError(res, 401, `Authentication required`);
               return;
             }
 

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -166,99 +166,152 @@ exports.startPackageServer = function startPackageServer(): Promise<string> {
   if (packageServerUrl !== null)
     return packageServerUrl;
 
-  async function processPackageInfo(params: Array<string> | null, res: ServerResponse): Promise<boolean> {
-    if (params === null)
-      return false;
-
-    const [, scope, localName] = params;
-    const name = scope ? `${scope}/${localName}` : localName;
-
-    const packageEntry = await exports.getPackageEntry(name);
-    if (!packageEntry)
-      return processError(res, 404, `Package not found: ${name}`);
-
-    let versions = Array.from(packageEntry.keys());
-
-    const whitelistedVersions = whitelist.get(name);
-    if (whitelistedVersions)
-      versions = versions.filter(version => whitelistedVersions.has(version));
-
-    const data = JSON.stringify({
-      name,
-      versions: Object.assign(
-        {},
-        ...(await Promise.all(
-          versions.map(async version => {
-            const packageVersionEntry = packageEntry.get(version);
-            invariant(packageVersionEntry, 'This can only exist');
-
-            return {
-              [version as string]: Object.assign({}, packageVersionEntry.packageJson, {
-                dist: {
-                  shasum: await exports.getPackageArchiveHash(name, version),
-                  tarball: await exports.getPackageHttpArchivePath(name, version),
-                },
-              }),
-            };
-          }),
-        )),
-      ),
-      ['dist-tags']: {latest: semver.maxSatisfying(versions, '*')},
-    });
-
-    res.writeHead(200, {['Content-Type']: 'application/json'});
-    res.end(data);
-
-    return true;
+  enum RequestType {
+    PackageInfo = 'packageInfo',
+    PackageTarball = 'packageTarball',
   }
 
-  async function processPackageTarball(params: Array<string> | null, res: ServerResponse): Promise<boolean> {
-    if (!params)
-      return false;
+  interface Request {
+    type: RequestType;
 
-    const [, scope, localName, version] = params;
-    const name = scope ? `${scope}/${localName}` : localName;
-
-    const packageEntry = await exports.getPackageEntry(name);
-    if (!packageEntry)
-      return processError(res, 404, `Package not found: ${name}`);
-
-    const packageVersionEntry = packageEntry.get(version);
-    if (!packageVersionEntry)
-      return processError(res, 404, `Package not found: ${name}@${version}`);
-
-    res.writeHead(200, {
-      ['Content-Type']: 'application/octet-stream',
-      ['Transfer-Encoding']: 'chunked',
-    });
-
-    const packStream = fsUtils.packToStream(packageVersionEntry.path, {virtualPath: '/package'});
-    packStream.pipe(res);
-
-    return true;
+    scope?: string;
+    localName: string;
+    version?: string;
   }
 
-  function processError(res: ServerResponse, statusCode: number, errorMessage: string): boolean {
+  const processors: {[requestType in RequestType]:(request: Request, response: ServerResponse) => Promise<void>} = {
+    async [RequestType.PackageInfo](request, response) {
+      const {scope, localName} = request;
+      const name = scope ? `${scope}/${localName}` : localName;
+
+      const packageEntry = await exports.getPackageEntry(name);
+      if (!packageEntry)
+        return processError(response, 404, `Package not found: ${name}`);
+
+      let versions = Array.from(packageEntry.keys());
+
+      const whitelistedVersions = whitelist.get(name);
+      if (whitelistedVersions)
+        versions = versions.filter(version => whitelistedVersions.has(version));
+
+      const data = JSON.stringify({
+        name,
+        versions: Object.assign(
+          {},
+          ...(await Promise.all(
+            versions.map(async version => {
+              const packageVersionEntry = packageEntry.get(version);
+              invariant(packageVersionEntry, 'This can only exist');
+
+              return {
+                [version as string]: Object.assign({}, packageVersionEntry.packageJson, {
+                  dist: {
+                    shasum: await exports.getPackageArchiveHash(name, version),
+                    tarball: await exports.getPackageHttpArchivePath(name, version),
+                  },
+                }),
+              };
+            }),
+          )),
+        ),
+        ['dist-tags']: {latest: semver.maxSatisfying(versions, '*')},
+      });
+
+      response.writeHead(200, {['Content-Type']: 'application/json'});
+      response.end(data);
+    },
+
+    async [RequestType.PackageTarball](request, response) {
+      const {scope, localName, version} = request;
+      const name = scope ? `${scope}/${localName}` : localName;
+
+      const packageEntry = await exports.getPackageEntry(name);
+      if (!packageEntry) {
+        processError(response, 404, `Package not found: ${name}`);
+        return;
+      }
+
+      const packageVersionEntry = packageEntry.get(version);
+      if (!packageVersionEntry) {
+        processError(response, 404, `Package not found: ${name}@${version}`);
+        return;
+      }
+
+      response.writeHead(200, {
+        ['Content-Type']: 'application/octet-stream',
+        ['Transfer-Encoding']: 'chunked',
+      });
+
+      const packStream = fsUtils.packToStream(packageVersionEntry.path, {virtualPath: '/package'});
+      packStream.pipe(response);
+    },
+  };
+
+  function processError(res: ServerResponse, statusCode: number, errorMessage: string): void {
     console.error(errorMessage);
 
     res.writeHead(statusCode);
     res.end(errorMessage);
-
-    return true;
   }
+
+  function parseRequest(url: string): Request|null {
+    let match: RegExpMatchArray|null;
+
+    if (match = url.match(/^\/(?:(@[^\/]+)\/)?([^@\/][^\/]*)$/)) {
+      const [_, scope, localName] = match;
+
+      return {
+        type: RequestType.PackageInfo,
+        scope,
+        localName,
+      };
+    } else if (match = url.match(/^\/(?:(@[^\/]+)\/)?([^@\/][^\/]*)\/-\/\2-(.*)\.tgz$/)) {
+      const [_, scope, localName, version] = match;
+
+      return {
+        type: RequestType.PackageTarball,
+        scope,
+        localName,
+        version,
+      };
+    }
+
+    return null;
+  }
+
+  function needsAuth({scope, localName}: Request): boolean {
+    return (scope != null && scope.startsWith('@private')) || localName.startsWith('private');
+  }
+
+  const validAuthorizations = [
+    `Bearer 686159dc-64b3-413e-a244-2de2b8d1c36f`,
+    `Basic dXNlcm5hbWU6YSB2ZXJ5IHNlY3VyZSBwYXNzd29yZA==` // username:a very secure password
+  ];
 
   return new Promise((resolve, reject) => {
     const server = http.createServer(
       (req, res) =>
         void (async () => {
           try {
-            if (await processPackageInfo(req.url.match(/^\/(?:(@[^\/]+)\/)?([^@\/][^\/]*)$/), res))
-              return;
+            const parsedRequest = parseRequest(req.url);
 
-            if (await processPackageTarball(req.url.match(/^\/(?:(@[^\/]+)\/)?([^@\/][^\/]*)\/-\/\2-(.*)\.tgz$/), res))
+            if (parsedRequest == null) {
+              processError(res, 404, `Invalid route: ${req.url}`);
               return;
+            }
 
-            processError(res, 404, `Invalid route: ${req.url}`);
+            const {authorization} = req.headers;
+            if (authorization != null) {
+              if (!validAuthorizations.includes(authorization)) {
+                processError(res, 403, `Forbidden`);
+                return;
+              }
+            } else if (needsAuth(parsedRequest)) {
+              processError(res, 401, `Authentication required`);
+              return;
+            }
+
+            await processors[parsedRequest.type](parsedRequest, res);
           } catch (error) {
             processError(res, 500, error.stack);
           }

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@private__package-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@private__package-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@private__package-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@private__package-1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "@private/package",
+    "version": "1.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/private-package-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/private-package-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/private-package-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/private-package-1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "private-package",
+    "version": "1.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
@@ -1,0 +1,155 @@
+const {
+  fs: {writeFile},
+  tests: {getPackageArchivePath, getPackageHttpArchivePath, getPackageDirectoryPath},
+} = require('pkg-tests-core');
+
+const AUTH_TOKEN = `686159dc-64b3-413e-a244-2de2b8d1c36f`;
+const AUTH_IDENT = `dXNlcm5hbWU6YSB2ZXJ5IHNlY3VyZSBwYXNzd29yZA==`; // username:a very secure password
+
+describe(`Auth tests`, () => {
+  test(
+    `it should fail to install unscoped packages which require authentication if no authentication is configured`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        // Rejected by 401 error from registry so no validation on the error message
+        await expect(run(`install`)).rejects.toThrow();
+      },
+    ),
+  );
+
+  test(
+    `it should fail to install scoped packages which require authentication if no authentication is configured`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        // Rejected by 401 error from registry so no validation on the error message
+        await expect(run(`install`)).rejects.toThrow();
+      },
+    ),
+  );
+
+  test(
+    `it should fail to install packages which if npmAlwaysAuth is set to true without auth present`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`no-deps`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAlwaysAuth true\n`);
+
+        await expect(run(`install`)).rejects.toThrowError(/No authentication configured for request/);
+      },
+    ),
+  );
+
+  test(
+    `it should fail to install unscoped packages which require authentication if an authentication token is configured but always-auth is false`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthToken "${AUTH_TOKEN}"\n`);
+
+        // Rejected by 401 error from registry so no validation on the error message
+        await expect(run(`install`)).rejects.toThrow();
+      },
+    ),
+  );
+
+  test(
+    `it should install scoped packages which require authentication if an authentication token is configured`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthToken "${AUTH_TOKEN}"\n`);
+
+        await run(`install`);
+
+        await expect(source(`require('@private/package')`)).resolves.toMatchObject({
+          name: `@private/package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  test(
+    `it should install unscoped packages which require authentication if npmAlwaysAuth is set to true and an authentication token is present`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthToken "${AUTH_TOKEN}"\nnpmAlwaysAuth true\n`);
+
+        await run(`install`);
+
+        await expect(source(`require('private-package')`)).resolves.toMatchObject({
+          name: `private-package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  test(
+    `it should fail to install unscoped packages which require authentication if an authentication ident is configured but always-auth is false`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthIdent "${AUTH_IDENT}"\n`);
+
+        // Rejected by 401 error from registry so no validation on the error message
+        await expect(run(`install`)).rejects.toThrow();
+      },
+    ),
+  );
+
+  test(
+    `it should install scoped packages which require authentication if an authentication ident is configured`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthIdent "${AUTH_IDENT}"\n`);
+
+        await run(`install`);
+
+        await expect(source(`require('@private/package')`)).resolves.toMatchObject({
+          name: `@private/package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  test(
+    `it should install unscoped packages which require authentication if npmAlwaysAuth is set to true and an authentication ident is present`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthIdent "${AUTH_IDENT}"\nnpmAlwaysAuth true\n`);
+
+        await run(`install`);
+
+        await expect(source(`require('private-package')`)).resolves.toMatchObject({
+          name: `private-package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+});

--- a/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
@@ -6,6 +6,9 @@ const {
 const AUTH_TOKEN = `686159dc-64b3-413e-a244-2de2b8d1c36f`;
 const AUTH_IDENT = `dXNlcm5hbWU6YSB2ZXJ5IHNlY3VyZSBwYXNzd29yZA==`; // username:a very secure password
 
+const INVALID_AUTH_TOKEN = `a24cb960-e6a5-45fc-b9ab-0f9fe0aaae57`;
+const INVALID_AUTH_IDENT = `dXNlcm5hbWU6bm90IHRoZSByaWdodCBwYXNzd29yZA==`; // username:not the right password
+
 describe(`Auth tests`, () => {
   test(
     `it should fail to install unscoped packages which require authentication if no authentication is configured`,
@@ -149,6 +152,34 @@ describe(`Auth tests`, () => {
           name: `private-package`,
           version: `1.0.0`,
         });
+      },
+    ),
+  );
+
+  test(
+    `it should fail when an invalid authenticaation token is used`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthToken "${INVALID_AUTH_TOKEN}"\nnpmAlwaysAuth true\n`);
+
+        await expect(run(`install`)).rejects.toThrow();
+      },
+    ),
+  );
+
+  test(
+    `it should fail when an invalid authentication ident is used`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`private-package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc`, `npmAuthIdent "${INVALID_AUTH_IDENT}"\nnpmAlwaysAuth true\n`);
+
+        await expect(run(`install`)).rejects.toThrow();
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/config.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/config.test.js.snap
@@ -25,6 +25,9 @@ Object {
 {\\"key\\":\\"initVersion\\",\\"effective\\":null,\\"description\\":\\"Version used when creating packages via the init command\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lastUpdateCheck\\",\\"effective\\":null,\\"description\\":\\"Last timestamp we checked whether new Yarn versions were available\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lockfileFilename\\",\\"effective\\":\\"yarn.lock\\",\\"description\\":\\"Name of the files where the Yarn dependency tree entries must be stored\\",\\"type\\":\\"STRING\\",\\"default\\":\\"yarn.lock\\"}
+{\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
+{\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
@@ -65,6 +68,9 @@ Object {
 ➤ YN0000: initVersion - Version used when creating packages via the init command - null
 ➤ YN0000: lastUpdateCheck - Last timestamp we checked whether new Yarn versions were available - null
 ➤ YN0000: lockfileFilename - Name of the files where the Yarn dependency tree entries must be stored - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
+➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
+➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
@@ -106,6 +112,9 @@ Object {
 ➤ YN0000: initVersion - <default> - null
 ➤ YN0000: lastUpdateCheck - <default> - null
 ➤ YN0000: lockfileFilename - <default> - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - <default> - false
+➤ YN0000: npmAuthIdent - <default> - null
+➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
@@ -147,6 +156,9 @@ Object {
 ➤ YN0000: initVersion - null
 ➤ YN0000: lastUpdateCheck - null
 ➤ YN0000: lockfileFilename - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - false
+➤ YN0000: npmAuthIdent - null
+➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
@@ -188,6 +200,9 @@ Object {
 {\\"key\\":\\"initVersion\\",\\"effective\\":null,\\"description\\":\\"Version used when creating packages via the init command\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lastUpdateCheck\\",\\"effective\\":\\"1555784893958\\",\\"source\\":\\"WORKSPACE_ROOT/.spec-yarnrc\\",\\"description\\":\\"Last timestamp we checked whether new Yarn versions were available\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lockfileFilename\\",\\"effective\\":\\"yarn.lock\\",\\"description\\":\\"Name of the files where the Yarn dependency tree entries must be stored\\",\\"type\\":\\"STRING\\",\\"default\\":\\"yarn.lock\\"}
+{\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
+{\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
@@ -228,6 +243,9 @@ Object {
 ➤ YN0000: initVersion - Version used when creating packages via the init command - null
 ➤ YN0000: lastUpdateCheck - Last timestamp we checked whether new Yarn versions were available - '1555784893958'
 ➤ YN0000: lockfileFilename - Name of the files where the Yarn dependency tree entries must be stored - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
+➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
+➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
@@ -269,6 +287,9 @@ Object {
 ➤ YN0000: initVersion - <default> - null
 ➤ YN0000: lastUpdateCheck - WORKSPACE_ROOT/.spec-yarnrc - '1555784893958'
 ➤ YN0000: lockfileFilename - <default> - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - <default> - false
+➤ YN0000: npmAuthIdent - <default> - null
+➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
@@ -310,6 +331,9 @@ Object {
 ➤ YN0000: initVersion - null
 ➤ YN0000: lastUpdateCheck - '1555784893958'
 ➤ YN0000: lockfileFilename - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - false
+➤ YN0000: npmAuthIdent - null
+➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
@@ -351,6 +375,9 @@ Object {
 {\\"key\\":\\"initVersion\\",\\"effective\\":null,\\"description\\":\\"Version used when creating packages via the init command\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lastUpdateCheck\\",\\"effective\\":\\"1555784893958\\",\\"source\\":\\"WORKSPACE_ROOT/subfolder/.spec-yarnrc\\",\\"description\\":\\"Last timestamp we checked whether new Yarn versions were available\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lockfileFilename\\",\\"effective\\":\\"yarn.lock\\",\\"description\\":\\"Name of the files where the Yarn dependency tree entries must be stored\\",\\"type\\":\\"STRING\\",\\"default\\":\\"yarn.lock\\"}
+{\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
+{\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
@@ -391,6 +418,9 @@ Object {
 ➤ YN0000: initVersion - Version used when creating packages via the init command - null
 ➤ YN0000: lastUpdateCheck - Last timestamp we checked whether new Yarn versions were available - '1555784893958'
 ➤ YN0000: lockfileFilename - Name of the files where the Yarn dependency tree entries must be stored - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
+➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
+➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
@@ -432,6 +462,9 @@ Object {
 ➤ YN0000: initVersion - <default> - null
 ➤ YN0000: lastUpdateCheck - WORKSPACE_ROOT/subfolder/.spec-yarnrc - '1555784893958'
 ➤ YN0000: lockfileFilename - <default> - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - <default> - false
+➤ YN0000: npmAuthIdent - <default> - null
+➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
@@ -473,6 +506,9 @@ Object {
 ➤ YN0000: initVersion - null
 ➤ YN0000: lastUpdateCheck - '1555784893958'
 ➤ YN0000: lockfileFilename - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - false
+➤ YN0000: npmAuthIdent - null
+➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
@@ -514,6 +550,9 @@ Object {
 {\\"key\\":\\"initVersion\\",\\"effective\\":null,\\"description\\":\\"Version used when creating packages via the init command\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lastUpdateCheck\\",\\"effective\\":null,\\"description\\":\\"Last timestamp we checked whether new Yarn versions were available\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lockfileFilename\\",\\"effective\\":\\"yarn.lock\\",\\"description\\":\\"Name of the files where the Yarn dependency tree entries must be stored\\",\\"type\\":\\"STRING\\",\\"default\\":\\"yarn.lock\\"}
+{\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
+{\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
@@ -554,6 +593,9 @@ Object {
 ➤ YN0000: initVersion - Version used when creating packages via the init command - null
 ➤ YN0000: lastUpdateCheck - Last timestamp we checked whether new Yarn versions were available - null
 ➤ YN0000: lockfileFilename - Name of the files where the Yarn dependency tree entries must be stored - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
+➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
+➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
@@ -595,6 +637,9 @@ Object {
 ➤ YN0000: initVersion - <default> - null
 ➤ YN0000: lastUpdateCheck - <default> - null
 ➤ YN0000: lockfileFilename - <default> - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - <default> - false
+➤ YN0000: npmAuthIdent - <default> - null
+➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
@@ -636,6 +681,9 @@ Object {
 ➤ YN0000: initVersion - null
 ➤ YN0000: lastUpdateCheck - null
 ➤ YN0000: lockfileFilename - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - false
+➤ YN0000: npmAuthIdent - null
+➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
@@ -677,6 +725,9 @@ Object {
 {\\"key\\":\\"initVersion\\",\\"effective\\":null,\\"description\\":\\"Version used when creating packages via the init command\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lastUpdateCheck\\",\\"effective\\":null,\\"description\\":\\"Last timestamp we checked whether new Yarn versions were available\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"lockfileFilename\\",\\"effective\\":\\"yarn.lock\\",\\"description\\":\\"Name of the files where the Yarn dependency tree entries must be stored\\",\\"type\\":\\"STRING\\",\\"default\\":\\"yarn.lock\\"}
+{\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
+{\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
@@ -717,6 +768,9 @@ Object {
 ➤ YN0000: initVersion - Version used when creating packages via the init command - null
 ➤ YN0000: lastUpdateCheck - Last timestamp we checked whether new Yarn versions were available - null
 ➤ YN0000: lockfileFilename - Name of the files where the Yarn dependency tree entries must be stored - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
+➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
+➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
@@ -758,6 +812,9 @@ Object {
 ➤ YN0000: initVersion - <default> - null
 ➤ YN0000: lastUpdateCheck - <default> - null
 ➤ YN0000: lockfileFilename - <default> - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - <default> - false
+➤ YN0000: npmAuthIdent - <default> - null
+➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
@@ -799,6 +856,9 @@ Object {
 ➤ YN0000: initVersion - null
 ➤ YN0000: lastUpdateCheck - null
 ➤ YN0000: lockfileFilename - 'yarn.lock'
+➤ YN0000: npmAlwaysAuth - false
+➤ YN0000: npmAuthIdent - null
+➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true

--- a/packages/berry-core/sources/Report.ts
+++ b/packages/berry-core/sources/Report.ts
@@ -37,6 +37,7 @@ export enum MessageName {
   FETCH_FAILED = 30,
   DANGEROUS_NODE_MODULES = 31,
   NODE_GYP_INJECTED = 32,
+  AUTHENTICATION_NOT_FOUND = 33,
 }
 
 export class ReportError extends Error {

--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -1,9 +1,10 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@berry/core';
-import {httpUtils, structUtils, tgzUtils}           from '@berry/core';
+import {structUtils, tgzUtils}                      from '@berry/core';
 import {Locator, MessageName}                       from '@berry/core';
 import semver                                       from 'semver';
 
 import {PROTOCOL}                                   from './constants';
+import * as npmHttpUtils                            from './npmHttpUtils';
 
 export class NpmFetcher implements Fetcher {
   supports(locator: Locator, opts: MinimalFetchOptions) {
@@ -41,7 +42,11 @@ export class NpmFetcher implements Fetcher {
   }
 
   private async fetchFromNetwork(locator: Locator, opts: FetchOptions) {
-    const sourceBuffer = await httpUtils.get(this.getLocatorUrl(locator, opts), opts.project.configuration);
+    const sourceBuffer = await npmHttpUtils.get(
+      this.getLocatorUrl(locator, opts),
+      locator,
+      opts.project.configuration,
+    );
 
     return await tgzUtils.makeArchive(sourceBuffer, {
       stripComponents: 1,

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -1,10 +1,11 @@
 import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions, Manifest} from '@berry/core';
 import {Ident, Descriptor, Locator}                                                          from '@berry/core';
 import {LinkType}                                                                            from '@berry/core';
-import {httpUtils, structUtils}                                                              from '@berry/core';
+import {structUtils}                                                                         from '@berry/core';
 import semver                                                                                from 'semver';
 
 import {PROTOCOL}                                                                            from './constants';
+import * as npmHttpUtils                                                                     from './npmHttpUtils';
 
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);
 const NODE_GYP_MATCH = /\b(node-gyp|prebuild-install)\b/;
@@ -44,7 +45,7 @@ export class NpmSemverResolver implements Resolver {
     if (semver.valid(range))
       return [structUtils.convertDescriptorToLocator(descriptor)];
 
-    const httpResponse = await httpUtils.get(this.getIdentUrl(descriptor, opts), opts.project.configuration);
+    const httpResponse = await npmHttpUtils.get(this.getIdentUrl(descriptor, opts), descriptor, opts.project.configuration);
 
     const versions = Object.keys(JSON.parse(httpResponse.toString()).versions);
     const candidates = versions.filter(version => semver.satisfies(version, range));
@@ -61,7 +62,7 @@ export class NpmSemverResolver implements Resolver {
   async resolve(locator: Locator, opts: ResolveOptions) {
     const version = locator.reference.slice(PROTOCOL.length);
 
-    const httpResponse = await httpUtils.get(this.getIdentUrl(locator, opts), opts.project.configuration);
+    const httpResponse = await npmHttpUtils.get(this.getIdentUrl(locator, opts), locator, opts.project.configuration);
     const registryData = JSON.parse(httpResponse.toString());
 
     if (!Object.prototype.hasOwnProperty.call(registryData, `versions`))

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -1,8 +1,9 @@
 import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions} from '@berry/core';
-import {httpUtils, structUtils}                                                    from '@berry/core';
+import {structUtils}                                                               from '@berry/core';
 import {Ident, Descriptor, Locator, Package}                                       from '@berry/core';
 
 import {PROTOCOL}                                                                  from './constants';
+import * as npmHttpUtils                                                           from './npmHttpUtils';
 
 export const TAG_REGEXP = /^[a-z]+$/;
 
@@ -34,7 +35,7 @@ export class NpmTagResolver implements Resolver {
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {
     const tag = descriptor.range.slice(PROTOCOL.length);
 
-    const httpResponse = await httpUtils.get(this.getIdentUrl(descriptor, opts), opts.project.configuration);
+    const httpResponse = await npmHttpUtils.get(this.getIdentUrl(descriptor, opts), descriptor, opts.project.configuration);
     const registryData = JSON.parse(httpResponse.toString());
 
     if (!Object.prototype.hasOwnProperty.call(registryData, `dist-tags`))

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -12,6 +12,21 @@ const plugin: Plugin = {
       type: SettingsType.STRING,
       default: `https://registry.yarnpkg.com`,
     },
+    npmAlwaysAuth: {
+      description: `URL of the selected npm registry (note: npm enterprise isn't supported)`,
+      type: SettingsType.BOOLEAN,
+      default: false,
+    },
+    npmAuthIdent: {
+      description: `Authentication identity for the npm registry (_auth in npm and yarn v1)`,
+      type: SettingsType.SECRET,
+      default: null,
+    },
+    npmAuthToken: {
+      description: `Authentication token for the npm registry (_authToken in npm and yarn v1)`,
+      type: SettingsType.SECRET,
+      default: null,
+    },
   },
   fetchers: [
     NpmFetcher,

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -9,9 +9,9 @@ export function get(url: string, ident: Ident, configuration: Configuration) {
     headers.authorization = auth;
 
   return httpUtils.get(
-      url,
-      configuration,
-      {headers},
+    url,
+    configuration,
+    {headers},
   );
 }
 

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,0 +1,28 @@
+import {Configuration, httpUtils, Ident} from '@berry/core';
+
+export function get(url: string, ident: Ident, configuration: Configuration) {
+  const headers: {[headerName: string]: string} = {};
+
+  const auth = getAuthenticationHeader(ident, configuration);
+  if (auth)
+    headers.authorization = auth;
+
+  return httpUtils.get(
+      url,
+      configuration,
+      {headers},
+  );
+}
+
+function getAuthenticationHeader(ident: Ident, configuration: Configuration) {
+  if (!configuration.get(`npmAlwaysAuth`) && !ident.scope)
+    return undefined;
+
+  if (configuration.get(`npmAuthToken`))
+    return `Bearer ${configuration.get(`npmAuthToken`)}`;
+
+  if (configuration.get(`npmAuthIdent`))
+    return `Basic ${configuration.get(`npmAuthIdent`)}`;
+
+  throw new Error(`No authentication configured for request`);
+}

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -15,8 +15,10 @@ export function get(url: string, ident: Ident, configuration: Configuration) {
 }
 
 function getAuthenticationHeader(ident: Ident, configuration: Configuration) {
-  if (!configuration.get(`npmAlwaysAuth`) && !ident.scope)
-    return undefined;
+  const mustAuthenticate = configuration.get(`npmAlwaysAuth`);
+
+  if (!mustAuthenticate && !ident.scope)
+    return null;
 
   if (configuration.get(`npmAuthToken`))
     return `Bearer ${configuration.get(`npmAuthToken`)}`;
@@ -24,5 +26,9 @@ function getAuthenticationHeader(ident: Ident, configuration: Configuration) {
   if (configuration.get(`npmAuthIdent`))
     return `Basic ${configuration.get(`npmAuthIdent`)}`;
 
-  throw new Error(`No authentication configured for request`);
+  if (mustAuthenticate) {
+    throw new Error(`No authentication configured for request`);
+  } else {
+    return null;
+  }
 }

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,4 +1,5 @@
 import {Configuration, httpUtils, Ident} from '@berry/core';
+import {MessageName, ReportError}        from '@berry/core';
 
 export function get(url: string, ident: Ident, configuration: Configuration) {
   const headers: {[headerName: string]: string} = {};
@@ -27,7 +28,7 @@ function getAuthenticationHeader(ident: Ident, configuration: Configuration) {
     return `Basic ${configuration.get(`npmAuthIdent`)}`;
 
   if (mustAuthenticate) {
-    throw new Error(`No authentication configured for request`);
+    throw new ReportError(MessageName.AUTHENTICATION_NOT_FOUND ,`No authentication configured for request`);
   } else {
     return null;
   }


### PR DESCRIPTION
Implements #10 

Tested against a SonaType Nexus 3 server containing both public and private packages at work, with `npmAlwaysAuth` set to true.

- [x] tweak config to get authentication header, it's wrong now
- [x] try and get this tested