### PR TITLE
Support overriding registry via publishConfig or configuration

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/config.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/config.test.js.snap
@@ -29,6 +29,7 @@ Object {
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmPublishAccess\\",\\"effective\\":null,\\"description\\":\\"Default access of the published packages\\",\\"type\\":\\"STRING\\",\\"default\\":null}
+{\\"key\\":\\"npmPublishRegistry\\",\\"effective\\":null,\\"description\\":\\"Registry to push packages to\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
@@ -76,6 +77,7 @@ Object {
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmPublishAccess - Default access of the published packages - null
+➤ YN0000: npmPublishRegistry - Registry to push packages to - null
 ➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Settings per package scope - Map {}
@@ -124,6 +126,7 @@ Object {
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmPublishAccess - <default> - null
+➤ YN0000: npmPublishRegistry - <default> - null
 ➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - <default> - Map {}
@@ -172,6 +175,7 @@ Object {
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmPublishAccess - null
+➤ YN0000: npmPublishRegistry - null
 ➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Map {}
@@ -220,6 +224,7 @@ Object {
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmPublishAccess\\",\\"effective\\":null,\\"description\\":\\"Default access of the published packages\\",\\"type\\":\\"STRING\\",\\"default\\":null}
+{\\"key\\":\\"npmPublishRegistry\\",\\"effective\\":null,\\"description\\":\\"Registry to push packages to\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
@@ -267,6 +272,7 @@ Object {
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmPublishAccess - Default access of the published packages - null
+➤ YN0000: npmPublishRegistry - Registry to push packages to - null
 ➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Settings per package scope - Map {}
@@ -315,6 +321,7 @@ Object {
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmPublishAccess - <default> - null
+➤ YN0000: npmPublishRegistry - <default> - null
 ➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - <default> - Map {}
@@ -363,6 +370,7 @@ Object {
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmPublishAccess - null
+➤ YN0000: npmPublishRegistry - null
 ➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Map {}
@@ -411,6 +419,7 @@ Object {
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmPublishAccess\\",\\"effective\\":null,\\"description\\":\\"Default access of the published packages\\",\\"type\\":\\"STRING\\",\\"default\\":null}
+{\\"key\\":\\"npmPublishRegistry\\",\\"effective\\":null,\\"description\\":\\"Registry to push packages to\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
@@ -458,6 +467,7 @@ Object {
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmPublishAccess - Default access of the published packages - null
+➤ YN0000: npmPublishRegistry - Registry to push packages to - null
 ➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Settings per package scope - Map {}
@@ -506,6 +516,7 @@ Object {
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmPublishAccess - <default> - null
+➤ YN0000: npmPublishRegistry - <default> - null
 ➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - <default> - Map {}
@@ -554,6 +565,7 @@ Object {
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmPublishAccess - null
+➤ YN0000: npmPublishRegistry - null
 ➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Map {}
@@ -602,6 +614,7 @@ Object {
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmPublishAccess\\",\\"effective\\":null,\\"description\\":\\"Default access of the published packages\\",\\"type\\":\\"STRING\\",\\"default\\":null}
+{\\"key\\":\\"npmPublishRegistry\\",\\"effective\\":null,\\"description\\":\\"Registry to push packages to\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
@@ -649,6 +662,7 @@ Object {
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmPublishAccess - Default access of the published packages - null
+➤ YN0000: npmPublishRegistry - Registry to push packages to - null
 ➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Settings per package scope - Map {}
@@ -697,6 +711,7 @@ Object {
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmPublishAccess - <default> - null
+➤ YN0000: npmPublishRegistry - <default> - null
 ➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - <default> - Map {}
@@ -745,6 +760,7 @@ Object {
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmPublishAccess - null
+➤ YN0000: npmPublishRegistry - null
 ➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Map {}
@@ -793,6 +809,7 @@ Object {
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmPublishAccess\\",\\"effective\\":null,\\"description\\":\\"Default access of the published packages\\",\\"type\\":\\"STRING\\",\\"default\\":null}
+{\\"key\\":\\"npmPublishRegistry\\",\\"effective\\":null,\\"description\\":\\"Registry to push packages to\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
@@ -840,6 +857,7 @@ Object {
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmPublishAccess - Default access of the published packages - null
+➤ YN0000: npmPublishRegistry - Registry to push packages to - null
 ➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Settings per package scope - Map {}
@@ -888,6 +906,7 @@ Object {
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmPublishAccess - <default> - null
+➤ YN0000: npmPublishRegistry - <default> - null
 ➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - <default> - Map {}
@@ -936,6 +955,7 @@ Object {
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmPublishAccess - null
+➤ YN0000: npmPublishRegistry - null
 ➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Map {}
@@ -984,6 +1004,7 @@ Object {
 {\\"key\\":\\"npmAuthIdent\\",\\"effective\\":null,\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmAuthToken\\",\\"effective\\":null,\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}
 {\\"key\\":\\"npmPublishAccess\\",\\"effective\\":null,\\"description\\":\\"Default access of the published packages\\",\\"type\\":\\"STRING\\",\\"default\\":null}
+{\\"key\\":\\"npmPublishRegistry\\",\\"effective\\":null,\\"description\\":\\"Registry to push packages to\\",\\"type\\":\\"STRING\\",\\"default\\":null}
 {\\"key\\":\\"npmRegistries\\",\\"effective\\":{},\\"description\\":\\"Settings per registry\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
 {\\"key\\":\\"npmRegistryServer\\",\\"effective\\":\\"http://yarn.test.registry\\",\\"source\\":\\"<environment>\\",\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"}
 {\\"key\\":\\"npmScopes\\",\\"effective\\":{},\\"description\\":\\"Settings per package scope\\",\\"type\\":\\"MAP\\",\\"valueDefinition\\":{\\"description\\":\\"\\",\\"type\\":\\"SHAPE\\",\\"properties\\":{\\"npmRegistryServer\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"STRING\\",\\"default\\":\\"https://registry.yarnpkg.com\\"},\\"npmAlwaysAuth\\":{\\"description\\":\\"URL of the selected npm registry (note: npm enterprise isn't supported)\\",\\"type\\":\\"BOOLEAN\\",\\"default\\":false},\\"npmAuthIdent\\":{\\"description\\":\\"Authentication identity for the npm registry (_auth in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null},\\"npmAuthToken\\":{\\"description\\":\\"Authentication token for the npm registry (_authToken in npm and yarn v1)\\",\\"type\\":\\"SECRET\\",\\"default\\":null}}}}
@@ -1031,6 +1052,7 @@ Object {
 ➤ YN0000: npmAuthIdent - Authentication identity for the npm registry (_auth in npm and yarn v1) - null
 ➤ YN0000: npmAuthToken - Authentication token for the npm registry (_authToken in npm and yarn v1) - null
 ➤ YN0000: npmPublishAccess - Default access of the published packages - null
+➤ YN0000: npmPublishRegistry - Registry to push packages to - null
 ➤ YN0000: npmRegistries - Settings per registry - Map {}
 ➤ YN0000: npmRegistryServer - URL of the selected npm registry (note: npm enterprise isn't supported) - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Settings per package scope - Map {}
@@ -1079,6 +1101,7 @@ Object {
 ➤ YN0000: npmAuthIdent - <default> - null
 ➤ YN0000: npmAuthToken - <default> - null
 ➤ YN0000: npmPublishAccess - <default> - null
+➤ YN0000: npmPublishRegistry - <default> - null
 ➤ YN0000: npmRegistries - <default> - Map {}
 ➤ YN0000: npmRegistryServer - <environment> - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - <default> - Map {}
@@ -1127,6 +1150,7 @@ Object {
 ➤ YN0000: npmAuthIdent - null
 ➤ YN0000: npmAuthToken - null
 ➤ YN0000: npmPublishAccess - null
+➤ YN0000: npmPublishRegistry - null
 ➤ YN0000: npmRegistries - Map {}
 ➤ YN0000: npmRegistryServer - 'http://yarn.test.registry'
 ➤ YN0000: npmScopes - Map {}

--- a/packages/berry-core/sources/Manifest.ts
+++ b/packages/berry-core/sources/Manifest.ts
@@ -27,6 +27,7 @@ export interface PublishConfig {
   access?: string;
   main?: PortablePath;
   module?: PortablePath;
+  registry?: string;
 };
 
 export class Manifest {
@@ -308,6 +309,9 @@ export class Manifest {
 
       if (typeof data.publishConfig.main === `string`)
         this.publishConfig.main = data.publishConfig.main;
+
+      if (typeof data.publishConfig.registry === `string`)
+        this.publishConfig.registry = data.publishConfig.registry;
 
       if (typeof data.publishConfig.module === `string`) {
         this.publishConfig.module = data.publishConfig.module;

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -50,6 +50,8 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
     const ident = workspace.manifest.name;
     const version = workspace.manifest.version;
 
+    const publishRegistry = workspace.manifest.publishConfig && workspace.manifest.publishConfig.registry || configuration.get('npmPublishRegistry') as string|undefined;
+
     const report = await StreamReport.start({configuration, stdout}, async report => {
       // Not an error if --tolerate-republish is set
       if (tolerateRepublish) {
@@ -57,6 +59,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
           const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(ident), {
             configuration,
             ident,
+            registry: publishRegistry,
             json: true,
           });
 
@@ -91,6 +94,7 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
           await npmHttpUtils.put(npmHttpUtils.getIdentUrl(ident), body, {
             configuration,
             ident,
+            registry: publishRegistry,
             json: true,
           });
         } catch (error) {

--- a/packages/plugin-npm-cli/sources/index.ts
+++ b/packages/plugin-npm-cli/sources/index.ts
@@ -11,6 +11,11 @@ const plugin: Plugin = {
       type: SettingsType.STRING,
       default: null,
     },
+    npmPublishRegistry: {
+      description: `Registry to push packages to`,
+      type: SettingsType.STRING,
+      default: null,
+    },
   },
   commands: [
     login,

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -16,7 +16,11 @@ type AuthOptions = {
   ident: Ident | null,
 }
 
-export type Options = httpUtils.Options & AuthOptions;
+type RegistryOptions = {
+  registry?: string;
+}
+
+export type Options = httpUtils.Options & AuthOptions & RegistryOptions;
 
 export function getIdentUrl(ident: Ident) {
   if (ident.scope) {
@@ -26,8 +30,10 @@ export function getIdentUrl(ident: Ident) {
   }
 }
 
-export async function get(path: string, {configuration, headers, ident, authType, ...rest}: Options) {
-  const registry = npmConfigUtils.getRegistry(ident, {configuration});
+export async function get(path: string, {configuration, headers, ident, authType, registry, ...rest}: Options) {
+  if (!registry)
+    registry = npmConfigUtils.getRegistry(ident, {configuration});
+
   const auth = getAuthenticationHeader({configuration}, {ident, authType});
 
   if (auth)
@@ -36,8 +42,10 @@ export async function get(path: string, {configuration, headers, ident, authType
   return await httpUtils.get(`${registry}${path}`, {configuration, headers, ...rest});
 }
 
-export async function put(path: string, body: httpUtils.Body, {configuration, headers, ident, authType = AuthType.ALWAYS_AUTH, ...rest}: Options) {
-  const registry = npmConfigUtils.getRegistry(ident, {configuration});
+export async function put(path: string, body: httpUtils.Body, {configuration, headers, ident, authType = AuthType.ALWAYS_AUTH, registry, ...rest}: Options) {
+  if (!registry)
+    registry = npmConfigUtils.getRegistry(ident, {configuration});
+
   const auth = getAuthenticationHeader({configuration}, {ident, authType});
 
   if (auth)


### PR DESCRIPTION
This adds support for `publishConfig.registry` in the manifest to set the publish registry for a single workspace, but it also introduces the `npmPublishRegistry` configuration variable that allows setting the publish registry for an entire project.

The way yarn finds the registry to which to push:

- `publishConfig.registry` in the workspace's manifest
- `npmPublishRegistry` configuration option
- the regular registry as configured

Relevance: 

- `publishConfig.registry` is supported in npm and yarn
- self-hosted Nexus npm registries are setup like so: a registry for your packages and a "group" that groups that registry with a mirror of the public registry. You set the group as registry in the yarn config, but you must publish to the other registry
- Lerna supports setting a `command.publish.registry` in `lerna.json`, which will then apply to all workspaces in the project. This is far less error prone than having the same `publishConfig.registry` in all workspace manifests (although constraints could help here)