### PR TITLE
Uses the proper protocol when importing legacy lockfiles

### DIFF
--- a/packages/berry-core/sources/YarnResolver.ts
+++ b/packages/berry-core/sources/YarnResolver.ts
@@ -1,5 +1,6 @@
 import {xfs, ppath}                                      from '@berry/fslib';
 import {parseSyml}                                       from '@berry/parsers';
+import semver                                            from 'semver';
 
 import {Project}                                         from './Project';
 import {MessageName, Report}                             from './Report';
@@ -39,12 +40,15 @@ export class YarnResolver implements Resolver {
     const resolutions = this.resolutions = new Map();
 
     for (const key of Object.keys(parsed)) {
-      const descriptor = structUtils.tryParseDescriptor(key);
+      let descriptor = structUtils.tryParseDescriptor(key);
 
       if (!descriptor) {
         report.reportWarning(MessageName.YARN_IMPORT_FAILED, `Failed to parse the string "${key}" into a proper descriptor`);
         continue;
       }
+
+      if (semver.validRange(descriptor.range))
+        descriptor = structUtils.makeDescriptor(descriptor, `npm:${descriptor.range}`);
 
       const {version, resolved} = (parsed as any)[key];
 


### PR DESCRIPTION
I noticed that migrated lockfiles didn't use the `npm:` qualified in the lockfile. I'd like to discourage that (at least in the lockfile), so I made a small patch to ensure that the protocol was properly added. It works because:

- ★ The `YarnResolver` is setup, finds an entry for `foo@^1.0.0`, but registers it as `foo@npm:^1.0.0`
- We resolve our top-level workspace, and find a reference to `foo@^1.0.0`
- ★ It goes through `SemverResolver`, which converts it into `foo@npm:^1.0.0` and reinject it
- It goes through `YarnResolver`, which finds the internal `foo@npm:^1.0.0` entry and resolves it

The two steps marked ★ are what changed. Before, the entry persisted in the `YarnResolver` store was untransformed (`foo@^1.0.0`). Since `YarnResolver` is prepended to the set of regular resolvers, we never were going through `SemverResolver` (which transforms the descriptors inside `bindDescriptor`).

An alternative might have been to move the `YarnResolver` after the `SemverResolver`, but we would still have had to transform the entries when loading them (otherwise we would never have found the input descriptors inside the legacy lockfiles), so it looked just more work for the same result.