### PR TITLE
Fixes the virtual link type

### DIFF
--- a/packages/berry-core/sources/VirtualFetcher.ts
+++ b/packages/berry-core/sources/VirtualFetcher.ts
@@ -86,7 +86,15 @@ export class VirtualFetcher implements Fetcher {
         throw new Error(`Conflicting virtual paths (current ${currentLink} != new ${target})`);
 
       if (currentLink === undefined) {
-        await xfs.symlinkPromise(`${target}/` as PortablePath, virtualPath);
+        // We need to check whether the target is a directory because the
+        // Windows symlinks are typed and we need to create the right one
+        const stat = await xfs.statPromise(to);
+
+        if (stat.isDirectory()) {
+          await xfs.symlinkPromise(`${target}/` as PortablePath, virtualPath);
+        } else {
+          await xfs.symlinkPromise(target, virtualPath);
+        }
       }
     });
 


### PR DESCRIPTION
Virtual links were created as `dir` on Windows even where they were pointing towards files, which was breaking installs. We didn't notice it before because:

- Our repository happens to contain the right type of symlinks (probably created before the regression), and the case didn't happen organically.

- For some reason Azure didn't catch the error, but running the tests locally did. Since I always run the tests on Azure only when working on Windows, I didn't notice it before.

A followup would be to refactor `NodeFS.symlinkPromise` to stop using this trailing-slash heuristic, and instead use the `type` parameter (I think we would just have to move this trailing-slash thing in the few places that actually need it, such as the `RawLinkFetcher`).