### PR TITLE
Fixes linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
     "arca"
   ],
   "rules": {
-    "@typescript-eslint/camelcase": ["error", {"allow": ["__non_webpack_require__", "^npm(_[a-z]+)+$"]}],
+    "@typescript-eslint/camelcase": ["error", {"allow": ["__non_webpack_module__", "__non_webpack_require__", "^npm(_[a-z]+)+$"]}],
     "@typescript-eslint/class-name-casing": 2,
     "@typescript-eslint/indent": ["error", 2, {"SwitchCase": 1}],
     "@typescript-eslint/no-unused-vars": [2, {"args": "none", "ignoreRestSiblings": true}],

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "scripts": {
     "gen-tssdk": "pnpify --sdk scripts",
-    "test:lint": "eslint packages/*/sources/**.ts",
+    "test:lint": "eslint packages/*/sources/**/*.ts",
     "test:unit": "jest"
   }
 }

--- a/packages/berry-parsers/sources/grammars/shell.d.ts
+++ b/packages/berry-parsers/sources/grammars/shell.d.ts
@@ -1,6 +1,6 @@
 export type CommandSegment = string |
-  {type: `shell`, shell: ShellLine, quoted: boolean} |
-  {type: `variable`, name: string, quoted: boolean};
+{type: `shell`, shell: ShellLine, quoted: boolean} |
+{type: `variable`, name: string, quoted: boolean};
 
 export type Command = {
   type: `command`,

--- a/packages/berry-pnp/sources/loader/_entryPoint.ts
+++ b/packages/berry-pnp/sources/loader/_entryPoint.ts
@@ -4,7 +4,7 @@ import Module                          from 'module';
 import path                            from 'path';
 import StringDecoder                   from 'string_decoder';
 
-import {RuntimeState} from '../types';
+import {RuntimeState}                  from '../types';
 
 import {applyPatch}                    from './applyPatch';
 import {hydrateRuntimeState}           from './hydrateRuntimeState';

--- a/packages/berry-pnp/sources/loader/applyPatch.ts
+++ b/packages/berry-pnp/sources/loader/applyPatch.ts
@@ -1,11 +1,11 @@
 import {FakeFS, NodeFS, PosixFS, patchFs, PortablePath} from '@berry/fslib';
-import fs                                 from 'fs';
-import Module                             from 'module';
-import path                               from 'path';
+import fs                                               from 'fs';
+import Module                                           from 'module';
+import path                                             from 'path';
 
-import {PackageLocator, PnpApi}           from '../types';
+import {PackageLocator, PnpApi}                         from '../types';
 
-import {makeError, getIssuerModule}       from './internalTools';
+import {makeError, getIssuerModule}                     from './internalTools';
 
 export type ApplyPatchOptions = {
   compatibilityMode?: boolean,

--- a/packages/berry-pnp/sources/loader/hydrateRuntimeState.ts
+++ b/packages/berry-pnp/sources/loader/hydrateRuntimeState.ts
@@ -1,6 +1,6 @@
 import {NodeFS, ppath, PortablePath}                                                                          from '@berry/fslib';
 
-import {PackageInformation, PackageLocator, PackageStore, RuntimeState, SerializedState} from '../types';
+import {PackageInformation, PackageLocator, PackageStore, RuntimeState, SerializedState}                      from '../types';
 
 export type HydrateRuntimeStateOptions = {
   basePath: string,

--- a/packages/berry-pnp/sources/loader/makeApi.ts
+++ b/packages/berry-pnp/sources/loader/makeApi.ts
@@ -39,9 +39,6 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
   // Matches if the path must point to a directory (ie ends with /)
   const isDirRegExp = /\/$/;
 
-  // Matches backslashes of Windows paths
-  const backwardSlashRegExp = /\\/g;
-
   // We only instantiate one of those so that we can use strict-equal comparisons
   const topLevelLocator = {name: null, reference: null};
 
@@ -111,24 +108,21 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
 
     if (Number.isFinite(level)) {
       if (level >= 2) {
-
-        return (... args: Array<any>) => {
+        return (...args: Array<any>) => {
           const logEntry = makeLogEntry(name, args);
 
           try {
-            return logEntry.result = fn(... args);
+            return logEntry.result = fn(...args);
           } catch (error) {
             throw logEntry.error = error;
           } finally {
             console.error(logEntry);
           }
         };
-
       } else if (level >= 1) {
-
-        return (... args: Array<any>) => {
+        return (...args: Array<any>) => {
           try {
-            return fn(... args);
+            return fn(...args);
           } catch (error) {
             const logEntry = makeLogEntry(name, args);
             logEntry.error = error;
@@ -136,7 +130,6 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
             throw error;
           }
         };
-
       }
     }
 
@@ -374,7 +367,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
 
       if (locator === null) {
         throw makeError(
-        `BLACKLISTED`,
+          `BLACKLISTED`,
           [
             `A package has been resolved through a blacklisted path - this is usually caused by one of your tool`,
             `calling "realpath" on the return value of "require.resolve". Since the returned values use symlinks to`,
@@ -631,7 +624,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
         return null;
 
       const packageLocation = NodeFS.fromPortablePath(info.packageLocation);
-      const nativeInfo = {... info, packageLocation};
+      const nativeInfo = {...info, packageLocation};
 
       return nativeInfo;
     },

--- a/packages/plugin-constraints/sources/commands/constraints/check.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/check.ts
@@ -1,11 +1,11 @@
-import {Configuration, Descriptor, Project, PluginConfiguration} from '@berry/core';
-import {MessageName, StreamReport}                               from '@berry/core';
-import {structUtils}                                             from '@berry/core';
-import { PortablePath } from '@berry/fslib';
-import getPath                                                   from 'lodash.get';
-import {Writable}                                                from 'stream';
+import {Configuration, Project, PluginConfiguration} from '@berry/core';
+import {MessageName, StreamReport}                   from '@berry/core';
+import {structUtils}                                 from '@berry/core';
+import {PortablePath}                                from '@berry/fslib';
+import getPath                                       from 'lodash.get';
+import {Writable}                                    from 'stream';
 
-import {Constraints}                                             from '../../Constraints';
+import {Constraints}                                 from '../../Constraints';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
@@ -38,8 +38,6 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
         const dependencyDescriptor = workspace.manifest[dependencyType].get(dependencyIdent.identHash);
 
         if (dependencyRange !== null) {
-          const constraintDescriptor = structUtils.makeDescriptor(dependencyIdent, dependencyRange);
-
           if (!dependencyDescriptor) {
             report.reportError(MessageName.CONSTRAINTS_MISSING_DEPENDENCY, `${structUtils.prettyWorkspace(configuration, workspace)} must depend on ${structUtils.prettyIdent(configuration, dependencyIdent)} (via ${structUtils.prettyRange(configuration, dependencyRange)}) in ${dependencyType}, but doesn't`);
           } else if (dependencyDescriptor.range !== dependencyRange) {

--- a/packages/plugin-constraints/sources/commands/constraints/fix.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/fix.ts
@@ -1,10 +1,10 @@
-import {Cache, Configuration, Descriptor, Project, PluginConfiguration} from '@berry/core';
-import {MessageName, StreamReport}                                      from '@berry/core';
-import {structUtils}                                                    from '@berry/core';
-import { PortablePath }                                                 from '@berry/fslib';
-import {Readable, Writable}                                             from 'stream';
+import {Cache, Configuration, Project, PluginConfiguration} from '@berry/core';
+import {MessageName, StreamReport}                          from '@berry/core';
+import {structUtils}                                        from '@berry/core';
+import {PortablePath}                                       from '@berry/fslib';
+import {Readable, Writable}                                 from 'stream';
 
-import {Constraints}                                                    from '../../Constraints';
+import {Constraints}                                        from '../../Constraints';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion

--- a/packages/plugin-constraints/sources/commands/constraints/query.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/query.ts
@@ -1,6 +1,6 @@
 import {Configuration, Project, PluginConfiguration} from '@berry/core';
-import {MessageName, StreamReport}                   from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {StreamReport}                                from '@berry/core';
+import {PortablePath}                                from '@berry/fslib';
 import {Writable}                                    from 'stream';
 
 import {Constraints}                                 from '../../Constraints';

--- a/packages/plugin-constraints/sources/commands/constraints/source.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/source.ts
@@ -1,5 +1,5 @@
 import {Configuration, Project, PluginConfiguration} from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {PortablePath}                                from '@berry/fslib';
 import {Writable}                                    from 'stream';
 
 import {Constraints}                                 from '../../Constraints';

--- a/packages/plugin-constraints/sources/types/tau-prolog.d.ts
+++ b/packages/plugin-constraints/sources/types/tau-prolog.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 declare module 'tau-prolog' {
   namespace tau {
     namespace type {
@@ -128,7 +130,7 @@ declare module 'tau-prolog' {
         public readonly dynamic: boolean;
 
         public constructor(
-            head: Term<number, string>, body: Term<number, string>|null, dynamic?: boolean);
+          head: Term<number, string>, body: Term<number, string>|null, dynamic?: boolean);
 
         public clone(): this;
 
@@ -162,7 +164,7 @@ declare module 'tau-prolog' {
         public answer(callback: (answer: Answer) => void): void;
 
         public answers(callback: (answer: Answer) => void, maxCount?: number, after?: () => void):
-            void;
+        void;
 
         public add_rule(rule: Rule, options?: {from?: string}): true;
 
@@ -195,7 +197,7 @@ declare module 'tau-prolog' {
         public answer(callback: (answer: Answer) => void): void;
 
         public answers(callback: (answer: Answer) => void, maxCount?: number, after?: () => void):
-            void;
+        void;
 
         public add_rule(rule: Rule, options?: {from?: string}): true;
 
@@ -235,22 +237,22 @@ declare module 'tau-prolog' {
 
     namespace error {
       function existence(type: string, object: type.Term<number, string>|string, indicator: string):
-          type.Term<1, 'error'>;
+      type.Term<1, 'error'>;
       function type(expected: string, found: type.Term<number, string>, indicator: string):
-          type.Term<1, 'error'>;
+      type.Term<1, 'error'>;
       function instantiation(indicator: string): type.Term<1, 'error'>;
       function domain(expected: string, found: type.Term<number, string>, indicator: string):
-          type.Term<1, 'error'>;
+      type.Term<1, 'error'>;
       function representation(flag: string, indicator: string): type.Term<1, 'error'>;
       function permission(
-          operation: string, type: string, found: type.Term<number, string>, indicator: string):
-          type.Term<1, 'error'>;
+        operation: string, type: string, found: type.Term<number, string>, indicator: string):
+      type.Term<1, 'error'>;
       function evaluation(error: string, indicator: string): type.Term<1, 'error'>;
       function syntax(
-          token: undefined|
-          {value: string, line: number, column: number, matches: string[], start: number},
-          expected: string,
-          last: boolean): type.Term<1, 'error'>;
+        token: undefined|
+        {value: string, line: number, column: number, matches: string[], start: number},
+        expected: string,
+        last: boolean): type.Term<1, 'error'>;
       function syntax_by_predicate(expected: string, indicator: string): type.Term<1, 'error'>;
     }
 

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -1,10 +1,10 @@
-import {WorkspaceRequiredError}                             from '@berry/cli';
-import {Cache, Configuration, PluginConfiguration, Project} from '@berry/core';
-import {LightReport}                                        from '@berry/core';
-import {scriptUtils, structUtils}                           from '@berry/core';
+import {WorkspaceRequiredError}                                                                        from '@berry/cli';
+import {Cache, Configuration, PluginConfiguration, Project}                                            from '@berry/core';
+import {LightReport}                                                                                   from '@berry/core';
+import {scriptUtils, structUtils}                                                                      from '@berry/core';
 import {NodeFS, xfs, PortablePath, ppath, Filename, toFilename}                                        from '@berry/fslib';
-import {Readable, Writable}                                 from 'stream';
-import tmp                                                  from 'tmp';
+import {Readable, Writable}                                                                            from 'stream';
+import tmp                                                                                             from 'tmp';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
@@ -28,7 +28,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     `yarn dlx create-react-app ./my-app`,
   )
 
-  .action(async ({cwd, stdin, stdout, stderr, command, package: packages, args, quiet, ... rest}: {cwd: PortablePath, stdin: Readable, stdout: Writable, stderr: Writable, command: string, package: Array<string>, args: Array<string>, quiet: boolean}) => {
+  .action(async ({cwd, stdin, stdout, stderr, command, package: packages, args, quiet, ...rest}: {cwd: PortablePath, stdin: Readable, stdout: Writable, stderr: Writable, command: string, package: Array<string>, args: Array<string>, quiet: boolean}) => {
     const tmpDir = await createTemporaryDirectory(toFilename(`dlx-${process.pid}`));
 
     try {
@@ -45,7 +45,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
       if (quiet)
         addOptions.push(`--quiet`);
 
-      const addExitCode = await clipanion.run(null, [`add`, ... addOptions, `--`, ... packages], {cwd: tmpDir, stdin, stdout, stderr, ... rest});
+      const addExitCode = await clipanion.run(null, [`add`, ...addOptions, `--`, ...packages], {cwd: tmpDir, stdin, stdout, stderr, ...rest});
       if (addExitCode !== 0)
         return addExitCode;
 

--- a/packages/plugin-essentials/sources/commands/_entry.ts
+++ b/packages/plugin-essentials/sources/commands/_entry.ts
@@ -7,7 +7,7 @@ export default (clipanion: any) => clipanion
   .describe(`select whether to use install or run`)
   .flags({proxyArguments: true, defaultCommand: true, hiddenCommand: true})
 
-  .action(async ({cwd, version, args, stdout, ... env}: any) => {
+  .action(async ({cwd, version, args, stdout, ...env}: any) => {
     // berry --version
     if (args.length === 1 && (args[0] === `--version` || args[0] === `-v`)) {
       // Injected via webpack DefinePlugin
@@ -19,15 +19,15 @@ export default (clipanion: any) => clipanion
 
     // berry --frozen-lockfile
     } else if (args.length === 0 || args[0].charAt(0) === `-`) {
-      return await clipanion.run(null, [`install`, ... args], {cwd, stdout, ... env});
+      return await clipanion.run(null, [`install`, ...args], {cwd, stdout, ...env});
 
     // berry ~/projects/foo install
     } else if (args.length !== 0 && args[0].match(/[\\\/]/)) {
       const newCwd = ppath.resolve(cwd, NodeFS.toPortablePath(args[0]));
-      return await clipanion.run(null, args.slice(1), {cwd: newCwd, stdout, ... env});
+      return await clipanion.run(null, args.slice(1), {cwd: newCwd, stdout, ...env});
 
     // berry start
     } else {
-      return await clipanion.run(null, [`run`, ... args], {cwd, stdout, ... env});
+      return await clipanion.run(null, [`run`, ...args], {cwd, stdout, ...env});
     }
   });

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -2,13 +2,13 @@ import {WorkspaceRequiredError}                                     from '@berry
 import {Cache, Configuration, Descriptor, LightReport, MessageName} from '@berry/core';
 import {PluginConfiguration, Project, StreamReport, Workspace}      from '@berry/core';
 import {structUtils}                                                from '@berry/core';
+import {PortablePath}                                               from '@berry/fslib';
 import {Clipanion}                                                  from 'clipanion';
 import inquirer                                                     from 'inquirer';
 import {Readable, Writable}                                         from 'stream';
 
 import * as suggestUtils                                            from '../suggestUtils';
 import {Hooks}                                                      from '..';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) => clipanion
@@ -69,11 +69,11 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
         : suggestUtils.Modifier.CARET;
 
     const strategies = [
-      ... interactive ? [
+      ...interactive ? [
         suggestUtils.Strategy.REUSE,
       ] : [],
       suggestUtils.Strategy.PROJECT,
-      ... cached ? [
+      ...cached ? [
         suggestUtils.Strategy.CACHE,
       ] : [],
       suggestUtils.Strategy.LATEST,
@@ -127,7 +127,7 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
       Descriptor
     ]> = [];
 
-    for (const [request, suggestions] of allSuggestions) {
+    for (const [/*request*/, suggestions] of allSuggestions) {
       let selected;
 
       const nonNullSuggestions = suggestions.filter(suggestion => {

--- a/packages/plugin-essentials/sources/commands/bin.ts
+++ b/packages/plugin-essentials/sources/commands/bin.ts
@@ -1,8 +1,8 @@
 import {Configuration, PluginConfiguration, Project} from '@berry/core';
 import {scriptUtils, structUtils}                    from '@berry/core';
+import {PortablePath}                                from '@berry/fslib';
 import {UsageError}                                  from 'clipanion';
 import {Writable}                                    from 'stream';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
@@ -37,14 +37,14 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
       if (!binary)
         throw new UsageError(`Couldn't find a binary named "${name}" for package "${structUtils.prettyLocator(configuration, locator)}"`);
 
-      const [pkg, binaryFile] = binary;
+      const [/*pkg*/, binaryFile] = binary;
       stdout.write(`${binaryFile}\n`);
     } else {
       const keys = Array.from(binaries.keys());
       const maxKeyLength = keys.reduce((max, key) => Math.max(max, key.length), 0);
 
       if (verbose) {
-        for (const [name, [pkg, binaryFile]] of binaries) {
+        for (const [name, [pkg]] of binaries) {
           stdout.write(`${name.padEnd(maxKeyLength, ` `)}   ${structUtils.prettyLocator(configuration, pkg)}\n`);
         }
       } else {

--- a/packages/plugin-essentials/sources/commands/cache/clean.ts
+++ b/packages/plugin-essentials/sources/commands/cache/clean.ts
@@ -1,7 +1,7 @@
-import {Configuration, Cache, PluginConfiguration, Project}     from '@berry/core';
-import {LightReport, MessageName, StreamReport, VirtualFetcher} from '@berry/core';
+import {Configuration, Cache, PluginConfiguration, Project}                   from '@berry/core';
+import {LightReport, MessageName, StreamReport, VirtualFetcher}               from '@berry/core';
 import {NodeFS, xfs, PortablePath, ppath}                                     from '@berry/fslib';
-import {Writable}                                               from 'stream';
+import {Writable}                                                             from 'stream';
 
 const PRESERVED_FILES = new Set([
   `.gitignore`,
@@ -21,7 +21,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     One quirk of this system is that \`yarn cache clean\` cannot be used directly if your cache is used by multiple projects, as it won't be able to detect the files being used by other projects than the current one. The best way to support multiple projects with a single mirror is to use the \`--dry-run\` and \`--json\` flags in order to get the list of files that aren't used by one unique project. After running this command on all your projects, you'll just have to remove the intersection of all those file sets as they'll be guaranteed not to be used by any project.
   `)
 
-    .example(
+  .example(
     `Remove all the unused cache files from the current project`,
     `yarn cache clean`,
   )

--- a/packages/plugin-essentials/sources/commands/config.ts
+++ b/packages/plugin-essentials/sources/commands/config.ts
@@ -1,8 +1,8 @@
 import {Configuration, MessageName, PluginConfiguration, SettingsType, StreamReport} from '@berry/core';
 import {miscUtils}                                                                   from '@berry/core';
+import {PortablePath}                                                                from '@berry/fslib';
 import {Writable}                                                                    from 'stream';
 import {inspect}                                                                     from 'util';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
@@ -61,7 +61,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
           if (verbose) {
             report.reportJson({key, effective, source});
           } else {
-            report.reportJson({key, effective, source, ... data});
+            report.reportJson({key, effective, source, ...data});
           }
         }
       } else {

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -1,5 +1,5 @@
 import {Configuration, PluginConfiguration} from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {PortablePath}                       from '@berry/fslib';
 import {UsageError}                         from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-essentials/sources/commands/help.ts
+++ b/packages/plugin-essentials/sources/commands/help.ts
@@ -4,7 +4,7 @@ export default (clipanion: any) => clipanion
   .command(`help [command]`)
   .describe(`print the program usage`)
 
-  .action(async ({command, ... rest}: {command: string | null, rest: {[key: string]: any}}) => {
+  .action(async ({command, ...rest}: {command: string | null, rest: {[key: string]: any}}) => {
     if (command) {
       return await clipanion.run(null, [command, `-h`], rest);
     } else {

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -1,8 +1,8 @@
-import {WorkspaceRequiredError}                                           from '@berry/cli';
-import {Configuration, Cache, PluginConfiguration, Project, StreamReport} from '@berry/core';
+import {WorkspaceRequiredError}                                                                from '@berry/cli';
+import {Configuration, Cache, PluginConfiguration, Project, StreamReport}                      from '@berry/core';
 import {xfs, PortablePath, ppath}                                                              from '@berry/fslib';
-import {parseSyml, stringifySyml}                                         from '@berry/parsers';
-import {Writable}                                                         from 'stream';
+import {parseSyml, stringifySyml}                                                              from '@berry/parsers';
+import {Writable}                                                                              from 'stream';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion

--- a/packages/plugin-essentials/sources/commands/node.ts
+++ b/packages/plugin-essentials/sources/commands/node.ts
@@ -1,8 +1,8 @@
-import {Configuration, PluginConfiguration, Project} from '@berry/core';
-import {scriptUtils}                                 from '@berry/core';
+import {Configuration, PluginConfiguration, Project}               from '@berry/core';
+import {scriptUtils}                                               from '@berry/core';
 import {NodeFS, PortablePath}                                      from '@berry/fslib';
-import execa                                         from 'execa';
-import {Readable, Writable}                          from 'stream';
+import execa                                                       from 'execa';
+import {Readable, Writable}                                        from 'stream';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion

--- a/packages/plugin-essentials/sources/commands/plugin/dl.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/dl.ts
@@ -1,9 +1,9 @@
-import {Configuration, MessageName, PluginConfiguration, Project, StreamReport, httpUtils, structUtils} from '@berry/core';
+import {Configuration, MessageName, PluginConfiguration, Project, StreamReport, httpUtils, structUtils}                      from '@berry/core';
 import {xfs, PortablePath, ppath}                                                                                            from '@berry/fslib';
-import {parseSyml}                                                                                      from '@berry/parsers';
-import {Clipanion}                                                                                      from 'clipanion';
-import {Writable}                                                                                       from 'stream';
-import {runInNewContext}                                                                                from 'vm';
+import {parseSyml}                                                                                                           from '@berry/parsers';
+import {Clipanion}                                                                                                           from 'clipanion';
+import {Writable}                                                                                                            from 'stream';
+import {runInNewContext}                                                                                                     from 'vm';
 
 const REMOTE_REGISTRY = `https://raw.githubusercontent.com/yarnpkg/berry/master/plugins.yml`;
 
@@ -43,7 +43,7 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
         const raw = await httpUtils.get(REMOTE_REGISTRY, {configuration});
         const data = parseSyml(raw.toString());
 
-        for (const [name, {experimental, description}] of Object.entries(data)) {
+        for (const [name, {experimental}] of Object.entries(data)) {
           let label = name;
 
           if (experimental)

--- a/packages/plugin-essentials/sources/commands/plugin/list.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/list.ts
@@ -1,5 +1,5 @@
-import {Configuration, PluginConfiguration, StreamReport} from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {Configuration, PluginConfiguration, StreamReport}              from '@berry/core';
+import {PortablePath}                                                  from '@berry/fslib';
 import {Clipanion}                                                     from 'clipanion';
 import {Writable}                                                      from 'stream';
 

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -2,7 +2,7 @@ import {WorkspaceRequiredError}                                         from '@b
 import {Configuration, Cache, Descriptor, PluginConfiguration, Project} from '@berry/core';
 import {StreamReport, Workspace}                                        from '@berry/core';
 import {structUtils}                                                    from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {PortablePath}                                                   from '@berry/fslib';
 import {Writable}                                                       from 'stream';
 
 import * as suggestUtils                                                from '../suggestUtils';

--- a/packages/plugin-essentials/sources/commands/run.ts
+++ b/packages/plugin-essentials/sources/commands/run.ts
@@ -1,7 +1,7 @@
 import {Configuration, PluginConfiguration, Project, Workspace, Cache} from '@berry/core';
 import {LightReport}                                                   from '@berry/core';
 import {scriptUtils, structUtils}                                      from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {PortablePath}                                                  from '@berry/fslib';
 import {UsageError}                                                    from 'clipanion';
 import {Readable, Writable}                                            from 'stream';
 

--- a/packages/plugin-essentials/sources/commands/set/resolution.ts
+++ b/packages/plugin-essentials/sources/commands/set/resolution.ts
@@ -1,8 +1,8 @@
 import {WorkspaceRequiredError}                                           from '@berry/cli';
 import {Configuration, Cache, PluginConfiguration, Project, StreamReport} from '@berry/core';
 import {structUtils}                                                      from '@berry/core';
+import {PortablePath}                                                     from '@berry/fslib';
 import {Writable}                                                         from 'stream';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,9 +1,9 @@
-import {Configuration, PluginConfiguration, Project, StreamReport, MessageName} from '@berry/core';
-import {httpUtils}                                                              from '@berry/core';
+import {Configuration, PluginConfiguration, Project, StreamReport, MessageName}                      from '@berry/core';
+import {httpUtils}                                                                                   from '@berry/core';
 import {xfs, PortablePath, ppath}                                                                    from '@berry/fslib';
-import semver, {SemVer}                                                         from 'semver';
-import {Readable, Writable}                                                     from 'stream';
-import * as yup                                                                 from 'yup';
+import semver, {SemVer}                                                                              from 'semver';
+import {Readable, Writable}                                                                          from 'stream';
+import * as yup                                                                                      from 'yup';
 
 const BUNDLE_REGEXP = /^yarn-[0-9]+\.[0-9]+\.[0-9]+\.js$/;
 const BERRY_RANGES = new Set([`berry`, `v2`, `2`, `nightly`, `nightlies`, `rc`]);
@@ -116,11 +116,11 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
         candidates = satisfying.map(release => release.version.version);
       }
 
-      if (candidates.length === 1) {
+      if (candidates.length === 1)
         report.reportInfo(MessageName.UNNAMED, `Found matching release with ${configuration.format(bundleVersion, `#87afff`)}`);
-      } else {
+      else
         report.reportInfo(MessageName.UNNAMED, `Selecting the highest release amongst ${configuration.format(bundleVersion, `#87afff`)} and ${candidates.length - 1} other${candidates.length === 2 ? `` : `s`}`);
-      }
+
 
       if (!dryRun) {
         report.reportInfo(MessageName.UNNAMED, `Downloading ${configuration.format(bundleUrl, `green`)}`);

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -2,7 +2,7 @@ import {WorkspaceRequiredError}                                     from '@berry
 import {Cache, Configuration, Descriptor, LightReport, MessageName} from '@berry/core';
 import {PluginConfiguration, Project, StreamReport, Workspace}      from '@berry/core';
 import {structUtils}                                                from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {PortablePath}                                               from '@berry/fslib';
 import inquirer                                                     from 'inquirer';
 import {Readable, Writable}                                         from 'stream';
 
@@ -53,10 +53,10 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     });
 
     const modifier = exact
-    ? suggestUtils.Modifier.EXACT
-    : tilde
-      ? suggestUtils.Modifier.TILDE
-      : suggestUtils.Modifier.CARET;
+      ? suggestUtils.Modifier.EXACT
+      : tilde
+        ? suggestUtils.Modifier.TILDE
+        : suggestUtils.Modifier.CARET;
 
     const strategies = interactive ? [
       suggestUtils.Strategy.KEEP,
@@ -84,7 +84,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
               workspace,
               target,
               existing,
-              await suggestUtils.getSuggestedDescriptors(descriptor, {project, workspace, cache, target, modifier, strategies})
+              await suggestUtils.getSuggestedDescriptors(descriptor, {project, workspace, cache, target, modifier, strategies}),
             ] as [
               Workspace,
               suggestUtils.Target,
@@ -99,7 +99,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     const allSuggestions = await Promise.all(allSuggestionsPromises);
 
     const checkReport = await LightReport.start({configuration, stdout, suggestInstall: false}, async report => {
-      for (const [workspace, target, existing, suggestions] of allSuggestions) {
+      for (const [/*workspace*/, /*target*/, existing, suggestions] of allSuggestions) {
         const nonNullSuggestions = suggestions.filter(suggestion => {
           return suggestion.descriptor !== null;
         });
@@ -129,7 +129,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
       Descriptor
     ]> = [];
 
-    for (const [workspace, target, existing, suggestions] of allSuggestions) {
+    for (const [workspace, target, /*existing*/, suggestions] of allSuggestions) {
       let selected;
 
       const nonNullSuggestions = suggestions.filter(suggestion => {
@@ -187,7 +187,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
         stdout.write(`\n`);
 
       const installReport = await StreamReport.start({configuration, stdout}, async report => {
-          await project.install({cache, report});
+        await project.install({cache, report});
       });
 
       return installReport.exitCode();

--- a/packages/plugin-essentials/sources/commands/why.ts
+++ b/packages/plugin-essentials/sources/commands/why.ts
@@ -2,7 +2,7 @@ import {WorkspaceRequiredError}                                  from '@berry/cl
 import {Cache, Configuration, LightReport, LocatorHash, Package} from '@berry/core';
 import {PluginConfiguration, Project, Workspace}                 from '@berry/core';
 import {miscUtils, structUtils}                                  from '@berry/core';
-import { PortablePath } from '@berry/fslib';
+import {PortablePath}                                            from '@berry/fslib';
 import {Writable}                                                from 'stream';
 import {asTree}                                                  from 'treeify';
 

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -1,6 +1,6 @@
-import {Configuration, MessageName, PluginConfiguration, Project, StreamReport, structUtils} from '@berry/core';
-import { PortablePath } from '@berry/fslib';
-import {Writable}                                                                            from 'stream';
+import {Configuration, PluginConfiguration, Project, StreamReport, structUtils} from '@berry/core';
+import {PortablePath}                                                           from '@berry/fslib';
+import {Writable}                                                               from 'stream';
 
 const DEPENDENCY_TYPES = ['devDependencies', 'dependencies'];
 
@@ -60,7 +60,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
             ? structUtils.stringifyIdent(manifest.name)
             : null,
 
-          ... extra,
+          ...extra,
         });
       }
     });

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -1,9 +1,9 @@
 import {Configuration, Ident, MessageName}              from '@berry/core';
 import {PluginConfiguration, StreamReport, structUtils} from '@berry/core';
+import {PortablePath}                                   from '@berry/fslib';
 import {npmHttpUtils}                                   from '@berry/plugin-npm';
 import inquirer                                         from 'inquirer';
 import {Readable, Writable}                             from 'stream';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
@@ -40,9 +40,9 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     const report = await StreamReport.start({configuration, stdout}, async report => {
       let ident: Ident | null = null;
 
-      if (scope) {
+      if (scope)
         ident = structUtils.makeIdent(scope, ``);
-      }
+
 
       const credentials = await getCredentials(prompt);
       const url = `/-/user/org.couchdb.user:${encodeURIComponent(credentials.name)}`;
@@ -74,9 +74,9 @@ async function setAuthToken(ident: Ident | null, npmAuthToken: string) {
   if (scope) {
     return await Configuration.updateHomeConfiguration({
       npmScopes: (scopes: {[key: string]: any} = {}) => ({
-        ... scopes,
+        ...scopes,
         [scope]: {
-          ... scopes[scope],
+          ...scopes[scope],
           npmAuthToken,
         },
       }),
@@ -99,13 +99,13 @@ async function getCredentials(prompt: any) {
       type: `input`,
       name: `username`,
       message: `Username:`,
-      validate: (input: string) => validateRequiredInput(input, `Username`)
+      validate: (input: string) => validateRequiredInput(input, `Username`),
     },
     {
       type: `password`,
       name: `password`,
       message: `Password:`,
-      validate: (input: string) => validateRequiredInput(input, `Password`)
+      validate: (input: string) => validateRequiredInput(input, `Password`),
     },
   ]);
 

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -1,6 +1,7 @@
 import {WorkspaceRequiredError}                                                            from '@berry/cli';
 import {Configuration, MessageName, PluginConfiguration, Project, StreamReport, Workspace} from '@berry/core';
 import {miscUtils, structUtils}                                                            from '@berry/core';
+import {PortablePath}                                                                      from '@berry/fslib';
 import {npmHttpUtils}                                                                      from '@berry/plugin-npm';
 import {packUtils}                                                                         from '@berry/plugin-pack';
 import {UsageError}                                                                        from 'clipanion';
@@ -8,7 +9,6 @@ import {createHash}                                                             
 import ssri                                                                                from 'ssri';
 import {Writable}                                                                          from 'stream';
 import * as yup                                                                            from 'yup';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
@@ -119,7 +119,7 @@ async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, ta
     _id: name,
     _attachments: {
       [`${name}-${version}.tgz`]: {
-        content_type: `application/octet-stream`,
+        [`content_type`]: `application/octet-stream`,
         data: buffer.toString(`base64`),
         length: buffer.length,
       },
@@ -134,7 +134,7 @@ async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, ta
 
     versions: {
       [version]: {
-        ... raw,
+        ...raw,
 
         _id: `${name}@${version}`,
 

--- a/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
@@ -1,9 +1,9 @@
 import {Configuration, Ident, MessageName}              from '@berry/core';
 import {PluginConfiguration, StreamReport, structUtils} from '@berry/core';
+import {PortablePath}                                   from '@berry/fslib';
 import {npmHttpUtils}                                   from '@berry/plugin-npm';
 import {Clipanion}                                      from 'clipanion';
 import {Readable, Writable}                             from 'stream';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) => clipanion
@@ -34,12 +34,12 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
     const report = await StreamReport.start({configuration, stdout}, async report => {
       let ident: Ident | null = null;
 
-      if (scope) {
+      if (scope)
         ident = structUtils.makeIdent(scope, ``);
-      }
+
 
       try {
-        const response = await npmHttpUtils.get(`/-/whoami`, { configuration, ident, authType: npmHttpUtils.AuthType.ALWAYS_AUTH, json: true });
+        const response = await npmHttpUtils.get(`/-/whoami`, {configuration, ident, authType: npmHttpUtils.AuthType.ALWAYS_AUTH, json: true});
 
         report.reportInfo(MessageName.UNNAMED, response.username);
       } catch (err) {

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -1,8 +1,8 @@
 import {WorkspaceRequiredError}                                           from '@berry/cli';
 import {Cache, Configuration, PluginConfiguration, Project, StreamReport} from '@berry/core';
 import {structUtils}                                                      from '@berry/core';
+import {PortablePath}                                                     from '@berry/fslib';
 import {Writable}                                                         from 'stream';
-import { PortablePath } from '@berry/fslib';
 
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion

--- a/packages/plugin-stage/sources/commands/stage.ts
+++ b/packages/plugin-stage/sources/commands/stage.ts
@@ -1,11 +1,11 @@
-import {Configuration, PluginConfiguration, Project} from '@berry/core';
+import {Configuration, PluginConfiguration, Project}                      from '@berry/core';
 import {NodeFS, xfs, PortablePath, ppath}                                 from '@berry/fslib';
-import {UsageError}                                  from 'clipanion';
-import {Writable}                                    from 'stream';
+import {UsageError}                                                       from 'clipanion';
+import {Writable}                                                         from 'stream';
 
-import {Driver as GitDriver}                         from '../drivers/GitDriver';
-import {Driver as MercurialDriver}                   from '../drivers/MercurialDriver';
-import {Hooks}                                       from '..';
+import {Driver as GitDriver}                                              from '../drivers/GitDriver';
+import {Driver as MercurialDriver}                                        from '../drivers/MercurialDriver';
+import {Hooks}                                                            from '..';
 
 const ALL_DRIVERS = [
   GitDriver,

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -99,7 +99,7 @@ export const Driver = {
     const {stdout} = await execUtils.execvp(`git`, [`status`, `-s`], {cwd, strict: true});
     const lines = stdout.toString().split(/\n/g);
 
-    const changes = ([] as Array<stageUtils.FileAction>).concat(... lines.map((line: string) => {
+    const changes = ([] as Array<stageUtils.FileAction>).concat(...lines.map((line: string) => {
       if (line === ``)
         return [];
 
@@ -110,22 +110,22 @@ export const Driver = {
       if (prefix === `?? ` && line.endsWith(`/`)) {
         return stageUtils.expandDirectory(path).map(path => ({
           action: stageUtils.ActionType.CREATE,
-          path
+          path,
         }));
       } else if (prefix === ` A ` || prefix === `?? `) {
         return [{
           action: stageUtils.ActionType.CREATE,
-          path
+          path,
         }];
       } else if (prefix === ` M `) {
         return [{
           action: stageUtils.ActionType.MODIFY,
-          path
+          path,
         }];
       } else if (prefix === ` D `) {
         return [{
           action: stageUtils.ActionType.DELETE,
-          path
+          path,
         }];
       }
       else {
@@ -148,13 +148,13 @@ export const Driver = {
   async makeCommit(cwd: PortablePath, changeList: Array<stageUtils.FileAction>, commitMessage: string) {
     const localPaths = changeList.map(file => NodeFS.fromPortablePath(file.path));
 
-    await execUtils.execvp(`git`, [`add`, `-N`, `--`, ... localPaths], {cwd, strict: true});
-    await execUtils.execvp(`git`, [`commit`, `-m`, `${commitMessage}\n\n${MESSAGE_MARKER}\n`, `--`, ... localPaths], {cwd, strict: true});
+    await execUtils.execvp(`git`, [`add`, `-N`, `--`, ...localPaths], {cwd, strict: true});
+    await execUtils.execvp(`git`, [`commit`, `-m`, `${commitMessage}\n\n${MESSAGE_MARKER}\n`, `--`, ...localPaths], {cwd, strict: true});
   },
 
   async makeReset(cwd: PortablePath, changeList: Array<stageUtils.FileAction>) {
     const localPaths = changeList.map(path => NodeFS.fromPortablePath(path.path));
 
-    await execUtils.execvp(`git`, [`reset`, `HEAD`, `--`, ... localPaths], {cwd, strict: true});
+    await execUtils.execvp(`git`, [`reset`, `HEAD`, `--`, ...localPaths], {cwd, strict: true});
   },
 };

--- a/packages/plugin-stage/sources/drivers/MercurialDriver.ts
+++ b/packages/plugin-stage/sources/drivers/MercurialDriver.ts
@@ -1,5 +1,6 @@
-import * as stageUtils from '../stageUtils';
-import { PortablePath, toFilename } from '@berry/fslib';
+import {PortablePath, toFilename} from '@berry/fslib';
+
+import * as stageUtils            from '../stageUtils';
 
 export const Driver = {
   async findRoot(cwd: PortablePath) {

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -1,10 +1,10 @@
-import { Configuration, LocatorHash, PluginConfiguration, Project, Workspace }   from '@berry/core';
-import { Cache, DescriptorHash, LightReport, MessageName, Report, StreamReport } from '@berry/core';
-import { miscUtils, structUtils }                                                from '@berry/core';
-import { PortablePath }                                                          from '@berry/fslib';
-import { cpus }                                                                  from 'os';
+import {Configuration, LocatorHash, PluginConfiguration, Project, Workspace}     from '@berry/core';
+import {Cache, DescriptorHash, LightReport, MessageName, Report, StreamReport}   from '@berry/core';
+import {miscUtils, structUtils}                                                  from '@berry/core';
+import {PortablePath}                                                            from '@berry/fslib';
+import {cpus}                                                                    from 'os';
 import pLimit                                                                    from 'p-limit';
-import { Writable }                                                              from 'stream';
+import {Writable}                                                                from 'stream';
 import * as yup                                                                  from 'yup';
 
 
@@ -25,127 +25,127 @@ type ForeachOptions = {
 // eslint-disable-next-line arca/no-default-export
 export default (clipanion: any, pluginConfiguration: PluginConfiguration) => clipanion
 
-    .command(`workspaces foreach run <command> [...args] [-p,--parallel] [--with-dependencies] [-I,--interlaced] [-P,--prefixed] [-j,--jobs JOBS] [-i,--include WORKSPACES...] [-x,--exclude WORKSPACES...]`)
-    .flags({proxyArguments: true})
+  .command(`workspaces foreach run <command> [...args] [-p,--parallel] [--with-dependencies] [-I,--interlaced] [-P,--prefixed] [-j,--jobs JOBS] [-i,--include WORKSPACES...] [-x,--exclude WORKSPACES...]`)
+  .flags({proxyArguments: true})
 
-    .validate(yup.object().shape({
-      jobs: yup.number().min(2),
-      parallel: yup.boolean().when('jobs', {
-        is: val => val > 1,
-        then: yup.boolean().oneOf([true], '--parallel must be set when using --jobs'),
-        otherwise: yup.boolean()
-      }),
-    }))
+  .validate(yup.object().shape({
+    jobs: yup.number().min(2),
+    parallel: yup.boolean().when('jobs', {
+      is: val => val > 1,
+      then: yup.boolean().oneOf([true], '--parallel must be set when using --jobs'),
+      otherwise: yup.boolean(),
+    }),
+  }))
 
-    .categorize(`Workspace-related commands`)
-    .describe(`run a command on all workspaces`)
+  .categorize(`Workspace-related commands`)
+  .describe(`run a command on all workspaces`)
 
-    .action(
-      async ({cwd, args, stdout, command, exclude, include, interlaced, parallel, withDependencies, prefixed, jobs, ...env}: ForeachOptions) => {
-        const configuration = await Configuration.find(cwd, pluginConfiguration);
-        const { project } = await Project.find(configuration, cwd);
-        const cache = await Cache.find(configuration);
+  .action(
+    async ({cwd, args, stdout, command, exclude, include, interlaced, parallel, withDependencies, prefixed, jobs, ...env}: ForeachOptions) => {
+      const configuration = await Configuration.find(cwd, pluginConfiguration);
+      const {project} = await Project.find(configuration, cwd);
+      const cache = await Cache.find(configuration);
 
-        let workspaces = project.workspaces.filter(workspace => workspace.manifest.scripts.has(command));
+      let workspaces = project.workspaces.filter(workspace => workspace.manifest.scripts.has(command));
 
-        if (include.length > 0)
-          workspaces = workspaces.filter(workspace => include.includes(workspace.locator.name))
+      if (include.length > 0)
+        workspaces = workspaces.filter(workspace => include.includes(workspace.locator.name))
 
-        if (exclude.length > 0)
-          workspaces = workspaces.filter(workspace => !exclude.includes(workspace.locator.name))
+      if (exclude.length > 0)
+        workspaces = workspaces.filter(workspace => !exclude.includes(workspace.locator.name))
 
-        // No need to buffer the output if we're executing the commands sequentially
-        if (!parallel)
-          interlaced = true;
+      // No need to buffer the output if we're executing the commands sequentially
+      if (!parallel)
+        interlaced = true;
 
-        const needsProcessing = new Map<LocatorHash, Workspace>();
-        const processing = new Set<DescriptorHash>();
+      const needsProcessing = new Map<LocatorHash, Workspace>();
+      const processing = new Set<DescriptorHash>();
 
-        const concurrency = parallel ? Math.max(1, cpus().length / 2) : 1;
-        const limit = pLimit(jobs || concurrency);
+      const concurrency = parallel ? Math.max(1, cpus().length / 2) : 1;
+      const limit = pLimit(jobs || concurrency);
 
-        let commandCount = 0;
+      let commandCount = 0;
 
-        const resolutionReport = await LightReport.start({configuration, stdout}, async (report: LightReport) => {
-          await project.resolveEverything({lockfileOnly: true, cache, report});
-        });
+      const resolutionReport = await LightReport.start({configuration, stdout}, async (report: LightReport) => {
+        await project.resolveEverything({lockfileOnly: true, cache, report});
+      });
 
-        if (resolutionReport.hasErrors())
-          return resolutionReport.exitCode();
+      if (resolutionReport.hasErrors())
+        return resolutionReport.exitCode();
 
-        const runReport = await StreamReport.start({configuration, stdout}, async report => {
-          for (const workspace of workspaces)
-            needsProcessing.set(workspace.anchoredLocator.locatorHash, workspace);
+      const runReport = await StreamReport.start({configuration, stdout}, async report => {
+        for (const workspace of workspaces)
+          needsProcessing.set(workspace.anchoredLocator.locatorHash, workspace);
 
-          while (needsProcessing.size > 0) {
-            const commandPromises = [];
+        while (needsProcessing.size > 0) {
+          const commandPromises = [];
 
-            for (const [identHash, workspace] of needsProcessing) {
-              // If we are already running the command on that workspace, skip
-              if (processing.has(workspace.anchoredDescriptor.descriptorHash))
-                continue;
+          for (const [identHash, workspace] of needsProcessing) {
+            // If we are already running the command on that workspace, skip
+            if (processing.has(workspace.anchoredDescriptor.descriptorHash))
+              continue;
 
-              let isRunnable = true;
+            let isRunnable = true;
 
-              // By default we do topological, however we don't care of the order when running
-              // in --parallel unless also given the --with-dependencies flag
-              if (!parallel || withDependencies) {
-                for (const [identHash, descriptor] of workspace.dependencies) {
-                  const locatorHash = project.storedResolutions.get(descriptor.descriptorHash);
-                  if (typeof locatorHash === `undefined`)
-                    throw new Error(`Assertion failed: The resolution should have been registered`);
+            // By default we do topological, however we don't care of the order when running
+            // in --parallel unless also given the --with-dependencies flag
+            if (!parallel || withDependencies) {
+              for (const [/*identHash*/, descriptor] of workspace.dependencies) {
+                const locatorHash = project.storedResolutions.get(descriptor.descriptorHash);
+                if (typeof locatorHash === `undefined`)
+                  throw new Error(`Assertion failed: The resolution should have been registered`);
 
-                  if (needsProcessing.has(locatorHash)) {
-                    isRunnable = false;
-                    break;
-                  }
+                if (needsProcessing.has(locatorHash)) {
+                  isRunnable = false;
+                  break;
                 }
               }
-
-              if (!isRunnable)
-                continue;
-
-              processing.add(workspace.anchoredDescriptor.descriptorHash);
-
-              commandPromises.push(limit(async () => {
-                await runCommand(workspace, {
-                  commandIndex: ++commandCount,
-                });
-
-                needsProcessing.delete(identHash);
-                processing.delete(workspace.anchoredDescriptor.descriptorHash);
-              }));
             }
 
-            if (commandPromises.length === 0)
-              return report.reportError(MessageName.CYCLIC_DEPENDENCIES, `Dependency cycle detected`);
+            if (!isRunnable)
+              continue;
 
-            await Promise.all(commandPromises);
-          }
+            processing.add(workspace.anchoredDescriptor.descriptorHash);
 
-          async function runCommand(workspace: Workspace, {commandIndex}: {commandIndex: number}) {
-            const prefix = getPrefix(workspace, {configuration, prefixed, commandIndex});
-
-            const stdout = createStream(report, {prefix, interlaced});
-            const stderr = createStream(report, {prefix, interlaced});
-
-            try {
-              await clipanion.run(null, [`run`, command, ...args], {
-                ...env,
-                cwd: workspace.cwd,
-                stdout: stdout,
-                stderr: stderr,
+            commandPromises.push(limit(async () => {
+              await runCommand(workspace, {
+                commandIndex: ++commandCount,
               });
-            } finally {
-              stdout.end();
-              stderr.end();
-            }
-          }
-        });
 
-        return runReport.exitCode();
-      }
-    );
+              needsProcessing.delete(identHash);
+              processing.delete(workspace.anchoredDescriptor.descriptorHash);
+            }));
+          }
+
+          if (commandPromises.length === 0)
+            return report.reportError(MessageName.CYCLIC_DEPENDENCIES, `Dependency cycle detected`);
+
+          await Promise.all(commandPromises);
+        }
+
+        async function runCommand(workspace: Workspace, {commandIndex}: {commandIndex: number}) {
+          const prefix = getPrefix(workspace, {configuration, prefixed, commandIndex});
+
+          const stdout = createStream(report, {prefix, interlaced});
+          const stderr = createStream(report, {prefix, interlaced});
+
+          try {
+            await clipanion.run(null, [`run`, command, ...args], {
+              ...env,
+              cwd: workspace.cwd,
+              stdout: stdout,
+              stderr: stderr,
+            });
+          } finally {
+            stdout.end();
+            stderr.end();
+          }
+        }
+      });
+
+      return runReport.exitCode();
+    }
+  );
 
 
 function createStream(report: Report, {prefix, interlaced}: {prefix: string | null, interlaced: boolean}) {


### PR DESCRIPTION
The lint command was erroneous:

```
eslint packages/*/sources/**.ts
```

Instead of:

```
eslint packages/*/sources/**/*.ts
```

This was causing eslint to only cover the files at the root of the `sources` folders (not the ones within nested directories, such as `sources/commands`).

This diff fixes the issue and the errors that crept in.