### PR TITLE
Improves the display when stack overflows occur

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -10339,6 +10339,10 @@ function $$SETUP_STATE(hydrateRuntimeState) {
               "packageLocation": "./packages/berry-pnpify/",
               "packageDependencies": [
                 [
+                  "@berry/pnpify",
+                  "workspace:packages/berry-pnpify"
+                ],
+                [
                   "@berry/builder",
                   "workspace:packages/berry-builder"
                 ],
@@ -10349,10 +10353,6 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                 [
                   "@berry/pnp",
                   "workspace:packages/berry-pnp"
-                ],
-                [
-                  "@berry/pnpify",
-                  "workspace:packages/berry-pnpify"
                 ],
                 [
                   "typescript",
@@ -54471,14 +54471,6 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                 [
                   "react-dom-core",
                   "virtual:eb984aafa4809c536767e60d24b7bd923578a3333b3da246798b062a7744d91f6e12c455abcc9a9551da1dbbe8b3b7d12f4e0f00dffcc2bd1a0c60e2e9dd4eff#npm:0.0.3"
-                ],
-                [
-                  "fbjs",
-                  "npm:1.0.0"
-                ],
-                [
-                  "object-assign",
-                  "npm:4.1.1"
                 ],
                 [
                   "react",

--- a/packages/berry-core/sources/Report.ts
+++ b/packages/berry-core/sources/Report.ts
@@ -52,6 +52,7 @@ export enum MessageName {
   PROLOG_UNKNOWN_ERROR = 42,
   PROLOG_SYNTAX_ERROR = 43,
   PROLOG_EXISTENCE_ERROR = 44,
+  STACK_OVERFLOW_RESOLUTION = 45,
 }
 
 export class ReportError extends Error {

--- a/packages/berry-pnpify/package.json
+++ b/packages/berry-pnpify/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "@berry/builder": "workspace:0.0.0",
     "@berry/pnp": "workspace:0.0.3",
-    "@berry/pnpify": "workspace:0.0.4",
     "typescript": "^3.3.3333",
     "webpack": "^4.28.4",
     "webpack-cli": "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,7 +1958,6 @@ __metadata:
     "@berry/builder": "workspace:0.0.0"
     "@berry/fslib": "workspace:0.0.6"
     "@berry/pnp": "workspace:0.0.3"
-    "@berry/pnpify": "workspace:0.0.4"
     typescript: "npm:^3.3.3333"
     webpack: "npm:^4.28.4"
     webpack-cli: "npm:^3.2.1"


### PR DESCRIPTION
This PR adds a better error message when a stack overflow occurs during the peers resolution step. This typically only occur in a single case: when a package that lists a peer dependency also somehow depends on itself (for example in this PR you can see I removed a dependency from `@berry/pnpify` - `@berry/pnpify` itself). When it happens we virtualize the package, but since the virtualization depends on its parent we need to revirtualize the child (even though it's the same package as its parent).

While we might be able to detect the one-level case (where A depends on A), it still wouldn't work for multi-level cases (where A depends on B which depends on A), so I decided to go with a simpler solution and just print the resolution stacktrace. In the case of `@berry/pnpify`, you clearly see where the cyclic loop starts.