### PR TITLE
Only removes the authorization header when switching hostnames

### DIFF
--- a/packages/berry-core/sources/httpUtils.ts
+++ b/packages/berry-core/sources/httpUtils.ts
@@ -60,11 +60,17 @@ async function request(target: string, body: Body, {configuration, headers, json
       : globalHttpsAgent;
 
   const gotOptions = {agent, body, headers, json, method, encoding: null};
+  let hostname: string | undefined;
 
   const makeHooks = <T extends string | null>() => ({
+    beforeRequest: [
+      (options: GotOptions<T>) => {
+        hostname = options.hostname;
+      },
+    ],
     beforeRedirect: [
       (options: GotOptions<T>) => {
-        if (options.headers && options.headers.authorization) {
+        if (options.headers && options.headers.authorization && options.hostname !== hostname) {
           delete options.headers.authorization;
         }
       },


### PR DESCRIPTION
Followup to #329

This diff changes the logic that removes the `Authorization` header on redirects to instead only do this if the hostname changed. We maybe should find a way to update the mock server to add an endpoint with such a logic, although that would make it harder to use Verdaccio in the future 🤔

Can you confirm it works for your use case, @Js-Brecht?