### PR TITLE
Sets the user agent when calling a script

### DIFF
--- a/packages/berry-core/sources/scriptUtils.ts
+++ b/packages/berry-core/sources/scriptUtils.ts
@@ -49,6 +49,8 @@ export async function makeScriptEnv(project: Project, lifecycleScript?: string) 
   scriptEnv.npm_execpath = `${nativeBinFolder}${npath.sep}yarn`;
   scriptEnv.npm_node_execpath = `${nativeBinFolder}${npath.sep}node`;
 
+  scriptEnv.npm_config_user_agent = `yarn/? npm/? node/${process.versions.node} ${process.platform} ${process.arch}`;
+
   if (lifecycleScript)
     scriptEnv.npm_lifecycle_event = lifecycleScript;
 


### PR DESCRIPTION
The user agent string is used by various tools to figure out under which package manager they're currently running. Even though the environment key is a bit unfortunate since we're no npm, there's no reason to break (especially given the precedence that are `npm_execpath` and co).