### PR TITLE
Adds the proper shebang for the pnpify bin

### DIFF
--- a/packages/berry-pnpify/lib/bin.js
+++ b/packages/berry-pnpify/lib/bin.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 module.exports =
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache

--- a/packages/berry-pnpify/webpack.config.pkg.js
+++ b/packages/berry-pnpify/webpack.config.pkg.js
@@ -1,4 +1,5 @@
 const makeConfig = require(`@berry/builder/sources/make-config.js`);
+const webpack = require(`webpack`);
 
 module.exports = makeConfig({
   context: __dirname,
@@ -17,4 +18,13 @@ module.exports = makeConfig({
     filename: `[name].js`,
     path: `${__dirname}/lib`,
   },
+
+  plugins: [
+    new webpack.BannerPlugin({
+      entryOnly: true,
+      include: `bin`,
+      banner: `#!/usr/bin/env node`,
+      raw: true,
+    }),
+  ],
 });


### PR DESCRIPTION
The shebang was missing in the pnpify binary, so it couldn't be used with Yarn 1.x (2.x was fine because we now [enforce running the binaries through Node](https://github.com/yarnpkg/berry/blob/7865c70d28a56af79ac3ebd734eff64f0c258dcc/packages/berry-core/sources/scriptUtils.ts#L145)).

Fixes #258