### PR TITLE
Adds a new plugin for the npm cli commands

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -8691,6 +8691,10 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                   "workspace:packages/plugin-npm"
                 ],
                 [
+                  "@berry/plugin-npm-cli",
+                  "workspace:packages/plugin-npm-cli"
+                ],
+                [
                   "@berry/plugin-pack",
                   "workspace:packages/plugin-pack"
                 ],
@@ -9699,6 +9703,35 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                 [
                   "semver",
                   "npm:5.6.0"
+                ]
+              ]
+            }
+          ]
+        ]
+      ],
+      [
+        "@berry/plugin-npm-cli",
+        [
+          [
+            "workspace:packages/plugin-npm-cli",
+            {
+              "packageLocation": "./packages/plugin-npm-cli/",
+              "packageDependencies": [
+                [
+                  "@berry/plugin-npm-cli",
+                  "workspace:packages/plugin-npm-cli"
+                ],
+                [
+                  "@berry/cli",
+                  "workspace:packages/berry-cli"
+                ],
+                [
+                  "@berry/core",
+                  "workspace:packages/berry-core"
+                ],
+                [
+                  "@berry/plugin-npm",
+                  "workspace:packages/plugin-npm"
                 ]
               ]
             }
@@ -66501,6 +66534,7 @@ function $$SETUP_STATE(hydrateRuntimeState) {
       30,
       29,
       28,
+      26,
       25,
       24,
       23,

--- a/packages/berry-cli/package.json
+++ b/packages/berry-cli/package.json
@@ -29,6 +29,7 @@
     "@berry/plugin-init": "workspace:*",
     "@berry/plugin-link": "workspace:*",
     "@berry/plugin-npm": "workspace:*",
+    "@berry/plugin-npm-cli": "workspace:*",
     "@berry/plugin-pack": "workspace:*",
     "@berry/plugin-pnp": "workspace:*",
     "@berry/plugin-typescript": "workspace:*",
@@ -50,6 +51,7 @@
         "@berry/plugin-init",
         "@berry/plugin-link",
         "@berry/plugin-npm",
+        "@berry/plugin-npm-cli",
         "@berry/plugin-pack",
         "@berry/plugin-pnp"
       ]

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@berry/plugin-npm-cli",
+  "private": true,
+  "main": "./sources/index.ts",
+  "dependencies": {
+    "@berry/cli": "workspace:*",
+    "@berry/core": "workspace:*",
+    "@berry/plugin-npm": "workspace:*"
+  }
+}

--- a/packages/plugin-npm-cli/sources/index.ts
+++ b/packages/plugin-npm-cli/sources/index.ts
@@ -1,0 +1,7 @@
+import {Plugin} from '@berry/core';
+
+const plugin: Plugin = {
+};
+
+// eslint-disable-next-line arca/no-default-export
+export default plugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,6 +1517,7 @@ __metadata:
     "@berry/plugin-init": "workspace:*"
     "@berry/plugin-link": "workspace:*"
     "@berry/plugin-npm": "workspace:*"
+    "@berry/plugin-npm-cli": "workspace:*"
     "@berry/plugin-pack": "workspace:*"
     "@berry/plugin-pnp": "workspace:*"
     "@berry/plugin-typescript": "workspace:*"
@@ -1816,6 +1817,16 @@ __metadata:
   dependencies:
     "@berry/core": "workspace:*"
     "@berry/fslib": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@berry/plugin-npm-cli@workspace:*, @berry/plugin-npm-cli@workspace:packages/plugin-npm-cli":
+  version: 0.0.0
+  resolution: "@berry/plugin-npm-cli@workspace:packages/plugin-npm-cli"
+  dependencies:
+    "@berry/cli": "workspace:*"
+    "@berry/core": "workspace:*"
+    "@berry/plugin-npm": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This diff adds a new plugin (`plugin-npm-cli`) to contain all the npm-specific commands.

Ref #121 