### PR TITLE
Changes yarn link syntax

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/link.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/link.test.js
@@ -1,30 +1,150 @@
 import {NodeFS} from '@berry/fslib';
 
 const {
-  fs: {createTemporaryFolder, mkdirp, readJson},
+  fs: {createTemporaryFolder, mkdirp, readJson, writeJson},
 } = require('pkg-tests-core');
 
 describe(`Commands`, () => {
   describe(`link`, () => {
     test(
-      `it should work with the classic link workflow`,
+      `it should allow to link a project with another one`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const tmp = await createTemporaryFolder();
-        await mkdirp(`${tmp}/my-package`);
 
-        await run(`init`, {
-          cwd: `${tmp}/my-package`,
+        await writeJson(`${tmp}/my-package/package.json`, {
+          name: `my-package`,
         });
 
-        await run(`link`, {
-          cwd: `${tmp}/my-package`,
-        });
-
-        await run(`link`, `my-package`);
+        await run(`link`, `${tmp}/my-package`);
 
         await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
-          dependencies: {
+          resolutions: {
             [`my-package`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-package`)}`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should add the resolution override to the top-level workspace`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run, source}) => {
+          const tmp = await createTemporaryFolder();
+
+          await writeJson(`${tmp}/my-package/package.json`, {
+            name: `my-package`,
+          });
+    
+          await writeJson(`${path}/packages/workspace/package.json`, {
+            name: `workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+            resolutions: {
+              [`my-package`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-package`)}`,
+            },
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should allow to link all workspaces from another project`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmp = await createTemporaryFolder();
+
+        await writeJson(`${tmp}/my-workspace/package.json`, {
+          private: true,
+          workspaces: [`packages/*`],
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-a/package.json`, {
+          name: `workspace-a`,
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-b/package.json`, {
+          name: `workspace-b`,
+        });
+
+        await run(`link`, `${tmp}/my-workspace`, `--all`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          resolutions: {
+            [`workspace-a`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+            [`workspace-b`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should not link the private workspaces by default`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmp = await createTemporaryFolder();
+
+        await writeJson(`${tmp}/my-workspace/package.json`, {
+          private: true,
+          workspaces: [`packages/*`],
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-a/package.json`, {
+          name: `workspace-a`,
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-b/package.json`, {
+          name: `workspace-b`,
+          private: true,
+        });
+
+        await run(`link`, `${tmp}/my-workspace`, `--all`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          resolutions: {
+            [`workspace-a`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+          },
+        });
+
+        await expect(readJson(`${path}/package.json`)).resolves.not.toMatchObject({
+          resolutions: {
+            [`workspace-b`]: expect.anything(),
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should link the private workspaces if the right flag is used`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmp = await createTemporaryFolder();
+
+        await writeJson(`${tmp}/my-workspace/package.json`, {
+          private: true,
+          workspaces: [`packages/*`],
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-a/package.json`, {
+          name: `workspace-a`,
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-b/package.json`, {
+          name: `workspace-b`,
+          private: true,
+        });
+
+        await run(`link`, `${tmp}/my-workspace`, `--all`, `--private`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          resolutions: {
+            [`workspace-a`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+            [`workspace-b`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
           },
         });
       }),

--- a/packages/berry-core/sources/Manifest.ts
+++ b/packages/berry-core/sources/Manifest.ts
@@ -1,12 +1,12 @@
-import {FakeFS, NodeFS}    from '@berry/fslib';
-import {parseResolution}   from '@berry/parsers';
-import {posix}             from 'path';
-import semver              from 'semver';
+import {FakeFS, NodeFS}                                   from '@berry/fslib';
+import {Resolution, parseResolution, stringifyResolution} from '@berry/parsers';
+import {posix}                                            from 'path';
+import semver                                             from 'semver';
 
-import * as miscUtils      from './miscUtils';
-import * as structUtils    from './structUtils';
-import {IdentHash}         from './types';
-import {Ident, Descriptor} from './types';
+import * as miscUtils                                     from './miscUtils';
+import * as structUtils                                   from './structUtils';
+import {IdentHash}                                        from './types';
+import {Ident, Descriptor}                                from './types';
 
 export interface WorkspaceDefinition {
   pattern: string;
@@ -42,7 +42,7 @@ export class Manifest {
   public dependenciesMeta: Map<string, Map<string | null, DependencyMeta>> = new Map();
   public peerDependenciesMeta: Map<string, PeerDependencyMeta> = new Map();
 
-  public resolutions: Array<{pattern: any, reference: string}> = [];
+  public resolutions: Array<{pattern: Resolution, reference: string}> = [];
 
   public files: Set<String> = new Set();
 
@@ -366,7 +366,11 @@ export class Manifest {
     data.peerDependenciesMeta = this.peerDependenciesMeta.size === 0 ? undefined : Object.assign({}, ... miscUtils.sortMap(this.peerDependenciesMeta.entries(), ([identString, meta]) => identString).map(([identString, meta]) => {
       return {[identString]: meta};
     }));
-    
+
+    data.resolutions = this.resolutions.length === 0 ? undefined : Object.assign({}, ... this.resolutions.map(({pattern, reference}) => {
+      return {[stringifyResolution(pattern)]: reference};
+    }));
+
     if(this.files.size === 0) {
       data.files = undefined;
     } else {

--- a/packages/berry-parsers/sources/index.ts
+++ b/packages/berry-parsers/sources/index.ts
@@ -1,6 +1,6 @@
 export {CommandSegment, CommandChain, CommandLine, ShellLine} from './grammars/shell';
 export {parseShell} from './shell';
 
-export {parseResolution} from './resolution';
+export {Resolution, parseResolution, stringifyResolution} from './resolution';
 
 export {parseSyml, stringifySyml} from './syml';

--- a/packages/berry-parsers/sources/resolution.ts
+++ b/packages/berry-parsers/sources/resolution.ts
@@ -1,11 +1,42 @@
 import {parse} from './grammars/resolution';
 
-export function parseResolution(source: string) {
+export type Resolution = {
+  from?: {
+    fullName: string,
+    description?: string,
+  },
+  descriptor: {
+    fullName: string,
+    description?: string,
+  },
+};
+
+export function parseResolution(source: string): Resolution {
   try {
-    return parse(source);
+    return parse(source) as Resolution;
   } catch (error) {
     if (error.location)
       error.message = error.message.replace(/(\.)?$/, ` (line ${error.location.start.line}, column ${error.location.start.column})$1`);
     throw error;
   }
+}
+
+export function stringifyResolution(resolution: Resolution) {
+  let str = ``;
+
+  if (resolution.from) {
+    str += resolution.from.fullName;
+
+    if (resolution.from.description)
+      str += `@${resolution.from.description}`;
+
+    str += `/`;
+  }
+
+  str += resolution.descriptor.fullName;
+
+  if (resolution.descriptor.description)
+    str += `@${resolution.descriptor.description}`;
+
+  return str;
 }


### PR DESCRIPTION
Given the positive response to [my tweet](https://twitter.com/arcanis/status/1120993281251454976) I went ahead and implemented it.

This diff changes the syntax for `yarn link`. Instead of "remembering" the local packages by first requiring our users to run `yarn link` in their individual directories and then to run `yarn link <package-name>` again but this time in their target project, we now only ask them to specify the link destination in their target workspace.

Before:

```
$> cd ~/source
$> yarn link
$> cd ~/target
$> yarn link source
```

After:

```
$> cd ~/target
$> yarn link ~/source
```

This behavior is simpler since we don't have to maintain a global store for `yarn link` to work, easier from a workflow perspective since our users need to run less commands, less frustrating because you don't have the problem of having directory names different from the package names ... generally speaking, it's all pros.

