### PR TITLE
PnPify: Symlink all the PnP files to their realpath

### DIFF
--- a/packages/berry-pnpify/lib/index.js
+++ b/packages/berry-pnpify/lib/index.js
@@ -1249,6 +1249,13 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         }
         return onRealPath();
     }
+    static makeSymlinkStats(stats) {
+        return Object.assign(stats, {
+            isFile: () => false,
+            isDirectory: () => false,
+            isSymbolicLink: () => true
+        });
+    }
     static createFsError(code, message) {
         return Object.assign(new Error(code + ': ' + message), { code });
     }
@@ -1331,10 +1338,10 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         return this.baseFs.statSync(this.resolveDirOrFilePath(p));
     }
     async lstatPromise(p) {
-        return this.resolveLink(p, 'lstat', (stats) => Object.assign(stats, { isSymbolicLink: () => true }), async () => await this.baseFs.lstatPromise(p));
+        return this.resolveLink(p, 'lstat', (stats) => NodeModulesFS_NodeModulesFS.makeSymlinkStats(stats), async () => await this.baseFs.lstatPromise(p));
     }
     lstatSync(p) {
-        return this.resolveLink(p, 'lstat', (stats) => Object.assign(stats, { isSymbolicLink: () => true }), () => this.baseFs.lstatSync(p));
+        return this.resolveLink(p, 'lstat', (stats) => NodeModulesFS_NodeModulesFS.makeSymlinkStats(stats), () => this.baseFs.lstatSync(p));
     }
     async chmodPromise(p, mask) {
         return await this.baseFs.chmodPromise(this.throwIfPathReadonly('chmod', p), mask);

--- a/packages/berry-pnpify/lib/index.js
+++ b/packages/berry-pnpify/lib/index.js
@@ -226,6 +226,7 @@ __webpack_require__.r(__webpack_exports__);
 
 // EXTERNAL MODULE: external "path"
 var external_path_ = __webpack_require__(1);
+var external_path_default = /*#__PURE__*/__webpack_require__.n(external_path_);
 
 // CONCATENATED MODULE: ../berry-fslib/sources/FakeFS.ts
 
@@ -885,26 +886,6 @@ class PosixFS_PosixFS extends FakeFS_FakeFS {
 
 
 
-function wrapSync(fn) {
-    return fn;
-}
-function wrapAsync(fn) {
-    return function (...args) {
-        const cb = typeof args[args.length - 1] === `function`
-            ? args.pop()
-            : null;
-        setImmediate(() => {
-            let error, result;
-            try {
-                result = fn(...args);
-            }
-            catch (caught) {
-                error = caught;
-            }
-            cb(error, result);
-        });
-    };
-}
 function patchFs(patchedFs, fakeFs) {
     const SYNC_IMPLEMENTATIONS = new Set([
         `accessSync`,
@@ -1050,7 +1031,7 @@ class NodePathResolver {
      * This method extracts `.../node_modules/pkgName/...` from the path
      * and uses previous package as an issuer for the next package.
      *
-     * @param nodePath path containing `node_modules`
+     * @param nodePath full path containing `node_modules`
      *
      * @returns resolved path
      */
@@ -1217,6 +1198,7 @@ var PnPApiLocator = __webpack_require__(3);
 
 
 
+
 class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
     constructor({ baseFs = new PosixFS_PosixFS(new NodeFS_NodeFS()) } = {}) {
         super();
@@ -1232,8 +1214,12 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
     getBaseFs() {
         return this.baseFs;
     }
+    resolvePath(p) {
+        const fullOriginalPath = external_path_default.a.resolve(p);
+        return Object.assign({}, this.pathResolver.resolvePath(fullOriginalPath), { fullOriginalPath });
+    }
     resolveFilePath(p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
+        const pnpPath = this.resolvePath(p);
         if (!pnpPath.resolvedPath) {
             throw NodeModulesFS_NodeModulesFS.createFsError('ENOENT', `no such file or directory, stat '${p}'`);
         }
@@ -1241,12 +1227,34 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
             return pnpPath.resolvedPath;
         }
     }
+    resolveLink(p, op, onSymlink, onRealPath) {
+        const pnpPath = this.resolvePath(p);
+        if (!pnpPath.resolvedPath) {
+            throw NodeModulesFS_NodeModulesFS.createFsError('ENOENT', `no such file or directory, ${op} '${p}'`);
+        }
+        else {
+            if (pnpPath.resolvedPath !== pnpPath.fullOriginalPath) {
+                try {
+                    const stats = this.baseFs.lstatSync(pnpPath.statPath || pnpPath.resolvedPath);
+                    if (stats.isDirectory()) {
+                        throw NodeModulesFS_NodeModulesFS.createFsError('EINVAL', `invalid argument, ${op} '${p}'`);
+                    }
+                    else {
+                        return onSymlink(stats, external_path_default.a.relative(external_path_default.a.dirname(pnpPath.fullOriginalPath), pnpPath.statPath || pnpPath.resolvedPath));
+                    }
+                }
+                catch (e) {
+                }
+            }
+        }
+        return onRealPath();
+    }
     static createFsError(code, message) {
         return Object.assign(new Error(code + ': ' + message), { code });
     }
     throwIfPathReadonly(op, p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
-        if (pnpPath.resolvedPath !== p) {
+        const pnpPath = this.resolvePath(p);
+        if (pnpPath.resolvedPath !== pnpPath.fullOriginalPath) {
             throw NodeModulesFS_NodeModulesFS.createFsError('EPERM', `operation not permitted, ${op} '${p}'`);
         }
         else {
@@ -1254,7 +1262,7 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         }
     }
     resolveDirOrFilePath(p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
+        const pnpPath = this.resolvePath(p);
         if (!pnpPath.resolvedPath) {
             throw NodeModulesFS_NodeModulesFS.createFsError('ENOENT', `no such file or directory, stat '${p}'`);
         }
@@ -1287,7 +1295,7 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         return this.baseFs.realpathSync(this.resolveFilePath(p));
     }
     async existsPromise(p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
+        const pnpPath = this.resolvePath(p);
         if (!pnpPath.resolvedPath) {
             return false;
         }
@@ -1299,7 +1307,7 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         }
     }
     existsSync(p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
+        const pnpPath = this.resolvePath(p);
         if (!pnpPath.resolvedPath) {
             return false;
         }
@@ -1323,10 +1331,10 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         return this.baseFs.statSync(this.resolveDirOrFilePath(p));
     }
     async lstatPromise(p) {
-        return await this.baseFs.lstatPromise(this.resolveDirOrFilePath(p));
+        return this.resolveLink(p, 'lstat', (stats) => Object.assign(stats, { isSymbolicLink: () => true }), async () => await this.baseFs.lstatPromise(p));
     }
     lstatSync(p) {
-        return this.baseFs.lstatSync(this.resolveDirOrFilePath(p));
+        return this.resolveLink(p, 'lstat', (stats) => Object.assign(stats, { isSymbolicLink: () => true }), () => this.baseFs.lstatSync(p));
     }
     async chmodPromise(p, mask) {
         return await this.baseFs.chmodPromise(this.throwIfPathReadonly('chmod', p), mask);
@@ -1401,7 +1409,7 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         }
     }
     async readdirPromise(p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
+        const pnpPath = this.resolvePath(p);
         if (!pnpPath.resolvedPath) {
             throw NodeModulesFS_NodeModulesFS.createFsError('ENOENT', `no such file or directory, scandir '${p}'`);
         }
@@ -1413,7 +1421,7 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         }
     }
     readdirSync(p) {
-        const pnpPath = this.pathResolver.resolvePath(p);
+        const pnpPath = this.resolvePath(p);
         if (!pnpPath.resolvedPath) {
             throw NodeModulesFS_NodeModulesFS.createFsError('ENOENT', `no such file or directory, scandir '${p}'`);
         }
@@ -1425,10 +1433,10 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
         }
     }
     async readlinkPromise(p) {
-        return await this.baseFs.readlinkPromise(this.resolveDirOrFilePath(p));
+        return this.resolveLink(p, 'readlink', (_stats, targetPath) => targetPath, async () => await this.baseFs.readlinkPromise(p));
     }
     readlinkSync(p) {
-        return this.baseFs.readlinkSync(this.resolveDirOrFilePath(p));
+        return this.resolveLink(p, 'readlink', (_stats, targetPath) => targetPath, () => this.baseFs.readlinkSync(p));
     }
 }
 
@@ -1436,7 +1444,6 @@ class NodeModulesFS_NodeModulesFS extends FakeFS_FakeFS {
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "patchFs", function() { return sources_patchFs; });
 /* concated harmony reexport PnPApiLocator */__webpack_require__.d(__webpack_exports__, "PnPApiLocator", function() { return PnPApiLocator["a" /* PnPApiLocator */]; });
 /* concated harmony reexport NodeModulesFS */__webpack_require__.d(__webpack_exports__, "NodeModulesFS", function() { return NodeModulesFS_NodeModulesFS; });
-
 
 
 
@@ -1450,9 +1457,10 @@ const sources_patchFs = () => {
         fsPatched = true;
     }
 };
-
 if (!process.mainModule)
     sources_patchFs();
+
+
 
 
 /***/ })

--- a/packages/berry-pnpify/lib/tsserver.js
+++ b/packages/berry-pnpify/lib/tsserver.js
@@ -212,19 +212,19 @@ class PnPApiLocator {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _dynamicRequire__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(2);
-/* harmony import */ var _PnPApiLocator__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(3);
+/* harmony import */ var _PnPApiLocator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
+/* harmony import */ var _dynamicRequire__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 
 
-process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + `-r ${_dynamicRequire__WEBPACK_IMPORTED_MODULE_0__[/* dynamicRequire */ "a"].resolve('.')}`;
-const pnpApiPath = new _PnPApiLocator__WEBPACK_IMPORTED_MODULE_1__[/* PnPApiLocator */ "a"]().findApi(__dirname);
+process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || '') + `-r ${_dynamicRequire__WEBPACK_IMPORTED_MODULE_1__[/* dynamicRequire */ "a"].resolve('.')}`;
+const pnpApiPath = new _PnPApiLocator__WEBPACK_IMPORTED_MODULE_0__[/* PnPApiLocator */ "a"]().findApi(__dirname);
 if (pnpApiPath) {
     process.mainModule.id = 'internal/preload';
-    Object(_dynamicRequire__WEBPACK_IMPORTED_MODULE_0__[/* dynamicRequire */ "a"])(pnpApiPath);
+    Object(_dynamicRequire__WEBPACK_IMPORTED_MODULE_1__[/* dynamicRequire */ "a"])(pnpApiPath);
     process.env.NODE_OPTIONS += ` -r ${pnpApiPath}`;
 }
-Object(_dynamicRequire__WEBPACK_IMPORTED_MODULE_0__[/* dynamicRequire */ "a"])('.').patchFs();
-Object(_dynamicRequire__WEBPACK_IMPORTED_MODULE_0__[/* dynamicRequire */ "a"])('typescript/lib/tsserver');
+Object(_dynamicRequire__WEBPACK_IMPORTED_MODULE_1__[/* dynamicRequire */ "a"])('.').patchFs();
+Object(_dynamicRequire__WEBPACK_IMPORTED_MODULE_1__[/* dynamicRequire */ "a"])('typescript/lib/tsserver');
 
 
 /***/ })

--- a/packages/berry-pnpify/sources/NodeModulesFS.ts
+++ b/packages/berry-pnpify/sources/NodeModulesFS.ts
@@ -2,8 +2,9 @@ import { CreateReadStreamOptions, CreateWriteStreamOptions } from '@berry/fslib'
 import { NodeFS, PosixFS, FakeFS, WriteFileOptions }         from '@berry/fslib';
 
 import fs                                                    from 'fs';
+import path                                                  from 'path';
 
-import { NodePathResolver }                                  from './NodePathResolver';
+import { NodePathResolver, ResolvedPath }                    from './NodePathResolver';
 import { PnPApiLoader }                                      from './PnPApiLoader';
 import { PnPApiLocator }                                     from './PnPApiLocator';
 
@@ -33,8 +34,13 @@ export class NodeModulesFS extends FakeFS {
     return this.baseFs;
   }
 
+  private resolvePath(p: string): ResolvedPath & { fullOriginalPath: string } {
+    const fullOriginalPath = path.resolve(p);
+    return { ...this.pathResolver.resolvePath(fullOriginalPath), fullOriginalPath };
+  }
+
   private resolveFilePath(p: string): string {
-    const pnpPath = this.pathResolver.resolvePath(p);
+    const pnpPath = this.resolvePath(p);
     if (!pnpPath.resolvedPath) {
       throw NodeModulesFS.createFsError('ENOENT', `no such file or directory, stat '${p}'`);
     } else {
@@ -42,13 +48,33 @@ export class NodeModulesFS extends FakeFS {
     }
   }
 
+  private resolveLink(p: string, op: string, onSymlink: (stats: fs.Stats, targetPath: string) => any, onRealPath: () => any) {
+    const pnpPath = this.resolvePath(p);
+    if (!pnpPath.resolvedPath) {
+      throw NodeModulesFS.createFsError('ENOENT', `no such file or directory, ${op} '${p}'`);
+    } else {
+      if (pnpPath.resolvedPath !== pnpPath.fullOriginalPath) {
+        try {
+          const stats = this.baseFs.lstatSync(pnpPath.statPath || pnpPath.resolvedPath);
+          if (stats.isDirectory()) {
+            throw NodeModulesFS.createFsError('EINVAL', `invalid argument, ${op} '${p}'`);
+          } else {
+            return onSymlink(stats, path.relative(path.dirname(pnpPath.fullOriginalPath), pnpPath.statPath || pnpPath.resolvedPath));
+          }
+        } catch (e) {
+        }
+      }
+    }
+    return onRealPath();
+  }
+
   private static createFsError(code: string, message: string) {
     return Object.assign(new Error(code + ': ' + message), { code });
   }
 
   private throwIfPathReadonly(op: string, p: string): string {
-    const pnpPath = this.pathResolver.resolvePath(p);
-    if (pnpPath.resolvedPath !== p) {
+    const pnpPath = this.resolvePath(p);
+    if (pnpPath.resolvedPath !== pnpPath.fullOriginalPath) {
       throw NodeModulesFS.createFsError('EPERM', `operation not permitted, ${op} '${p}'`);
     } else {
       return p;
@@ -56,7 +82,7 @@ export class NodeModulesFS extends FakeFS {
   }
 
   private resolveDirOrFilePath(p: string): string {
-    const pnpPath = this.pathResolver.resolvePath(p);
+    const pnpPath = this.resolvePath(p);
     if (!pnpPath.resolvedPath) {
       throw NodeModulesFS.createFsError('ENOENT', `no such file or directory, stat '${p}'`);
     } else {
@@ -97,7 +123,7 @@ export class NodeModulesFS extends FakeFS {
   }
 
   async existsPromise(p: string) {
-    const pnpPath = this.pathResolver.resolvePath(p);
+    const pnpPath = this.resolvePath(p);
     if (!pnpPath.resolvedPath) {
       return false;
     } else if (pnpPath.statPath) {
@@ -108,7 +134,7 @@ export class NodeModulesFS extends FakeFS {
   }
 
   existsSync(p: string) {
-    const pnpPath = this.pathResolver.resolvePath(p);
+    const pnpPath = this.resolvePath(p);
     if (!pnpPath.resolvedPath) {
       return false;
     } else if (pnpPath.statPath) {
@@ -135,11 +161,17 @@ export class NodeModulesFS extends FakeFS {
   }
 
   async lstatPromise(p: string) {
-    return await this.baseFs.lstatPromise(this.resolveDirOrFilePath(p));
+    return this.resolveLink(p, 'lstat',
+      (stats) => Object.assign(stats, { isSymbolicLink: () => true }),
+      async () => await this.baseFs.lstatPromise(p)
+    );
   }
 
   lstatSync(p: string) {
-    return this.baseFs.lstatSync(this.resolveDirOrFilePath(p));
+    return this.resolveLink(p, 'lstat',
+      (stats) => Object.assign(stats, { isSymbolicLink: () => true }),
+      () => this.baseFs.lstatSync(p)
+    );
   }
 
   async chmodPromise(p: string, mask: number) {
@@ -239,7 +271,7 @@ export class NodeModulesFS extends FakeFS {
   }
 
   async readdirPromise(p: string) {
-    const pnpPath = this.pathResolver.resolvePath(p);
+    const pnpPath = this.resolvePath(p);
     if (!pnpPath.resolvedPath) {
       throw NodeModulesFS.createFsError('ENOENT', `no such file or directory, scandir '${p}'`);
     } else if (pnpPath.dirList) {
@@ -250,7 +282,7 @@ export class NodeModulesFS extends FakeFS {
   }
 
   readdirSync(p: string) {
-    const pnpPath = this.pathResolver.resolvePath(p);
+    const pnpPath = this.resolvePath(p);
     if (!pnpPath.resolvedPath) {
       throw NodeModulesFS.createFsError('ENOENT', `no such file or directory, scandir '${p}'`);
     } else if (pnpPath.dirList) {
@@ -261,10 +293,16 @@ export class NodeModulesFS extends FakeFS {
   }
 
   async readlinkPromise(p: string) {
-    return await this.baseFs.readlinkPromise(this.resolveDirOrFilePath(p));
+    return this.resolveLink(p, 'readlink',
+      (_stats, targetPath) => targetPath,
+      async () => await this.baseFs.readlinkPromise(p)
+    );
   }
 
   readlinkSync(p: string) {
-    return this.baseFs.readlinkSync(this.resolveDirOrFilePath(p));
+    return this.resolveLink(p, 'readlink',
+      (_stats, targetPath) => targetPath,
+      () => this.baseFs.readlinkSync(p)
+    );
   }
 }

--- a/packages/berry-pnpify/sources/NodeModulesFS.ts
+++ b/packages/berry-pnpify/sources/NodeModulesFS.ts
@@ -68,6 +68,14 @@ export class NodeModulesFS extends FakeFS {
     return onRealPath();
   }
 
+  private static makeSymlinkStats(stats: fs.Stats): fs.Stats {
+    return Object.assign(stats, {
+      isFile: () => false,
+      isDirectory: () => false,
+      isSymbolicLink: () => true
+    });
+  }
+
   private static createFsError(code: string, message: string) {
     return Object.assign(new Error(code + ': ' + message), { code });
   }
@@ -162,14 +170,14 @@ export class NodeModulesFS extends FakeFS {
 
   async lstatPromise(p: string) {
     return this.resolveLink(p, 'lstat',
-      (stats) => Object.assign(stats, { isSymbolicLink: () => true }),
+      (stats) => NodeModulesFS.makeSymlinkStats(stats),
       async () => await this.baseFs.lstatPromise(p)
     );
   }
 
   lstatSync(p: string) {
     return this.resolveLink(p, 'lstat',
-      (stats) => Object.assign(stats, { isSymbolicLink: () => true }),
+      (stats) => NodeModulesFS.makeSymlinkStats(stats),
       () => this.baseFs.lstatSync(p)
     );
   }

--- a/packages/berry-pnpify/sources/NodePathResolver.ts
+++ b/packages/berry-pnpify/sources/NodePathResolver.ts
@@ -118,7 +118,7 @@ export class NodePathResolver {
    * This method extracts `.../node_modules/pkgName/...` from the path
    * and uses previous package as an issuer for the next package.
    *
-   * @param nodePath path containing `node_modules`
+   * @param nodePath full path containing `node_modules`
    *
    * @returns resolved path
    */


### PR DESCRIPTION
This should fix the problem with Webpack including the same package multiple times. The reason Webpack does this under pnpify is because it sees the same npm package in multiple places. To prevent this, we symlink all the PnP files on the emulated fs to their target locations.