### PR TITLE
Fix double home menu link activation

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -1,10 +1,10 @@
-import styled                          from '@emotion/styled';
-import {Link, graphql, useStaticQuery} from 'gatsby';
-import PropTypes                       from 'prop-types';
-import React, {useState}               from 'react';
+import styled                                      from '@emotion/styled';
+import {Link, graphql, useStaticQuery, withPrefix} from 'gatsby';
+import PropTypes                                   from 'prop-types';
+import React, {useState}                           from 'react';
 
-import Logo                            from './logo';
-import {ifDesktop, ifMobile}           from './responsive';
+import Logo                                        from './logo';
+import {ifDesktop, ifMobile}                       from './responsive';
 
 const HeaderContainer = styled.div`
   ${ifDesktop} {
@@ -130,10 +130,17 @@ const MenuEntry = styled.div`
 `;
 
 const isActive = ({ href, location }) => {
-  return ((href === '/' && ['/', '/package'].includes(location.pathname)) ||
-    (href !== '/' && location.pathname.startsWith(href))) ?
-      { className: 'active' } :
-      null;
+  const homeUrl = withPrefix('/');
+  const packageInfoUrl = withPrefix('/package/');
+
+  // Make all menu links (except home) active when itself or deeper routes are be current
+  const isMenuLinkActive = href !== homeUrl && location.pathname.startsWith(href);
+
+  // Make home menu active when home or package info routes are current
+  const isHomeMenuLinkActive = href === homeUrl
+      && [homeUrl, packageInfoUrl].includes(location.pathname)
+
+  return isMenuLinkActive || isHomeMenuLinkActive ? { className: 'active' } : null;
 };
 
 const Header = ({ children }) => {


### PR DESCRIPTION
I have noticed on production website that my search bar PR introduced the problem that Home top menu link stays active on doc pages. This PR fixes the problem - the Home menu link will be active on home page, during package search and while showing package details, on all doc pages it will be inactive.