### PR TITLE
Implements optional dependencies

### DIFF
--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "no-deps-scripted-to-fail",
+    "version": "1.0.0",
+    "scripts": {
+        "install": "exit 1"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/scripts/install.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/scripts/install.js
@@ -1,0 +1,6 @@
+const fs = require(`fs`);
+
+console.log(`install out`);
+console.error(`install err`);
+
+fs.appendFileSync(`${__dirname}/../log.js`, `module.exports.push('install');`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/scripts/postinstall.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/scripts/postinstall.js
@@ -1,0 +1,7 @@
+const fs = require(`fs`);
+
+console.log(`postinstall out`);
+console.error(`postinstall err`);
+
+fs.appendFileSync(`${__dirname}/../log.js`, `/*${fs.appendFileSync.toString()}*/ module.exports.push('postinstall');`);
+fs.appendFileSync(`${__dirname}/../rnd.js`, `module.exports = ${Math.floor(Math.random() * 512000)};`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/scripts/preinstall.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-deeply-fail-1.0.0/scripts/preinstall.js
@@ -1,0 +1,6 @@
+const fs = require(`fs`);
+
+console.log(`preinstall out`);
+console.error(`preinstall err`);
+
+fs.appendFileSync(`${__dirname}/../log.js`, `module.exports.push('preinstall');`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "no-deps-scripted-to-fail",
+    "version": "1.0.0",
+    "scripts": {
+        "install": "exit 1"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "no-deps-scripted-to-fail",
+    "name": "no-deps-scripted-to-deeply-fail",
     "version": "1.0.0",
-    "scripts": {
-        "install": "exit 1"
+    "dependencies": {
+        "no-deps-scripted-to-fail": "1.0.0"
     }
 }

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/scripts/install.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/scripts/install.js
@@ -1,0 +1,6 @@
+const fs = require(`fs`);
+
+console.log(`install out`);
+console.error(`install err`);
+
+fs.appendFileSync(`${__dirname}/../log.js`, `module.exports.push('install');`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/scripts/postinstall.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/scripts/postinstall.js
@@ -1,0 +1,7 @@
+const fs = require(`fs`);
+
+console.log(`postinstall out`);
+console.error(`postinstall err`);
+
+fs.appendFileSync(`${__dirname}/../log.js`, `/*${fs.appendFileSync.toString()}*/ module.exports.push('postinstall');`);
+fs.appendFileSync(`${__dirname}/../rnd.js`, `module.exports = ${Math.floor(Math.random() * 512000)};`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/scripts/preinstall.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-to-fail-1.0.0/scripts/preinstall.js
@@ -1,0 +1,6 @@
+const fs = require(`fs`);
+
+console.log(`preinstall out`);
+console.error(`preinstall err`);
+
+fs.appendFileSync(`${__dirname}/../log.js`, `module.exports.push('preinstall');`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -178,6 +178,25 @@ describe(`Scripts tests`, () => {
   );
 
   test(
+    `it should abort with an error if a package can't be built`,
+    makeTemporaryEnv({dependencies: {[`no-deps-scripted-to-fail`]: `1.0.0`}}, async ({path, run, source}) => {
+      await expect(run(`install`)).rejects.toThrow();
+    }),
+  );
+
+  test(
+    `it shouldn't abort with an error if the package that can't be built is optional`,
+    makeTemporaryEnv({optionalDependencies: {[`no-deps-scripted-to-fail`]: `1.0.0`}}, async ({path, run, source}) => {
+      await run(`install`);
+
+      await expect(source(`require('no-deps-scripted-to-fail')`)).resolves.toMatchObject({
+        name: `no-deps-scripted-to-fail`,
+        version: `1.0.0`,
+      });
+    }),
+  );
+
+  test(
     `it should allow dependencies with install scripts to run the binaries exposed by their own dependencies`,
     makeTemporaryEnv(
       {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -197,6 +197,24 @@ describe(`Scripts tests`, () => {
   );
 
   test(
+    `it shouldn't abort with an error if the package that can't be built is a transitive dependency of an optional package`,
+    makeTemporaryEnv({optionalDependencies: {[`no-deps-scripted-to-deeply-fail`]: `1.0.0`}}, async ({path, run, source}) => {
+      await run(`install`);
+
+      await expect(source(`require('no-deps-scripted-to-deeply-fail')`)).resolves.toMatchObject({
+        name: `no-deps-scripted-to-deeply-fail`,
+        version: `1.0.0`,
+        dependencies: {
+          [`no-deps-scripted-to-fail`]: {
+            name: `no-deps-scripted-to-fail`,
+            version: `1.0.0`,
+          },
+        },
+      });
+    }),
+  );
+
+  test(
     `it should allow dependencies with install scripts to run the binaries exposed by their own dependencies`,
     makeTemporaryEnv(
       {

--- a/packages/berry-core/sources/Manifest.ts
+++ b/packages/berry-core/sources/Manifest.ts
@@ -525,7 +525,7 @@ export class Manifest {
           ? structUtils.stringifyDescriptor(structUtils.makeDescriptor(structUtils.parseIdent(identString), range))
           : identString;
 
-        const metaCopy = {... meta};
+        const metaCopy = {...meta};
         delete metaCopy.optionalBuild;
 
         if (Object.keys(metaCopy).length === 0)

--- a/packages/berry-core/sources/Project.ts
+++ b/packages/berry-core/sources/Project.ts
@@ -1142,7 +1142,6 @@ export class Project {
               continue;
             }
 
-            const dependencyMeta = this.getDependencyMeta(pkg, pkg.version);
             const buildMessage = `${structUtils.prettyLocator(this.configuration, pkg)} couldn't be built successfully (exit code ${exitCode}, logs can be found here: ${logFile})`;
 
             if (!this.optionalBuilds.has(pkg.locatorHash)) {

--- a/packages/berry-core/sources/Project.ts
+++ b/packages/berry-core/sources/Project.ts
@@ -1121,10 +1121,19 @@ export class Project {
 
             if (exitCode === 0) {
               nextBState[pkg.locatorHash] = buildHash;
-            } else {
-              report.reportError(MessageName.BUILD_FAILED, `${structUtils.prettyLocator(this.configuration, pkg)} couldn't be built successfully (exit code ${exitCode}, logs can be found here: ${logFile})`);
+              continue;
+            }
+
+            const dependencyMeta = this.getDependencyMeta(pkg, pkg.version);
+            const buildMessage = `${structUtils.prettyLocator(this.configuration, pkg)} couldn't be built successfully (exit code ${exitCode}, logs can be found here: ${logFile})`;
+
+            if (!dependencyMeta.optionalBuild) {
+              report.reportError(MessageName.BUILD_FAILED, buildMessage);
               break;
             }
+
+            nextBState[pkg.locatorHash] = buildHash;
+            report.reportInfo(MessageName.BUILD_FAILED, buildMessage);
           }
         })());
       }

--- a/packages/berry-core/sources/Project.ts
+++ b/packages/berry-core/sources/Project.ts
@@ -707,7 +707,7 @@ export class Project {
         // Mark this package as being used (won't be removed from the lockfile)
         volatileDescriptors.delete(descriptor.descriptorHash);
 
-        // Detect whether this package is being required 
+        // Detect whether this package is being required
         let isOptional = optional;
         if (!isOptional) {
           const dependencyMetaSet = parentPackage.dependenciesMeta.get(structUtils.stringifyIdent(descriptor));

--- a/packages/berry-core/sources/Project.ts
+++ b/packages/berry-core/sources/Project.ts
@@ -65,6 +65,8 @@ export class Project {
   public storedPackages: Map<LocatorHash, Package> = new Map();
   public storedChecksums: Map<LocatorHash, string> = new Map();
 
+  public optionalBuilds: Set<LocatorHash> = new Set();
+
   static async find(configuration: Configuration, startingCwd: PortablePath): Promise<{project: Project, workspace: Workspace | null, locator: Locator}> {
     if (!configuration.projectCwd)
       throw new Error(`No project found in the initial directory`);
@@ -644,6 +646,7 @@ export class Project {
 
     const hasBeenTraversed = new Set();
     const volatileDescriptors = new Set(this.resolutionAliases.values());
+    const optionalBuilds = new Set(allPackages.keys());
 
     const resolutionStack: Array<Locator> = [];
 
@@ -666,19 +669,22 @@ export class Project {
       throw new ReportError(MessageName.STACK_OVERFLOW_RESOLUTION, `Encountered a stack overflow when resolving peer dependencies; cf ${logFile}`);
     };
 
-    const resolvePeerDependencies = (parentLocator: Locator) => {
+    const resolvePeerDependencies = (parentLocator: Locator, optional: boolean) => {
       resolutionStack.push(parentLocator);
-      const result = resolvePeerDependenciesImpl(parentLocator);
+      const result = resolvePeerDependenciesImpl(parentLocator, optional);
       resolutionStack.pop();
 
       return result;
     };
 
-    const resolvePeerDependenciesImpl = (parentLocator: Locator) => {
+    const resolvePeerDependenciesImpl = (parentLocator: Locator, optional: boolean) => {
       if (hasBeenTraversed.has(parentLocator.locatorHash))
         return;
 
       hasBeenTraversed.add(parentLocator.locatorHash);
+
+      if (!optional)
+        optionalBuilds.delete(parentLocator.locatorHash);
 
       const parentPackage = allPackages.get(parentLocator.locatorHash);
       if (!parentPackage)
@@ -698,10 +704,20 @@ export class Project {
         if (parentPackage.peerDependencies.has(descriptor.identHash))
           continue;
 
+        // Mark this package as being used (won't be removed from the lockfile)
         volatileDescriptors.delete(descriptor.descriptorHash);
 
-        if (descriptor.range === `missing:`)
-          continue;
+        // Detect whether this package is being required 
+        let isOptional = optional;
+        if (!isOptional) {
+          const dependencyMetaSet = parentPackage.dependenciesMeta.get(structUtils.stringifyIdent(descriptor));
+          if (typeof dependencyMetaSet !== `undefined`) {
+            const dependencyMeta = dependencyMetaSet.get(null);
+            if (typeof dependencyMeta !== `undefined` && dependencyMeta.optional) {
+              isOptional = true;
+            }
+          }
+        }
 
         const resolution = allResolutions.get(descriptor.descriptorHash);
         if (!resolution)
@@ -712,7 +728,7 @@ export class Project {
           throw new Error(`Assertion failed: The package (${resolution}, resolved from ${structUtils.prettyDescriptor(this.configuration, descriptor)}) should have been registered`);
 
         if (pkg.peerDependencies.size === 0) {
-          resolvePeerDependencies(pkg);
+          resolvePeerDependencies(pkg, isOptional);
           continue;
         }
 
@@ -771,7 +787,7 @@ export class Project {
         });
 
         thirdPass.push(() => {
-          resolvePeerDependencies(virtualizedPackage);
+          resolvePeerDependencies(virtualizedPackage, isOptional);
         });
 
         fourthPass.push(() => {
@@ -795,7 +811,7 @@ export class Project {
 
     try {
       for (const workspace of this.workspaces) {
-        resolvePeerDependencies(workspace.anchoredLocator);
+        resolvePeerDependencies(workspace.anchoredLocator, false);
       }
     } catch (error) {
       if (error.name === `RangeError` && error.message === `Maximum call stack size exceeded`) {
@@ -830,6 +846,8 @@ export class Project {
     this.storedResolutions = allResolutions;
     this.storedDescriptors = allDescriptors;
     this.storedPackages = allPackages;
+
+    this.optionalBuilds = optionalBuilds;
   }
 
   async fetchEverything({cache, report, fetcher: userFetcher}: InstallOptions) {
@@ -1127,7 +1145,7 @@ export class Project {
             const dependencyMeta = this.getDependencyMeta(pkg, pkg.version);
             const buildMessage = `${structUtils.prettyLocator(this.configuration, pkg)} couldn't be built successfully (exit code ${exitCode}, logs can be found here: ${logFile})`;
 
-            if (!dependencyMeta.optionalBuild) {
+            if (!this.optionalBuilds.has(pkg.locatorHash)) {
               report.reportError(MessageName.BUILD_FAILED, buildMessage);
               break;
             }
@@ -1288,7 +1306,9 @@ export class Project {
           manifest.dependencies.set(identHash, structUtils.devirtualizeDescriptor(descriptor));
 
       optimizedLockfile[key] = {
-        ...manifest.exportTo({}),
+        ...manifest.exportTo({}, {
+          compatibilityMode: false,
+        }),
 
         linkType: pkg.linkType,
 

--- a/packages/gatsby/src/components/syntax.js
+++ b/packages/gatsby/src/components/syntax.js
@@ -75,6 +75,14 @@ const DescriptionAnchor = styled.div`
 
   padding: 1.5em 0;
 
+  p {
+    margin-top: 0;
+  }
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+
   &:target > div {
     background: ${props => props.theme.colors.highlight};
   }

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -104,7 +104,8 @@ const PackageJsonDoc = () => <>
       <JsonObjectProperty
         name={`optionalDependencies`}
         description={<>
-          Similar to the <code>devDependencies</code> field, except that these dependencies are not required to build properly should they have any build script. Note that such dependencies must still be resolvable and fetchable (otherwise we couldn't store it in the lockfile, which could lead to non-reproducible installs). Only the build part is optional.
+          <p>Similar to the <code>devDependencies</code> field, except that these dependencies are not required to build properly should they have any build script. Note that such dependencies must still be resolvable and fetchable (otherwise we couldn't store it in the lockfile, which could lead to non-reproducible installs). Only the build part is optional.</p>
+          <p><b>This field is usually not what you're looking for</b>, unless you depend on <code>fsevents</code>. If you need a package to be required only when a specific feature is used then use a peer dependency.</p>
         </>}
       >
         <JsonScalarProperty
@@ -167,12 +168,12 @@ const PackageJsonDoc = () => <>
             </>}
           />
           <JsonScalarProperty
-            name={`optionalBuild`}
-            anchor={`dependenciesMeta.optionalBuild`}
+            name={`optional`}
+            anchor={`dependenciesMeta.optional`}
             placeholder={false}
             description={<>
               <p>If true, the build isn't required to succeed for the install to be considered a success. It's what the <code>optionalDependencies</code> field compiles down to.</p>
-              <p><b>This settings will be applied even when found within a nested manifest</b> (although the highest requirement in the dependency will prevale).</p>
+              <p><b>This settings will be applied even when found within a nested manifest</b>, but the highest requirement in the dependency tree will prevale.</p>
             </>}
           />
           <JsonScalarProperty

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -104,8 +104,8 @@ const PackageJsonDoc = () => <>
       <JsonObjectProperty
         name={`optionalDependencies`}
         description={<>
-          <p>Similar to the <code>devDependencies</code> field, except that these dependencies are not required to build properly should they have any build script. Note that such dependencies must still be resolvable and fetchable (otherwise we couldn't store it in the lockfile, which could lead to non-reproducible installs). Only the build part is optional.</p>
-          <p><b>This field is usually not what you're looking for</b>, unless you depend on <code>fsevents</code>. If you need a package to be required only when a specific feature is used then use a peer dependency.</p>
+          <p>Similar to the <code>dependencies</code> field, except that these entries will not be required to build properly should they have any build script. Note that such dependencies must still be resolvable and fetchable (otherwise we couldn't store it in the lockfile, which could lead to non-reproducible installs) - only the build step is optional.</p>
+          <p><b>This field is usually not what you're looking for</b>, unless you depend on the <code>fsevents</code> package. If you need a package to be required only when a specific feature is used then use an optional peer dependency. Your users will have to satisfy it should they use the feature, but it won't cause the build errors to be silently swallowed when the feature is needed.</p>
         </>}
       >
         <JsonScalarProperty

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -102,6 +102,17 @@ const PackageJsonDoc = () => <>
         />
       </JsonObjectProperty>
       <JsonObjectProperty
+        name={`optionalDependencies`}
+        description={<>
+          Similar to the <code>devDependencies</code> field, except that these dependencies are not required to build properly should they have any build script. Note that such dependencies must still be resolvable and fetchable (otherwise we couldn't store it in the lockfile, which could lead to non-reproducible installs). Only the build part is optional.
+        </>}
+      >
+        <JsonScalarProperty
+          name={`fsevents`}
+          placeholder={`^5.0.0`}
+        />
+      </JsonObjectProperty>
+      <JsonObjectProperty
         name={`devDependencies`}
         description={<>
           Similar to the <code>dependencies</code> field, except that these dependencies are only installed on local installs and will never be installed by the consumers of your package. Note that because that would lead to different install trees depending on whether the install is made in "production" or "development" mode, Yarn doesn't offer a way to prevent the installation of dev dependencies at the moment.
@@ -153,6 +164,15 @@ const PackageJsonDoc = () => <>
             placeholder={false}
             description={<>
               If false, the package will never be built. When the global settings <code>enableScripts</code> is toggled off, setting this additional flag will also downgrade the warning into a simple notice for this specific package.
+            </>}
+          />
+          <JsonScalarProperty
+            name={`optionalBuild`}
+            anchor={`dependenciesMeta.optionalBuild`}
+            placeholder={false}
+            description={<>
+              <p>If true, the build isn't required to succeed for the install to be considered a success. It's what the <code>optionalDependencies</code> field compiles down to.</p>
+              <p><b>This settings will be applied even when found within a nested manifest</b> (although the highest requirement in the dependency will prevale).</p>
             </>}
           />
           <JsonScalarProperty


### PR DESCRIPTION
Optional dependencies are regular dependencies that don't cause the install to abort should they fail (the idea being that those packages have fallbacks they can rely on).

This diff implements this.

**Note:** I wouldn't recommend to use optional dependencies in the context of "a package only required in some specific cases whose may build may fail under some systems". Such use cases might be better solved by having a peer dependency and letting the user add the dependency themselves if they need the features that require them. It avoids downloading packages for nothing and doesn't cause all build errors to be swallowed.

**Note bis:** My particular use case is `less`, which puts a bunch of its packages inside optional dependencies, [even those that don't have build steps](https://github.com/less/less.js/blob/162327ae20c503cfaab7799c231adcd8914817c1/package.json#L48).