### PR TITLE
Update regex for github urls

### DIFF
--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -10,6 +10,7 @@
     "@berry/fslib": "workspace:*"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "run test:unit packages/plugin-github"
   }
 }

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -1,10 +1,10 @@
 
 const githubPatterns = [
   /^github:([^\/#]+)\/([^\/#]+)(?:#(.+))?$/,
-  /^[git@github.com:|git:\/\/github.com]+([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
+  /^(?:git@github.com:|git:\/\/github\.com)\/?([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
   /^git\+https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
   /^https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\/tarball\/([^\/#]+)(?:#|$)/,
-  /^[http|https]+:\/\/.*github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
+  /^(?:http|https):\/\/.*github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
 ];
 
 /**
@@ -46,10 +46,5 @@ export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
 }
 
 export function invalidGithubUrlMessage(url: string): string {
-  const message = `Input cannot be parsed as a valid Github URL ('${url}').\n
-  Consider trying:\n
-  https://github.com/username/repo.git\n
-  `
-
-  return message;
+  return `Input cannot be parsed as a valid Github URL ('${url}').`
 }

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -9,8 +9,8 @@ const githubPatterns = [
   /^git@github.com:([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
   /^git:\/\/github\.com\/([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
   /^git\+https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
-  /^https?:\/\/(?:[^@]+@)?github.com\/([^\/#]+)\/([^\/#]+)\/tarball\/([^\/#]+)(?:#|$)/,
-  /^https?:\/\/(?:[^@]+@)?github.com\/([^\/#]+)\/([^\/#]+)(?:\.git)?(?:#(.+))?$/,
+  /^https?:\/\/(?:.+?@)?github.com\/([^\/#]+)\/([^\/#]+)\/tarball\/([^\/#]+)(?:#|$)/,
+  /^https?:\/\/(?:.+?@)?github.com\/([^\/#]+)\/([^\/#]+?)(?:\.git)?(?:#(.+))?$/,
 ];
 
 /**
@@ -25,9 +25,13 @@ export function isGithubUrl(url: string): boolean {
  * an object of type `ParsedGithubUrl`
  */
 export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
-  let match = githubPatterns.find(pattern => {
-    return urlStr.match(pattern);
-  });
+  let match;
+  for (const pattern of githubPatterns) {
+    match = urlStr.match(pattern);
+    if (match) {
+      break;
+    }
+  }
 
   if (!match)
     throw new Error(invalidGithubUrlMessage(urlStr));

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -1,27 +1,55 @@
+
 const githubPatterns = [
   /^github:([^\/#]+)\/([^\/#]+)(?:#(.+))?$/,
-  /^git@github.com:([^\/#]+)\/([^\/#]+)(?:#(.+))?$/,
+  /^[git@github.com:|git:\/\/github.com]+([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
   /^git\+https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
   /^https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\/tarball\/([^\/#]+)(?:#|$)/,
+  /^[http|https]+:\/\/.*github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
 ];
 
-export function isGithubUrl(string: string) {
-  return githubPatterns.some(pattern => !!string.match(pattern));
+/**
+  Determines whether a given url is a valid github git url via regex
+*/
+export function isGithubUrl(url: string): boolean {
+  return url ? githubPatterns.some(pattern => !!url.match(pattern)) : false;
 }
 
-export function parseGithubUrl(string: string) {
-  let match;
+const getBranch = (parsedBranch: string): string | undefined => {
+  return parsedBranch ? parsedBranch : undefined;
+}
+
+interface ParsedGithubUrl {
+  username: string;
+  reponame: string;
+  branch?: string;
+}
+
+/**
+ * Takes a valid github repository url and parses it, returning
+ * an object of type `ParsedGithubUrl`
+ */
+export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
+  let match: Array<string> | null = null;
 
   for (const pattern of githubPatterns) {
-    match = string.match(pattern);
+    match = urlStr.match(pattern);
     if (match) {
       break;
     }
   }
 
   if (!match)
-    throw new Error(`Input cannot be parsed as a valid Github URL ('${string}')`);
+    throw new Error(invalidGithubUrlMessage(urlStr));
 
   const [, username, reponame, branch] = match;
-  return {username, reponame, branch: branch ? branch : undefined};
+  return {username, reponame, branch: getBranch(branch)};
+}
+
+export function invalidGithubUrlMessage(url: string): string {
+  const message = `Input cannot be parsed as a valid Github URL ('${url}').\n
+  Consider trying:\n
+  https://github.com/username/repo.git\n
+  `
+
+  return message;
 }

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -1,10 +1,16 @@
+type ParsedGithubUrl = {
+  username: string;
+  reponame: string;
+  branch?: string;
+};
 
 const githubPatterns = [
   /^github:([^\/#]+)\/([^\/#]+)(?:#(.+))?$/,
-  /^(?:git@github.com:|git:\/\/github\.com)\/?([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
+  /^git@github.com:([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
+  /^git:\/\/github\.com\/([^\/#]+)\/([^\/#]+)\.git(?:#(.+))?$/,
   /^git\+https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
-  /^https:\/\/github.com\/([^\/#]+)\/([^\/#]+)\/tarball\/([^\/#]+)(?:#|$)/,
-  /^(?:http|https):\/\/.*github.com\/([^\/#]+)\/([^\/#]+)\.git?(?:#(.+))?$/,
+  /^https?:\/\/(?:[^@]+@)?github.com\/([^\/#]+)\/([^\/#]+)\/tarball\/([^\/#]+)(?:#|$)/,
+  /^https?:\/\/(?:[^@]+@)?github.com\/([^\/#]+)\/([^\/#]+)(?:\.git)?(?:#(.+))?$/,
 ];
 
 /**
@@ -14,35 +20,20 @@ export function isGithubUrl(url: string): boolean {
   return url ? githubPatterns.some(pattern => !!url.match(pattern)) : false;
 }
 
-const getBranch = (parsedBranch: string): string | undefined => {
-  return parsedBranch ? parsedBranch : undefined;
-}
-
-interface ParsedGithubUrl {
-  username: string;
-  reponame: string;
-  branch?: string;
-}
-
 /**
  * Takes a valid github repository url and parses it, returning
  * an object of type `ParsedGithubUrl`
  */
 export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
-  let match: Array<string> | null = null;
-
-  for (const pattern of githubPatterns) {
-    match = urlStr.match(pattern);
-    if (match) {
-      break;
-    }
-  }
+  let match = githubPatterns.find(pattern => {
+    return urlStr.match(pattern);
+  });
 
   if (!match)
     throw new Error(invalidGithubUrlMessage(urlStr));
 
   const [, username, reponame, branch] = match;
-  return {username, reponame, branch: getBranch(branch)};
+  return {username, reponame, branch};
 }
 
 export function invalidGithubUrlMessage(url: string): string {

--- a/packages/plugin-github/tests/githubUtils.test.ts
+++ b/packages/plugin-github/tests/githubUtils.test.ts
@@ -36,6 +36,7 @@ describe(`githubUtils`, () => {
     it(`should respond false to invalid urls`, () => {
 
       const invalidUrls = [
+        'shttp://github.com/yarnpkg/berry.git#master',
         'got://github.com/yarnpkg/berry#ff786f9f',
         'git://github.com/yarnpkg/berry',
         'http://github.com/yarnpkg',

--- a/packages/plugin-github/tests/githubUtils.test.ts
+++ b/packages/plugin-github/tests/githubUtils.test.ts
@@ -1,75 +1,98 @@
+import { isGithubUrl, parseGithubUrl, invalidGithubUrlMessage } from '../sources/githubUtils';
 
+const validScenarios = [{
+  url: 'git://github.com/yarnpkg/berry.git#ff786f9f',
+  username: 'yarnpkg', reponame: 'berry', branch: 'ff786f9f',
+}, {
+  url: 'git://github.com/yarnpkg/berry.git#foo_bar',
+  username: 'yarnpkg', reponame: 'berry', branch: 'foo_bar',
+}, {
+  url: 'git://github.com/yarnpkg/berry.git#master',
+  username: 'yarnpkg', reponame: 'berry', branch: 'master',
+}, {
+  url: 'git://github.com/yarnpkg/berry.git#Foo-Bar',
+  username: 'yarnpkg', reponame: 'berry', branch: 'Foo-Bar',
+}, {
+  url: 'git://github.com/yarnpkg/berry.git#foo_bar',
+  username: 'yarnpkg', reponame: 'berry', branch: 'foo_bar',
+}, {
+  url: 'git://github.com/yarnpkg/berry.git#v2.0.0',
+  username: 'yarnpkg', reponame: 'berry', branch: 'v2.0.0',
+}, {
+  url: 'git@github.com:yarnpkg/berry.git',
+  username: 'yarnpkg', reponame: 'berry', branch: undefined,
+}, {
+  url: 'git@github.com:yarnpkg/berry-project.git',
+  username: 'yarnpkg', reponame: 'berry-project', branch: undefined,
+}, {
+  url: 'git@github.com:yarnpkg/berry_project.git',
+  username: 'yarnpkg', reponame: 'berry_project', branch: undefined,
+}, {
+  url: 'http://github.com/yarnpkg/berry.git',
+  username: 'yarnpkg', reponame: 'berry', branch: undefined,
+}, {
+  url: 'https://github.com/yarnpkg/berry.git',
+  username: 'yarnpkg', reponame: 'berry', branch: undefined,
+}, {
+  url: 'https://yarnpkg::;*%$:@github.com/yarnpkg/berry.git',
+  username: 'yarnpkg', reponame: 'berry', branch: undefined,
+}, {
+  url: 'https://yarnpkg:$fooABC@:@github.com/yarnpkg/berry.git',
+  username: 'yarnpkg', reponame: 'berry', branch: undefined,
+}, {
+  url: 'https://yarnpkg:password@github.com/yarnpkg/berry.git',
+  username: 'yarnpkg', reponame: 'berry', branch: undefined,
+}];
 
-import { isGithubUrl, parseGithubUrl, invalidGithubUrlMessage } from "../sources/githubUtils";
-
-const validScenarios = [
-  { username: 'yarnpkg', repo: 'berry', branch: 'ff786f9f',   url: 'git://github.com/yarnpkg/berry.git#ff786f9f', },
-  { username: 'yarnpkg', repo: 'berry', branch: 'foo_bar',    url: 'git://github.com/yarnpkg/berry.git#foo_bar', },
-  { username: 'yarnpkg', repo: 'berry', branch: 'master',     url: 'git://github.com/yarnpkg/berry.git#master', },
-  { username: 'yarnpkg', repo: 'berry', branch: 'Foo-Bar',    url: 'git://github.com/yarnpkg/berry.git#Foo-Bar', },
-  { username: 'yarnpkg', repo: 'berry', branch: 'foo_bar',    url: 'git://github.com/yarnpkg/berry.git#foo_bar', },
-  { username: 'yarnpkg', repo: 'berry', branch: 'v2.0.0',     url: 'git://github.com/yarnpkg/berry.git#v2.0.0', },
-  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'git@github.com:yarnpkg/berry.git', },
-  { username: 'yarnpkg', repo: 'berry-project', branch: undefined,   url: 'git@github.com:yarnpkg/berry-project.git', },
-  { username: 'yarnpkg', repo: 'berry_project', branch: undefined,   url: 'git@github.com:yarnpkg/berry_project.git', },
-  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'http://github.com/yarnpkg/berry.git', },
-  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://github.com/yarnpkg/berry.git', },
-  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://yarnpkg::;*%$:@github.com/yarnpkg/berry.git', },
-  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://yarnpkg:$fooABC@:@github.com/yarnpkg/berry.git', },
-  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://yarnpkg:password@github.com/yarnpkg/berry.git' }
-];
+const invalidScenarios = [{
+  url: 'shttp://github.com/yarnpkg/berry.git#master',
+}, {
+  url: 'got://github.com/yarnpkg/berry#ff786f9f',
+}, {
+  url: 'git://github.com/yarnpkg/berry',
+}, {
+  url: 'http://github.com/yarnpkg',
+}];
 
 describe(`githubUtils`, () => {
-
   describe('isGithubUrl', () => {
-
     it('should handle undefined', () => {
       expect(isGithubUrl(undefined)).not.toBeTruthy();
     })
 
-    it(`should respond truthy to valid urls`, () => {
+    for (const scenario of validScenarios) {
+      it(`should properly detect GitHub urls (${scenario.url})`, () => {
+          expect(isGithubUrl(scenario.url)).toBeTruthy();
+      });
+    }
 
-      for (const scenario of validScenarios)
-        expect(isGithubUrl(scenario.url)).toBeTruthy();
-    });
-
-    it(`should respond false to invalid urls`, () => {
-
-      const invalidUrls = [
-        'shttp://github.com/yarnpkg/berry.git#master',
-        'got://github.com/yarnpkg/berry#ff786f9f',
-        'git://github.com/yarnpkg/berry',
-        'http://github.com/yarnpkg',
-      ];
-
-      for (const url of invalidUrls)
-        expect(isGithubUrl(url)).not.toBeTruthy();
-    });
+    for (const scenario of invalidScenarios) {
+      it(`should properly reject invalid GitHub urls (${scenario.url})`, () => {
+        expect(isGithubUrl(scenario.url)).not.toBeTruthy();
+      });
+    }
   })
 
   describe('parseGithubUrl', () => {
-
-    it(`should correctly parse valid github urls`, () => {
-      for (const scenario of validScenarios) {
+    for (const scenario of validScenarios) {
+      it(`should properly parse GitHub urls (${scenario.url})`, () => {
         let parsed = parseGithubUrl(scenario.url);
-        expect(parsed.username).toEqual(scenario.username);
-        expect(parsed.reponame).toEqual(scenario.repo);
-        expect(parsed.branch).toEqual(scenario.branch);
-      }
-    });
 
-    it(`should throw an error given an invalid URL`, () => {
+        expect(parsed).toMatchObject({
+          username: scenario.username,
+          reponame: scenario.reponame,
+          branch: scenario.branch,
+        });
+      });
+    }
+
+    it(`should throw an error when given an invalid URL`, () => {
       const invalidUrl = 'http://invalid.com/yarnpkg/berry.git';
-      let error = undefined;
       const expected = invalidGithubUrlMessage(invalidUrl);
 
-      try {
-        const url = parseGithubUrl(invalidUrl);
-      } catch(e) {
-        error = e.message;
-      }
-
-      expect(error).toEqual(expected);
+      expect(() => {
+        parseGithubUrl(invalidUrl);
+      }).toThrow(expected);
     });
   });
 })

--- a/packages/plugin-github/tests/githubUtils.test.ts
+++ b/packages/plugin-github/tests/githubUtils.test.ts
@@ -1,0 +1,74 @@
+
+
+import { isGithubUrl, parseGithubUrl, invalidGithubUrlMessage } from "../sources/githubUtils";
+
+const validScenarios = [
+  { username: 'yarnpkg', repo: 'berry', branch: 'ff786f9f',   url: 'git://github.com/yarnpkg/berry.git#ff786f9f', },
+  { username: 'yarnpkg', repo: 'berry', branch: 'foo_bar',    url: 'git://github.com/yarnpkg/berry.git#foo_bar', },
+  { username: 'yarnpkg', repo: 'berry', branch: 'master',     url: 'git://github.com/yarnpkg/berry.git#master', },
+  { username: 'yarnpkg', repo: 'berry', branch: 'Foo-Bar',    url: 'git://github.com/yarnpkg/berry.git#Foo-Bar', },
+  { username: 'yarnpkg', repo: 'berry', branch: 'foo_bar',    url: 'git://github.com/yarnpkg/berry.git#foo_bar', },
+  { username: 'yarnpkg', repo: 'berry', branch: 'v2.0.0',     url: 'git://github.com/yarnpkg/berry.git#v2.0.0', },
+  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'git@github.com:yarnpkg/berry.git', },
+  { username: 'yarnpkg', repo: 'berry-project', branch: undefined,   url: 'git@github.com:yarnpkg/berry-project.git', },
+  { username: 'yarnpkg', repo: 'berry_project', branch: undefined,   url: 'git@github.com:yarnpkg/berry_project.git', },
+  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'http://github.com/yarnpkg/berry.git', },
+  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://github.com/yarnpkg/berry.git', },
+  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://yarnpkg::;*%$:@github.com/yarnpkg/berry.git', },
+  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://yarnpkg:$fooABC@:@github.com/yarnpkg/berry.git', },
+  { username: 'yarnpkg', repo: 'berry', branch: undefined,           url: 'https://yarnpkg:password@github.com/yarnpkg/berry.git' }
+];
+
+describe(`githubUtils`, () => {
+
+  describe('isGithubUrl', () => {
+
+    it('should handle undefined', () => {
+      expect(isGithubUrl(undefined)).not.toBeTruthy();
+    })
+
+    it(`should respond truthy to valid urls`, () => {
+
+      for (const scenario of validScenarios)
+        expect(isGithubUrl(scenario.url)).toBeTruthy();
+    });
+
+    it(`should respond false to invalid urls`, () => {
+
+      const invalidUrls = [
+        'got://github.com/yarnpkg/berry#ff786f9f',
+        'git://github.com/yarnpkg/berry',
+        'http://github.com/yarnpkg',
+      ];
+
+      for (const url of invalidUrls)
+        expect(isGithubUrl(url)).not.toBeTruthy();
+    });
+  })
+
+  describe('parseGithubUrl', () => {
+
+    it(`should correctly parse valid github urls`, () => {
+      for (const scenario of validScenarios) {
+        let parsed = parseGithubUrl(scenario.url);
+        expect(parsed.username).toEqual(scenario.username);
+        expect(parsed.reponame).toEqual(scenario.repo);
+        expect(parsed.branch).toEqual(scenario.branch);
+      }
+    });
+
+    it(`should throw an error given an invalid URL`, () => {
+      const invalidUrl = 'http://invalid.com/yarnpkg/berry.git';
+      let error = undefined;
+      const expected = invalidGithubUrlMessage(invalidUrl);
+
+      try {
+        const url = parseGithubUrl(invalidUrl);
+      } catch(e) {
+        error = e.message;
+      }
+
+      expect(error).toEqual(expected);
+    });
+  });
+})


### PR DESCRIPTION
Currently, I can't install a package I forked via git url. 
- `https://github.com/olingern/ink-select-input.git`

The github plugn's current regex pattern will not recognize this as a valid github url.

This PR fixes that.