### PR TITLE
Implements publishConfig.main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 
 ### Package manifests (`package.json`)
 
-  - Two new fields are now supported: `dependenciesMeta` and `peerDependenciesMeta` (`peerDependenciesMeta` actually was supported in Yarn 1 as well, but `dependenciesMeta` is a new addition). These fields are meant to store dependency settings unique to each package.
+  - Two new fields are now supported in the `publishConfig` key of your manifests: the `main` and `module` fields will be used to replace the value of their respective top-level counterparts in the manifest shipped along with the generated file.
+
+  - Two new fields are now supported at the root of the manifest: `dependenciesMeta` and `peerDependenciesMeta` (`peerDependenciesMeta` actually was supported in Yarn 1 as well, but `dependenciesMeta` is a new addition). These fields are meant to store dependency settings unique to each package.
 
     - Both of these new fields, and all settings the support, are entirely optional. Yarn will keep doing what you expect if they're not there - they're just a mechanism to expose more fine-grained settings.
 

--- a/packages/berry-libzip/package.json
+++ b/packages/berry-libzip/package.json
@@ -4,5 +4,8 @@
   "main": "./sources/index.ts",
   "scripts": {
     "build:libzip": "cd ./artifacts && ./build.sh"
+  },
+  "publishConfig": {
+    "main": "./lib"
   }
 }

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -37,6 +37,20 @@ const PackageJsonDoc = () => <>
         </>}
       />
       <JsonStringProperty
+        name={`main`}
+        placeholder={`./sources/index.js`}
+        description={<>
+          The path that will be used to resolve the qualified path to use when accessing the package by its name. This field can be modified at publish-time through the use of the <code>publishConfig.main</code> field.
+        </>}
+      />
+      <JsonStringProperty
+        name={`module`}
+        placeholder={`./sources/index.mjs`}
+        description={<>
+          The path that will be used when an ES6-compatible environment will try to access the package by its name. Doesn't have any direct effect on Yarn itself.
+        </>}
+      />
+      <JsonStringProperty
         name={`languageName`}
         placeholder={`node`}
         description={<>
@@ -194,6 +208,24 @@ const PackageJsonDoc = () => <>
         <JsonStringProperty
           name={`@babel/core/@npm:babel/generator@npm:^7.0.0`}
           placeholder={`7.3.4`}
+        />
+      </JsonObjectProperty>
+      <JsonObjectProperty
+        name={`publishConfig`}
+      >
+        <JsonStringProperty
+          name={`main`}
+          placeholder={`./build/index.js`}
+          description={<>
+            If present, the top-level <code>main</code> field from the manifest will be set to this new value before the package is packed to be shipped to remote registries. This won't modified the actual file, just the one in the tarball.
+          </>}
+        />
+        <JsonStringProperty
+          name={`module`}
+          placeholder={`./build/index.mjs`}
+          description={<>
+            Same principle as the <code>publishConfig.main</code> property; this value will be used instead of the top-level <code>module</code> field when generating the workspace tarball.
+          </>}
         />
       </JsonObjectProperty>
     </JsonContainer>

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -53,7 +53,7 @@ export async function genPackStream(workspace: Workspace, files?: Array<string>)
             }
           }
 
-          content = JSON.stringify(data, null, 2);
+          content = Buffer.from(JSON.stringify(data, null, 2));
         }
 
         pack.entry({... opts, type: `file`}, content, cb);

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -37,10 +37,29 @@ export async function genPackStream(workspace: Workspace, files?: Array<string>)
         }
       };
 
-      if (stat.isFile()) 
-        pack.entry({... opts, type: `file`}, await xfs.readFilePromise(source), cb);
-      else if (stat.isSymbolicLink()) 
+      if (stat.isFile()) {
+        let content = await xfs.readFilePromise(source);
+
+        // The root package.json supports replacement fields in publishConfig
+        if (file === `package.json`) {
+          const data = JSON.parse(content.toString());
+
+          if (data.publishConfig) {
+            if (data.publishConfig.main)
+              data.main = data.publishConfig.main;
+            
+            if (data.publishConfig.module) {
+              data.module = data.publishConfig.module;
+            }
+          }
+
+          content = JSON.stringify(data, null, 2);
+        }
+
+        pack.entry({... opts, type: `file`}, content, cb);
+      } else if (stat.isSymbolicLink()) {
         pack.entry({... opts, type: `symlink`, linkname: await xfs.readlinkPromise(source)}, cb);
+      }
 
       await awaitTarget;
     }


### PR DESCRIPTION
I think it happens often that you would want to use a different `main` entry for your local development than after the packages have been published to the Yarn registry (for example in this very repository we want the `main` fields to point towards our TypeScript sources in most cases, but towards the JS sources when they're downloaded from the registry). To this effect I implemented two special fields in the `package.json` that allow just that.

Also note that it's even more important in a workspace-oriented environment, because packages often require each other by their name (which often isn't the case with traditional setups).