### PR TITLE
Add generation of tssdk/package.json to remove VS Code warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ yarn-error.log
 
 .vscode
 .history
+tssdk
 
 junit.xml
 

--- a/packages/berry-pnpify/lib/NodeModulesFS.d.ts
+++ b/packages/berry-pnpify/lib/NodeModulesFS.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { CreateReadStreamOptions, CreateWriteStreamOptions } from '@berry/fslib';
 import { FakeFS, WriteFileOptions } from '@berry/fslib';
-import { NativePath, Path } from '@berry/fslib';
+import { NativePath } from '@berry/fslib';
 import fs from 'fs';
 export declare type NodeModulesFSOptions = {
     baseFs?: FakeFS<NativePath>;
@@ -62,30 +62,4 @@ export declare class NodeModulesFS extends FakeFS<NativePath> {
     readdirSync(p: NativePath): import("@berry/fslib").Filename[];
     readlinkPromise(p: NativePath): Promise<any>;
     readlinkSync(p: NativePath): any;
-    removePromise(p: NativePath): Promise<void>;
-    removeSync(p: NativePath): void;
-    mkdirpPromise(p: NativePath, options?: {
-        chmod?: number;
-        utimes?: [Date | string | number, Date | string | number];
-    }): Promise<void>;
-    mkdirpSync(p: NativePath, options?: {
-        chmod?: number;
-        utimes?: [Date | string | number, Date | string | number];
-    }): void;
-    copyPromise(destination: NativePath, source: NativePath, options?: {
-        baseFs?: undefined;
-        overwrite?: boolean;
-    }): Promise<void>;
-    copyPromise<P2 extends Path>(destination: NativePath, source: P2, options: {
-        baseFs: FakeFS<P2>;
-        overwrite?: boolean;
-    }): Promise<void>;
-    copySync(destination: NativePath, source: NativePath, options?: {
-        baseFs?: undefined;
-        overwrite?: boolean;
-    }): void;
-    copySync<P2 extends Path>(destination: NativePath, source: P2, options: {
-        baseFs: FakeFS<P2>;
-        overwrite?: boolean;
-    }): void;
 }

--- a/packages/berry-pnpify/lib/NodePathResolver.d.ts
+++ b/packages/berry-pnpify/lib/NodePathResolver.d.ts
@@ -69,7 +69,7 @@ export declare class NodePathResolver {
      *
      * @returns `undefined` - if dir does not exist, or `readdir`-like list of subdirs in the virtual dir
      */
-    readDir(issuerInfo: PackageInformation, scope: string | null): Filename[] | undefined;
+    readDir(issuerInfo: PackageInformation<NativePath>, scope: string | null): Filename[] | undefined;
     private getIssuer;
     /**
      * Resolves paths containing `/node_modules` inside PnP projects. If path is outside PnP

--- a/packages/berry-pnpify/lib/bin.js
+++ b/packages/berry-pnpify/lib/bin.js
@@ -82,7 +82,7 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 19);
+/******/ 	return __webpack_require__(__webpack_require__.s = 20);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -91,11 +91,12 @@ module.exports =
 
 "use strict";
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return PortablePath; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return npath; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return ppath; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return toFilename; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return fromPortablePath; });
-/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "f", function() { return toPortablePath; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return npath; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return ppath; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return fromPortablePath; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "g", function() { return toPortablePath; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return convertPath; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "f", function() { return toFilename; });
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 
@@ -105,11 +106,6 @@ const PortablePath = {
 };
 const npath = path__WEBPACK_IMPORTED_MODULE_0___default.a;
 const ppath = path__WEBPACK_IMPORTED_MODULE_0___default.a.posix;
-function toFilename(filename) {
-    if (npath.parse(filename).dir !== '' || ppath.parse(filename).dir !== '')
-        throw new Error(`Invalid filename: "${filename}"`);
-    return filename;
-}
 const WINDOWS_PATH_REGEXP = /^[a-zA-Z]:.*$/;
 const PORTABLE_PATH_REGEXP = /^\/[a-zA-Z]:.*$/;
 // Path should look like "/N:/berry/scripts/plugin-pack.js"
@@ -125,6 +121,14 @@ function toPortablePath(p) {
     if (process.platform !== 'win32')
         return p;
     return (p.match(WINDOWS_PATH_REGEXP) ? `/${p}` : p).replace(/\\/g, `/`);
+}
+function convertPath(targetPathUtils, sourcePath) {
+    return (targetPathUtils === npath ? fromPortablePath(sourcePath) : toPortablePath(sourcePath));
+}
+function toFilename(filename) {
+    if (npath.parse(filename).dir !== '' || ppath.parse(filename).dir !== '')
+        throw new Error(`Invalid filename: "${filename}"`);
+    return filename;
 }
 
 
@@ -460,10 +464,10 @@ class NodeFS extends _FakeFS__WEBPACK_IMPORTED_MODULE_1__[/* BasePortableFakeFS 
         };
     }
     static fromPortablePath(p) {
-        return Object(_path__WEBPACK_IMPORTED_MODULE_2__[/* fromPortablePath */ "b"])(p);
+        return Object(_path__WEBPACK_IMPORTED_MODULE_2__[/* fromPortablePath */ "c"])(p);
     }
     static toPortablePath(p) {
-        return Object(_path__WEBPACK_IMPORTED_MODULE_2__[/* toPortablePath */ "f"])(p);
+        return Object(_path__WEBPACK_IMPORTED_MODULE_2__[/* toPortablePath */ "g"])(p);
     }
 }
 
@@ -481,98 +485,6 @@ class NodeFS extends _FakeFS__WEBPACK_IMPORTED_MODULE_1__[/* BasePortableFakeFS 
 class FakeFS {
     constructor(pathUtils) {
         this.pathUtils = pathUtils;
-    }
-    async changeFilePromise(p, content) {
-        try {
-            const current = await this.readFilePromise(p, `utf8`);
-            if (current === content) {
-                return;
-            }
-        }
-        catch (error) {
-            // ignore errors, no big deal
-        }
-        await this.writeFilePromise(p, content);
-    }
-    changeFileSync(p, content) {
-        try {
-            const current = this.readFileSync(p, `utf8`);
-            if (current === content) {
-                return;
-            }
-        }
-        catch (error) {
-            // ignore errors, no big deal
-        }
-        this.writeFileSync(p, content);
-    }
-    async movePromise(fromP, toP) {
-        try {
-            await this.renamePromise(fromP, toP);
-        }
-        catch (error) {
-            if (error.code === `EXDEV`) {
-                await this.copyPromise(toP, fromP);
-                await this.removePromise(fromP);
-            }
-            else {
-                throw error;
-            }
-        }
-    }
-    moveSync(fromP, toP) {
-        try {
-            this.renameSync(fromP, toP);
-        }
-        catch (error) {
-            if (error.code === `EXDEV`) {
-                this.copySync(toP, fromP);
-                this.removeSync(fromP);
-            }
-            else {
-                throw error;
-            }
-        }
-    }
-    async lockPromise(affectedPath, callback) {
-        const lockPath = `${affectedPath}.lock`;
-        const interval = 1000 / 60;
-        const timeout = Date.now() + 60 * 1000;
-        let fd = null;
-        while (fd === null) {
-            try {
-                fd = await this.openPromise(lockPath, `wx`);
-            }
-            catch (error) {
-                if (error.code === `EEXIST`) {
-                    if (Date.now() < timeout) {
-                        await new Promise(resolve => setTimeout(resolve, interval));
-                    }
-                    else {
-                        throw new Error(`Couldn't acquire a lock in a reasonable time (via ${lockPath})`);
-                    }
-                }
-                else {
-                    throw error;
-                }
-            }
-        }
-        try {
-            await callback();
-        }
-        finally {
-            await this.closePromise(fd);
-            await this.unlinkPromise(lockPath);
-        }
-    }
-}
-;
-class BasePortableFakeFS extends FakeFS {
-    constructor() {
-        super(_path__WEBPACK_IMPORTED_MODULE_0__[/* ppath */ "d"]);
-    }
-    resolve(p) {
-        return this.pathUtils.resolve(_path__WEBPACK_IMPORTED_MODULE_0__[/* PortablePath */ "a"].root, p);
     }
     async removePromise(p) {
         let stat;
@@ -694,7 +606,7 @@ class BasePortableFakeFS extends FakeFS {
             await this.mkdirpPromise(destination);
             const directoryListing = await baseFs.readdirPromise(source);
             await Promise.all(directoryListing.map(entry => {
-                return this.copyPromise(_path__WEBPACK_IMPORTED_MODULE_0__[/* ppath */ "d"].join(destination, entry), baseFs.pathUtils.join(source, entry), { baseFs, overwrite });
+                return this.copyPromise(this.pathUtils.join(destination, entry), baseFs.pathUtils.join(source, entry), { baseFs, overwrite });
             }));
         }
         else if (stat.isFile()) {
@@ -710,7 +622,7 @@ class BasePortableFakeFS extends FakeFS {
                 if (exists)
                     await this.removePromise(destination);
                 const target = await baseFs.readlinkPromise(source);
-                await this.symlinkPromise(Object(_path__WEBPACK_IMPORTED_MODULE_0__[/* toPortablePath */ "f"])(target), destination);
+                await this.symlinkPromise(Object(_path__WEBPACK_IMPORTED_MODULE_0__[/* convertPath */ "b"])(this.pathUtils, target), destination);
             }
         }
         else {
@@ -742,7 +654,7 @@ class BasePortableFakeFS extends FakeFS {
                 if (exists)
                     this.removeSync(destination);
                 const target = baseFs.readlinkSync(source);
-                this.symlinkSync(Object(_path__WEBPACK_IMPORTED_MODULE_0__[/* toPortablePath */ "f"])(target), destination);
+                this.symlinkSync(Object(_path__WEBPACK_IMPORTED_MODULE_0__[/* convertPath */ "b"])(this.pathUtils, target), destination);
             }
         }
         else {
@@ -750,6 +662,98 @@ class BasePortableFakeFS extends FakeFS {
         }
         const mode = stat.mode & 0o777;
         this.chmodSync(destination, mode);
+    }
+    async changeFilePromise(p, content) {
+        try {
+            const current = await this.readFilePromise(p, `utf8`);
+            if (current === content) {
+                return;
+            }
+        }
+        catch (error) {
+            // ignore errors, no big deal
+        }
+        await this.writeFilePromise(p, content);
+    }
+    changeFileSync(p, content) {
+        try {
+            const current = this.readFileSync(p, `utf8`);
+            if (current === content) {
+                return;
+            }
+        }
+        catch (error) {
+            // ignore errors, no big deal
+        }
+        this.writeFileSync(p, content);
+    }
+    async movePromise(fromP, toP) {
+        try {
+            await this.renamePromise(fromP, toP);
+        }
+        catch (error) {
+            if (error.code === `EXDEV`) {
+                await this.copyPromise(toP, fromP);
+                await this.removePromise(fromP);
+            }
+            else {
+                throw error;
+            }
+        }
+    }
+    moveSync(fromP, toP) {
+        try {
+            this.renameSync(fromP, toP);
+        }
+        catch (error) {
+            if (error.code === `EXDEV`) {
+                this.copySync(toP, fromP);
+                this.removeSync(fromP);
+            }
+            else {
+                throw error;
+            }
+        }
+    }
+    async lockPromise(affectedPath, callback) {
+        const lockPath = `${affectedPath}.lock`;
+        const interval = 1000 / 60;
+        const timeout = Date.now() + 60 * 1000;
+        let fd = null;
+        while (fd === null) {
+            try {
+                fd = await this.openPromise(lockPath, `wx`);
+            }
+            catch (error) {
+                if (error.code === `EEXIST`) {
+                    if (Date.now() < timeout) {
+                        await new Promise(resolve => setTimeout(resolve, interval));
+                    }
+                    else {
+                        throw new Error(`Couldn't acquire a lock in a reasonable time (via ${lockPath})`);
+                    }
+                }
+                else {
+                    throw error;
+                }
+            }
+        }
+        try {
+            await callback();
+        }
+        finally {
+            await this.closePromise(fd);
+            await this.unlinkPromise(lockPath);
+        }
+    }
+}
+;
+class BasePortableFakeFS extends FakeFS {
+    constructor() {
+        super(_path__WEBPACK_IMPORTED_MODULE_0__[/* ppath */ "e"]);
+    }
+    resolve(p) {
+        return this.pathUtils.resolve(_path__WEBPACK_IMPORTED_MODULE_0__[/* PortablePath */ "a"].root, p);
     }
 }
 
@@ -776,9 +780,15 @@ module.exports = require("child_process");
 
 /***/ }),
 /* 16 */,
-/* 17 */,
+/* 17 */
+/***/ (function(module) {
+
+module.exports = {"name":"typescript","author":"Microsoft Corp.","homepage":"https://www.typescriptlang.org/","version":"3.3.3333","license":"Apache-2.0","description":"TypeScript is a language for application scale JavaScript development","keywords":["TypeScript","Microsoft","compiler","language","javascript"],"bugs":{"url":"https://github.com/Microsoft/TypeScript/issues"},"repository":{"type":"git","url":"https://github.com/Microsoft/TypeScript.git"},"main":"./lib/typescript.js","typings":"./lib/typescript.d.ts","bin":{"tsc":"./bin/tsc","tsserver":"./bin/tsserver"},"engines":{"node":">=4.2.0"},"devDependencies":{"@octokit/rest":"latest","@types/browserify":"latest","@types/chai":"latest","@types/convert-source-map":"latest","@types/del":"latest","@types/glob":"latest","@types/gulp":"3.X","@types/gulp-concat":"latest","@types/gulp-help":"latest","@types/gulp-if":"0.0.33","@types/gulp-newer":"latest","@types/gulp-rename":"0.0.33","@types/gulp-sourcemaps":"0.0.32","@types/jake":"latest","@types/merge2":"latest","@types/minimatch":"latest","@types/minimist":"latest","@types/mkdirp":"latest","@types/mocha":"latest","@types/node":"8.5.5","@types/q":"latest","@types/run-sequence":"latest","@types/source-map-support":"latest","@types/through2":"latest","@types/travis-fold":"latest","@types/xml2js":"^0.4.0","browser-resolve":"^1.11.2","browserify":"latest","chai":"latest","chalk":"latest","convert-source-map":"latest","del":"latest","fancy-log":"latest","fs-extra":"^6.0.1","gulp":"3.X","gulp-clone":"latest","gulp-concat":"latest","gulp-help":"latest","gulp-if":"latest","gulp-insert":"latest","gulp-newer":"latest","gulp-rename":"latest","gulp-sourcemaps":"latest","gulp-typescript":"latest","istanbul":"latest","jake":"latest","lodash":"4.17.10","merge2":"latest","minimist":"latest","mkdirp":"latest","mocha":"latest","mocha-fivemat-progress-reporter":"latest","plugin-error":"latest","pretty-hrtime":"^1.0.3","prex":"^0.4.3","q":"latest","remove-internal":"^2.9.2","run-sequence":"latest","source-map-support":"latest","through2":"latest","travis-fold":"latest","tslint":"latest","typescript":"next","vinyl":"latest","vinyl-sourcemaps-apply":"latest","xml2js":"^0.4.19"},"scripts":{"pretest":"jake tests","test":"jake runtests-parallel light=false","build":"npm run build:compiler && npm run build:tests","build:compiler":"jake local","build:tests":"jake tests","start":"node lib/tsc","clean":"jake clean","gulp":"gulp","jake":"jake","lint":"jake lint","setup-hooks":"node scripts/link-hooks.js"},"browser":{"fs":false,"os":false,"path":false},"dependencies":{}};
+
+/***/ }),
 /* 18 */,
-/* 19 */
+/* 19 */,
+/* 20 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -822,18 +832,20 @@ const TEMPLATE = (relPnpApiPath) => [
 async function generateSdk(projectRoot, targetFolder) {
     if (targetFolder === null)
         targetFolder = projectRoot;
-    const tssdk = path["d" /* ppath */].join(targetFolder, `tssdk`);
-    const tsserver = path["d" /* ppath */].join(tssdk, `lib/tsserver.js`);
-    const relPnpApiPath = path["d" /* ppath */].relative(path["d" /* ppath */].dirname(tsserver), path["d" /* ppath */].join(projectRoot, `.pnp.js`));
+    const tssdk = path["e" /* ppath */].join(targetFolder, `tssdk`);
+    const tssdkManifest = path["e" /* ppath */].join(tssdk, `package.json`);
+    const tsserver = path["e" /* ppath */].join(tssdk, `lib/tsserver.js`);
+    const relPnpApiPath = path["e" /* ppath */].relative(path["e" /* ppath */].dirname(tsserver), path["e" /* ppath */].join(projectRoot, `.pnp.js`));
     await sources["b" /* xfs */].removePromise(tssdk);
-    await sources["b" /* xfs */].mkdirpPromise(path["d" /* ppath */].dirname(tsserver));
+    await sources["b" /* xfs */].mkdirpPromise(path["e" /* ppath */].dirname(tsserver));
+    await sources["b" /* xfs */].writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: __webpack_require__(17).version }, null, 2));
     await sources["b" /* xfs */].writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
-    const settings = path["d" /* ppath */].join(projectRoot, `.vscode/settings.json`);
+    const settings = path["e" /* ppath */].join(projectRoot, `.vscode/settings.json`);
     const content = await sources["b" /* xfs */].existsPromise(settings) ? await sources["b" /* xfs */].readFilePromise(settings, `utf8`) : ``;
     const data = JSON.parse(content);
-    data[`typescript.tsdk`] = NodeFS["a" /* NodeFS */].fromPortablePath(path["d" /* ppath */].relative(projectRoot, path["d" /* ppath */].dirname(tsserver)));
-    const patched = JSON.stringify(data, null, 2) + `\n`;
-    await sources["b" /* xfs */].mkdirpPromise(path["d" /* ppath */].dirname(settings));
+    data[`typescript.tsdk`] = NodeFS["a" /* NodeFS */].fromPortablePath(path["e" /* ppath */].relative(projectRoot, path["e" /* ppath */].dirname(tsserver)));
+    const patched = `${JSON.stringify(data, null, 2)}\n`;
+    await sources["b" /* xfs */].mkdirpPromise(path["e" /* ppath */].dirname(settings));
     await sources["b" /* xfs */].changeFilePromise(settings, patched);
 }
 
@@ -848,7 +860,7 @@ if (bin_name === `--help` || bin_name === `-h`)
 else if (bin_name === `--sdk` && rest.length === 0)
     sdk(null);
 else if (bin_name === `--sdk` && rest.length === 1)
-    sdk(path["d" /* ppath */].resolve(NodeFS["a" /* NodeFS */].toPortablePath(rest[0])));
+    sdk(path["e" /* ppath */].resolve(NodeFS["a" /* NodeFS */].toPortablePath(rest[0])));
 else if (typeof bin_name !== `undefined` && bin_name[0] !== `-`)
     run(bin_name, rest);
 else

--- a/packages/berry-pnpify/lib/bin.js
+++ b/packages/berry-pnpify/lib/bin.js
@@ -838,7 +838,7 @@ async function generateSdk(projectRoot, targetFolder) {
     const relPnpApiPath = path["e" /* ppath */].relative(path["e" /* ppath */].dirname(tsserver), path["e" /* ppath */].join(projectRoot, `.pnp.js`));
     await sources["b" /* xfs */].removePromise(tssdk);
     await sources["b" /* xfs */].mkdirpPromise(path["e" /* ppath */].dirname(tsserver));
-    await sources["b" /* xfs */].writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: __webpack_require__(17).version + '-pnpify' }, null, 2));
+    await sources["b" /* xfs */].writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: `${__webpack_require__(17).version}-pnpify` }, null, 2));
     await sources["b" /* xfs */].writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
     const settings = path["e" /* ppath */].join(projectRoot, `.vscode/settings.json`);
     const content = await sources["b" /* xfs */].existsPromise(settings) ? await sources["b" /* xfs */].readFilePromise(settings, `utf8`) : ``;

--- a/packages/berry-pnpify/lib/bin.js
+++ b/packages/berry-pnpify/lib/bin.js
@@ -838,7 +838,7 @@ async function generateSdk(projectRoot, targetFolder) {
     const relPnpApiPath = path["e" /* ppath */].relative(path["e" /* ppath */].dirname(tsserver), path["e" /* ppath */].join(projectRoot, `.pnp.js`));
     await sources["b" /* xfs */].removePromise(tssdk);
     await sources["b" /* xfs */].mkdirpPromise(path["e" /* ppath */].dirname(tsserver));
-    await sources["b" /* xfs */].writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: __webpack_require__(17).version }, null, 2));
+    await sources["b" /* xfs */].writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: __webpack_require__(17).version + '-pnpify' }, null, 2));
     await sources["b" /* xfs */].writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
     const settings = path["e" /* ppath */].join(projectRoot, `.vscode/settings.json`);
     const content = await sources["b" /* xfs */].existsPromise(settings) ? await sources["b" /* xfs */].readFilePromise(settings, `utf8`) : ``;

--- a/packages/berry-pnpify/lib/tsserver.js
+++ b/packages/berry-pnpify/lib/tsserver.js
@@ -82,7 +82,7 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 17);
+/******/ 	return __webpack_require__(__webpack_require__.s = 18);
 /******/ })
 /************************************************************************/
 /******/ ({
@@ -94,7 +94,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 17:
+/***/ 18:
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/packages/berry-pnpify/sources/generateSdk.ts
+++ b/packages/berry-pnpify/sources/generateSdk.ts
@@ -31,7 +31,7 @@ export async function generateSdk(projectRoot: PortablePath, targetFolder: Porta
 
   await xfs.removePromise(tssdk);
   await xfs.mkdirpPromise(ppath.dirname(tsserver));
-  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: require('typescript/package.json').version }, null, 2));
+  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({name: 'typescript', version: require('typescript/package.json').version}, null, 2));
   await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
 
   const settings = ppath.join(projectRoot, `.vscode/settings.json` as PortablePath);

--- a/packages/berry-pnpify/sources/generateSdk.ts
+++ b/packages/berry-pnpify/sources/generateSdk.ts
@@ -24,12 +24,14 @@ export async function generateSdk(projectRoot: PortablePath, targetFolder: Porta
     targetFolder = projectRoot;
 
   const tssdk = ppath.join(targetFolder, `tssdk` as PortablePath);
+  const tssdkManifest = ppath.join(tssdk, `package.json` as PortablePath);
   const tsserver = ppath.join(tssdk, `lib/tsserver.js` as PortablePath);
 
   const relPnpApiPath = ppath.relative(ppath.dirname(tsserver), ppath.join(projectRoot, `.pnp.js` as Filename));
 
   await xfs.removePromise(tssdk);
   await xfs.mkdirpPromise(ppath.dirname(tsserver));
+  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: require('typescript/package.json').version }, null, 2));
   await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
 
   const settings = ppath.join(projectRoot, `.vscode/settings.json` as PortablePath);

--- a/packages/berry-pnpify/sources/generateSdk.ts
+++ b/packages/berry-pnpify/sources/generateSdk.ts
@@ -31,7 +31,7 @@ export async function generateSdk(projectRoot: PortablePath, targetFolder: Porta
 
   await xfs.removePromise(tssdk);
   await xfs.mkdirpPromise(ppath.dirname(tsserver));
-  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({name: 'typescript', version: require('typescript/package.json').version}, null, 2));
+  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({name: 'typescript', version: require('typescript/package.json').version + '-pnpify' }, null, 2));
   await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
 
   const settings = ppath.join(projectRoot, `.vscode/settings.json` as PortablePath);

--- a/packages/berry-pnpify/sources/generateSdk.ts
+++ b/packages/berry-pnpify/sources/generateSdk.ts
@@ -31,7 +31,7 @@ export async function generateSdk(projectRoot: PortablePath, targetFolder: Porta
 
   await xfs.removePromise(tssdk);
   await xfs.mkdirpPromise(ppath.dirname(tsserver));
-  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({name: 'typescript', version: require('typescript/package.json').version + '-pnpify' }, null, 2));
+  await xfs.writeFilePromise(tssdkManifest, JSON.stringify({name: 'typescript', version: `${require('typescript/package.json').version}-pnpify`}, null, 2));
   await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
 
   const settings = ppath.join(projectRoot, `.vscode/settings.json` as PortablePath);


### PR DESCRIPTION
VS Code complains that it cannot determine TypeScript version. This PR adds `tssdk/package.json` generation during `yarn pnpify --sdk` execution. The version of typescript used by `@berry/pnpify` is recorded into `package.json`. It might be not the best approach, but at least we will get rid of unpleasant warning and user confusion