### PR TITLE
Gatsby fix website generation

### DIFF
--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -71,9 +71,7 @@ const Content = styled.div`
 `;
 
 const Navigation = ({items, children}) => {
-  // eslint-disable-next-line no-restricted-globals
-  const id = location.pathname.split(`/`)[1];
-  const scrollRef = useScroll(id);
+  const scrollRef = useScroll();
 
   return <>
     <Container>

--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -4,15 +4,15 @@ const useScroll = () => {
   const ref = useRef();
 
   const readBrowserStorage = id => {
-    return sessionStorage.getItem(`gatsby:navigation:${id}`);
+    return sessionStorage.getItem(`berry:navigation:${id}`);
   }
 
   const setBrowserStorage = (id, pos) => {
-    sessionStorage.setItem(`gatsby:navigation:${id}`, pos.toString());
+    sessionStorage.setItem(`berry:navigation:${id}`, pos.toString());
   }
 
   useLayoutEffect(() => {
-    const id = window.location.pathname.split(`/`)[1];
+    const id = window.location.pathname.split(`/`)[2];
     const initPos = readBrowserStorage(id);
     ref.current.scrollTop = initPos == null ? 0 : parseInt(initPos, 10);
     return () => setBrowserStorage(id, ref.current.scrollTop);

--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -1,11 +1,7 @@
 import { useLayoutEffect, useRef } from "react";
 
-const useScroll = id => {
+const useScroll = () => {
   const ref = useRef();
-
-  const handleScroll = () => {
-    setBrowserStorage(id ,ref.current.scrollTop);
-  };
 
   const readBrowserStorage = id => {
     return sessionStorage.getItem(`gatsby:navigation:${id}`);
@@ -16,9 +12,10 @@ const useScroll = id => {
   }
 
   useLayoutEffect(() => {
+    const id = window.location.pathname.split(`/`)[1];
     const initPos = readBrowserStorage(id);
     ref.current.scrollTop = initPos == null ? 0 : parseInt(initPos, 10);
-    return () => handleScroll();
+    return () => setBrowserStorage(id, ref.current.scrollTop);
   }, []);
 
   return ref;


### PR DESCRIPTION
Fixes website generation by calling window once the component has mounted.

Changes the sessionStorage key to account for the build's `prefix-paths` option, from `gatsby:navigation:berry` to `berry:navigation:<top level menu item>`.

Doc build was tested [here](https://github.com/andrewl33/berry/tree/test-documentation-generation), using `yarn build` and `yarn serve`, the latter modified to `gatsby serve --prefix-paths`.