### PR TITLE
Updates descriptive text for plugin dl command

### DIFF
--- a/packages/plugin-essentials/sources/commands/plugin/dl.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/dl.ts
@@ -12,7 +12,7 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
 
   .command(`plugin dl [name] [-l,--list]`)
   .alias(`plugins dl`)
-  .describe(`downloads a plugin or lists the active official plugins`)
+  .describe(`download a plugin, or list the available official plugins`)
 
   .detail(`
     This command download the specified plugin from its remote location and updates the configuration to reference it in further CLI invocations.

--- a/packages/plugin-essentials/sources/commands/plugin/dl.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/dl.ts
@@ -12,7 +12,7 @@ export default (clipanion: Clipanion, pluginConfiguration: PluginConfiguration) 
 
   .command(`plugin dl [name] [-l,--list]`)
   .alias(`plugins dl`)
-  .describe(`list the active plugins`)
+  .describe(`downloads a plugin or lists the active official plugins`)
 
   .detail(`
     This command download the specified plugin from its remote location and updates the configuration to reference it in further CLI invocations.


### PR DESCRIPTION
The description for the two `plugin dl` and `plugin list` commands looks the same which might cause some confusion. I updated the command description for `plugin dl` to reflect what it actually does.

This is how `yarn --help` looks prior to this PR:
```
  pack                 bundle local packages for publishing
  plugin dl           list the active plugins
  plugin list         list the active plugins
  remove             remove dependencies from the project
```