### PR TITLE
Fixes fetcher url generation

### DIFF
--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -57,7 +57,7 @@ export class NpmFetcher implements Fetcher {
   private getLocatorUrl(locator: Locator, opts: FetchOptions) {
     const version = locator.reference.slice(PROTOCOL.length);
 
-    return `/${structUtils.requirableIdent(locator)}/-/${locator.name}-${version}.tgz`;
+    return `${npmHttpUtils.getIdentUrl(locator)}/-/${locator.name}-${version}.tgz`;
   }
 
   private getPrefixPath(locator: Locator) {

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -1,5 +1,5 @@
 import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions, Manifest} from '@berry/core';
-import {Ident, Descriptor, Locator}                                                          from '@berry/core';
+import {Descriptor, Locator}                                                                 from '@berry/core';
 import {LinkType}                                                                            from '@berry/core';
 import {structUtils}                                                                         from '@berry/core';
 import semver                                                                                from 'semver';

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -45,7 +45,7 @@ export class NpmSemverResolver implements Resolver {
     if (semver.valid(range))
       return [structUtils.convertDescriptorToLocator(descriptor)];
 
-    const registryData = await npmHttpUtils.get(this.getIdentUrl(descriptor, opts), {
+    const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(descriptor), {
       configuration: opts.project.configuration,
       ident: descriptor,
       json: true,
@@ -66,7 +66,7 @@ export class NpmSemverResolver implements Resolver {
   async resolve(locator: Locator, opts: ResolveOptions) {
     const version = locator.reference.slice(PROTOCOL.length);
 
-    const registryData = await npmHttpUtils.get(this.getIdentUrl(locator, opts), {
+    const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(locator), {
       configuration: opts.project.configuration,
       ident: locator,
       json: true,
@@ -111,13 +111,5 @@ export class NpmSemverResolver implements Resolver {
 
       bin: manifest.bin,
     };
-  }
-
-  private getIdentUrl(ident: Ident, opts: MinimalResolveOptions) {
-    if (ident.scope) {
-      return `/@${ident.scope}%2f${ident.name}`;
-    } else {
-      return `/${ident.name}`;
-    }
   }
 }

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -35,7 +35,7 @@ export class NpmTagResolver implements Resolver {
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {
     const tag = descriptor.range.slice(PROTOCOL.length);
 
-    const registryData = await npmHttpUtils.get(this.getIdentUrl(descriptor, opts), {
+    const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(descriptor), {
       configuration: opts.project.configuration,
       ident: descriptor,
       json: true,
@@ -55,13 +55,5 @@ export class NpmTagResolver implements Resolver {
   async resolve(locator: Locator, opts: ResolveOptions): Promise<Package> {
     // Once transformed into locators, the tags are resolved by the NpmSemverResolver
     throw new Error(`Unreachable`);
-  }
-
-  private getIdentUrl(ident: Ident, opts: MinimalResolveOptions) {
-    if (ident.scope) {
-      return `/@${ident.scope}%2f${ident.name}`;
-    } else {
-      return `/${ident.name}`;
-    }
   }
 }

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -1,6 +1,6 @@
 import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions} from '@berry/core';
 import {structUtils}                                                               from '@berry/core';
-import {Ident, Descriptor, Locator, Package}                                       from '@berry/core';
+import {Descriptor, Locator, Package}                                              from '@berry/core';
 
 import {PROTOCOL}                                                                  from './constants';
 import * as npmHttpUtils                                                           from './npmHttpUtils';

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -18,6 +18,14 @@ type AuthOptions = {
 
 export type Options = httpUtils.Options & AuthOptions;
 
+export function getIdentUrl(ident: Ident) {
+  if (ident.scope) {
+    return `/@${ident.scope}%2f${ident.name}`;
+  } else {
+    return `/${ident.name}`;
+  }
+}
+
 export async function get(path: string, {configuration, headers, ident, authType, ...rest}: Options) {
   const registry = npmConfigUtils.getRegistry(ident, {configuration});
   const auth = getAuthenticationHeader({configuration}, {ident, authType});


### PR DESCRIPTION
The npm fetcher wasn't encoding the `/` character on scoped packages. This was working fine with the npm registry, but was breaking for others (such as TaoBao, cf #191).

This diff slightly refactors the url generation to be inside `npmHttpUtils` (so that we don't have to reimplement it in three different files).

Fixes #191 