### PR TITLE
Allow plugin-npm to be configured per scope and registry

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/config.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/config.test.js.snap
@@ -28,7 +28,9 @@ Object {
 {\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
+{\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
 {\\"key\\":\\"pnpIgnorePattern\\",\\"effective\\":null,\\"description\\":\\"Regex defining a pattern of files that should use the classic resolution\\",\\"type\\":\\"STRING\\",\\"default\\":null}
@@ -71,7 +73,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
+➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Settings per package scope - Map {}
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
 ➤ YN0000: pnpIgnorePattern - Regex defining a pattern of files that should use the classic resolution - null
@@ -115,7 +119,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - <default> - false
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
+➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - <default> - Map {}
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
 ➤ YN0000: pnpIgnorePattern - <default> - null
@@ -159,7 +165,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - false
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
+➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Map {}
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
 ➤ YN0000: pnpIgnorePattern - null
@@ -203,7 +211,9 @@ Object {
 {\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
+{\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
 {\\"key\\":\\"pnpIgnorePattern\\",\\"effective\\":null,\\"description\\":\\"Regex defining a pattern of files that should use the classic resolution\\",\\"type\\":\\"STRING\\",\\"default\\":null}
@@ -246,7 +256,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
+➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Settings per package scope - Map {}
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
 ➤ YN0000: pnpIgnorePattern - Regex defining a pattern of files that should use the classic resolution - null
@@ -290,7 +302,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - <default> - false
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
+➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - <default> - Map {}
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
 ➤ YN0000: pnpIgnorePattern - <default> - null
@@ -334,7 +348,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - false
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
+➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Map {}
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
 ➤ YN0000: pnpIgnorePattern - null
@@ -378,7 +394,9 @@ Object {
 {\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
+{\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
 {\\"key\\":\\"pnpIgnorePattern\\",\\"effective\\":null,\\"description\\":\\"Regex defining a pattern of files that should use the classic resolution\\",\\"type\\":\\"STRING\\",\\"default\\":null}
@@ -421,7 +439,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
+➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Settings per package scope - Map {}
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
 ➤ YN0000: pnpIgnorePattern - Regex defining a pattern of files that should use the classic resolution - null
@@ -465,7 +485,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - <default> - false
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
+➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - <default> - Map {}
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
 ➤ YN0000: pnpIgnorePattern - <default> - null
@@ -509,7 +531,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - false
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
+➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Map {}
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
 ➤ YN0000: pnpIgnorePattern - null
@@ -553,7 +577,9 @@ Object {
 {\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
+{\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
 {\\"key\\":\\"pnpIgnorePattern\\",\\"effective\\":null,\\"description\\":\\"Regex defining a pattern of files that should use the classic resolution\\",\\"type\\":\\"STRING\\",\\"default\\":null}
@@ -596,7 +622,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
+➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Settings per package scope - Map {}
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
 ➤ YN0000: pnpIgnorePattern - Regex defining a pattern of files that should use the classic resolution - null
@@ -640,7 +668,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - <default> - false
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
+➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - <default> - Map {}
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
 ➤ YN0000: pnpIgnorePattern - <default> - null
@@ -684,7 +714,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - false
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
+➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Map {}
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
 ➤ YN0000: pnpIgnorePattern - null
@@ -728,7 +760,9 @@ Object {
 {\\"key\\":\\"npmAlwaysAuth\\",\\"effective\\":false,\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false}
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
+{\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
+{\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"pnpDataPath\\",\\"effective\\":\\"WORKSPACE_ROOT/.pnp.data.json\\",\\"description\\":\\"Path of the file where the PnP data (used by the loader) must be written\\",\\"type\\":\\"ABSOLUTE_PATH\\",\\"default\\":\\"./.pnp.data.json\\"}
 {\\"key\\":\\"pnpEnableInlining\\",\\"effective\\":true,\\"description\\":\\"If true, the PnP data will be inlined along with the generated loader\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":true}
 {\\"key\\":\\"pnpIgnorePattern\\",\\"effective\\":null,\\"description\\":\\"Regex defining a pattern of files that should use the classic resolution\\",\\"type\\":\\"STRING\\",\\"default\\":null}
@@ -771,7 +805,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - URL of the selected npm registry (note: npm enterprise isn't supported) - false
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
+➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Settings per package scope - Map {}
 ➤ YN0000: pnpDataPath - Path of the file where the PnP data (used by the loader) must be written - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - If true, the PnP data will be inlined along with the generated loader - true
 ➤ YN0000: pnpIgnorePattern - Regex defining a pattern of files that should use the classic resolution - null
@@ -815,7 +851,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - <default> - false
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
+➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - <default> - Map {}
 ➤ YN0000: pnpDataPath - <default> - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - <default> - true
 ➤ YN0000: pnpIgnorePattern - <default> - null
@@ -859,7 +897,9 @@ Object {
 ➤ YN0000: npmAlwaysAuth - false
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
+➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
+➤ YN0000: npmScopes - Map {}
 ➤ YN0000: pnpDataPath - 'WORKSPACE_ROOT/.pnp.data.json'
 ➤ YN0000: pnpEnableInlining - true
 ➤ YN0000: pnpIgnorePattern - null

--- a/packages/berry-core/sources/Configuration.ts
+++ b/packages/berry-core/sources/Configuration.ts
@@ -319,7 +319,7 @@ function parseObject(path: string, value: unknown, definition: ObjectSettingsDef
     throw new Error(`Object configuration settings "${path}" must be an object`);
 
   for (const [propKey, propValue] of Object.entries(value!)) {
-    const name = normalizeKey(propKey);
+    const name = camelcase(propKey);
     const subPath = `${path}.${name}`;
     const subDefinition = definition.properties[name];
 
@@ -347,10 +347,6 @@ function parseMap(path: string, value: unknown, definition: MapSettingsDefinitio
   return result;
 }
 
-function normalizeKey(key: string) {
-  return key.replace(/[_-]([a-z])/g, ($0, $1) => $1.toUpperCase());
-}
-
 function getDefaultGlobalFolder() {
   if (process.platform === `win32`) {
     const base = NodeFS.toPortablePath(process.env.LOCALAPPDATA || win32.join(homedir(), 'AppData', 'Local'));
@@ -375,7 +371,7 @@ function getEnvironmentSettings() {
     if (!key.startsWith(ENVIRONMENT_PREFIX))
       continue;
 
-    key = normalizeKey(key.slice(ENVIRONMENT_PREFIX.length));
+    key = camelcase(key.slice(ENVIRONMENT_PREFIX.length));
 
     environmentSettings[key] = value;
   }
@@ -686,7 +682,7 @@ export class Configuration {
       data = data.berry;
 
     for (const key of Object.keys(data)) {
-      const name = normalizeKey(key);
+      const name = camelcase(key);
 
       // The plugins have already been loaded at this point
       if (name === `plugins`)

--- a/packages/berry-core/sources/Configuration.ts
+++ b/packages/berry-core/sources/Configuration.ts
@@ -293,7 +293,7 @@ function parseSingleValue(path: string, value: unknown, definition: SettingsDefi
       return parseBoolean(value);
     case SettingsType.OBJECT:
       return parseObject(path, value, definition, folder);
-      case SettingsType.MAP:
+    case SettingsType.MAP:
       return parseMap(path, value, definition, folder);
   }
 

--- a/packages/berry-parsers/tests/syml.test.js
+++ b/packages/berry-parsers/tests/syml.test.js
@@ -6,4 +6,10 @@ describe(`Syml parser`, () => {
       foo: `C:\\foobar`,
     });
   });
+
+  it(`should parse objects`, () => {
+    expect(parseSyml(`foo:\n  bar true\n  baz "quux"\n`)).toEqual({
+      foo: {bar: `true`, baz: `quux`},
+    })
+  });
 });

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -53,10 +53,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
       const body = makePublishBody(ident, version, buffer, {tag});
 
       try {
-        const registry = npmConfigUtils.getRegistry(ident, configuration);
-        const packageRegistryPath = `${registry}/${structUtils.stringifyIdent(ident)}`;
-
-        await npmHttpUtils.put(packageRegistryPath, body, {
+        await npmHttpUtils.put(`/${structUtils.stringifyIdent(ident)}`, body, {
           configuration,
           ident,
           json: true,

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -1,7 +1,7 @@
 import {WorkspaceRequiredError}                                                       from '@berry/cli';
 import {Configuration, Ident,MessageName, PluginConfiguration, Project, StreamReport} from '@berry/core';
 import {miscUtils, structUtils}                                                       from '@berry/core';
-import {npmHttpUtils}                                                                 from '@berry/plugin-npm';
+import {npmConfigUtils, npmHttpUtils}                                                 from '@berry/plugin-npm';
 import {packUtils}                                                                    from '@berry/plugin-pack';
 import {UsageError}                                                                   from 'clipanion';
 import {createHash}                                                                   from 'crypto';
@@ -53,7 +53,8 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
       const body = makePublishBody(ident, version, buffer, {tag});
 
       try {
-        const packageRegistryPath = `https://registry.npmjs.org/${structUtils.stringifyIdent(ident)}`;
+        const registry = npmConfigUtils.getRegistry(ident, configuration);
+        const packageRegistryPath = `${registry}/${structUtils.stringifyIdent(ident)}`;
 
         await npmHttpUtils.put(packageRegistryPath, body, {
           configuration,

--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -4,6 +4,7 @@ import {Locator, MessageName}                       from '@berry/core';
 import semver                                       from 'semver';
 
 import {PROTOCOL}                                   from './constants';
+import * as npmConfigUtils                          from './npmConfigUtils';
 import * as npmHttpUtils                            from './npmHttpUtils';
 
 export class NpmFetcher implements Fetcher {
@@ -55,7 +56,7 @@ export class NpmFetcher implements Fetcher {
 
   private getLocatorUrl(locator: Locator, opts: FetchOptions) {
     const version = locator.reference.slice(PROTOCOL.length);
-    const registry = opts.project.configuration.get(`npmRegistryServer`);
+    const registry = npmConfigUtils.getRegistry(locator, opts.project.configuration);
 
     return `${registry}/${structUtils.requirableIdent(locator)}/-/${locator.name}-${version}.tgz`;
   }

--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -4,7 +4,6 @@ import {Locator, MessageName}                       from '@berry/core';
 import semver                                       from 'semver';
 
 import {PROTOCOL}                                   from './constants';
-import * as npmConfigUtils                          from './npmConfigUtils';
 import * as npmHttpUtils                            from './npmHttpUtils';
 
 export class NpmFetcher implements Fetcher {

--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -56,9 +56,8 @@ export class NpmFetcher implements Fetcher {
 
   private getLocatorUrl(locator: Locator, opts: FetchOptions) {
     const version = locator.reference.slice(PROTOCOL.length);
-    const registry = npmConfigUtils.getRegistry(locator, opts.project.configuration);
 
-    return `${registry}/${structUtils.requirableIdent(locator)}/-/${locator.name}-${version}.tgz`;
+    return `/${structUtils.requirableIdent(locator)}/-/${locator.name}-${version}.tgz`;
   }
 
   private getPrefixPath(locator: Locator) {

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -5,7 +5,6 @@ import {structUtils}                                                            
 import semver                                                                                from 'semver';
 
 import {PROTOCOL}                                                                            from './constants';
-import * as npmConfigUtils                                                                   from './npmConfigUtils';
 import * as npmHttpUtils                                                                     from './npmHttpUtils';
 
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -113,12 +113,10 @@ export class NpmSemverResolver implements Resolver {
   }
 
   private getIdentUrl(ident: Ident, opts: MinimalResolveOptions) {
-    const registry = npmConfigUtils.getRegistry(ident, opts.project.configuration);
-
     if (ident.scope) {
-      return `${registry}/@${ident.scope}%2f${ident.name}`;
+      return `/@${ident.scope}%2f${ident.name}`;
     } else {
-      return `${registry}/${ident.name}`;
+      return `/${ident.name}`;
     }
   }
 }

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -5,6 +5,7 @@ import {structUtils}                                                            
 import semver                                                                                from 'semver';
 
 import {PROTOCOL}                                                                            from './constants';
+import * as npmConfigUtils                                                                   from './npmConfigUtils';
 import * as npmHttpUtils                                                                     from './npmHttpUtils';
 
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);
@@ -112,7 +113,7 @@ export class NpmSemverResolver implements Resolver {
   }
 
   private getIdentUrl(ident: Ident, opts: MinimalResolveOptions) {
-    const registry = opts.project.configuration.get(`npmRegistryServer`);
+    const registry = npmConfigUtils.getRegistry(ident, opts.project.configuration);
 
     if (ident.scope) {
       return `${registry}/@${ident.scope}%2f${ident.name}`;

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -59,12 +59,10 @@ export class NpmTagResolver implements Resolver {
   }
 
   private getIdentUrl(ident: Ident, opts: MinimalResolveOptions) {
-    const registry = npmConfigUtils.getRegistry(ident, opts.project.configuration);
-
     if (ident.scope) {
-      return `${registry}/@${ident.scope}%2f${ident.name}`;
+      return `/@${ident.scope}%2f${ident.name}`;
     } else {
-      return `${registry}/${ident.name}`;
+      return `/${ident.name}`;
     }
   }
 }

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -3,6 +3,7 @@ import {structUtils}                                                            
 import {Ident, Descriptor, Locator, Package}                                       from '@berry/core';
 
 import {PROTOCOL}                                                                  from './constants';
+import * as npmConfigUtils                                                         from './npmConfigUtils';
 import * as npmHttpUtils                                                           from './npmHttpUtils';
 
 export const TAG_REGEXP = /^[a-z]+$/;
@@ -45,7 +46,7 @@ export class NpmTagResolver implements Resolver {
       throw new ReportError(MessageName.REMOTE_INVALID, `Registry returned invalid data - missing "dist-tags" field`);
 
     const distTags = registryData[`dist-tags`];
-      
+
     if (!Object.prototype.hasOwnProperty.call(distTags, tag))
       throw new ReportError(MessageName.REMOTE_NOT_FOUND, `Registry failed to return tag "${tag}"`);
 
@@ -58,7 +59,7 @@ export class NpmTagResolver implements Resolver {
   }
 
   private getIdentUrl(ident: Ident, opts: MinimalResolveOptions) {
-    const registry = opts.project.configuration.get(`npmRegistryServer`);
+    const registry = npmConfigUtils.getRegistry(ident, opts.project.configuration);
 
     if (ident.scope) {
       return `${registry}/@${ident.scope}%2f${ident.name}`;

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -3,7 +3,6 @@ import {structUtils}                                                            
 import {Ident, Descriptor, Locator, Package}                                       from '@berry/core';
 
 import {PROTOCOL}                                                                  from './constants';
-import * as npmConfigUtils                                                         from './npmConfigUtils';
 import * as npmHttpUtils                                                           from './npmHttpUtils';
 
 export const TAG_REGEXP = /^[a-z]+$/;

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -46,12 +46,9 @@ const plugin: Plugin = {
     npmScopes: {
       description: `Settings per package scope`,
       type: SettingsType.MAP,
-      default: null,
       valueDefinition: {
         description: ``,
         type: SettingsType.SHAPE,
-        isNullable: false,
-        default: null,
         properties: {
           ...registrySettings,
         },
@@ -61,12 +58,9 @@ const plugin: Plugin = {
     npmRegistries: {
       description: `Settings per registry`,
       type: SettingsType.MAP,
-      default: null,
       valueDefinition: {
         description: ``,
         type: SettingsType.SHAPE,
-        isNullable: false,
-        default: null,
         properties: {
           ...authSettings,
         },

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -49,7 +49,7 @@ const plugin: Plugin = {
       default: null,
       valueDefinition: {
         description: ``,
-        type: SettingsType.OBJECT,
+        type: SettingsType.SHAPE,
         isNullable: false,
         default: null,
         properties: {
@@ -64,7 +64,7 @@ const plugin: Plugin = {
       default: null,
       valueDefinition: {
         description: ``,
-        type: SettingsType.OBJECT,
+        type: SettingsType.SHAPE,
         isNullable: false,
         default: null,
         properties: {

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -1,34 +1,76 @@
 import {Plugin, SettingsType} from '@berry/core';
+import {SettingsDefinition}   from '@berry/core';
 
 import {NpmFetcher}           from './NpmFetcher';
 import {NpmRemapResolver}     from './NpmRemapResolver';
 import {NpmSemverResolver}    from './NpmSemverResolver';
 import {NpmTagResolver}       from './NpmTagResolver';
+import * as npmConfigUtils    from './npmConfigUtils';
 import * as npmHttpUtils      from './npmHttpUtils';
 
+export {npmConfigUtils};
 export {npmHttpUtils};
+
+const authSettings: {[name: string]: SettingsDefinition} = {
+  npmAlwaysAuth: {
+    description: `URL of the selected npm registry (note: npm enterprise isn't supported)`,
+    type: SettingsType.BOOLEAN,
+    default: false,
+  },
+  npmAuthIdent: {
+    description: `Authentication identity for the npm registry (_auth in npm and yarn v1)`,
+    type: SettingsType.SECRET,
+    default: null,
+  },
+  npmAuthToken: {
+    description: `Authentication token for the npm registry (_authToken in npm and yarn v1)`,
+    type: SettingsType.SECRET,
+    default: null,
+  },
+};
+
+const registrySettings: {[name: string]: SettingsDefinition} = {
+  npmRegistryServer: {
+    description: `URL of the selected npm registry (note: npm enterprise isn't supported)`,
+    type: SettingsType.STRING,
+    default: `https://registry.yarnpkg.com`,
+  },
+
+  ...authSettings,
+}
 
 const plugin: Plugin = {
   configuration: {
-    npmRegistryServer: {
-      description: `URL of the selected npm registry (note: npm enterprise isn't supported)`,
-      type: SettingsType.STRING,
-      default: `https://registry.yarnpkg.com`,
-    },
-    npmAlwaysAuth: {
-      description: `URL of the selected npm registry (note: npm enterprise isn't supported)`,
-      type: SettingsType.BOOLEAN,
-      default: false,
-    },
-    npmAuthIdent: {
-      description: `Authentication identity for the npm registry (_auth in npm and yarn v1)`,
-      type: SettingsType.SECRET,
+    ...registrySettings,
+
+    npmScopes: {
+      description: `Settings per package scope`,
+      type: SettingsType.MAP,
       default: null,
+      valueDefinition: {
+        description: ``,
+        type: SettingsType.OBJECT,
+        isNullable: false,
+        default: null,
+        properties: {
+          ...registrySettings,
+        },
+      },
     },
-    npmAuthToken: {
-      description: `Authentication token for the npm registry (_authToken in npm and yarn v1)`,
-      type: SettingsType.SECRET,
+
+    npmRegistries: {
+      description: `Settings per registry`,
+      type: SettingsType.MAP,
       default: null,
+      valueDefinition: {
+        description: ``,
+        type: SettingsType.OBJECT,
+        isNullable: false,
+        default: null,
+        properties: {
+          ...authSettings,
+        },
+      },
     },
   },
   fetchers: [

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -28,12 +28,8 @@ export function getAuthenticationConfiguration(ident: Ident, {configuration}: {c
 function getScopedConfiguration(ident: Ident, {configuration}: {configuration: Configuration}): MapLike {
   if (ident.scope) {
     const scopeConfigurations: Map<string, Map<string, any>> | null = configuration.get(`npmScopes`);
-    if (scopeConfigurations && scopeConfigurations.has(ident.scope))
+    if (scopeConfigurations && scopeConfigurations.has(ident.scope)) {
       return scopeConfigurations.get(ident.scope)!;
-
-    const scopeWithAt = `@${ident.scope}`;
-    if (scopeConfigurations && scopeConfigurations.has(scopeWithAt)) {
-      return scopeConfigurations.get(scopeWithAt)!;
     }
   }
 

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -1,0 +1,37 @@
+import {Configuration, Ident} from '@berry/core';
+
+function getScopedConfiguration(ident: Ident, configuration: Configuration): Configuration|Map<string, any> {
+  if (ident.scope) {
+    const scopeConfigurations: Map<string, Map<string, any>> | null = configuration.get(`npmScopes`);
+    if (scopeConfigurations && scopeConfigurations.has(ident.scope))
+      return scopeConfigurations.get(ident.scope)!;
+
+    const scopeWithAt = `@${ident.scope}`;
+    if (scopeConfigurations && scopeConfigurations.has(scopeWithAt)) {
+      return scopeConfigurations.get(scopeWithAt)!;
+    }
+  }
+
+  return configuration;
+}
+
+export function getRegistry(ident: Ident, configuration: Configuration): string {
+  return getScopedConfiguration(ident, configuration).get(`npmRegistryServer`);
+}
+
+export function getAuthenticationConfiguration(ident: Ident, configuration: Configuration): Configuration | Map<string, any> {
+  const registryConfigurations: Map<string, Map<string, any>> | null = configuration.get(`npmRegistries`);
+
+  if (registryConfigurations) {
+    const registry = getRegistry(ident, configuration);
+    if (registryConfigurations.has(registry))
+      return registryConfigurations.get(registry)!;
+
+    const registryWithoutProtocol = registry.replace(/^[a-z]+:/, '');
+    if (registryConfigurations.has(registryWithoutProtocol)) {
+      return registryConfigurations.get(registryWithoutProtocol)!;
+    }
+  }
+
+  return getScopedConfiguration(ident, configuration);
+}

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -7,27 +7,31 @@ export type Options = httpUtils.Options & {
   ident: Ident,
 };
 
-export async function get(url: string, {configuration, headers, ident, ... rest}: Options) {
+export async function get(path: string, {configuration, headers, ident, ... rest}: Options) {
+  const registry = npmConfigUtils.getRegistry(ident, {configuration});
   const auth = getAuthenticationHeader(ident, {configuration});
+
   if (auth)
     headers = {... headers, authorization: auth};
 
-  return await httpUtils.get(url, {configuration, headers, ... rest});
+  return await httpUtils.get(`${registry}${path}`, {configuration, headers, ... rest});
 }
 
-export async function put(url: string, body: httpUtils.Body, {configuration, headers, ident, ... rest}: Options) {
+export async function put(path: string, body: httpUtils.Body, {configuration, headers, ident, ... rest}: Options) {
   // We always must authenticate our PUT requests
   configuration = configuration.extend({npmAlwaysAuth: true});
 
+  const registry = npmConfigUtils.getRegistry(ident, {configuration});
   const auth = getAuthenticationHeader(ident, {configuration});
+
   if (auth)
     headers = {... headers, authorization: auth};
 
-  return await httpUtils.put(url, body, {configuration, headers, ... rest});
+  return await httpUtils.put(`${registry}${path}`, body, {configuration, headers, ... rest});
 }
 
 function getAuthenticationHeader(ident: Ident, {configuration}: {configuration: Configuration}) {
-  const authConfiguration = npmConfigUtils.getAuthenticationConfiguration(ident, configuration);
+  const authConfiguration = npmConfigUtils.getAuthenticationConfiguration(ident, {configuration});
   const mustAuthenticate = authConfiguration.get(`npmAlwaysAuth`);
 
   if (!mustAuthenticate && !ident.scope)

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,6 +1,8 @@
 import {Configuration, Ident, httpUtils} from '@berry/core';
 import {MessageName, ReportError}        from '@berry/core';
 
+import * as npmConfigUtils               from './npmConfigUtils';
+
 export type Options = httpUtils.Options & {
   ident: Ident,
 };
@@ -25,16 +27,16 @@ export async function put(url: string, body: httpUtils.Body, {configuration, hea
 }
 
 function getAuthenticationHeader(ident: Ident, {configuration}: {configuration: Configuration}) {
-  const mustAuthenticate = configuration.get(`npmAlwaysAuth`);
+  const authConfiguration = npmConfigUtils.getAuthenticationConfiguration(ident, configuration);
+  const mustAuthenticate = authConfiguration.get(`npmAlwaysAuth`);
 
   if (!mustAuthenticate && !ident.scope)
     return null;
 
-  if (configuration.get(`npmAuthToken`))
-    return `Bearer ${configuration.get(`npmAuthToken`)}`;
-
-  if (configuration.get(`npmAuthIdent`))
-    return `Basic ${configuration.get(`npmAuthIdent`)}`;
+  if (authConfiguration.get(`npmAuthToken`))
+    return `Bearer ${authConfiguration.get(`npmAuthToken`)}`;
+  if (authConfiguration.get(`npmAuthIdent`))
+    return `Basic ${authConfiguration.get(`npmAuthIdent`)}`;
 
   if (mustAuthenticate) {
     throw new ReportError(MessageName.AUTHENTICATION_NOT_FOUND ,`No authentication configured for request`);


### PR DESCRIPTION
As discussed at https://github.com/yarnpkg/berry/pull/95#discussion_r278822902

I've verified the behaviour by running it against a repo at work and only using our internal SonaType Nexus 3 registry for our private packages.

TODO:

- [ ] add tests for this
- [x] get answers to questions inline
- [x] get default values for top-level `SHAPE`-type configuration values to work

Finishes #10 