### PR TITLE
Gatsby: Maintain navigation scroll position from page to page

### DIFF
--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -2,6 +2,8 @@ import styled      from '@emotion/styled';
 import {Link}      from 'gatsby';
 import React       from 'react';
 
+import useScroll   from '../utils/useScroll';
+
 import {ifDesktop} from './responsive';
 
 const Container = styled.div`
@@ -68,19 +70,24 @@ const Content = styled.div`
   }
 `;
 
-const Navigation = ({items, children}) => <>
-  <Container>
-    <Menu>
-      {items.map(({to, name}) => <React.Fragment key={name}>
-        <MenuEntry to={to} activeClassName={`active`}>
-          {name.match(/^`.*`$/) ? <code>{name.slice(1, -1)}</code> : name}
-        </MenuEntry>
-      </React.Fragment>)}
-    </Menu>
-    <Content>
-      {children}
-    </Content>
-  </Container>
-</>;
+const Navigation = ({items, children}) => {
+  const id = window.location.pathname.split(`/`)[1];
+  const scrollRef = useScroll(id);
+
+  return <>
+    <Container>
+      <Menu ref={scrollRef}>
+        {items.map(({to, name}) => <React.Fragment key={name}>
+          <MenuEntry to={to} activeClassName={`active`}>
+            {name.match(/^`.*`$/) ? <code>{name.slice(1, -1)}</code> : name}
+          </MenuEntry>
+        </React.Fragment>)}
+      </Menu>
+      <Content>
+        {children}
+      </Content>
+    </Container>
+  </>
+};
 
 export default Navigation;

--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -8,11 +8,11 @@ const useScroll = id => {
   };
 
   const readBrowserStorage = id => {
-    return sessionStorage.getItem(`gatsby:sidebar:${id}`);
+    return sessionStorage.getItem(`gatsby:navigation:${id}`);
   }
 
   const setBrowserStorage = (id ,pos) => {
-    sessionStorage.setItem(`gatsby:sidebar:${id}`, pos.toString());
+    sessionStorage.setItem(`gatsby:navigation:${id}`, pos.toString());
   }
 
   // initial render

--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -15,15 +15,10 @@ const useScroll = id => {
     sessionStorage.setItem(`gatsby:navigation:${id}`, pos.toString());
   }
 
-  // initial render
   useLayoutEffect(() => {
     const initPos = readBrowserStorage(id);
     ref.current.scrollTop = initPos == null ? 0 : parseInt(initPos, 10);
-  }, []);
-
-  useLayoutEffect(() => {
-    ref.current.addEventListener("scroll", handleScroll);
-    return () => ref.current.removeEventListener("scroll", handleScroll);
+    return () => handleScroll();
   }, []);
 
   return ref;

--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -1,0 +1,32 @@
+import { useLayoutEffect, useRef } from "react";
+
+const useScroll = id => {
+  const ref = useRef();
+
+  const handleScroll = () => {
+    setBrowserStorage(id ,ref.current.scrollTop);
+  };
+
+  const readBrowserStorage = id => {
+    return sessionStorage.getItem(`gatsby:sidebar:${id}`);
+  }
+
+  const setBrowserStorage = (id ,pos) => {
+    sessionStorage.setItem(`gatsby:sidebar:${id}`, pos.toString());
+  }
+
+  // initial render
+  useLayoutEffect(() => {
+    const initPos = readBrowserStorage(id);
+    ref.current.scrollTop = initPos == null ? 0 : parseInt(initPos, 10);
+  }, []);
+
+  useLayoutEffect(() => {
+    ref.current.addEventListener("scroll", handleScroll);
+    return () => ref.current.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return ref;
+};
+
+export default useScroll;


### PR DESCRIPTION
Currently, the [cli page](https://yarnpkg.github.io/berry/cli/install) resets its left navigation to the top on page refresh. 
This change attempts to fix that issue by storing scroll position in sessionStorage, with a key of `gatsby:navigation:<leftmost path name>`.

