### PR TITLE
Checks-in the sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ junit.xml
 /.yarn/build-state.yml
 
 lib
+!/scripts/tssdk/lib
+
 /packages/*/bundles/*
 !/packages/berry-pnp/bundles/hook.js
 !/packages/berry-pnpify/lib

--- a/scripts/tssdk/lib/tsserver.js
+++ b/scripts/tssdk/lib/tsserver.js
@@ -1,0 +1,16 @@
+const relPnpApiPath = "../../../.pnp.js";
+const absPnpApiPath = require(`path`).resolve(__dirname, relPnpApiPath);
+
+// Setup the environment to be able to require @berry/pnpify
+require(absPnpApiPath).setup();
+
+// Prepare the environment (to be ready in case of child_process.spawn etc)
+process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
+process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
+process.env.NODE_OPTIONS += ` -r ${require.resolve(`@berry/pnpify/lib`)}`;
+
+// Apply PnPify to the current process
+require(`@berry/pnpify/lib`).patchFs();
+
+// Defer to the real typescript your application uses
+require(`typescript/lib/tsserver`);


### PR DESCRIPTION
This diff removes the sdk from the gitignore, since we always want to have it available.