### PR TITLE
Prevents crashes when link: points to a folder without package.json

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
@@ -1,0 +1,64 @@
+const {xfs} = require(`@berry/fslib`);
+const {
+  fs: {createTemporaryFolder, readJson, writeJson},
+  tests: {getPackageDirectoryPath},
+} = require('pkg-tests-core');
+
+describe(`Protocols`, () => {
+  describe(`portal:`, () => {
+    test(
+      `it should link a remote location into the current dependency tree`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: getPackageDirectoryPath(`no-deps`, `1.0.0`).then(dirPath => `link:${dirPath}`),
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(source(`require('no-deps/package.json')`)).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+      }),
+    );
+
+    test(
+      `it should ignore links' own dependencies`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: getPackageDirectoryPath(`one-fixed-dep`, `1.0.0`).then(dirPath => `link:${dirPath}`),
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(source(`{ try { require('one-fixed-dep') } catch (error) { return error.code } }`)).resolves.toEqual(`UNDECLARED_DEPENDENCY`);
+      }),
+    );
+
+    test(
+      `it should work even when the target doesn't have a manifest`,
+      makeTemporaryEnv(
+        {},
+        async ({path, run, source}) => {
+          const tmp = await createTemporaryFolder();
+
+          await writeJson(`${tmp}/data.json`, {
+            data: 42,
+          });
+
+          await writeJson(`${path}/package.json`, {
+            dependencies: {
+              [`foo`]: `link:${tmp}`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(source(`require('foo/data.json')`)).resolves.toMatchObject({
+            data: 42,
+          });
+        },
+      ),
+    );
+  });
+});

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -251,6 +251,9 @@ class PnpInstaller implements Installer {
   }
 
   private async getBuildScripts(fetchResult: FetchResult) {
+    if (!await fetchResult.packageFs.existsPromise(ppath.resolve(fetchResult.prefixPath, toFilename(`package.json`))))
+      return [];
+
     const buildScripts = [];
     const {scripts} = await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs});
 


### PR DESCRIPTION
This diff allows folders that don't even contain a manifest to still be used with the `link:` protocol (contrary to `portal:`, the `link:` protocol doesn't care about the content of the link destination).

There's still a problem in the design somewhere in that it (probably?) shouldn't be up to the linker to extract the metadata from the packages. It might not matter outside of `link:` though, so for now I'll sleep on it, but I'll keep it in mind in case we see another reason why it would make sense.

Also added some tests for the `link:` protocol in general.