### PR TITLE
Fixes old-style import w/ workspaces

### DIFF
--- a/packages/berry-core/sources/YarnResolver.ts
+++ b/packages/berry-core/sources/YarnResolver.ts
@@ -44,6 +44,12 @@ export class YarnResolver implements Resolver {
       }
 
       const {version, resolved} = (parsed as any)[key];
+
+      // Workspaces don't have the "resolved" key; we can skip them, as their
+      // resolution will be recomputed when needed anyway
+      if (!resolved)
+        continue;
+
       let reference;
 
       for (const [pattern, matcher] of IMPORTED_PATTERNS) {


### PR DESCRIPTION
It seems that workspaces don't have any `resolved` field in old-style lockfiles. Since we don't handle this case, we break when running `yarn` within a v1 project that used workspaces. This diff simply ignores such entries and let Yarn resolve them again (which isn't a problem for workspaces, as they're local to the project).

Example of a lockfile that now works:
https://github.com/mui-org/material-ui/blob/60071b8b6d4406af3c0a7a332ff86ca02cffa32d/yarn.lock