### PR TITLE
Stops printing the same build warning multiple times

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -54807,14 +54807,6 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                   "virtual:eb984aafa4809c536767e60d24b7bd923578a3333b3da246798b062a7744d91f6e12c455abcc9a9551da1dbbe8b3b7d12f4e0f00dffcc2bd1a0c60e2e9dd4eff#npm:0.0.3"
                 ],
                 [
-                  "fbjs",
-                  "npm:1.0.0"
-                ],
-                [
-                  "object-assign",
-                  "npm:4.1.1"
-                ],
-                [
                   "react",
                   "npm:15.6.2"
                 ]

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -73,19 +73,19 @@ class PnpInstaller implements Installer {
     const buildScripts = await this.getBuildScripts(fetchResult);
 
     if (buildScripts.length > 0 && !this.opts.project.configuration.get(`enableScripts`)) {
-      this.opts.report.reportWarning(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but all build scripts have been disabled.`);
+      this.opts.report.reportWarningOnce(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but all build scripts have been disabled.`);
       buildScripts.length = 0;
     }
 
     if (buildScripts.length > 0 && pkg.linkType !== LinkType.HARD && !this.opts.project.tryWorkspaceByLocator(pkg)) {
-      this.opts.report.reportWarning(MessageName.SOFT_LINK_BUILD, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but is referenced through a soft link. Soft links don't support build scripts, so they'll be ignored.`);
+      this.opts.report.reportWarningOnce(MessageName.SOFT_LINK_BUILD, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but is referenced through a soft link. Soft links don't support build scripts, so they'll be ignored.`);
       buildScripts.length = 0;
     }
 
     const dependencyMeta = this.opts.project.getDependencyMeta(pkg, pkg.version);
 
     if (buildScripts.length > 0 && dependencyMeta && dependencyMeta.built === false) {
-      this.opts.report.reportInfo(MessageName.BUILD_DISABLED, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but its build has been explicitly disabled through configuration.`);
+      this.opts.report.reportInfoOnce(MessageName.BUILD_DISABLED, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but its build has been explicitly disabled through configuration.`);
       buildScripts.length = 0;
     }
 


### PR DESCRIPTION
Since those warnings/infos don't provide value apart from the first instance we can discard them 🙂