### PR TITLE
FIX: Support CRLF in legacy regexp

### DIFF
--- a/packages/berry-parsers/sources/syml.ts
+++ b/packages/berry-parsers/sources/syml.ts
@@ -100,7 +100,7 @@ function parseViaPeg(source: string) {
   return parse(source);
 }
 
-const LEGACY_REGEXP = /^(#.*\n)*?#\s+yarn\s+lockfile\s+v1\n/i;
+const LEGACY_REGEXP = /^(#.*(\r?\n))*?#\s+yarn\s+lockfile\s+v1\r?\n/i;
 
 function parseViaJsYaml(source: string) {
   if (LEGACY_REGEXP.test(source))


### PR DESCRIPTION
Fixes #235.

The regexp detecting v1 yarnrc files only looks for linefeeds, this PR simply adds support for CRLF as well.