### PR TITLE
Concurrent cache

### DIFF
--- a/packages/berry-core/package.json
+++ b/packages/berry-core/package.json
@@ -18,7 +18,6 @@
     "globby": "^8.0.1",
     "got": "^9.2.2",
     "json-file-plus": "^3.3.1",
-    "lockfile": "^1.0.4",
     "logic-solver": "^2.0.1",
     "mkdirp": "^0.5.1",
     "p-limit": "^2.2.0",

--- a/packages/berry-core/sources/Cache.ts
+++ b/packages/berry-core/sources/Cache.ts
@@ -1,6 +1,5 @@
 import {FakeFS, LazyFS, NodeFS, ZipFS, PortablePath, Filename} from '@berry/fslib';
 import {xfs, ppath, toFilename}                                from '@berry/fslib';
-import {lock, unlock}                                          from 'lockfile';
 import {promisify}                                             from 'util';
 
 import {Configuration}                                         from './Configuration';

--- a/packages/berry-core/sources/Cache.ts
+++ b/packages/berry-core/sources/Cache.ts
@@ -1,15 +1,11 @@
 import {FakeFS, LazyFS, NodeFS, ZipFS, PortablePath, Filename} from '@berry/fslib';
 import {xfs, ppath, toFilename}                                from '@berry/fslib';
-import {promisify}                                             from 'util';
 
 import {Configuration}                                         from './Configuration';
 import {MessageName, ReportError}                              from './Report';
 import * as hashUtils                                          from './hashUtils';
 import * as structUtils                                        from './structUtils';
 import {LocatorHash, Locator}                                  from './types';
-
-const lockP = promisify(lock);
-const unlockP = promisify(unlock);
 
 export type FetchFromCacheOptions = {
   checksums: Map<LocatorHash, Locator>,

--- a/packages/berry-fslib/sources/FakeFS.ts
+++ b/packages/berry-fslib/sources/FakeFS.ts
@@ -338,7 +338,7 @@ export abstract class FakeFS<P extends Path> {
     }
   }
 
-  async lockPromise(affectedPath: P, callback: () => Promise<void>) {
+  async lockPromise<T>(affectedPath: P, callback: () => Promise<T>): Promise<T> {
     const lockPath = `${affectedPath}.lock` as P;
 
     const interval = 1000 / 60;
@@ -363,7 +363,7 @@ export abstract class FakeFS<P extends Path> {
     }
 
     try {
-      await callback();
+      return await callback();
     } finally {
       await this.closePromise(fd);
       await this.unlinkPromise(lockPath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,7 +1554,6 @@ __metadata:
     globby: "npm:^8.0.1"
     got: "npm:^9.2.2"
     json-file-plus: "npm:^3.3.1"
-    lockfile: "npm:^1.0.4"
     logic-solver: "npm:^2.0.1"
     mkdirp: "npm:^0.5.1"
     p-limit: "npm:^2.2.0"


### PR DESCRIPTION
Our cache was already designed to be accessed concurrently (much easier now that we have a single file per package), but the package we were using (`lockfile`) wasn't working very well in our case, so I swapped it to use our own implementation. After a quick try, it seems to work with four different processes installing the same project into the same cache.

Followup: avoid writing the cache files N times (we can just bailout after the siblings have finished generating their version of the file, if the checksum matches what we would expect).

Note: we can't make a regression test at the moment, because Azure runs with a single core.