### PR TITLE
Navigation fix

### DIFF
--- a/packages/gatsby/content/advanced/lexicon.md
+++ b/packages/gatsby/content/advanced/lexicon.md
@@ -30,6 +30,12 @@ A locator is a combination of a package name (for example `lodash`) and a packag
 
 A manifest is a `package.json` file.
 
+### Monorepository
+
+A monorepository is a repository that contains multiple packages. For example, [Babel](https://github.com/babel/babel/tree/master/packages) and [Jest](https://github.com/facebook/jest/tree/master/packages) are examples of such repositories - they each contain dozen of small packages that each rely on one another.
+
+See also: [Workspaces](/features/workspaces)
+
 ### Peer-dependent Package
 
 A peer-dependent package is a package that lists peer dependencies.

--- a/packages/gatsby/content/features/workspaces.md
+++ b/packages/gatsby/content/features/workspaces.md
@@ -4,7 +4,7 @@ path: /features/workspaces
 title: "Workspaces"
 ---
 
-The Yarn workspaces are a feature designed to make monorepos easy to use, solving one of the main use cases for `yarn link` in a more declarative way. In short, they allow multiple of your projects to live together in the same repository AND to cross-reference each others.
+The Yarn workspaces aim to make working with [monorepos](/advanced/lexicon#monorepository) easy, solving one of the main use cases for `yarn link` in a more declarative way. In short, they allow multiple of your projects to live together in the same repository AND to cross-reference each others - any modification to one's source code being instantly applied to the others.
 
 First, some vocabulary: in the context of the workspace feature, a *project* is the whole directory tree making up your workspaces (often the repository itself). A *workspace* is a specific named package stored anywhere within the project. Finally, a *worktree* is the name given to private packages that list their own child workspaces. A project contains one or more worktrees, which may themselves contain any number of workspaces.
 

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -17,10 +17,13 @@ const HeaderContainer = styled.div`
 const NewsContainer = styled.a`
   display: block;
 
-  padding: 0.8em 1em;
+  height: 2.5em;
+
+  padding: 0 1em;
 
   font-weight: light;
   text-decoration: none;
+  line-height: 2.5em;
 
   background: #2188b6;
   color: rgba(255, 255, 255, 0.8);

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -20,7 +20,7 @@ const Menu = styled.div`
     left: 0;
 
     width: 300px;
-    height: calc(100vh - 4em);
+    height: calc(100vh - 6.5em);
     overflow-y: auto;
 
     background: #d1dee8;


### PR DESCRIPTION
There was a problem on the website where the last navigation entry was often hidden from the view, even when scrolling as much as possible (this was caused by the top banner not being taken into account in the positioning of the navigation). This diff fixes the measures.

