### PR TITLE
docs: Fix publishConfig fields

### DIFF
--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -247,7 +247,7 @@ const PackageJsonDoc = () => <>
         <JsonScalarProperty
           name={`access`}
           anchor={`publishConfig.main`}
-          placeholder={`./build/index.js`}
+          placeholder={`public`}
           description={<>
             Defines the package access level to use when publishing packages to the npm registry. Valid values are <code>public</code> and <code>restricted</code>, but <code>restricted</code> usually requires to register for a paid plan (this is up to the registry you use).
           </>}
@@ -269,7 +269,7 @@ const PackageJsonDoc = () => <>
           </>}
         />
         <JsonScalarProperty
-          name={`module`}
+          name={`registry`}
           anchor={`publishConfig.registry`}
           placeholder={`https://npm.pkg.github.com`}
           description={<>

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -246,7 +246,7 @@ const PackageJsonDoc = () => <>
       >
         <JsonScalarProperty
           name={`access`}
-          anchor={`publishConfig.main`}
+          anchor={`publishConfig.access`}
           placeholder={`public`}
           description={<>
             Defines the package access level to use when publishing packages to the npm registry. Valid values are <code>public</code> and <code>restricted</code>, but <code>restricted</code> usually requires to register for a paid plan (this is up to the registry you use).


### PR DESCRIPTION
Fixes https://yarnpkg.github.io/berry/configuration/manifest#publishConfig: 
- not displaying the correct field name of `registry`
- `access` using an invalid placeholder
- `main` anchor linking to `publishConfig.access`.

[Fixed section](https://deploy-preview-331--keen-leavitt-98f35d.netlify.com/configuration/manifest#publishConfig)