### PR TITLE
Fix endless loop in foreach cmd

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -10271,6 +10271,10 @@ function $$SETUP_STATE(hydrateRuntimeState) {
                   "workspace:packages/berry-builder"
                 ],
                 [
+                  "@berry/cli",
+                  "workspace:packages/berry-cli"
+                ],
+                [
                   "@berry/core",
                   "workspace:packages/berry-core"
                 ],

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following packages are plugins for Berry and can be installed through `berry
 - [plugin-stage](packages/plugin-pack) adds support for the [`yarn stage`](https://yarnpkg.github.io/berry/cli/stage) command.
 - [plugin-pnp★](packages/plugin-pnp) adds support for installing Javascript dependencies through the [Plug'n'Play](https://yarnpkg.github.io/berry/features/pnp) specification.
 - [plugin-typescript★](packages/plugin-typescript) improves the user experience when working with TypeScript.
+- [plugin-workspace-tools](packages/plugin-workspace-tools) adds support for the [`yarn workspaces foreach`](https://yarnpkg.github.io/berry/cli/workspaces/foreach) command.
 
 To create your own plugin, please refer to the [documentation](https://yarnpkg.github.io/berry/features/plugins).
 
@@ -90,7 +91,7 @@ Clone this repository, then run the following commands:
 $> yarn build:cli
 ```
 
-**How it works**  
+**How it works**
 
 After building the CLI your global `yarn` will immediatly start to reflect your local changes. This is because Yarn will pick up the `yarn-path` settings in this repository's `.yarnrc`, which is configured to use the newly built CLI if available.
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -10,6 +10,18 @@ Object {
 }
 `;
 
+exports[`Commands workspace foreach should not fall into endless loop if foreach run cmd is the same as lifecycle script name 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Test Workspace A
+➤ YN0000: Test Workspace C
+➤ YN0000: Test Workspace B
+➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands workspace foreach should only run the scripts on workspaces that match the --include list 1`] = `
 Object {
   "code": 0,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -10,13 +10,15 @@ Object {
 }
 `;
 
-exports[`Commands workspace foreach should not fall into endless loop if foreach run cmd is the same as lifecycle script name 1`] = `
+exports[`Commands workspace foreach should not fall into endless loop if foreach cmd is the same as lifecycle script name 1`] = `
 Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: Test Workspace A
-➤ YN0000: Test Workspace C
 ➤ YN0000: Test Workspace B
+➤ YN0000: Test Workspace C
+➤ YN0000: Test Workspace D
+➤ YN0000: Test Workspace E
 ➤ YN0000: Done
 ",
 }
@@ -43,6 +45,17 @@ Object {
 ➤ YN0000: [workspace-b]: Test Workspace B
 
 ➤ YN0000: [workspace-c]: Test Workspace C
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands workspace foreach should run on child workspaces by default 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Test Workspace D
+➤ YN0000: Test Workspace E
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -67,7 +67,8 @@ exports[`Commands workspace foreach should run on child workspaces by default 1`
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Test Workspace D
+  "stdout": "➤ YN0000: Test Workspace C
+➤ YN0000: Test Workspace D
 ➤ YN0000: Test Workspace E
 ➤ YN0000: Test Workspace F
 ➤ YN0000: Done

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -5,6 +5,12 @@ Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: [workspace-c]: Test Workspace C
+
+➤ YN0000: [workspace-d]: Test Workspace D
+
+➤ YN0000: [workspace-e]: Test Workspace E
+
+➤ YN0000: [workspace-f]: Test Workspace F
 ➤ YN0000: Done
 ",
 }
@@ -19,6 +25,7 @@ Object {
 ➤ YN0000: Test Workspace C
 ➤ YN0000: Test Workspace D
 ➤ YN0000: Test Workspace E
+➤ YN0000: Test Workspace F
 ➤ YN0000: Done
 ",
 }
@@ -45,6 +52,12 @@ Object {
 ➤ YN0000: [workspace-b]: Test Workspace B
 
 ➤ YN0000: [workspace-c]: Test Workspace C
+
+➤ YN0000: [workspace-d]: Test Workspace D
+
+➤ YN0000: [workspace-e]: Test Workspace E
+
+➤ YN0000: [workspace-f]: Test Workspace F
 ➤ YN0000: Done
 ",
 }
@@ -56,6 +69,7 @@ Object {
   "stderr": "",
   "stdout": "➤ YN0000: Test Workspace D
 ➤ YN0000: Test Workspace E
+➤ YN0000: Test Workspace F
 ➤ YN0000: Done
 ",
 }
@@ -68,6 +82,9 @@ Object {
   "stdout": "➤ YN0000: Test Workspace A
 ➤ YN0000: Test Workspace C
 ➤ YN0000: Test Workspace B
+➤ YN0000: Test Workspace D
+➤ YN0000: Test Workspace E
+➤ YN0000: Test Workspace F
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -193,6 +193,35 @@ describe(`Commands`, () => {
     );
 
     test(
+      `should not fall into endless loop if foreach run cmd is the same as lifecycle script name`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          scripts: {
+            print: `yarn workspaces foreach run --parallel --topological --jobs=2 print`
+          },
+          workspaces: [`packages/*`]
+        },
+        async ({ path, run }) => {
+          await setupWorkspaces(path);
+
+          let code;
+          let stdout;
+          let stderr;
+
+          try {
+            await run(`install`);
+            ({code, stdout, stderr} = await run(`print`));
+          } catch (error) {
+            ({code, stdout, stderr} = error);
+          }
+
+          await expect({code, stdout, stderr}).toMatchSnapshot();
+        }
+      )
+    );
+
+    test(
       `should throw an error when using --jobs without --parallel`,
       makeTemporaryEnv(
         {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -36,27 +36,45 @@ async function setupWorkspaces(path) {
     name: `workspace-c`,
     version: `1.0.0`,
     scripts: {
-      print: `echo Test Workspace C`,
+      print: `echo Test Workspace C`
     },
     workspaces: [`packages/*`],
     dependencies: {
-      [`workspace-a`]: `workspace:*`
+      [`workspace-a`]: `workspace:*`,
     }
   });
 
   await writeJson(`${path}/packages/workspace-c/packages/workspace-d/package.json`, {
     name: `workspace-d`,
     version: `1.0.0`,
+    workspaces: [`packages/*`],
     scripts: {
-      print: `echo Test Workspace D`,
+      print: `echo Test Workspace D`
+    },
+    dependencies: {
+      [`workspace-b`]: `workspace:*`
     }
   });
 
-  await writeJson(`${path}/packages/workspace-c/packages/workspace-e/package.json`, {
+  await writeJson(`${path}/packages/workspace-c/packages/workspace-d/packages/workspace-e/package.json`, {
     name: `workspace-e`,
     version: `1.0.0`,
     scripts: {
-      print: `echo Test Workspace E`,
+      print: `echo Test Workspace E`
+    },
+    dependencies: {
+      [`workspace-d`]: `workspace:*`
+    }
+  });
+
+  await writeJson(`${path}/packages/workspace-c/packages/workspace-f/package.json`, {
+    name: `workspace-f`,
+    version: `1.0.0`,
+    scripts: {
+      print: `echo Test Workspace F`
+    },
+    dependencies: {
+      [`workspace-e`]: `workspace:*`
     }
   });
 }

--- a/packages/plugin-workspace-tools/bin/@berry/plugin-workspace-tools.js
+++ b/packages/plugin-workspace-tools/bin/@berry/plugin-workspace-tools.js
@@ -192,12 +192,12 @@ exports.default = (clipanion, pluginConfiguration) => clipanion
     .action(async (_a) => {
     var { cwd, args, stdout, command, exclude, include, interlaced, parallel, topological, topologicalDev, all, verbose, jobs } = _a, env = __rest(_a, ["cwd", "args", "stdout", "command", "exclude", "include", "interlaced", "parallel", "topological", "topologicalDev", "all", "verbose", "jobs"]);
     const configuration = await core_1.Configuration.find(cwd, pluginConfiguration);
-    const { project, workspace } = await core_1.Project.find(configuration, cwd);
-    if (!all && !workspace)
+    const { project, workspace: cwdWorkspace } = await core_1.Project.find(configuration, cwd);
+    if (!all && !cwdWorkspace)
         throw new cli_1.WorkspaceRequiredError(cwd);
     const rootWorkspace = all
         ? project.topLevelWorkspace
-        : workspace;
+        : cwdWorkspace;
     const candidates = [rootWorkspace, ...getWorkspaceChildrenRecursive(rootWorkspace, project)];
     const workspaces = [];
     for (const workspace of candidates) {
@@ -205,7 +205,7 @@ exports.default = (clipanion, pluginConfiguration) => clipanion
             continue;
         // Prevents infinite loop in the case of configuring a script as such:
         //     "lint": "yarn workspaces foreach --all lint"
-        if (command === process.env.npm_lifecycle_event && workspace.cwd === cwd)
+        if (command === process.env.npm_lifecycle_event && workspace.cwd === cwdWorkspace.cwd)
             continue;
         if (include.length > 0 && !include.includes(workspace.locator.name))
             continue;

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -4,6 +4,7 @@
   "main": "./sources/index.ts",
   "dependencies": {
     "@berry/builder": "workspace:0.0.0",
+    "@berry/cli": "workspace:2.0.0",
     "@berry/core": "workspace:0.0.0",
     "@berry/fslib": "workspace:0.0.6",
     "clipanion": "^0.15.0",

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -79,14 +79,14 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
   .action(
     async ({cwd, args, stdout, command, exclude, include, interlaced, parallel, topological, topologicalDev, all, verbose, jobs, ...env}: ForeachOptions) => {
       const configuration = await Configuration.find(cwd, pluginConfiguration);
-      const {project, workspace} = await Project.find(configuration, cwd);
+      const {project, workspace: cwdWorkspace} = await Project.find(configuration, cwd);
 
-      if (!all && !workspace)
+      if (!all && !cwdWorkspace)
         throw new WorkspaceRequiredError(cwd);
 
       const rootWorkspace = all
         ? project.topLevelWorkspace
-        : workspace!;
+        : cwdWorkspace!;
 
       const candidates = [rootWorkspace, ...getWorkspaceChildrenRecursive(rootWorkspace, project)];
 
@@ -98,7 +98,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
 
         // Prevents infinite loop in the case of configuring a script as such:
         //     "lint": "yarn workspaces foreach --all lint"
-        if (command === process.env.npm_lifecycle_event && workspace.cwd === cwd)
+        if (command === process.env.npm_lifecycle_event && workspace.cwd === cwdWorkspace!.cwd)
           continue;
 
         if (include.length > 0 && !include.includes(workspace.locator.name))

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -80,21 +80,21 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     async ({cwd, args, stdout, command, exclude, include, interlaced, parallel, topological, topologicalDev, all, verbose, jobs, ...env}: ForeachOptions) => {
       const configuration = await Configuration.find(cwd, pluginConfiguration);
       const {project, workspace} = await Project.find(configuration, cwd);
-      
+
       if (!all && !workspace)
         throw new WorkspaceRequiredError(cwd);
 
       const rootWorkspace = all
         ? project.topLevelWorkspace
-        : workspace;
+        : workspace!;
 
       const candidates = getWorkspaceChildrenRecursive(rootWorkspace, project);
-      const workspaces = [];
+      const workspaces: Array<Workspace> = [];
 
       for (const workspace of candidates) {
         if (!workspace.manifest.scripts.has(command))
           continue;
-        
+
         if (include.length > 0 && !include.includes(workspace.locator.name))
           continue;
 

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -58,7 +58,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
       const configuration = await Configuration.find(cwd, pluginConfiguration);
       const {project} = await Project.find(configuration, cwd);
 
-      let workspaces = project.workspaces.filter(workspace => workspace.manifest.scripts.has(command));
+      let workspaces = project.workspaces.filter(workspace => workspace.manifest.scripts.has(command) && (command !== process.env.npm_lifecycle_event || workspace.cwd !== cwd));
 
       if (include.length > 0)
         workspaces = workspaces.filter(workspace => include.includes(workspace.locator.name))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,6 +1929,7 @@ __metadata:
   resolution: "@berry/plugin-workspace-tools@workspace:packages/plugin-workspace-tools"
   dependencies:
     "@berry/builder": "workspace:0.0.0"
+    "@berry/cli": "workspace:2.0.0"
     "@berry/core": "workspace:0.0.0"
     "@berry/fslib": "workspace:0.0.6"
     clipanion: "npm:^0.15.0"


### PR DESCRIPTION
This PR fixes endless loop in foreach cmd which happens when lifecycle script name is the same as cmd name being run by `workspaces foreach run`