### PR TITLE
Fix webpack generating bundles with errors

### DIFF
--- a/packages/berry-builder/sources/build-bundle.js
+++ b/packages/berry-builder/sources/build-bundle.js
@@ -23,6 +23,8 @@ clipanion
     const compiler = webpack(makeConfig({
       context: basedir,
 
+      bail: true,
+
       entry: `./sources/cli.ts`,
 
       output: {


### PR DESCRIPTION
I had a typo doing something like `yarn build:cli --plugin @berry/plugin-typoHere` and got into a state where I couldn't rebuild the cli without deleting `berry-cli/bundles`.

This will make webpack not output the bundle if an error exists.