### PR TITLE
Bump jest timeout for osx

### DIFF
--- a/packages/acceptance-tests/berry.setup.js
+++ b/packages/acceptance-tests/berry.setup.js
@@ -60,7 +60,7 @@ global.makeTemporaryEnv = generatePkgDriver({
   },
 });
 
-if (process.platform === `win32` || isWsl) {
+if (process.platform === `win32` || isWsl || process.platform === `darwin`) {
   jest.setTimeout(10000);
 }
 


### PR DESCRIPTION
Running tests in Azure with OSX has been inconsistent with timeouts with the default jest timeout of 5 seconds. This PR bumps it to 10 as we do for windows.

Note: Let's keep an eye and see if 10 is enough.