### PR TITLE
Publish fixes

### DIFF
--- a/packages/berry-pnpify/package.json
+++ b/packages/berry-pnpify/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@berry/pnpify",
   "private": true,
+  "sideEffects": false,
+  "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "bin": {
     "pnpify": "./bin.js"
-  },
-  "types": "./lib/index.d.ts",
-  "sideEffects": false,
-  "peerDependencies": {
-    "pnpapi": "^0.0.0"
   },
   "scripts": {
     "build:pnpify": "run webpack-cli --config webpack.config.pkg.js",
@@ -22,6 +19,10 @@
     "webpack-cli": "npm:3.2.1"
   },
   "dependencies": {
-    "@berry/fslib": "workspace:*"
-  }
+    "@berry/fslib": "^0.0.4"
+  },
+  "files": [
+    "/lib/*",
+    "/bin.js"
+  ]
 }

--- a/packages/berry-pnpify/package.json
+++ b/packages/berry-pnpify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@berry/pnpify",
-  "private": true,
+  "version": "0.0.1",
   "sideEffects": false,
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -61,7 +61,11 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
         const body = makePublishBody(workspace, buffer, {access, tag});
   
         try {
-          await npmHttpUtils.put(`/${structUtils.stringifyIdent(ident)}`, body, {
+          const path = ident.scope
+            ? `/@${ident.scope}%2f${ident.name}`
+            : `/${ident.name}`;
+
+          await npmHttpUtils.put(path, body, {
             configuration,
             ident,
             json: true,

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -46,7 +46,7 @@ export async function prepareForPack(workspace: Workspace, {report}: {report: Re
   const stdout = new PassThrough();
   const stderr = new PassThrough();
 
-  if (scriptUtils.hasWorkspaceScript(workspace, `prepack`)) {
+  if (await scriptUtils.hasWorkspaceScript(workspace, `prepack`)) {
     report.reportInfo(MessageName.LIFECYCLE_SCRIPT, `Calling the "prepack" lifecycle script`);
     await scriptUtils.executeWorkspaceScript(workspace, `prepack`, [], {stdin, stdout, stderr});
   }
@@ -54,7 +54,7 @@ export async function prepareForPack(workspace: Workspace, {report}: {report: Re
   try {
     await cb();
   } finally {
-    if (scriptUtils.hasWorkspaceScript(workspace, `postpack`)) {
+    if (await scriptUtils.hasWorkspaceScript(workspace, `postpack`)) {
       report.reportInfo(MessageName.LIFECYCLE_SCRIPT, `Calling the "postpack" lifecycle script`);
       await scriptUtils.executeWorkspaceScript(workspace, `postpack`, [], {stdin, stdout, stderr});
     }


### PR DESCRIPTION
This diff fixes two issues I spotted with the publish workflow:

- The pack was checking whether the workspaces had the prepack/postpack scripts, but because I forgot to await the promise it was always truthy.

- The remote path to publish packages needs to have the `/` escaped when working with scoped packages. This was causing the server to timeout.