### PR TITLE
`yarn run` with no parameters prints the list of available commands

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/run.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/run.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Commands run with prefix it should print the list of available scripts if no parameters passed to command 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: foo   'echo hello'
+➤ YN0000: bar   'echo hi'
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands run without prefix it should print the list of available scripts if no parameters passed to command 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: foo   'echo hello'
+➤ YN0000: bar   'echo hi'
+➤ YN0000: Done
+",
+}
+`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
@@ -100,6 +100,24 @@ describe(`Commands`, () => {
           },
         ),
       ); 
+      test(`it should print the list of available scripts if no parameters passed to command`,
+        makeTemporaryEnv(
+          {
+            scripts: {
+              foo: `echo hello`,
+              bar: `echo hi`
+            },
+          },
+          async ({path, run, source}) => {
+            let code;
+            let stdout;
+            let stderr;
+
+            ({code, stdout, stderr} = await run(`run`));
+            expect({code, stdout, stderr}).toMatchSnapshot();
+          }
+        )
+      );
     });
   }
 });

--- a/packages/berry-cli/sources/cli.ts
+++ b/packages/berry-cli/sources/cli.ts
@@ -1,10 +1,9 @@
-import {Configuration, StreamReport, Project}                   from '@berry/core';
+import {Configuration}                                          from '@berry/core';
 import {xfs, NodeFS, ppath, PortablePath}                       from '@berry/fslib';
 import {execFileSync}                                           from 'child_process';
 import {Clipanion}                                              from 'clipanion';
 import * as yup                                                 from 'yup';
 
-import {WorkspaceRequiredError}                                 from './WorkspaceRequiredError';
 import {pluginConfiguration}                                    from './pluginConfiguration';
 
 const clipanion = new Clipanion({configKey: null});
@@ -39,25 +38,6 @@ function runBinary(path: PortablePath) {
   }
 }
 
-async function printAvailableScripts(configuration: Configuration) {
-  const stdout = process.stdout;
-  const report = await StreamReport.start({configuration, stdout}, async (report: StreamReport) => {
-    const {workspace} = await Project.find(configuration, configuration.startingCwd);
-    if (!workspace)
-      throw new WorkspaceRequiredError(configuration.startingCwd);
-
-
-    var projectCommands: string[] = []
-    workspace!.manifest.scripts.forEach((value: string, key: string) => {
-      projectCommands.push(`${' '}- ${key}`)
-      projectCommands.push(`  ${' '} ${value}`)
-    });
-
-    report.reportInfo(null, `Project commands\r\n${projectCommands.join('\r\n')}`);
-  });
-  return report.exitCode()
-}
-
 async function run() {
   // Since we only care about a few very specific settings (yarn-path and ignore-path) we tolerate extra configuration key.
   // If we didn't, we wouldn't even be able to run `yarn config` (which is recommended in the invalid config error message)
@@ -87,15 +67,9 @@ async function run() {
       for (const command of plugin.commands || [])
         command(clipanion, pluginConfiguration);
 
-    // Print the list of available scripts if a `run` command is executed without the parameters
-    const noParamsPassedToRunCommand = process.argv.slice(2).length === 1 && process.argv[2] === `run`;
-    if (noParamsPassedToRunCommand) {
-      printAvailableScripts(configuration)
-    } else {
-      clipanion.runExit(`yarn`, process.argv.slice(2), {
-        cwd: NodeFS.toPortablePath(process.cwd()),
-      });
-    }
+    clipanion.runExit(`yarn`, process.argv.slice(2), {
+      cwd: NodeFS.toPortablePath(process.cwd()),
+    });
   }
 }
 

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -103,8 +103,8 @@ export default (clipanion: any, pluginConfiguration: PluginConfiguration) => cli
         throw new WorkspaceRequiredError(cwd);
 
       const {commandPath, env: parsedEnv} = clipanion.parse([command, ...rest]);
-      const scriptName = commandPath.length === 1 && commandPath[0] === `run`
-        ? parsedEnv.name
+      const scriptName = commandPath.length === 1 && commandPath[0] === `run` && parsedEnv.args.length > 0
+        ? parsedEnv.args[0]
         : null;
 
       if (commandPath.length === 0)


### PR DESCRIPTION
### Checklist 

- [x] I've run `yarn test:unit` from the root directory to see all new and existing unit tests pass
- [x] I've run `yarn test:integration` from the root directory to see all new and existing integration tests pass
- [x] I've run `yarn test:lint` to ensure the code style is valid

### Description

> I'm a Yarn user who's just starting on a repository, and I'd like to have a better idea of the main scripts of the project.

closes https://github.com/yarnpkg/berry/issues/284

When a user runs `yarn run` command without any parameters, he / she will get the list of the available scripts in the project. 

I did manual testing including regression tests - calling `yarn run` with some parameters or skipping `run` keyword and calling the commands like `yarn test:unit` 👍 

<img width="869" alt="Screen Shot 2019-07-09 at 18 30 15" src="https://user-images.githubusercontent.com/10795657/60908387-07ae0400-a27c-11e9-9811-a775a91ce4ed.png">

### TODO / Questions 

* [x] Should we format the output differently, i.e. using bold font / color for script names? 🤔 
* [x] Would be great to add unit tests, any ideas how / if we could do that? 🤔 
* [x] `--json` support, which would be helpful for things like autocompletion - 👋 @arcanis, the idea is to format the output of the command `yarn run --json` in JSON format and print it to the console? 🤔 

Thanks you  🙇 🙇 