### PR TITLE
Fixes links/portals being used in the `resolutions` field

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/resolutions.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/resolutions.test.js
@@ -1,0 +1,38 @@
+const {
+  fs: {writeFile, writeJson},
+} = require('pkg-tests-core');
+
+describe(`Features`, () => {
+  describe(`Resolutions`, () => {
+    test(
+      `it should support overriding packages with portals`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`one-fixed-dep`]: `1.0.0`,
+          },
+          resolutions: {
+            [`no-deps`]: `portal:./my-package`,
+          },
+        },
+        async ({path, run, source}) => {
+          await writeFile(`${path}/my-package/index.js`, `module.exports = 42;\n`);
+          await writeJson(`${path}/my-package/package.json`, {
+            name: `no-deps`,
+            version: `42.0.0`,
+          });
+
+          await run(`install`);
+
+          await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+            name: `one-fixed-dep`,
+            version: `1.0.0`,
+            dependencies: {
+              [`no-deps`]: 42,
+            },
+          });
+        },
+      ),
+    );
+  });
+});

--- a/packages/berry-core/sources/structUtils.ts
+++ b/packages/berry-core/sources/structUtils.ts
@@ -1,4 +1,5 @@
 import {toFilename}                             from '@berry/fslib';
+import querystring                              from 'querystring';
 import semver                                   from 'semver';
 
 import {Configuration}                          from './Configuration';

--- a/packages/berry-core/sources/structUtils.ts
+++ b/packages/berry-core/sources/structUtils.ts
@@ -94,6 +94,13 @@ export function devirtualizeLocator(locator: Locator): Locator {
   return makeLocator(locator, locator.reference.replace(/^[^#]*#/, ``));
 }
 
+export function bindDescriptor(descriptor: Descriptor, params: {[key: string]: string}) {
+  if (descriptor.range.includes(`?`))
+    return descriptor;
+
+  return makeDescriptor(descriptor, `${descriptor.range}?${querystring.stringify(params)}`);
+}
+
 export function areIdentsEqual(a: Ident, b: Ident) {
   return a.identHash === b.identHash;
 }

--- a/packages/plugin-file/sources/FileResolver.ts
+++ b/packages/plugin-file/sources/FileResolver.ts
@@ -3,7 +3,6 @@ import {Descriptor, Locator, Manifest}                   from '@berry/core';
 import {LinkType}                                        from '@berry/core';
 import {miscUtils, structUtils}                          from '@berry/core';
 import {NodeFS}                                          from '@berry/fslib';
-import querystring                                       from 'querystring';
 
 import {FILE_REGEXP, PROTOCOL}                           from './constants';
 
@@ -33,12 +32,9 @@ export class FileResolver implements Resolver {
     if (FILE_REGEXP.test(descriptor.range))
       descriptor = structUtils.makeDescriptor(descriptor, `file:${descriptor.range}`);
 
-    if (descriptor.range.includes(`?`))
-      throw new Error(`File-type dependencies cannot contain the character "?"`);
-
-    return structUtils.makeDescriptor(descriptor, `${descriptor.range}?${querystring.stringify({
+    return structUtils.bindDescriptor(descriptor, {
       locator: structUtils.stringifyLocator(fromLocator),
-    })}`);
+    });
   }
 
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {

--- a/packages/plugin-link/sources/LinkResolver.ts
+++ b/packages/plugin-link/sources/LinkResolver.ts
@@ -27,12 +27,9 @@ export class LinkResolver implements Resolver {
   }
 
   bindDescriptor(descriptor: Descriptor, fromLocator: Locator, opts: MinimalResolveOptions) {
-    if (descriptor.range.includes(`?`))
-      throw new Error(`Link-type dependencies cannot contain the character "?"`);
-
-    return structUtils.makeDescriptor(descriptor, `${descriptor.range}?${querystring.stringify({
+    return structUtils.bindDescriptor(descriptor, {
       locator: structUtils.stringifyLocator(fromLocator),
-    })}`);
+    });
   }
 
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {

--- a/packages/plugin-link/sources/LinkResolver.ts
+++ b/packages/plugin-link/sources/LinkResolver.ts
@@ -3,7 +3,6 @@ import {Descriptor, Locator, Manifest, Package}          from '@berry/core';
 import {LinkType}                                        from '@berry/core';
 import {miscUtils, structUtils}                          from '@berry/core';
 import {NodeFS}                                          from '@berry/fslib';
-import querystring                                       from 'querystring';
 
 import {LINK_PROTOCOL}                                   from './constants';
 

--- a/packages/plugin-link/sources/RawLinkResolver.ts
+++ b/packages/plugin-link/sources/RawLinkResolver.ts
@@ -3,7 +3,6 @@ import {Descriptor, Locator}                             from '@berry/core';
 import {LinkType}                                        from '@berry/core';
 import {structUtils}                                     from '@berry/core';
 import {NodeFS}                                          from '@berry/fslib';
-import querystring                                       from 'querystring';
 
 import {RAW_LINK_PROTOCOL}                               from './constants';
 
@@ -27,12 +26,9 @@ export class RawLinkResolver implements Resolver {
   }
 
   bindDescriptor(descriptor: Descriptor, fromLocator: Locator, opts: MinimalResolveOptions) {
-    if (descriptor.range.includes(`?`))
-      throw new Error(`Link-type dependencies cannot contain the character "?"`);
-
-    return structUtils.makeDescriptor(descriptor, `${descriptor.range}?${querystring.stringify({
+    return structUtils.bindDescriptor(descriptor, {
       locator: structUtils.stringifyLocator(fromLocator),
-    })}`);
+    });
   }
 
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {


### PR DESCRIPTION
When a portal is used in the `resolutions` field (for example because of the new implementation of `yarn link`) the descriptor is "bound" to the top-level: it means that if the portal is a relative path, it will always be resolved relative to the location of the top-level package (and this without having to use an absolute path, which would impair portability).

The problem was that we were preventing portals from being bound twice; so when they were injected into the overriden dependencies (through the action of the `resolutions` field) we caused the code to crash.

This diff makes it so that binding a descriptor that's already bound has no effect. We might want to ensure that the binding schema is the same (so those in this case that both current and tentative bindings only contain a `locator` field), but that might be overkill.

I've added a test to prevent regressions.

Fixes #184 