### PR TITLE
Fixes --sdk when the VSCode configuration isnt there yet

### DIFF
--- a/packages/berry-pnpify/lib/bin.js
+++ b/packages/berry-pnpify/lib/bin.js
@@ -840,7 +840,7 @@ async function generateSdk(projectRoot, targetFolder) {
     await sources["b" /* xfs */].writeFilePromise(tssdkManifest, JSON.stringify({ name: 'typescript', version: `${__webpack_require__(16).version}-pnpify` }, null, 2));
     await sources["b" /* xfs */].writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
     const settings = path["e" /* ppath */].join(projectRoot, `.vscode/settings.json`);
-    const content = await sources["b" /* xfs */].existsPromise(settings) ? await sources["b" /* xfs */].readFilePromise(settings, `utf8`) : ``;
+    const content = await sources["b" /* xfs */].existsPromise(settings) ? await sources["b" /* xfs */].readFilePromise(settings, `utf8`) : `{}`;
     const data = JSON.parse(content);
     data[`typescript.tsdk`] = NodeFS["a" /* NodeFS */].fromPortablePath(path["e" /* ppath */].relative(projectRoot, path["e" /* ppath */].dirname(tsserver)));
     const patched = `${JSON.stringify(data, null, 2)}\n`;

--- a/packages/berry-pnpify/sources/generateSdk.ts
+++ b/packages/berry-pnpify/sources/generateSdk.ts
@@ -35,7 +35,7 @@ export async function generateSdk(projectRoot: PortablePath, targetFolder: Porta
   await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath));
 
   const settings = ppath.join(projectRoot, `.vscode/settings.json` as PortablePath);
-  const content = await xfs.existsPromise(settings) ? await xfs.readFilePromise(settings, `utf8`) : ``;
+  const content = await xfs.existsPromise(settings) ? await xfs.readFilePromise(settings, `utf8`) : `{}`;
 
   const data = JSON.parse(content);
   data[`typescript.tsdk`] = NodeFS.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver)));


### PR DESCRIPTION
It was parsing an empty string instead of an empty object, which was causing `JSON.parse` to fail.