### PR TITLE
gatsby: fix cli and advanced links active display

### DIFF
--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -18,10 +18,10 @@ module.exports = {
       link: `/features`,
     }, {
       name: `CLI`,
-      link: `/cli/install`,
+      link: `/cli`,
     }, {
       name: `Advanced`,
-      link: `/advanced/architecture`,
+      link: `/advanced`,
     }],
     algolia: {
       // Note that the appId and appKey are specific to Yarn's website - please

--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -50,5 +50,19 @@ module.exports = {
       redirectInBrowser: true,
       isPermanent: true,
     });
+
+    createRedirect({
+      fromPath: `/cli`,
+      toPath: `/cli/install`,
+      redirectInBrowser: true,
+      isPermanent: true,
+    });
+
+    createRedirect({
+      fromPath: `/advanced`,
+      toPath: `/advanced/architecture`,
+      redirectInBrowser: true,
+      isPermanent: true,
+    });
   },
 };


### PR DESCRIPTION
Currently on the yarn v2 docs site for the `cli` and `advanced` sections, if you select one of the pages other than the default (`install` for cli, `architecture` for advanced), the header links will lose the `active` class. It is because the header links themselves link directly to `/cli/install` and `/advanced/architecture`. 

This PR makes these sections behave like the others. The header links now just go to `/cli` and `/advanced`, and a redirect is added to take `/cli` to `/cli/install` and from `/advanced` to `/advanced/architecture`

![active-tab (2)](https://user-images.githubusercontent.com/5084492/58445865-ffcb4380-80c3-11e9-9952-0e38453947f0.gif)
