### PR TITLE
Implements a hook for scripts being run

### DIFF
--- a/packages/berry-core/sources/Configuration.ts
+++ b/packages/berry-core/sources/Configuration.ts
@@ -834,6 +834,24 @@ export class Configuration {
     }
   }
 
+  async reduceHook<U extends any[], V, HooksDefinition = Hooks>(get: (hooks: HooksDefinition) => ((reduced: V, ...args: U) => Promise<V>) | undefined, initialValue: V, ...args: U): Promise<V> {
+    let value = initialValue;
+
+    for (const plugin of this.plugins.values()) {
+      const hooks = plugin.hooks as HooksDefinition;
+      if (!hooks)
+        continue;
+
+      const hook = get(hooks);
+      if (!hook)
+        continue;
+
+      value = await hook(value, ...args);
+    }
+
+    return value;
+  }
+
   format(text: string, color: string) {
     if (this.get(`enableColors`)) {
       if (color.charAt(0) === `#`) {

--- a/packages/berry-core/sources/Plugin.ts
+++ b/packages/berry-core/sources/Plugin.ts
@@ -1,8 +1,14 @@
+import {PortablePath}                            from '@berry/fslib';
+import {Writable, Readable}                      from 'stream';
+
 import {SettingsDefinition, PluginConfiguration} from './Configuration';
 import {Fetcher}                                 from './Fetcher';
 import {Linker}                                  from './Linker';
 import {Project}                                 from './Project';
 import {Resolver}                                from './Resolver';
+import {Locator}                                 from './types';
+
+type ProcessEnvironment = {[key: string]: string};
 
 export interface FetcherPlugin {
   new(): Fetcher;
@@ -27,9 +33,19 @@ export type Hooks = {
   // might enforce it later on).
   setupScriptEnvironment?: (
     project: Project,
-    env: {[key: string]: string},
+    env: ProcessEnvironment,
     makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>,
   ) => Promise<void>,
+
+  // When a script is getting executed. You must call the executor, or the
+  // script won't be called at all.
+  wrapScriptExecution?: (
+    executor: () => Promise<number>,
+    project: Project,
+    locator: Locator,
+    scriptName: string,
+    extra: {script: string, args: Array<string>, cwd: PortablePath, env: ProcessEnvironment, stdin: Readable | null, stdout: Writable, stderr: Writable},
+  ) => Promise<() => Promise<number>>,
 
   // Called after the `install` method from the `Project` class successfully
   // completed.

--- a/packages/berry-core/sources/scriptUtils.ts
+++ b/packages/berry-core/sources/scriptUtils.ts
@@ -115,7 +115,7 @@ export async function executePackageScript(locator: Locator, scriptName: string,
   const executor = await project.configuration.reduceHook(hooks => {
     return hooks.wrapScriptExecution;
   }, realExecutor, project, locator, scriptName, {
-    script, args, cwd: realCwd, env, stdin, stdout, stderr
+    script, args, cwd: realCwd, env, stdin, stdout, stderr,
   });
 
   try {

--- a/packages/berry-core/sources/scriptUtils.ts
+++ b/packages/berry-core/sources/scriptUtils.ts
@@ -108,8 +108,18 @@ export async function executePackageScript(locator: Locator, scriptName: string,
   if (!script)
     return;
 
-  try {
+  const realExecutor = async () => {
     return await execute(script, args, {cwd: realCwd, env, stdin, stdout, stderr});
+  };
+
+  const executor = await project.configuration.reduceHook(hooks => {
+    return hooks.wrapScriptExecution;
+  }, realExecutor, project, locator, scriptName, {
+    script, args, cwd: realCwd, env, stdin, stdout, stderr
+  });
+
+  try {
+    return await executor();
   } finally {
     await xfs.removePromise(binFolder);
   }


### PR DESCRIPTION
This diff implements a new hook called `wrapScriptExecution` that gets invoked when a script would get executed. It wraps the actual executor, meaning that the following use cases can now be implemented from within plugins:

- Use a different shell than the default one (for example if you want to leverage features only available in your native shell instead of the portable one).

- Log metrics regarding which scripts are run and how much time they take to execute (useful for frontend infrastructure teams that wish to get a better understanding of how product teams use the platform).

- Security measures (you can simply prevent a script from being executed based on the heuristic of your choice, for example the package name, author, ...).