### PR TITLE
Bugfix: Do not translate paths that are outside PnP projects

### DIFF
--- a/packages/berry-pnpify/lib/index.js
+++ b/packages/berry-pnpify/lib/index.js
@@ -152,20 +152,20 @@ function mountVirtualNodeModulesFs() {
             else if (['realpathSync'].indexOf(this.method) >= 0) {
                 const pnpPath = pathResolver.resolvePath(args[0]);
                 if (pnpPath.apiPath) {
-                    let realPath;
                     if (pnpPath.resolvedPath) {
-                        realPath = pnpPath.resolvedPath;
+                        args[0] = pnpPath.resolvedPath;
                     }
                     else if (pnpPath.resolvedPath === undefined) {
-                        if (dirReader.readDir(pnpPath) !== null) {
-                            realPath = args[0];
-                        }
+                        if (dirReader.readDir(pnpPath) !== null)
+                            result = args[0];
+                        else
+                            result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
+                        hasResult = true;
                     }
-                    if (realPath)
-                        result = realPath;
-                    else
+                    else if (pnpPath.resolvedPath === null) {
                         result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
-                    hasResult = true;
+                        hasResult = true;
+                    }
                 }
             }
             else if (['readFileSync'].indexOf(this.method) >= 0) {

--- a/packages/berry-pnpify/lib/index.js
+++ b/packages/berry-pnpify/lib/index.js
@@ -124,75 +124,83 @@ function mountVirtualNodeModulesFs() {
         try {
             if (['accessSync', 'existsSync', 'stat', 'statSync'].indexOf(this.method) >= 0) {
                 const pnpPath = pathResolver.resolvePath(args[0]);
-                let fileMightExist = true;
-                if (pnpPath.resolvedPath === null) {
-                    fileMightExist = false;
-                }
-                else if (pnpPath.resolvedPath === undefined) {
-                    if (dirReader.readDir(pnpPath) === null) {
+                if (pnpPath.apiPath) {
+                    let fileMightExist = true;
+                    if (pnpPath.resolvedPath === null) {
                         fileMightExist = false;
                     }
-                    else {
-                        args[0] = pnpPath.issuer;
+                    else if (pnpPath.resolvedPath === undefined) {
+                        if (dirReader.readDir(pnpPath) === null) {
+                            fileMightExist = false;
+                        }
+                        else {
+                            args[0] = pnpPath.issuer;
+                        }
                     }
-                }
-                else {
-                    args[0] = pnpPath.resolvedPath;
-                }
-                if (!fileMightExist) {
-                    if (['existsSync'].indexOf(this.method) >= 0)
-                        result = false;
-                    else if (['stat'].indexOf(this.method) < 0)
-                        result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
-                    hasResult = true;
+                    else {
+                        args[0] = pnpPath.resolvedPath;
+                    }
+                    if (!fileMightExist) {
+                        if (['existsSync'].indexOf(this.method) >= 0)
+                            result = false;
+                        else if (['stat'].indexOf(this.method) < 0)
+                            result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
+                        hasResult = true;
+                    }
                 }
             }
             else if (['realpathSync'].indexOf(this.method) >= 0) {
                 const pnpPath = pathResolver.resolvePath(args[0]);
-                let realPath;
-                if (pnpPath.resolvedPath) {
-                    realPath = pnpPath.resolvedPath;
-                }
-                else if (pnpPath.resolvedPath === undefined) {
-                    if (dirReader.readDir(pnpPath) !== null) {
-                        realPath = args[0];
+                if (pnpPath.apiPath) {
+                    let realPath;
+                    if (pnpPath.resolvedPath) {
+                        realPath = pnpPath.resolvedPath;
                     }
+                    else if (pnpPath.resolvedPath === undefined) {
+                        if (dirReader.readDir(pnpPath) !== null) {
+                            realPath = args[0];
+                        }
+                    }
+                    if (realPath)
+                        result = realPath;
+                    else
+                        result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
+                    hasResult = true;
                 }
-                if (realPath)
-                    result = realPath;
-                else
-                    result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
-                hasResult = true;
             }
             else if (['readFileSync'].indexOf(this.method) >= 0) {
                 const pnpPath = pathResolver.resolvePath(args[0]);
-                if (!pnpPath.resolvedPath) {
-                    result = new Error(`ENOENT: no such file or directory, open '${args[0]}'`);
-                    hasResult = true;
-                }
-                else {
-                    args[0] = pnpPath.resolvedPath;
+                if (pnpPath.apiPath) {
+                    if (!pnpPath.resolvedPath) {
+                        result = new Error(`ENOENT: no such file or directory, open '${args[0]}'`);
+                        hasResult = true;
+                    }
+                    else {
+                        args[0] = pnpPath.resolvedPath;
+                    }
                 }
             }
             else if (['readdirSync'].indexOf(this.method) >= 0) {
                 const pnpPath = pathResolver.resolvePath(args[0]);
-                if (pnpPath.resolvedPath === null) {
-                    result = new Error(`ENOENT: no such file or directory, scandir '${args[0]}'`);
-                    hasResult = true;
-                }
-                else if (pnpPath.resolvedPath === undefined) {
-                    const dirList = dirReader.readDir(pnpPath);
-                    if (dirList === null) {
+                if (pnpPath.apiPath) {
+                    if (pnpPath.resolvedPath === null) {
                         result = new Error(`ENOENT: no such file or directory, scandir '${args[0]}'`);
                         hasResult = true;
                     }
-                    else {
-                        result = dirList;
-                        hasResult = true;
+                    else if (pnpPath.resolvedPath === undefined) {
+                        const dirList = dirReader.readDir(pnpPath);
+                        if (dirList === null) {
+                            result = new Error(`ENOENT: no such file or directory, scandir '${args[0]}'`);
+                            hasResult = true;
+                        }
+                        else {
+                            result = dirList;
+                            hasResult = true;
+                        }
                     }
-                }
-                else {
-                    args[0] = pnpPath.resolvedPath;
+                    else {
+                        args[0] = pnpPath.resolvedPath;
+                    }
                 }
             }
         }

--- a/packages/berry-pnpify/sources/index.ts
+++ b/packages/berry-pnpify/sources/index.ts
@@ -31,66 +31,74 @@ function mountVirtualNodeModulesFs() {
     try {
       if (['accessSync', 'existsSync', 'stat', 'statSync'].indexOf(this.method) >= 0) {
         const pnpPath = pathResolver.resolvePath(args[0]);
-        let fileMightExist = true;
-        if (pnpPath.resolvedPath === null) {
-          fileMightExist = false;
-        } else if (pnpPath.resolvedPath === undefined) {
-          if (dirReader.readDir(pnpPath) === null) {
+        if (pnpPath.apiPath) {
+          let fileMightExist = true;
+          if (pnpPath.resolvedPath === null) {
             fileMightExist = false;
+          } else if (pnpPath.resolvedPath === undefined) {
+            if (dirReader.readDir(pnpPath) === null) {
+              fileMightExist = false;
+            } else {
+              args[0] = pnpPath.issuer;
+            }
           } else {
-            args[0] = pnpPath.issuer;
+            args[0] = pnpPath.resolvedPath;
           }
-        } else {
-          args[0] = pnpPath.resolvedPath;
+          if (!fileMightExist) {
+            if (['existsSync'].indexOf(this.method) >= 0)
+              result = false;
+            else if (['stat'].indexOf(this.method) < 0)
+              result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
+
+            hasResult = true;
+          }
         }
-        if (!fileMightExist) {
-          if (['existsSync'].indexOf(this.method) >= 0)
-            result = false;
-          else if (['stat'].indexOf(this.method) < 0)
+      } else if (['realpathSync'].indexOf(this.method) >= 0) {
+        const pnpPath = pathResolver.resolvePath(args[0]);
+        if (pnpPath.apiPath) {
+          let realPath;
+          if (pnpPath.resolvedPath) {
+            realPath = pnpPath.resolvedPath;
+          } else if (pnpPath.resolvedPath === undefined) {
+            if (dirReader.readDir(pnpPath) !== null) {
+              realPath = args[0];
+            }
+          }
+          if (realPath)
+            result = realPath;
+          else
             result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
 
           hasResult = true;
         }
-      } else if (['realpathSync'].indexOf(this.method) >= 0) {
-        const pnpPath = pathResolver.resolvePath(args[0]);
-        let realPath;
-        if (pnpPath.resolvedPath) {
-          realPath = pnpPath.resolvedPath;
-        } else if (pnpPath.resolvedPath === undefined) {
-          if (dirReader.readDir(pnpPath) !== null) {
-            realPath = args[0];
-          }
-        }
-        if (realPath)
-          result = realPath;
-        else
-          result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
-
-        hasResult = true;
       } else if (['readFileSync'].indexOf(this.method) >= 0) {
         const pnpPath = pathResolver.resolvePath(args[0]);
-        if (!pnpPath.resolvedPath) {
-          result = new Error(`ENOENT: no such file or directory, open '${args[0]}'`);
-          hasResult = true;
-        } else {
-          args[0] = pnpPath.resolvedPath;
+        if (pnpPath.apiPath) {
+          if (!pnpPath.resolvedPath) {
+            result = new Error(`ENOENT: no such file or directory, open '${args[0]}'`);
+            hasResult = true;
+          } else {
+            args[0] = pnpPath.resolvedPath;
+          }
         }
       } else if (['readdirSync'].indexOf(this.method) >= 0) {
         const pnpPath = pathResolver.resolvePath(args[0]);
-        if (pnpPath.resolvedPath === null) {
-          result = new Error(`ENOENT: no such file or directory, scandir '${args[0]}'`);
-          hasResult = true;
-        } else if (pnpPath.resolvedPath === undefined) {
-          const dirList = dirReader.readDir(pnpPath);
-          if (dirList === null) {
+        if (pnpPath.apiPath) {
+          if (pnpPath.resolvedPath === null) {
             result = new Error(`ENOENT: no such file or directory, scandir '${args[0]}'`);
             hasResult = true;
+          } else if (pnpPath.resolvedPath === undefined) {
+            const dirList = dirReader.readDir(pnpPath);
+            if (dirList === null) {
+              result = new Error(`ENOENT: no such file or directory, scandir '${args[0]}'`);
+              hasResult = true;
+            } else {
+              result = dirList;
+              hasResult = true;
+            }
           } else {
-            result = dirList;
-            hasResult = true;
+            args[0] = pnpPath.resolvedPath;
           }
-        } else {
-          args[0] = pnpPath.resolvedPath;
         }
       }
     } catch (e) {

--- a/packages/berry-pnpify/sources/index.ts
+++ b/packages/berry-pnpify/sources/index.ts
@@ -56,20 +56,19 @@ function mountVirtualNodeModulesFs() {
       } else if (['realpathSync'].indexOf(this.method) >= 0) {
         const pnpPath = pathResolver.resolvePath(args[0]);
         if (pnpPath.apiPath) {
-          let realPath;
           if (pnpPath.resolvedPath) {
-            realPath = pnpPath.resolvedPath;
+            args[0] = pnpPath.resolvedPath;
           } else if (pnpPath.resolvedPath === undefined) {
-            if (dirReader.readDir(pnpPath) !== null) {
-              realPath = args[0];
-            }
-          }
-          if (realPath)
-            result = realPath;
-          else
+            if (dirReader.readDir(pnpPath) !== null) 
+              result = args[0];
+            else 
+              result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
+            
+            hasResult = true;
+          } else if (pnpPath.resolvedPath === null) {
             result = new Error(`ENOENT: no such file or directory, stat '${args[0]}'`);
-
-          hasResult = true;
+            hasResult = true;
+          }
         }
       } else if (['readFileSync'].indexOf(this.method) >= 0) {
         const pnpPath = pathResolver.resolvePath(args[0]);


### PR DESCRIPTION
Extra check is added, before any and each translation on paths happens whether the path is indeed inside PnP project or not. 

`realpathSync` is changed to forward path to underlying fs for the cases where it is not possible to determine result otherwise.