### PR TITLE
Adds support for dotfolders in node_modules

### DIFF
--- a/packages/berry-pnpify/lib/bin.js
+++ b/packages/berry-pnpify/lib/bin.js
@@ -2912,7 +2912,7 @@ var path = __webpack_require__(0);
 // EXTERNAL MODULE: ../berry-fslib/sources/NodeFS.ts
 var NodeFS = __webpack_require__(5);
 
-// EXTERNAL MODULE: /mnt/d/berry/.yarn/cache/cross-spawn-npm-6.0.5-0ba5f883cf582a4248c1c8575ef31c368634c587aa0b9731c596cf866746bf5e.zip/node_modules/cross-spawn/index.js
+// EXTERNAL MODULE: /Users/mael.nison/berry/.yarn/cache/cross-spawn-npm-6.0.5-0ba5f883cf582a4248c1c8575ef31c368634c587aa0b9731c596cf866746bf5e.zip/node_modules/cross-spawn/index.js
 var cross_spawn = __webpack_require__(15);
 var cross_spawn_default = /*#__PURE__*/__webpack_require__.n(cross_spawn);
 

--- a/packages/berry-pnpify/lib/index.js
+++ b/packages/berry-pnpify/lib/index.js
@@ -669,8 +669,13 @@ class NodePathResolver_NodePathResolver {
      */
     resolvePath(nodePath) {
         const result = { resolvedPath: nodePath };
-        if (nodePath.indexOf(`/node_modules`) < 0)
-            // Non-node_modules paths should not be processed
+        const marker = `/node_modules`;
+        const index = nodePath.indexOf(marker);
+        // Non-node_modules paths should not be processed
+        if (index === -1 || (index + marker.length < nodePath.length && nodePath.charAt(index + marker.length) !== `/`))
+            return result;
+        // Directories that start with a dot are usually cache folders and shouldn't be touched
+        if (nodePath.charAt(index + marker.length + 1) === `.`)
             return result;
         // Extract first issuer from the path using PnP API
         let issuer = this.getIssuer(this.pnp, nodePath);

--- a/packages/berry-pnpify/sources/NodePathResolver.ts
+++ b/packages/berry-pnpify/sources/NodePathResolver.ts
@@ -109,8 +109,16 @@ export class NodePathResolver {
    */
   public resolvePath(nodePath: PortablePath): ResolvedPath {
     const result: ResolvedPath = {resolvedPath: nodePath};
-    if (nodePath.indexOf(`/node_modules`) < 0)
-      // Non-node_modules paths should not be processed
+
+    const marker = `/node_modules`;
+    const index = nodePath.indexOf(marker);
+
+    // Non-node_modules paths should not be processed
+    if (index === -1 || (index + marker.length < nodePath.length && nodePath.charAt(index + marker.length) !== `/`))
+      return result;
+
+    // Directories that start with a dot are usually cache folders and shouldn't be touched
+    if (nodePath.charAt(index + marker.length + 1) === `.`)
       return result;
 
     // Extract first issuer from the path using PnP API

--- a/packages/berry-pnpify/tests/NodePathResolver.test.ts
+++ b/packages/berry-pnpify/tests/NodePathResolver.test.ts
@@ -60,6 +60,12 @@ describe('NodePathResolver', () => {
     expect(pnpPath).toEqual({ resolvedPath: nodePath });
   });
 
+  it('should not try to alter paths from a dotted node_modules entry', () => {
+    const nodePath = '/home/user/proj/node_modules/.foo/bar';
+    const pnpPath = resolver.resolvePath(nodePath);
+    expect(pnpPath).toEqual({ resolvedPath: nodePath });
+  });
+
   it('should resolve /home/user/proj path', () => {
     const nodePath = '/home/user/proj';
     const pnpPath = resolver.resolvePath(nodePath);


### PR DESCRIPTION
Some tools (for example `babel-loader`) use "dot folders" (`n_m/.cache`) to store cached data. Such paths were resolved into `null` since `.cache` wasn't a valid dependency.

This diff adds a bailout when the first character for the package name is a dot.