### PR TITLE
Implements --inline-builds

### DIFF
--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/install.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/install.js
@@ -1,3 +1,6 @@
 const fs = require(`fs`);
 
+console.log(`install out`);
+console.error(`install err`);
+
 fs.appendFileSync(`${__dirname}/../log.js`, `module.exports.push('install');`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/postinstall.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/postinstall.js
@@ -1,4 +1,7 @@
 const fs = require(`fs`);
 
+console.log(`postinstall out`);
+console.error(`postinstall err`);
+
 fs.appendFileSync(`${__dirname}/../log.js`, `/*${fs.appendFileSync.toString()}*/ module.exports.push('postinstall');`);
 fs.appendFileSync(`${__dirname}/../rnd.js`, `module.exports = ${Math.floor(Math.random() * 512000)};`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/preinstall.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-1.0.0/scripts/preinstall.js
@@ -1,3 +1,6 @@
 const fs = require(`fs`);
 
+console.log(`preinstall out`);
+console.error(`preinstall err`);
+
 fs.appendFileSync(`${__dirname}/../log.js`, `module.exports.push('preinstall');`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Commands add it should print the logs to the standard output when using --inline-builds 1`] = `
+"➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0013: │ no-deps-scripted@npm:1.0.0 can't be found in the cache and will be fetched from the remote registry
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0007: │ no-deps-scripted@npm:1.0.0 must be built because it never did before or the last one failed
+preinstall
+➤ YN0000: │ no-deps-scripted@npm:1.0.0 STDOUT preinstall out
+➤ YN0000: │ no-deps-scripted@npm:1.0.0 STDERR preinstall err
+install
+➤ YN0000: │ no-deps-scripted@npm:1.0.0 STDOUT install out
+➤ YN0000: │ no-deps-scripted@npm:1.0.0 STDERR install err
+postinstall
+➤ YN0000: │ no-deps-scripted@npm:1.0.0 STDOUT postinstall out
+➤ YN0000: │ no-deps-scripted@npm:1.0.0 STDERR postinstall err
+➤ YN0000: └ Completed
+➤ YN0000: Done
+"
+`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -1,0 +1,16 @@
+describe(`Commands`, () => {
+  describe(`add`, () => {
+    test(
+      `it should print the logs to the standard output when using --inline-builds`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-scripted`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        const {stdout} = await run(`install`, `--inline-builds`);
+
+        await expect(stdout).toMatchSnapshot();
+      }),
+    );
+  });
+});

--- a/packages/berry-shell/sources/index.ts
+++ b/packages/berry-shell/sources/index.ts
@@ -208,7 +208,7 @@ function makeCommandAction(args: Array<string>, opts: ShellOptions, state: Shell
 
   const [name, ...rest] = args;
   if (name === `command`) {
-    return makeProcess(rest[0], rest.slice(1), {
+    return makeProcess(rest[0], rest.slice(1), opts, {
       cwd: NodeFS.fromPortablePath(state.cwd),
       env: state.environment,
     });

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -7,7 +7,7 @@ import {Writable}                                                         from '
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
 
-  .command(`install [--frozen-lockfile?]`)
+  .command(`install [--frozen-lockfile?] [--inline-builds?]`)
   .describe(`install the project dependencies`)
 
   .detail(`
@@ -22,6 +22,10 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     - **Build:** Once the dependency tree has been written on the disk, the package manager will now be free to run the build scripts for all packages that might need it, in a topological order compatible with the way they depend on one another.
 
     Note that running this command is not part of the recommended workflow. Yarn supports zero-installs, which means that as long as you store your cache and your .pnp.js file inside your repository, everything will work without requiring any install right after cloning your repository or switching branches.
+
+    If the \`--frozen-lockfile\` option is used, Yarn will abort with an error exit code if anything in the install artifacts (\`yarn.lock\`, \`.pnp.js\`, ...) was to be modified.
+
+    If the \`--inline-builds\` option is used, Yarn will verbosely print the output of the build steps of your dependencies (instead of writing them into individual files). This is likely useful mostly for debug purposes only when using Docker-like environments.
   `)
 
   .example(
@@ -29,7 +33,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     `yarn install`,
   )
 
-  .action(async ({cwd, stdout, frozenLockfile}: {cwd: string, stdout: Writable, frozenLockfile: boolean}) => {
+  .action(async ({cwd, stdout, frozenLockfile, inlineBuilds}: {cwd: string, stdout: Writable, frozenLockfile: boolean, inlineBuilds: boolean}) => {
     const configuration = await Configuration.find(cwd, pluginConfiguration);
 
     if (frozenLockfile === null)
@@ -53,7 +57,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     // in order to ask for design feedback before writing features.
 
     const report = await StreamReport.start({configuration, stdout}, async (report: StreamReport) => {
-      await project.install({cache, report, frozenLockfile});
+      await project.install({cache, report, frozenLockfile, inlineBuilds});
     });
 
     return report.exitCode();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,7 +1571,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@berry/fslib@^0.0.4, @berry/fslib@workspace:*, @berry/fslib@workspace:packages/berry-fslib":
+"@berry/fslib@^0.0.5, @berry/fslib@workspace:*, @berry/fslib@workspace:packages/berry-fslib":
   version: 0.0.0-use.local
   resolution: "@berry/fslib@workspace:packages/berry-fslib"
   dependencies:
@@ -1908,7 +1908,7 @@ __metadata:
   resolution: "@berry/pnp@workspace:packages/berry-pnp"
   dependencies:
     "@berry/builder": "workspace:packages/berry-builder"
-    "@berry/fslib": "workspace:*"
+    "@berry/fslib": ^0.0.5
     webpack: "npm:^4.28.4"
     webpack-cli: "npm:3.2.1"
     webpack-sources: "npm:^1.3.0"
@@ -1920,7 +1920,7 @@ __metadata:
   resolution: "@berry/pnpify@workspace:packages/berry-pnpify"
   dependencies:
     "@berry/builder": "workspace:*"
-    "@berry/fslib": ^0.0.4
+    "@berry/fslib": ^0.0.5
     "@berry/pnp": "workspace:*"
     "@berry/pnpify": "workspace:packages/berry-pnpify"
     webpack: "npm:^4.28.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,7 +1571,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@berry/fslib@^0.0.5, @berry/fslib@workspace:*, @berry/fslib@workspace:packages/berry-fslib":
+"@berry/fslib@^0.0.4, @berry/fslib@workspace:*, @berry/fslib@workspace:packages/berry-fslib":
   version: 0.0.0-use.local
   resolution: "@berry/fslib@workspace:packages/berry-fslib"
   dependencies:
@@ -1908,7 +1908,7 @@ __metadata:
   resolution: "@berry/pnp@workspace:packages/berry-pnp"
   dependencies:
     "@berry/builder": "workspace:packages/berry-builder"
-    "@berry/fslib": ^0.0.5
+    "@berry/fslib": "workspace:*"
     webpack: "npm:^4.28.4"
     webpack-cli: "npm:3.2.1"
     webpack-sources: "npm:^1.3.0"
@@ -1920,7 +1920,7 @@ __metadata:
   resolution: "@berry/pnpify@workspace:packages/berry-pnpify"
   dependencies:
     "@berry/builder": "workspace:*"
-    "@berry/fslib": ^0.0.5
+    "@berry/fslib": ^0.0.4
     "@berry/pnp": "workspace:*"
     "@berry/pnpify": "workspace:packages/berry-pnpify"
     webpack: "npm:^4.28.4"


### PR DESCRIPTION
This diff adds a new option to `yarn install`: `--inline-builds` instructs Yarn to print the build output to the standard output instead of creating temporary files.

cc @deini who wanted to use the new `createStreamReporter` function.