### PR TITLE
Add shorthand version

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/_entry.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/_entry.test.js
@@ -1,0 +1,25 @@
+const semver = require('semver');
+
+describe(`Entry`, () => {
+  describe(`version option`, () => {
+
+    test(
+      `it should print the version from the package.json when given --version`,
+       makeTemporaryEnv({}, async ({path, run, source}) => {
+        const {stdout} = await run(`--version`);
+        const [prefix, version] = stdout.replace("\n", "").split("v")
+        expect(semver.valid(version)).toBeTruthy()
+      }),
+    );
+
+    test(
+      `it should print the version from the package.json when given -v`,
+       makeTemporaryEnv({}, async ({path, run, source}) => {
+        const {stdout} = await run(`-v`);
+        const [prefix, version] = stdout.replace("\n", "").split("v")
+        expect(semver.valid(version)).toBeTruthy()
+      }),
+    );
+
+  });
+});

--- a/packages/berry-builder/sources/build-bundle.js
+++ b/packages/berry-builder/sources/build-bundle.js
@@ -9,6 +9,11 @@ const dynamicLibs = require(`./dynamic-libs`);
 const findPlugins = require(`./find-plugins`);
 const makeConfig = require(`./make-config`);
 
+const pkgJsonVersion = () => {
+  const pkgJson = require(`${basedir}/package.json`);
+  return JSON.stringify(pkgJson["version"]);
+}
+
 clipanion
   .command(`[-w,--watch] [--profile TYPE] [--plugin PLUGIN ...]`)
   .action(async ({watch, profile, plugin, stdout, stderr}) => {
@@ -50,6 +55,7 @@ clipanion
           banner: `#!/usr/bin/env node`,
           raw: true,
         }),
+        new webpack.DefinePlugin({[`BERRY_VERSION`]: pkgJsonVersion() }),
       ],
     }));
 
@@ -81,7 +87,6 @@ clipanion
           reject(err);
         } else {
           const erroredStats = [];
-
           for (const stats of allStats)
             if (stats.compilation.errors.length > 0)
               erroredStats.push(stats.toString(`errors-only`));

--- a/packages/berry-cli/package.json
+++ b/packages/berry-cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@berry/cli",
+  "version": "2.0.0",
   "private": true,
   "main": "./sources/index.ts",
   "bin": {

--- a/packages/plugin-essentials/sources/commands/_entry.ts
+++ b/packages/plugin-essentials/sources/commands/_entry.ts
@@ -10,8 +10,9 @@ export default (clipanion: any) => clipanion
 
   .action(async ({cwd, version, args, stdout, ... env}: any) => {
     // berry --version
-    if (args.length === 1 && args[0] === `--version`) {
-      stdout.write(`v2.0.0\n`);
+    if (args.length === 1 && (args[0] === `--version` || args[0] === `-v`)) {
+      // Injected via webpack DefinePlugin
+      stdout.write(`v${BERRY_VERSION}\n`);
 
     // berry --help
     } else if (args.length === 1 && (args[0] === `--help` || args[0] === `-h`)) {

--- a/packages/plugin-essentials/sources/commands/index.d.ts
+++ b/packages/plugin-essentials/sources/commands/index.d.ts
@@ -1,0 +1,2 @@
+// Global var injected by build-bundle.js
+declare var BERRY_VERSION: string;


### PR DESCRIPTION
### Description

- Adds support for `yarn -v` alongside `yarn --version`
- Injects version via a webpack defined global `BERRY_VERSION`

Fixes #164 

### Tests
- Added snapshot tests for new `-v` and existing `--version`

It's difficult to mock the version via the temporary env due to the constant being injected ... 