### PR TITLE
docs: Improve anchor links UX for JSON docs

### DIFF
--- a/packages/gatsby/src/components/syntax.js
+++ b/packages/gatsby/src/components/syntax.js
@@ -128,8 +128,8 @@ const Key = ({theme, name, anchorTarget}) => <>
   <span style={{color: theme.colors.key}}>
     {anchorTarget ? <>
       <a style={{color: `inherit`}} href={`#${anchorTarget}`}>
-        <Anchor/> {theme.formatKey(name)}
-      </a>
+        <Anchor/>
+      </a> {theme.formatKey(name)}
     </> : <>
       {theme.formatKey(name)}
     </>}

--- a/packages/gatsby/src/components/syntax.js
+++ b/packages/gatsby/src/components/syntax.js
@@ -21,6 +21,8 @@ export const Container = styled.div`
   color: ${props => props.theme.colors.documentation};
 
   a[href^="#"] {
+    margin-left: -15px;
+    padding: 15px;
     text-decoration: none;
   }
 
@@ -129,7 +131,7 @@ const Key = ({theme, name, anchorTarget}) => <>
     {anchorTarget ? <>
       <a style={{color: `inherit`}} href={`#${anchorTarget}`}>
         <Anchor/>
-      </a> {theme.formatKey(name)}
+      </a>{theme.formatKey(name)}
     </> : <>
       {theme.formatKey(name)}
     </>}


### PR DESCRIPTION
For API documentation it's useful to be able to copy method/variable names. This is currently not possible for properties that have an anchor since the name is part of the anchor. This PR moves the name outside of the anchor while retaining hit size of the anchor.

Before:
![yarn-berry-anchor-master](https://user-images.githubusercontent.com/12292047/62414099-f86e6c00-b617-11e9-9567-6c84f0f4f30a.gif)

After:
![yarn-berry-anchor-pr](https://user-images.githubusercontent.com/12292047/62414101-fad0c600-b617-11e9-9cf2-950885d1f5e9.gif)
