### PR TITLE
Implements shell redirections

### DIFF
--- a/packages/berry-parsers/sources/grammars/shell.d.ts
+++ b/packages/berry-parsers/sources/grammars/shell.d.ts
@@ -1,10 +1,31 @@
-export type CommandSegment = string |
-{type: `shell`, shell: ShellLine, quoted: boolean} |
-{type: `variable`, name: string, defaultValue?: Array<Array<CommandSegment>>, quoted: boolean};
+// From the top to the bottom:
+//
+// - A shell line is composed of multiple command lines, first separated by ";" and then chained by "&&" / "||"
+// - A command line is composed of multiple commands chained by "|" / "|&"
+// - A command is composed of multiple arguments separated by spaces
+// - An argument can be a value argument (sent to the underlying program), or a redirection
+// - A value argument is a combination of argument segments
+
+export type ArgumentSegment =
+  | {type: `text`, text: string}
+  | {type: `shell`, shell: ShellLine, quoted: boolean}
+  | {type: `variable`, name: string, defaultValue?: Array<ValueArgument>, quoted: boolean};
+
+export type Argument =
+  | {type: `redirection`, subtype: `>` | `<` | `>>` | `<<<`, args: Array<ValueArgument>}
+  | ValueArgument;
+
+export type ValueArgument =
+| {type: `argument`, segments: Array<ArgumentSegment>};
+
+export type EnvSegment = {
+  name: string,
+  args: [] | [ValueArgument],
+};
 
 export type Command = {
   type: `command`,
-  args: Array<Array<CommandSegment>>,
+  args: Array<Argument>,
   envs: Array<EnvSegment>,
 } | {
   type: `subshell`,
@@ -36,9 +57,3 @@ export type CommandLineThen = {
 export type ShellLine = Array<CommandLine>;
 
 export declare const parse: (code: string) => ShellLine;
-
-export type EnvSegment = {
-  name: string,
-  args: Array<Array<CommandSegment>>,
-};
-

--- a/packages/berry-parsers/sources/grammars/shell.js
+++ b/packages/berry-parsers/sources/grammars/shell.js
@@ -170,14 +170,14 @@ function peg$parse(input, options) {
       peg$c26 = function(envs, args) { return { type: `command`, args, envs } },
       peg$c27 = function(envs) { return { type: `envs`, envs } },
       peg$c28 = function(args) { return args },
-      peg$c29 = ">",
-      peg$c30 = peg$literalExpectation(">", false),
-      peg$c31 = ">>",
-      peg$c32 = peg$literalExpectation(">>", false),
-      peg$c33 = "<",
-      peg$c34 = peg$literalExpectation("<", false),
-      peg$c35 = "<<<",
-      peg$c36 = peg$literalExpectation("<<<", false),
+      peg$c29 = ">>",
+      peg$c30 = peg$literalExpectation(">>", false),
+      peg$c31 = ">",
+      peg$c32 = peg$literalExpectation(">", false),
+      peg$c33 = "<<<",
+      peg$c34 = peg$literalExpectation("<<<", false),
+      peg$c35 = "<",
+      peg$c36 = peg$literalExpectation("<", false),
       peg$c37 = function(redirect, arg) { return { type: `redirection`, subtype: redirect, args: [arg] } },
       peg$c38 = function(arg) { return arg },
       peg$c39 = function(segments) { return { type: `argument`, segments: [].concat(... segments) } },
@@ -1012,33 +1012,33 @@ function peg$parse(input, options) {
       s2 = peg$parseS();
     }
     if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 62) {
+      if (input.substr(peg$currPos, 2) === peg$c29) {
         s2 = peg$c29;
-        peg$currPos++;
+        peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c31) {
+        if (input.charCodeAt(peg$currPos) === 62) {
           s2 = peg$c31;
-          peg$currPos += 2;
+          peg$currPos++;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s2 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 60) {
+          if (input.substr(peg$currPos, 3) === peg$c33) {
             s2 = peg$c33;
-            peg$currPos++;
+            peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
             if (peg$silentFails === 0) { peg$fail(peg$c34); }
           }
           if (s2 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c35) {
+            if (input.charCodeAt(peg$currPos) === 60) {
               s2 = peg$c35;
-              peg$currPos += 3;
+              peg$currPos++;
             } else {
               s2 = peg$FAILED;
               if (peg$silentFails === 0) { peg$fail(peg$c36); }

--- a/packages/berry-parsers/sources/grammars/shell.js
+++ b/packages/berry-parsers/sources/grammars/shell.js
@@ -169,50 +169,57 @@ function peg$parse(input, options) {
       peg$c25 = function(subshell) { return { type: `subshell`, subshell } },
       peg$c26 = function(envs, args) { return { type: `command`, args, envs } },
       peg$c27 = function(envs) { return { type: `envs`, envs } },
-      peg$c28 = function(segments) { return [].concat(... segments) },
-      peg$c29 = function(string) { return string },
-      peg$c30 = "'",
-      peg$c31 = peg$literalExpectation("'", false),
-      peg$c32 = function(text) { return [ text ] },
-      peg$c33 = "\"",
-      peg$c34 = peg$literalExpectation("\"", false),
-      peg$c35 = function(segments) { return [ ... segments ] },
-      peg$c36 = function(segments) { return segments },
-      peg$c37 = function(shell) { return { type: `shell`, shell, quoted: true } },
-      peg$c38 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
-      peg$c39 = function(shell) { return { type: `shell`, shell, quoted: false } },
-      peg$c40 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
-      peg$c41 = "\\",
-      peg$c42 = peg$literalExpectation("\\", false),
-      peg$c43 = peg$anyExpectation(),
-      peg$c44 = function(c) { return c },
-      peg$c45 = /^[^']/,
-      peg$c46 = peg$classExpectation(["'"], true, false),
-      peg$c47 = function(chars) { return chars.join(``) },
-      peg$c48 = /^[^$"]/,
-      peg$c49 = peg$classExpectation(["$", "\""], true, false),
-      peg$c50 = "$(",
-      peg$c51 = peg$literalExpectation("$(", false),
-      peg$c52 = function(command) { return command },
-      peg$c53 = "${",
-      peg$c54 = peg$literalExpectation("${", false),
-      peg$c55 = ":-",
-      peg$c56 = peg$literalExpectation(":-", false),
-      peg$c57 = "}",
-      peg$c58 = peg$literalExpectation("}", false),
-      peg$c59 = function(name, defaultValue) { return { name, defaultValue } },
-      peg$c60 = function(name) { return { name } },
-      peg$c61 = "$",
-      peg$c62 = peg$literalExpectation("$", false),
-      peg$c63 = /^[a-zA-Z0-9_]/,
-      peg$c64 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
-      peg$c65 = function() { return text() },
-      peg$c66 = /^[@*?#a-zA-Z0-9_\-]/,
-      peg$c67 = peg$classExpectation(["@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
-      peg$c68 = /^[(){}<>$|&; \t"']/,
-      peg$c69 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
-      peg$c70 = /^[ \t]/,
-      peg$c71 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c28 = ">",
+      peg$c29 = peg$literalExpectation(">", false),
+      peg$c30 = ">>",
+      peg$c31 = peg$literalExpectation(">>", false),
+      peg$c32 = "<<<",
+      peg$c33 = peg$literalExpectation("<<<", false),
+      peg$c34 = function(redirect, segments) { return {type: `>`, segments: [].concat(... segments)} },
+      peg$c35 = function(segments) { return [].concat(... segments) },
+      peg$c36 = function(string) { return string },
+      peg$c37 = "'",
+      peg$c38 = peg$literalExpectation("'", false),
+      peg$c39 = function(text) { return [ text ] },
+      peg$c40 = "\"",
+      peg$c41 = peg$literalExpectation("\"", false),
+      peg$c42 = function(segments) { return [ ... segments ] },
+      peg$c43 = function(segments) { return segments },
+      peg$c44 = function(shell) { return { type: `shell`, shell, quoted: true } },
+      peg$c45 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
+      peg$c46 = function(shell) { return { type: `shell`, shell, quoted: false } },
+      peg$c47 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
+      peg$c48 = "\\",
+      peg$c49 = peg$literalExpectation("\\", false),
+      peg$c50 = peg$anyExpectation(),
+      peg$c51 = function(c) { return c },
+      peg$c52 = /^[^']/,
+      peg$c53 = peg$classExpectation(["'"], true, false),
+      peg$c54 = function(chars) { return chars.join(``) },
+      peg$c55 = /^[^$"]/,
+      peg$c56 = peg$classExpectation(["$", "\""], true, false),
+      peg$c57 = "$(",
+      peg$c58 = peg$literalExpectation("$(", false),
+      peg$c59 = function(command) { return command },
+      peg$c60 = "${",
+      peg$c61 = peg$literalExpectation("${", false),
+      peg$c62 = ":-",
+      peg$c63 = peg$literalExpectation(":-", false),
+      peg$c64 = "}",
+      peg$c65 = peg$literalExpectation("}", false),
+      peg$c66 = function(name, defaultValue) { return { name, defaultValue } },
+      peg$c67 = function(name) { return { name } },
+      peg$c68 = "$",
+      peg$c69 = peg$literalExpectation("$", false),
+      peg$c70 = /^[a-zA-Z0-9_]/,
+      peg$c71 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
+      peg$c72 = function() { return text() },
+      peg$c73 = /^[@*?#a-zA-Z0-9_\-]/,
+      peg$c74 = peg$classExpectation(["@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
+      peg$c75 = /^[(){}<>$|&; \t"']/,
+      peg$c76 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
+      peg$c77 = /^[ \t]/,
+      peg$c78 = peg$classExpectation([" ", "\t"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -949,7 +956,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseArgument() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = [];
@@ -959,20 +966,61 @@ function peg$parse(input, options) {
       s2 = peg$parseS();
     }
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseArgumentSegment();
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$parseArgumentSegment();
-        }
+      if (input.charCodeAt(peg$currPos) === 62) {
+        s2 = peg$c28;
+        peg$currPos++;
       } else {
         s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+      }
+      if (s2 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c30) {
+          s2 = peg$c30;
+          peg$currPos += 2;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+        }
+        if (s2 === peg$FAILED) {
+          if (input.substr(peg$currPos, 3) === peg$c32) {
+            s2 = peg$c32;
+            peg$currPos += 3;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+          }
+        }
       }
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c28(s2);
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseS();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parseS();
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = [];
+          s5 = peg$parseArgumentSegment();
+          if (s5 !== peg$FAILED) {
+            while (s5 !== peg$FAILED) {
+              s4.push(s5);
+              s5 = peg$parseArgumentSegment();
+            }
+          } else {
+            s4 = peg$FAILED;
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c34(s2, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -980,6 +1028,38 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = [];
+      s2 = peg$parseS();
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$parseS();
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parseArgumentSegment();
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parseArgumentSegment();
+          }
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c35(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;
@@ -992,7 +1072,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSglQuoteString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c29(s1);
+      s1 = peg$c36(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1000,7 +1080,7 @@ function peg$parse(input, options) {
       s1 = peg$parseDblQuoteString();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c29(s1);
+        s1 = peg$c36(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1008,7 +1088,7 @@ function peg$parse(input, options) {
         s1 = peg$parsePlainString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c29(s1);
+          s1 = peg$c36(s1);
         }
         s0 = s1;
       }
@@ -1022,25 +1102,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c30;
+      s1 = peg$c37;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c31); }
+      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSglQuoteStringText();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c30;
+          s3 = peg$c37;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c38); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c32(s2);
+          s1 = peg$c39(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1063,11 +1143,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c33;
+      s1 = peg$c40;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
+      if (peg$silentFails === 0) { peg$fail(peg$c41); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1078,15 +1158,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c33;
+          s3 = peg$c40;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c34); }
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c35(s2);
+          s1 = peg$c42(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1120,7 +1200,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c36(s1);
+      s1 = peg$c43(s1);
     }
     s0 = s1;
 
@@ -1134,7 +1214,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSubshell();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c37(s1);
+      s1 = peg$c44(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1142,7 +1222,7 @@ function peg$parse(input, options) {
       s1 = peg$parseVariable();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c45(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1160,7 +1240,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSubshell();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c39(s1);
+      s1 = peg$c46(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1168,7 +1248,7 @@ function peg$parse(input, options) {
       s1 = peg$parseVariable();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c40(s1);
+        s1 = peg$c47(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1186,11 +1266,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c41;
+      s3 = peg$c48;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1198,11 +1278,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c43); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c44(s4);
+        s3 = peg$c51(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1213,12 +1293,12 @@ function peg$parse(input, options) {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$c45.test(input.charAt(peg$currPos))) {
+      if (peg$c52.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -1226,11 +1306,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c41;
+          s3 = peg$c48;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1238,11 +1318,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            if (peg$silentFails === 0) { peg$fail(peg$c50); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c44(s4);
+            s3 = peg$c51(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1253,12 +1333,12 @@ function peg$parse(input, options) {
           s2 = peg$FAILED;
         }
         if (s2 === peg$FAILED) {
-          if (peg$c45.test(input.charAt(peg$currPos))) {
+          if (peg$c52.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c46); }
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
           }
         }
       }
@@ -1267,7 +1347,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c54(s1);
     }
     s0 = s1;
 
@@ -1281,11 +1361,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c41;
+      s3 = peg$c48;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1293,11 +1373,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c43); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c44(s4);
+        s3 = peg$c51(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1308,12 +1388,12 @@ function peg$parse(input, options) {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$c48.test(input.charAt(peg$currPos))) {
+      if (peg$c55.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        if (peg$silentFails === 0) { peg$fail(peg$c56); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -1321,11 +1401,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c41;
+          s3 = peg$c48;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1333,11 +1413,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            if (peg$silentFails === 0) { peg$fail(peg$c50); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c44(s4);
+            s3 = peg$c51(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1348,12 +1428,12 @@ function peg$parse(input, options) {
           s2 = peg$FAILED;
         }
         if (s2 === peg$FAILED) {
-          if (peg$c48.test(input.charAt(peg$currPos))) {
+          if (peg$c55.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c49); }
+            if (peg$silentFails === 0) { peg$fail(peg$c56); }
           }
         }
       }
@@ -1362,7 +1442,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c54(s1);
     }
     s0 = s1;
 
@@ -1376,11 +1456,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c41;
+      s3 = peg$c48;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1388,11 +1468,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c43); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c44(s4);
+        s3 = peg$c51(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1420,11 +1500,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
+          if (peg$silentFails === 0) { peg$fail(peg$c50); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c44(s4);
+          s3 = peg$c51(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1440,11 +1520,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c41;
+          s3 = peg$c48;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c42); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1452,11 +1532,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            if (peg$silentFails === 0) { peg$fail(peg$c50); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c44(s4);
+            s3 = peg$c51(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1484,11 +1564,11 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c43); }
+              if (peg$silentFails === 0) { peg$fail(peg$c50); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c44(s4);
+              s3 = peg$c51(s4);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -1505,7 +1585,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c54(s1);
     }
     s0 = s1;
 
@@ -1516,12 +1596,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c50) {
-      s1 = peg$c50;
+    if (input.substr(peg$currPos, 2) === peg$c57) {
+      s1 = peg$c57;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c58); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseShellLine();
@@ -1535,7 +1615,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c52(s2);
+          s1 = peg$c59(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1557,22 +1637,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c53) {
-      s1 = peg$c53;
+    if (input.substr(peg$currPos, 2) === peg$c60) {
+      s1 = peg$c60;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c55) {
-          s3 = peg$c55;
+        if (input.substr(peg$currPos, 2) === peg$c62) {
+          s3 = peg$c62;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c56); }
+          if (peg$silentFails === 0) { peg$fail(peg$c63); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -1587,15 +1667,15 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c57;
+              s5 = peg$c64;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c58); }
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c59(s2, s4);
+              s1 = peg$c66(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1619,26 +1699,26 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c53) {
-        s1 = peg$c53;
+      if (input.substr(peg$currPos, 2) === peg$c60) {
+        s1 = peg$c60;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c54); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseIdentifier();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 125) {
-            s3 = peg$c57;
+            s3 = peg$c64;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c58); }
+            if (peg$silentFails === 0) { peg$fail(peg$c65); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c60(s2);
+            s1 = peg$c67(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1655,17 +1735,17 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 36) {
-          s1 = peg$c61;
+          s1 = peg$c68;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdentifier();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c60(s2);
+            s1 = peg$c67(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1686,22 +1766,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c63.test(input.charAt(peg$currPos))) {
+    if (peg$c70.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c64); }
+      if (peg$silentFails === 0) { peg$fail(peg$c71); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c63.test(input.charAt(peg$currPos))) {
+        if (peg$c70.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c64); }
+          if (peg$silentFails === 0) { peg$fail(peg$c71); }
         }
       }
     } else {
@@ -1709,7 +1789,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c65();
+      s1 = peg$c72();
     }
     s0 = s1;
 
@@ -1721,22 +1801,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c66.test(input.charAt(peg$currPos))) {
+    if (peg$c73.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c67); }
+      if (peg$silentFails === 0) { peg$fail(peg$c74); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c66.test(input.charAt(peg$currPos))) {
+        if (peg$c73.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
       }
     } else {
@@ -1744,7 +1824,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c65();
+      s1 = peg$c72();
     }
     s0 = s1;
 
@@ -1754,12 +1834,12 @@ function peg$parse(input, options) {
   function peg$parseSpecialShellChars() {
     var s0;
 
-    if (peg$c68.test(input.charAt(peg$currPos))) {
+    if (peg$c75.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      if (peg$silentFails === 0) { peg$fail(peg$c76); }
     }
 
     return s0;
@@ -1769,22 +1849,22 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = [];
-    if (peg$c70.test(input.charAt(peg$currPos))) {
+    if (peg$c77.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c71); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c70.test(input.charAt(peg$currPos))) {
+        if (peg$c77.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
       }
     } else {

--- a/packages/berry-parsers/sources/grammars/shell.js
+++ b/packages/berry-parsers/sources/grammars/shell.js
@@ -160,8 +160,8 @@ function peg$parse(input, options) {
       peg$c16 = peg$literalExpectation("|", false),
       peg$c17 = "=",
       peg$c18 = peg$literalExpectation("=", false),
-      peg$c19 = function(name, args) { return { name, args } },
-      peg$c20 = function(name) { return { name, args : [] } },
+      peg$c19 = function(name, arg) { return { name, args: [arg] } },
+      peg$c20 = function(name) { return { name, args: [] } },
       peg$c21 = "(",
       peg$c22 = peg$literalExpectation("(", false),
       peg$c23 = ")",
@@ -169,57 +169,64 @@ function peg$parse(input, options) {
       peg$c25 = function(subshell) { return { type: `subshell`, subshell } },
       peg$c26 = function(envs, args) { return { type: `command`, args, envs } },
       peg$c27 = function(envs) { return { type: `envs`, envs } },
-      peg$c28 = ">",
-      peg$c29 = peg$literalExpectation(">", false),
-      peg$c30 = ">>",
-      peg$c31 = peg$literalExpectation(">>", false),
-      peg$c32 = "<<<",
-      peg$c33 = peg$literalExpectation("<<<", false),
-      peg$c34 = function(redirect, segments) { return {type: `>`, segments: [].concat(... segments)} },
-      peg$c35 = function(segments) { return [].concat(... segments) },
-      peg$c36 = function(string) { return string },
-      peg$c37 = "'",
-      peg$c38 = peg$literalExpectation("'", false),
-      peg$c39 = function(text) { return [ text ] },
-      peg$c40 = "\"",
-      peg$c41 = peg$literalExpectation("\"", false),
-      peg$c42 = function(segments) { return [ ... segments ] },
-      peg$c43 = function(segments) { return segments },
-      peg$c44 = function(shell) { return { type: `shell`, shell, quoted: true } },
-      peg$c45 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
-      peg$c46 = function(shell) { return { type: `shell`, shell, quoted: false } },
-      peg$c47 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
-      peg$c48 = "\\",
-      peg$c49 = peg$literalExpectation("\\", false),
-      peg$c50 = peg$anyExpectation(),
-      peg$c51 = function(c) { return c },
-      peg$c52 = /^[^']/,
-      peg$c53 = peg$classExpectation(["'"], true, false),
-      peg$c54 = function(chars) { return chars.join(``) },
-      peg$c55 = /^[^$"]/,
-      peg$c56 = peg$classExpectation(["$", "\""], true, false),
-      peg$c57 = "$(",
-      peg$c58 = peg$literalExpectation("$(", false),
-      peg$c59 = function(command) { return command },
-      peg$c60 = "${",
-      peg$c61 = peg$literalExpectation("${", false),
-      peg$c62 = ":-",
-      peg$c63 = peg$literalExpectation(":-", false),
-      peg$c64 = "}",
-      peg$c65 = peg$literalExpectation("}", false),
-      peg$c66 = function(name, defaultValue) { return { name, defaultValue } },
-      peg$c67 = function(name) { return { name } },
-      peg$c68 = "$",
-      peg$c69 = peg$literalExpectation("$", false),
-      peg$c70 = /^[a-zA-Z0-9_]/,
-      peg$c71 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
-      peg$c72 = function() { return text() },
-      peg$c73 = /^[@*?#a-zA-Z0-9_\-]/,
-      peg$c74 = peg$classExpectation(["@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
-      peg$c75 = /^[(){}<>$|&; \t"']/,
-      peg$c76 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
-      peg$c77 = /^[ \t]/,
-      peg$c78 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c28 = function(args) { return args },
+      peg$c29 = ">",
+      peg$c30 = peg$literalExpectation(">", false),
+      peg$c31 = ">>",
+      peg$c32 = peg$literalExpectation(">>", false),
+      peg$c33 = "<",
+      peg$c34 = peg$literalExpectation("<", false),
+      peg$c35 = "<<<",
+      peg$c36 = peg$literalExpectation("<<<", false),
+      peg$c37 = function(redirect, arg) { return { type: `redirection`, subtype: redirect, args: [arg] } },
+      peg$c38 = function(arg) { return arg },
+      peg$c39 = function(segments) { return { type: `argument`, segments: [].concat(... segments) } },
+      peg$c40 = function(string) { return string },
+      peg$c41 = "'",
+      peg$c42 = peg$literalExpectation("'", false),
+      peg$c43 = function(text) { return [ { type: `text`, text } ] },
+      peg$c44 = "\"",
+      peg$c45 = peg$literalExpectation("\"", false),
+      peg$c46 = function(segments) { return segments },
+      peg$c47 = function(shell) { return { type: `shell`, shell, quoted: true } },
+      peg$c48 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
+      peg$c49 = function(text) { return { type: `text`, text } },
+      peg$c50 = function(shell) { return { type: `shell`, shell, quoted: false } },
+      peg$c51 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
+      peg$c52 = "\\",
+      peg$c53 = peg$literalExpectation("\\", false),
+      peg$c54 = peg$anyExpectation(),
+      peg$c55 = function(c) { return c },
+      peg$c56 = /^[^']/,
+      peg$c57 = peg$classExpectation(["'"], true, false),
+      peg$c58 = function(chars) { return chars.join(``) },
+      peg$c59 = /^[^$"]/,
+      peg$c60 = peg$classExpectation(["$", "\""], true, false),
+      peg$c61 = "$(",
+      peg$c62 = peg$literalExpectation("$(", false),
+      peg$c63 = function(command) { return command },
+      peg$c64 = "${",
+      peg$c65 = peg$literalExpectation("${", false),
+      peg$c66 = ":-",
+      peg$c67 = peg$literalExpectation(":-", false),
+      peg$c68 = "}",
+      peg$c69 = peg$literalExpectation("}", false),
+      peg$c70 = function(name, arg) { return { name, defaultValue: arg } },
+      peg$c71 = ":-}",
+      peg$c72 = peg$literalExpectation(":-}", false),
+      peg$c73 = function(name) { return { name, defaultValue: [] } },
+      peg$c74 = function(name) { return { name } },
+      peg$c75 = "$",
+      peg$c76 = peg$literalExpectation("$", false),
+      peg$c77 = /^[a-zA-Z0-9_]/,
+      peg$c78 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
+      peg$c79 = function() { return text() },
+      peg$c80 = /^[@*?#a-zA-Z0-9_\-]/,
+      peg$c81 = peg$classExpectation(["@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
+      peg$c82 = /^[(){}<>$|&; \t"']/,
+      peg$c83 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
+      peg$c84 = /^[ \t]/,
+      peg$c85 = peg$classExpectation([" ", "\t"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -686,16 +693,7 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$c18); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseArgumentSegment();
-        if (s4 !== peg$FAILED) {
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseArgumentSegment();
-          }
-        } else {
-          s3 = peg$FAILED;
-        }
+        s3 = peg$parseStrictValueArgument();
         if (s3 !== peg$FAILED) {
           s4 = [];
           s5 = peg$parseS();
@@ -955,8 +953,56 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseCommandString() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parseS();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parseS();
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseValueArgument();
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseValueArgument();
+        }
+      } else {
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$parseS();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parseS();
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c28(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseArgument() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = [];
@@ -967,56 +1013,45 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 62) {
-        s2 = peg$c28;
+        s2 = peg$c29;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
       }
       if (s2 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c30) {
-          s2 = peg$c30;
+        if (input.substr(peg$currPos, 2) === peg$c31) {
+          s2 = peg$c31;
           peg$currPos += 2;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c31); }
+          if (peg$silentFails === 0) { peg$fail(peg$c32); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c32) {
-            s2 = peg$c32;
-            peg$currPos += 3;
+          if (input.charCodeAt(peg$currPos) === 60) {
+            s2 = peg$c33;
+            peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+            if (peg$silentFails === 0) { peg$fail(peg$c34); }
+          }
+          if (s2 === peg$FAILED) {
+            if (input.substr(peg$currPos, 3) === peg$c35) {
+              s2 = peg$c35;
+              peg$currPos += 3;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c36); }
+            }
           }
         }
       }
       if (s2 !== peg$FAILED) {
-        s3 = [];
-        s4 = peg$parseS();
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          s4 = peg$parseS();
-        }
+        s3 = peg$parseValueArgument();
         if (s3 !== peg$FAILED) {
-          s4 = [];
-          s5 = peg$parseArgumentSegment();
-          if (s5 !== peg$FAILED) {
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parseArgumentSegment();
-            }
-          } else {
-            s4 = peg$FAILED;
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c34(s2, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+          peg$savedPos = s0;
+          s1 = peg$c37(s2, s3);
+          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1038,19 +1073,10 @@ function peg$parse(input, options) {
         s2 = peg$parseS();
       }
       if (s1 !== peg$FAILED) {
-        s2 = [];
-        s3 = peg$parseArgumentSegment();
-        if (s3 !== peg$FAILED) {
-          while (s3 !== peg$FAILED) {
-            s2.push(s3);
-            s3 = peg$parseArgumentSegment();
-          }
-        } else {
-          s2 = peg$FAILED;
-        }
+        s2 = peg$parseValueArgument();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c35(s2);
+          s1 = peg$c38(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1065,6 +1091,57 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseValueArgument() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parseS();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parseS();
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseStrictValueArgument();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c38(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseStrictValueArgument() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parseArgumentSegment();
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$parseArgumentSegment();
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c39(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseArgumentSegment() {
     var s0, s1;
 
@@ -1072,7 +1149,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSglQuoteString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c36(s1);
+      s1 = peg$c40(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1080,7 +1157,7 @@ function peg$parse(input, options) {
       s1 = peg$parseDblQuoteString();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c36(s1);
+        s1 = peg$c40(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1088,7 +1165,7 @@ function peg$parse(input, options) {
         s1 = peg$parsePlainString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c36(s1);
+          s1 = peg$c40(s1);
         }
         s0 = s1;
       }
@@ -1102,25 +1179,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c37;
+      s1 = peg$c41;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c38); }
+      if (peg$silentFails === 0) { peg$fail(peg$c42); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSglQuoteStringText();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c37;
+          s3 = peg$c41;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c38); }
+          if (peg$silentFails === 0) { peg$fail(peg$c42); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c39(s2);
+          s1 = peg$c43(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1143,11 +1220,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c40;
+      s1 = peg$c44;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c41); }
+      if (peg$silentFails === 0) { peg$fail(peg$c45); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1158,15 +1235,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c40;
+          s3 = peg$c44;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c45); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s2);
+          s1 = peg$c46(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1200,7 +1277,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c43(s1);
+      s1 = peg$c46(s1);
     }
     s0 = s1;
 
@@ -1214,7 +1291,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSubshell();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c44(s1);
+      s1 = peg$c47(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1222,11 +1299,17 @@ function peg$parse(input, options) {
       s1 = peg$parseVariable();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s1);
+        s1 = peg$c48(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        s0 = peg$parseDblQuoteStringText();
+        s0 = peg$currPos;
+        s1 = peg$parseDblQuoteStringText();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c49(s1);
+        }
+        s0 = s1;
       }
     }
 
@@ -1240,7 +1323,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSubshell();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c46(s1);
+      s1 = peg$c50(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1248,11 +1331,17 @@ function peg$parse(input, options) {
       s1 = peg$parseVariable();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c47(s1);
+        s1 = peg$c51(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        s0 = peg$parsePlainStringText();
+        s0 = peg$currPos;
+        s1 = peg$parsePlainStringText();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c49(s1);
+        }
+        s0 = s1;
       }
     }
 
@@ -1266,11 +1355,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c48;
+      s3 = peg$c52;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1278,11 +1367,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c51(s4);
+        s3 = peg$c55(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1293,12 +1382,12 @@ function peg$parse(input, options) {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$c52.test(input.charAt(peg$currPos))) {
+      if (peg$c56.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -1306,11 +1395,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c48;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1318,11 +1407,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c54); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c51(s4);
+            s3 = peg$c55(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1333,12 +1422,12 @@ function peg$parse(input, options) {
           s2 = peg$FAILED;
         }
         if (s2 === peg$FAILED) {
-          if (peg$c52.test(input.charAt(peg$currPos))) {
+          if (peg$c56.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c57); }
           }
         }
       }
@@ -1347,7 +1436,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54(s1);
+      s1 = peg$c58(s1);
     }
     s0 = s1;
 
@@ -1361,11 +1450,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c48;
+      s3 = peg$c52;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1373,11 +1462,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c51(s4);
+        s3 = peg$c55(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1388,12 +1477,12 @@ function peg$parse(input, options) {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$c55.test(input.charAt(peg$currPos))) {
+      if (peg$c59.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c56); }
+        if (peg$silentFails === 0) { peg$fail(peg$c60); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -1401,11 +1490,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c48;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1413,11 +1502,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c54); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c51(s4);
+            s3 = peg$c55(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1428,12 +1517,12 @@ function peg$parse(input, options) {
           s2 = peg$FAILED;
         }
         if (s2 === peg$FAILED) {
-          if (peg$c55.test(input.charAt(peg$currPos))) {
+          if (peg$c59.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c56); }
+            if (peg$silentFails === 0) { peg$fail(peg$c60); }
           }
         }
       }
@@ -1442,7 +1531,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54(s1);
+      s1 = peg$c58(s1);
     }
     s0 = s1;
 
@@ -1456,11 +1545,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c48;
+      s3 = peg$c52;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1468,11 +1557,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c51(s4);
+        s3 = peg$c55(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1500,11 +1589,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+          if (peg$silentFails === 0) { peg$fail(peg$c54); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c51(s4);
+          s3 = peg$c55(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1520,11 +1609,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c48;
+          s3 = peg$c52;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1532,11 +1621,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+            if (peg$silentFails === 0) { peg$fail(peg$c54); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c51(s4);
+            s3 = peg$c55(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1564,11 +1653,11 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c50); }
+              if (peg$silentFails === 0) { peg$fail(peg$c54); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c51(s4);
+              s3 = peg$c55(s4);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -1585,7 +1674,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54(s1);
+      s1 = peg$c58(s1);
     }
     s0 = s1;
 
@@ -1596,12 +1685,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c57) {
-      s1 = peg$c57;
+    if (input.substr(peg$currPos, 2) === peg$c61) {
+      s1 = peg$c61;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c62); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseShellLine();
@@ -1615,7 +1704,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c59(s2);
+          s1 = peg$c63(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1637,45 +1726,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c60) {
-      s1 = peg$c60;
+    if (input.substr(peg$currPos, 2) === peg$c64) {
+      s1 = peg$c64;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      if (peg$silentFails === 0) { peg$fail(peg$c65); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c62) {
-          s3 = peg$c62;
+        if (input.substr(peg$currPos, 2) === peg$c66) {
+          s3 = peg$c66;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c63); }
+          if (peg$silentFails === 0) { peg$fail(peg$c67); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = [];
-          s5 = peg$parseArgument();
-          if (s5 !== peg$FAILED) {
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$parseArgument();
-            }
-          } else {
-            s4 = peg$FAILED;
-          }
+          s4 = peg$parseCommandString();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c64;
+              s5 = peg$c68;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c65); }
+              if (peg$silentFails === 0) { peg$fail(peg$c69); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c66(s2, s4);
+              s1 = peg$c70(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1699,26 +1779,26 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c60) {
-        s1 = peg$c60;
+      if (input.substr(peg$currPos, 2) === peg$c64) {
+        s1 = peg$c64;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseIdentifier();
         if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 125) {
-            s3 = peg$c64;
-            peg$currPos++;
+          if (input.substr(peg$currPos, 3) === peg$c71) {
+            s3 = peg$c71;
+            peg$currPos += 3;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c72); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c67(s2);
+            s1 = peg$c73(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1734,19 +1814,31 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 36) {
-          s1 = peg$c68;
-          peg$currPos++;
+        if (input.substr(peg$currPos, 2) === peg$c64) {
+          s1 = peg$c64;
+          peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdentifier();
           if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c67(s2);
-            s0 = s1;
+            if (input.charCodeAt(peg$currPos) === 125) {
+              s3 = peg$c68;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            }
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c74(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1754,6 +1846,30 @@ function peg$parse(input, options) {
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 36) {
+            s1 = peg$c75;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parseIdentifier();
+            if (s2 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c74(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         }
       }
     }
@@ -1766,22 +1882,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c70.test(input.charAt(peg$currPos))) {
+    if (peg$c77.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c71); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c70.test(input.charAt(peg$currPos))) {
+        if (peg$c77.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
       }
     } else {
@@ -1789,7 +1905,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c79();
     }
     s0 = s1;
 
@@ -1801,22 +1917,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c73.test(input.charAt(peg$currPos))) {
+    if (peg$c80.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c74); }
+      if (peg$silentFails === 0) { peg$fail(peg$c81); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c73.test(input.charAt(peg$currPos))) {
+        if (peg$c80.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c81); }
         }
       }
     } else {
@@ -1824,7 +1940,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c72();
+      s1 = peg$c79();
     }
     s0 = s1;
 
@@ -1834,12 +1950,12 @@ function peg$parse(input, options) {
   function peg$parseSpecialShellChars() {
     var s0;
 
-    if (peg$c75.test(input.charAt(peg$currPos))) {
+    if (peg$c82.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
 
     return s0;
@@ -1849,22 +1965,22 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = [];
-    if (peg$c77.test(input.charAt(peg$currPos))) {
+    if (peg$c84.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c85); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c77.test(input.charAt(peg$currPos))) {
+        if (peg$c84.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
       }
     } else {

--- a/packages/berry-parsers/sources/grammars/shell.pegjs
+++ b/packages/berry-parsers/sources/grammars/shell.pegjs
@@ -37,7 +37,8 @@ Command
   / S* envs:VariableAssignment+ S* { return { type: `envs`, envs } }
 
 Argument
-  = S* segments:ArgumentSegment+ { return [].concat(... segments) }
+  = S* redirect:(">" / ">>" / "<<<") S* segments:ArgumentSegment+ { return {type: `>`, segments: [].concat(... segments)} }
+  / S* segments:ArgumentSegment+ { return [].concat(... segments) }
 
 ArgumentSegment
   = string:SglQuoteString { return string }

--- a/packages/berry-parsers/sources/grammars/shell.pegjs
+++ b/packages/berry-parsers/sources/grammars/shell.pegjs
@@ -28,17 +28,26 @@ CommandChainType
   / '|'
 
 VariableAssignment
-  = name:EnvVariable '=' args:ArgumentSegment+ S* { return { name, args } }
-  / name:EnvVariable '=' S* { return { name, args : [] } }
+  = name:EnvVariable '=' arg:StrictValueArgument S* { return { name, args: [arg] } }
+  / name:EnvVariable '=' S* { return { name, args: [] } }
 
 Command
   = S* "(" S* subshell:ShellLine S* ")" S* { return { type: `subshell`, subshell } }
   / S* envs:VariableAssignment* S* args:Argument+ S* { return { type: `command`, args, envs } }
   / S* envs:VariableAssignment+ S* { return { type: `envs`, envs } }
 
+CommandString
+  = S* args:ValueArgument+ S* { return args }
+
 Argument
-  = S* redirect:(">" / ">>" / "<<<") S* segments:ArgumentSegment+ { return {type: `>`, segments: [].concat(... segments)} }
-  / S* segments:ArgumentSegment+ { return [].concat(... segments) }
+  = S* redirect:(">" / ">>" / "<" / "<<<") arg:ValueArgument { return { type: `redirection`, subtype: redirect, args: [arg] } }
+  / S* arg:ValueArgument { return arg }
+
+ValueArgument
+  = S* arg:StrictValueArgument { return arg }
+
+StrictValueArgument
+  = segments:ArgumentSegment+ { return { type: `argument`, segments: [].concat(... segments) } }
 
 ArgumentSegment
   = string:SglQuoteString { return string }
@@ -46,10 +55,10 @@ ArgumentSegment
   / string:PlainString { return string }
 
 SglQuoteString
-  = "'" text:SglQuoteStringText "'" { return [ text ] }
+  = "'" text:SglQuoteStringText "'" { return [ { type: `text`, text } ] }
 
 DblQuoteString
-  = '"' segments:DblQuoteStringSegment* '"' { return [ ... segments ] }
+  = '"' segments:DblQuoteStringSegment* '"' { return segments }
 
 PlainString
   = segments:PlainStringSegment+ { return segments }
@@ -57,12 +66,12 @@ PlainString
 DblQuoteStringSegment
   = shell:Subshell { return { type: `shell`, shell, quoted: true } }
   / variable:Variable { return { type: `variable`, ...variable, quoted: true } }
-  / DblQuoteStringText
+  / text:DblQuoteStringText { return { type: `text`, text } }
 
 PlainStringSegment
   = shell:Subshell { return { type: `shell`, shell, quoted: false } }
   / variable:Variable { return { type: `variable`, ...variable, quoted: false } }
-  / PlainStringText
+  / text:PlainStringText { return { type: `text`, text } }
 
 SglQuoteStringText
   = chars:('\\' c:. { return c } / [^'])+ { return chars.join(``) }
@@ -77,7 +86,8 @@ Subshell
   = '$(' command:ShellLine ')' { return command }
 
 Variable
-  = '${' name:Identifier ':-' defaultValue:Argument+ '}' { return { name, defaultValue } }
+  = '${' name:Identifier ':-' arg:CommandString '}' { return { name, defaultValue: arg } }
+  / '${' name:Identifier ':-}' { return { name, defaultValue: [] } }
   / '${' name:Identifier '}' { return { name } }
   / '$' name:Identifier { return { name } }
 

--- a/packages/berry-parsers/sources/grammars/shell.pegjs
+++ b/packages/berry-parsers/sources/grammars/shell.pegjs
@@ -40,7 +40,7 @@ CommandString
   = S* args:ValueArgument+ S* { return args }
 
 Argument
-  = S* redirect:(">" / ">>" / "<" / "<<<") arg:ValueArgument { return { type: `redirection`, subtype: redirect, args: [arg] } }
+  = S* redirect:(">>" / ">" / "<<<" / "<") arg:ValueArgument { return { type: `redirection`, subtype: redirect, args: [arg] } }
   / S* arg:ValueArgument { return arg }
 
 ValueArgument

--- a/packages/berry-parsers/sources/index.ts
+++ b/packages/berry-parsers/sources/index.ts
@@ -1,6 +1,6 @@
-export {CommandSegment, CommandChain, CommandLine, EnvSegment, ShellLine} from './grammars/shell';
-export {parseShell}                                                       from './shell';
+export {ArgumentSegment, Argument, CommandChain, CommandLine, EnvSegment, ShellLine} from './grammars/shell';
+export {parseShell}                                                                  from './shell';
 
-export {Resolution, parseResolution, stringifyResolution}                 from './resolution';
+export {Resolution, parseResolution, stringifyResolution}                            from './resolution';
 
-export {parseSyml, stringifySyml}                                         from './syml';
+export {parseSyml, stringifySyml}                                                    from './syml';

--- a/packages/berry-shell/sources/index.ts
+++ b/packages/berry-shell/sources/index.ts
@@ -1,10 +1,10 @@
-import {xfs, NodeFS, ppath, PortablePath}                                 from '@berry/fslib';
-import {CommandSegment, CommandChain, CommandLine, ShellLine, parseShell} from '@berry/parsers';
-import {EnvSegment}                                                       from '@berry/parsers';
-import {PassThrough, Readable, Writable}                                  from 'stream';
+import {xfs, NodeFS, ppath, PortablePath}                                  from '@berry/fslib';
+import {Argument, ArgumentSegment, CommandChain, CommandLine, ShellLine, parseShell} from '@berry/parsers';
+import {EnvSegment}                                                        from '@berry/parsers';
+import {PassThrough, Readable, Writable}                                   from 'stream';
 
-import {Handle, ProtectedStream, Stdio, start}                            from './pipe';
-import {makeBuiltin, makeProcess}                                         from './pipe';
+import {Handle, ProtectedStream, Stdio, start}                             from './pipe';
+import {makeBuiltin, makeProcess}                                          from './pipe';
 
 export type UserOptions = {
   builtins: {[key: string]: ShellBuiltin},
@@ -84,6 +84,11 @@ const BUILTINS = new Map<string, ShellBuiltin>([
     state.stdout.write(`${args.join(` `)}\n`);
     return 0;
   }],
+
+  [`setredirects`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
+    state.stderr.write(`Shell redirections aren't implemented yet.\n`);
+    return 1;
+  }],
 ]);
 
 async function executeBufferedSubshell(ast: ShellLine, opts: ShellOptions, state: ShellState) {
@@ -102,7 +107,7 @@ async function applyEnvVariables(environmentSegments: Array<EnvSegment>, opts: S
 
     return {
       name: envSegment.name,
-      value: interpolatedArgs.join(``),
+      value: interpolatedArgs.join(` `),
     };
   });
 
@@ -114,7 +119,9 @@ async function applyEnvVariables(environmentSegments: Array<EnvSegment>, opts: S
   }, {} as ShellState['environment']);
 }
 
-async function interpolateArguments(commandArgs: Array<Array<CommandSegment>>, opts: ShellOptions, state: ShellState) {
+async function interpolateArguments(commandArgs: Array<Argument>, opts: ShellOptions, state: ShellState) {
+  const redirections = new Map();
+
   const interpolated: Array<string> = [];
   let interpolatedSegments: Array<string> = [];
 
@@ -137,82 +144,111 @@ async function interpolateArguments(commandArgs: Array<Array<CommandSegment>>, o
     close();
   };
 
+  const redirect = (type: string, target: string) => {
+    let targets = redirections.get(type);
+
+    if (typeof targets === `undefined`)
+      redirections.set(type, targets = []);
+
+    targets.push(target);
+  };
+
   for (const commandArg of commandArgs) {
-    for (const segment of commandArg) {
-      if (typeof segment === 'string') {
-        push(segment);
-      } else {
-        switch (segment.type) {
-          case `shell`: {
-            const raw = await executeBufferedSubshell(segment.shell, opts, state);
-            if (segment.quoted) {
-              push(raw);
-            } else {
-              for (const part of split(raw)) {
-                pushAndClose(part);
+    switch (commandArg.type) {
+      case `redirection`: {
+        const interpolatedArgs = await interpolateArguments(commandArg.args, opts, state);
+        for (const interpolatedArg of interpolatedArgs) {
+          redirect(commandArg.subtype, interpolatedArg);
+        }
+      } break;
+
+      case `argument`: {
+        for (const segment of commandArg.segments) {
+          switch (segment.type) {
+            case `text`: {
+              push(segment.text);
+            } break;
+
+            case `shell`: {
+              const raw = await executeBufferedSubshell(segment.shell, opts, state);
+              if (segment.quoted) {
+                push(raw);
+              } else {
+                for (const part of split(raw)) {
+                  pushAndClose(part);
+                }
               }
-            }
-          } break;
+            } break;
 
-          case `variable`: {
-            switch (segment.name) {
-              case `#`: {
-                push(String(opts.args.length));
-              } break;
+            case `variable`: {
+              switch (segment.name) {
+                case `#`: {
+                  push(String(opts.args.length));
+                } break;
 
-              case `@`: {
-                if (segment.quoted) {
-                  for (const raw of opts.args) {
-                    pushAndClose(raw);
+                case `@`: {
+                  if (segment.quoted) {
+                    for (const raw of opts.args) {
+                      pushAndClose(raw);
+                    }
+                  } else {
+                    for (const raw of opts.args) {
+                      for (const part of split(raw)) {
+                        pushAndClose(part);
+                      }
+                    }
                   }
-                } else {
-                  for (const raw of opts.args) {
+                } break;
+
+                case `*`: {
+                  const raw = opts.args.join(` `);
+                  if (segment.quoted) {
+                    push(raw);
+                  } else {
                     for (const part of split(raw)) {
                       pushAndClose(part);
                     }
                   }
-                }
-              } break;
+                } break;
 
-              case `*`: {
-                const raw = opts.args.join(` `);
-                if (segment.quoted) {
-                  push(raw);
-                } else {
-                  for (const part of split(raw)) {
-                    pushAndClose(part);
-                  }
-                }
-              } break;
+                default: {
+                  const argIndex = parseInt(segment.name, 10);
 
-              default: {
-                const argIndex = parseInt(segment.name, 10);
-
-                if (Number.isFinite(argIndex)) {
-                  if (!(argIndex >= 0 && argIndex < opts.args.length)) {
-                    throw new Error(`Unbound argument #${argIndex}`);
+                  if (Number.isFinite(argIndex)) {
+                    if (!(argIndex >= 0 && argIndex < opts.args.length)) {
+                      throw new Error(`Unbound argument #${argIndex}`);
+                    } else {
+                      push(opts.args[argIndex]);
+                    }
                   } else {
-                    push(opts.args[argIndex]);
+                    if (Object.prototype.hasOwnProperty.call(state.variables, segment.name)) {
+                      push(state.variables[segment.name]);
+                    } else if (Object.prototype.hasOwnProperty.call(state.environment, segment.name)) {
+                      push(state.environment[segment.name]);
+                    } else if (segment.defaultValue) {
+                      push((await interpolateArguments(segment.defaultValue, opts, state)).join(` `));
+                    } else {
+                      throw new Error(`Unbound variable "${segment.name}"`);
+                    }
                   }
-                } else {
-                  if (Object.prototype.hasOwnProperty.call(state.variables, segment.name)) {
-                    push(state.variables[segment.name]);
-                  } else if (Object.prototype.hasOwnProperty.call(state.environment, segment.name)) {
-                    push(state.environment[segment.name]);
-                  } else if (segment.defaultValue) {
-                    push((await interpolateArguments(segment.defaultValue, opts, state)).join(` `));
-                  } else {
-                    throw new Error(`Unbound variable "${segment.name}"`);
-                  }
-                }
-              } break;
-            }
-          } break;
+                } break;
+              }
+            } break;
+          }
         }
-      }
+      } break;
     }
 
     close();
+  }
+
+  if (redirections.size > 0) {
+    const redirectionArgs: Array<string> = [];
+
+    for (const [subtype, targets] of redirections.entries())
+      redirectionArgs.splice(redirectionArgs.length, 0, subtype, String(targets.length), ...targets);
+
+    interpolated.splice(0, 0, `setredirects`, ... redirectionArgs, `--`);
   }
 
   return interpolated;
@@ -397,6 +433,34 @@ async function executeShellLine(node: ShellLine, opts: ShellOptions, state: Shel
   return rightMostExitCode;
 }
 
+function locateArgsVariableInSegment(segment: ArgumentSegment): boolean {
+  switch (segment.type) {
+    case `variable`: {
+      return segment.name === `@` || segment.name === `#` || segment.name === `*` || Number.isFinite(parseInt(segment.name, 10)) || (!!segment.defaultValue && segment.defaultValue.some(arg => locateArgsVariableInArgument(arg)));
+    } break;
+
+    case `shell`: {
+      return locateArgsVariable(segment.shell);
+    } break;
+
+    default: {
+      return false;
+    } break;
+  }  
+}
+
+function locateArgsVariableInArgument(arg: Argument): boolean {
+  switch (arg.type) {
+    case `redirection`: {
+      return arg.args.some(arg => locateArgsVariableInArgument(arg));
+    } break;
+
+    case `argument`: {
+      return arg.segments.some(segment => locateArgsVariableInSegment(segment));
+    } break;
+  }
+}
+
 function locateArgsVariable(node: ShellLine): boolean {
   return node.some(command => {
     while (command) {
@@ -411,25 +475,10 @@ function locateArgsVariable(node: ShellLine): boolean {
           } break;
 
           case `command`: {
-            hasArgs = chain.args.some(arg => {
-              return arg.some(segment => {
-                if (typeof segment === 'string')
-                  return false;
-
-                switch (segment.type) {
-                  case `variable`: {
-                    return segment.name === `@` || segment.name === `#` || segment.name === `*` || Number.isFinite(parseInt(segment.name, 10));
-                  } break;
-
-                  case `shell`: {
-                    return locateArgsVariable(segment.shell);
-                  } break;
-
-                  default: {
-                    return false;
-                  } break;
-                }
-              });
+            hasArgs = chain.envs.some(env => env.args.some(arg => {
+              return locateArgsVariableInArgument(arg);
+            })) || chain.args.some(arg => {
+              return locateArgsVariableInArgument(arg);
             });
           } break;
         }
@@ -481,7 +530,7 @@ export async function execute(command: string, args: Array<string> = [], {
 
   // If the shell line doesn't use the args, inject it at the end of the
   // right-most command
-  if (!locateArgsVariable(ast) && ast.length > 0) {
+  if (!locateArgsVariable(ast) && ast.length > 0 && args.length > 0) {
     let command = ast[ast.length - 1];
     while (command.then)
       command = command.then.line;
@@ -492,7 +541,13 @@ export async function execute(command: string, args: Array<string> = [], {
 
     if (chain.type === `command`) {
       chain.args = chain.args.concat(args.map(arg => {
-        return [arg];
+        return {
+          type: `argument` as 'argument',
+          segments: [{
+            type: `text` as 'text',
+            text: arg,
+          }],
+        };
       }));
     }
   }

--- a/packages/berry-shell/sources/index.ts
+++ b/packages/berry-shell/sources/index.ts
@@ -1,10 +1,10 @@
-import {xfs, NodeFS, ppath, PortablePath}                                  from '@berry/fslib';
+import {xfs, NodeFS, ppath, PortablePath}                                            from '@berry/fslib';
 import {Argument, ArgumentSegment, CommandChain, CommandLine, ShellLine, parseShell} from '@berry/parsers';
-import {EnvSegment}                                                        from '@berry/parsers';
-import {PassThrough, Readable, Writable}                                   from 'stream';
+import {EnvSegment}                                                                  from '@berry/parsers';
+import {PassThrough, Readable, Writable}                                             from 'stream';
 
-import {Handle, ProtectedStream, Stdio, start}                             from './pipe';
-import {makeBuiltin, makeProcess}                                          from './pipe';
+import {Handle, ProtectedStream, Stdio, start}                                       from './pipe';
+import {makeBuiltin, makeProcess}                                                    from './pipe';
 
 export type UserOptions = {
   builtins: {[key: string]: ShellBuiltin},
@@ -248,7 +248,7 @@ async function interpolateArguments(commandArgs: Array<Argument>, opts: ShellOpt
     for (const [subtype, targets] of redirections.entries())
       redirectionArgs.splice(redirectionArgs.length, 0, subtype, String(targets.length), ...targets);
 
-    interpolated.splice(0, 0, `setredirects`, ... redirectionArgs, `--`);
+    interpolated.splice(0, 0, `setredirects`, ...redirectionArgs, `--`);
   }
 
   return interpolated;
@@ -446,7 +446,7 @@ function locateArgsVariableInSegment(segment: ArgumentSegment): boolean {
     default: {
       return false;
     } break;
-  }  
+  }
 }
 
 function locateArgsVariableInArgument(arg: Argument): boolean {

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -404,9 +404,49 @@ describe(`Simple shell features`, () => {
     });
   });
 
-  it(`should support input redirections`, async () => {
+  it(`should support input redirections (file)`, async () => {
+    await expect(bufferResult(
+      `echo foo < bar`,
+    )).resolves.toMatchObject({
+      stderr: `Shell redirections aren't implemented yet.\n`,
+    });
+  });
+
+  it(`should support input redirections (string)`, async () => {
+    await expect(bufferResult(
+      `echo foo <<< bar`,
+    )).resolves.toMatchObject({
+      stderr: `Shell redirections aren't implemented yet.\n`,
+    });
+  });
+
+  it(`should support output redirections (overwrite)`, async () => {
     await expect(bufferResult(
       `echo foo > bar`,
+    )).resolves.toMatchObject({
+      stderr: `Shell redirections aren't implemented yet.\n`,
+    });
+  });
+
+  it(`should support output redirections (append)`, async () => {
+    await expect(bufferResult(
+      `echo foo >> bar`,
+    )).resolves.toMatchObject({
+      stderr: `Shell redirections aren't implemented yet.\n`,
+    });
+  });
+
+  it(`should support multiple outputs`, async () => {
+    await expect(bufferResult(
+      `echo foo > bar > baz`,
+    )).resolves.toMatchObject({
+      stderr: `Shell redirections aren't implemented yet.\n`,
+    });
+  });
+
+  it(`should support multiple inputs`, async () => {
+    await expect(bufferResult(
+      `echo foo < bar < baz`,
     )).resolves.toMatchObject({
       stderr: `Shell redirections aren't implemented yet.\n`,
     });

--- a/packages/berry-shell/tests/shell.test.ts
+++ b/packages/berry-shell/tests/shell.test.ts
@@ -403,4 +403,12 @@ describe(`Simple shell features`, () => {
       stdout: `hello world\n`
     });
   });
+
+  it(`should support input redirections`, async () => {
+    await expect(bufferResult(
+      `echo foo > bar`,
+    )).resolves.toMatchObject({
+      stderr: `Shell redirections aren't implemented yet.\n`,
+    });
+  });
 });


### PR DESCRIPTION
This PR implements the syntax and base logic for shell redirections. The way it works is pretty simple: during the interpolation pass, the engine converts `foo > bar` into `setredirects ">" 1 bar -- foo`. This command is then executed as-is.

The `setredirects` command is a new builtin that can be implemented by the `@berry/shell` consumers. We'll provide a default implementation that uses the filesystem, but the idea is that it will make it possible to use `@berry/shell` for other purposes than executing shell commands, and in a secure way (for example you could imagine a game shell).

I also added support for [multios](http://zsh.sourceforge.net/Doc/Release/Redirection.html#index-multios) (from zsh), as that sounds a super useful feature I wasn't aware of until recently:

```
cat foo > bar > baz
```

Becomes:

```
setredirects ">" 2 bar baz -- cat foo
```

---

Supercedes #218 (cc @kaylie-alexa; I unfortunately needed to make a different PR because the approach you had - adding `>` etc as secondary `|` operators - was incompatible with commands such as `foo > bar < baz` etc).