### PR TITLE
Throws the right error when a peer dependency is missing

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -68493,10 +68493,12 @@ class NodeFS extends FakeFS_1.BasePortableFakeFS {
         this.realFs.closeSync(fd);
     }
     createReadStream(p, opts) {
-        return this.realFs.createReadStream(NodeFS.fromPortablePath(p), opts);
+        const realPath = (p !== null ? NodeFS.fromPortablePath(p) : p);
+        return this.realFs.createReadStream(realPath, opts);
     }
     createWriteStream(p, opts) {
-        return this.realFs.createWriteStream(NodeFS.fromPortablePath(p), opts);
+        const realPath = (p !== null ? NodeFS.fromPortablePath(p) : p);
+        return this.realFs.createWriteStream(realPath, opts);
     }
     async realpathPromise(p) {
         return await new Promise((resolve, reject) => {
@@ -68704,10 +68706,10 @@ class ProxiedFS extends FakeFS_1.FakeFS {
         this.baseFs.closeSync(fd);
     }
     createReadStream(p, opts) {
-        return this.baseFs.createReadStream(this.mapToBase(p), opts);
+        return this.baseFs.createReadStream(p !== null ? this.mapToBase(p) : p, opts);
     }
     createWriteStream(p, opts) {
-        return this.baseFs.createWriteStream(this.mapToBase(p), opts);
+        return this.baseFs.createWriteStream(p !== null ? this.mapToBase(p) : p, opts);
     }
     async realpathPromise(p) {
         return this.mapFromBase(await this.baseFs.realpathPromise(this.mapToBase(p)));
@@ -69461,6 +69463,8 @@ class ZipFS extends FakeFS_1.BasePortableFakeFS {
         throw new Error(`Unimplemented`);
     }
     createReadStream(p, { encoding } = {}) {
+        if (p === null)
+            throw new Error(`Unimplemented`);
         const stream = Object.assign(new stream_1.PassThrough(), {
             bytesRead: 0,
             path: p,
@@ -69483,6 +69487,8 @@ class ZipFS extends FakeFS_1.BasePortableFakeFS {
         return stream;
     }
     createWriteStream(p, { encoding } = {}) {
+        if (p === null)
+            throw new Error(`Unimplemented`);
         const stream = Object.assign(new stream_1.PassThrough(), {
             bytesWritten: 0,
             path: p,
@@ -70427,6 +70433,8 @@ class ZipOpenFS extends FakeFS_1.BasePortableFakeFS {
         return this.baseFs.closeSync(fd);
     }
     createReadStream(p, opts) {
+        if (p === null)
+            return this.baseFs.createReadStream(p, opts);
         return this.makeCallSync(p, () => {
             return this.baseFs.createReadStream(p, opts);
         }, (zipFs, { subPath }) => {
@@ -70434,6 +70442,8 @@ class ZipOpenFS extends FakeFS_1.BasePortableFakeFS {
         });
     }
     createWriteStream(p, opts) {
+        if (p === null)
+            return this.baseFs.createWriteStream(p, opts);
         return this.makeCallSync(p, () => {
             return this.baseFs.createWriteStream(p, opts);
         }, (zipFs, { subPath }) => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -216,6 +216,20 @@ describe(`Plug'n'Play`, () => {
         await run(`install`);
 
         await expect(source(`require('various-requires/invalid-require')`)).rejects.toBeTruthy();
+        await expect(source(`{ try { require('various-requires/invalid-require') } catch (error) { return error.code } }`)).resolves.toEqual(`UNDECLARED_DEPENDENCY`);
+      },
+    ),
+  );
+
+  test(
+    `it should throw an exception if a dependency tries to require a missing peer dependency`,
+    makeTemporaryEnv(
+      {dependencies: {[`peer-deps`]: `1.0.0`}},
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(source(`require('peer-deps')`)).rejects.toBeTruthy();
+        await expect(source(`{ try { require('peer-deps') } catch (error) { return error.code } }`)).resolves.toEqual(`MISSING_PEER_DEPENDENCY`);
       },
     ),
   );

--- a/packages/berry-pnp/sources/generateSerializedState.ts
+++ b/packages/berry-pnp/sources/generateSerializedState.ts
@@ -63,7 +63,7 @@ function generatePackageRegistryData(settings: PnpSettings): PackageRegistryData
     packageRegistryData.push([packageName, packageStoreData]);
 
     for (const [packageReference, {packageLocation, packageDependencies}] of sortMap(packageStore, ([packageReference]) => packageReference === null ? `0` : `1${packageReference}`)) {
-      const normalizedDependencies: Array<[string, string | [string, string]]> = [];
+      const normalizedDependencies: Array<[string, string | [string, string] | null]> = [];
 
       if (packageName !== null && packageReference !== null && !packageDependencies.has(packageName))
         normalizedDependencies.push([packageName, packageReference]);

--- a/packages/berry-pnp/sources/types.ts
+++ b/packages/berry-pnp/sources/types.ts
@@ -11,8 +11,8 @@ export type TopLevelPackageLocator = {name: null, reference: null};
 
 export type PackageLocator = PhysicalPackageLocator | TopLevelPackageLocator;
 
-export type PackageInformation<P extends Path> = {packageLocation: P, packageDependencies: Map<string, string | [string, string]>};
-export type PackageInformationData<P extends Path> = {packageLocation: P, packageDependencies: Array<[string, string | [string, string]]>};
+export type PackageInformation<P extends Path> = {packageLocation: P, packageDependencies: Map<string, string | [string, string] | null>};
+export type PackageInformationData<P extends Path> = {packageLocation: P, packageDependencies: Array<[string, string | [string, string] | null]>};
 
 export type PackageStore = Map<string | null, PackageInformation<PortablePath>>;
 export type PackageStoreData = Array<[string | null, PackageInformationData<PortablePath>]>;

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -98,6 +98,9 @@ class PnpInstaller implements Installer {
     const packageLocation = this.normalizeDirectoryPath(packageRawLocation);
     const packageDependencies = new Map();
 
+    for (const descriptor of pkg.peerDependencies.values())
+      packageDependencies.set(structUtils.requirableIdent(descriptor), null);
+
     const packageStore = this.getPackageStore(key1);
     packageStore.set(key2, {packageLocation, packageDependencies});
 
@@ -110,18 +113,19 @@ class PnpInstaller implements Installer {
   async attachInternalDependencies(locator: Locator, dependencies: Array<[Descriptor, Locator]>) {
     const packageInformation = this.getPackageInformation(locator);
 
-    packageInformation.packageDependencies = new Map(dependencies.map(([descriptor, locator]) => {
+    for (const [descriptor, locator] of dependencies) {
       const target = !structUtils.areIdentsEqual(descriptor, locator)
         ? [structUtils.requirableIdent(locator), locator.reference] as [string, string]
         : locator.reference;
 
-      return [structUtils.requirableIdent(descriptor), target];
-    }) as Array<[string, string]>);
+      packageInformation.packageDependencies.set(structUtils.requirableIdent(descriptor), target);
+    }
   }
 
   async attachExternalDependents(locator: Locator, dependentPaths: Array<PortablePath>) {
     for (const dependentPath of dependentPaths) {
       const packageInformation = this.getDiskInformation(dependentPath);
+
       packageInformation.packageDependencies.set(structUtils.requirableIdent(locator), locator.reference);
     }
   }


### PR DESCRIPTION
The current linker wasn't forwarding to the PnP API which peer dependencies weren't met (by opposition to not existing at all). This diff adds this capability, and a test to prevent regressions.

Fixes #265