### PR TITLE
Ignores prism specificity on the website

### DIFF
--- a/packages/gatsby/src/components/layout.css
+++ b/packages/gatsby/src/components/layout.css
@@ -19,6 +19,6 @@ code {
 
 /* unset styling from primsjs theme (set in gatsby-browser.js) */
 :not(pre) > code[class*="language-"] {
-  background: transparent;
-  padding: unset;
+  background: transparent !important;
+  padding: unset !important;
 }


### PR DESCRIPTION
It seems like #152 introduced a small visual bug that only appears in production, not in dev:

![image](https://user-images.githubusercontent.com/1037931/58307896-5274d900-7e00-11e9-931a-8805389a9f9d.png)

I think it's related to the specificity of the rules (my guess is that the order of the rules is different versus prod and dev, hence why we only see this after being deployed), which should hopefully be fixed by an `!important` tag.