### PR TITLE
Fixes the gitignore definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,18 @@
 node_modules
 yarn-error.log
 
-.vscode/**
 .history
 
 junit.xml
 
+# This is the Yarn build state; it's local to each clone
 /.yarn/build-state.yml
 
 # Those files are meant to be local-only
 /packages/*/bundles
 
 # Those folders are meant to contain the prepack build artifacts; we don't commit them
-lib
+/packages/*/lib
 
 # We check-in the PnP hook because it would be heavy to regenerate it before each bundle build
 !/packages/berry-pnp/lib/hook.js
-
-!/.vscode/pnpify
-!/.vscode/pnpify/**/lib

--- a/.vscode/pnpify/eslint/lib/api.js
+++ b/.vscode/pnpify/eslint/lib/api.js
@@ -1,0 +1,12 @@
+const relPnpApiPath = "../../../../.pnp.js";
+const absPnpApiPath = require(`path`).resolve(__dirname, relPnpApiPath);
+
+// Setup the environment to be able to require eslint
+require(absPnpApiPath).setup();
+
+// Prepare the environment (to be ready in case of child_process.spawn etc)
+process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
+process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
+
+// Defer to the real eslint your application uses
+module.exports = require(`eslint`);

--- a/.vscode/pnpify/eslint/package.json
+++ b/.vscode/pnpify/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint",
+  "version": "5.16.0-pnpify",
+  "main": "lib/api.js"
+}

--- a/.vscode/pnpify/typescript/lib/tsserver.js
+++ b/.vscode/pnpify/typescript/lib/tsserver.js
@@ -1,0 +1,20 @@
+const path = require(`path`);
+
+const relPnpApiPath = "../../../../.pnp.js";
+const absPnpApiPath = path.resolve(__dirname, relPnpApiPath);
+
+// Setup the environment to be able to require typescript/lib/tsserver
+require(absPnpApiPath).setup();
+
+// Prepare the environment (to be ready in case of child_process.spawn etc)
+process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
+process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
+process.env.NODE_OPTIONS += ` -r ${require.resolve(`@berry/monorepo/scripts/setup-ts-execution`)}`;
+process.env.NODE_OPTIONS += ` -r ${require.resolve(`@berry/pnpify`)}`;
+
+// Apply PnPify to the current process
+require(`@berry/monorepo/scripts/setup-ts-execution`);
+require(`@berry/pnpify`).patchFs();
+
+// Defer to the real typescript/lib/tsserver your application uses
+module.exports = require(`typescript/lib/tsserver`);

--- a/.vscode/pnpify/typescript/package.json
+++ b/.vscode/pnpify/typescript/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "typescript",
+  "version": "3.3.3333-pnpify"
+}


### PR DESCRIPTION
This diff ensures that the `.vscode` directory is properly checked into the repository (which is important because it contains the VSCode glue required for typecheck + linting).

It previously wasn't, because `.vscode` was ignored - and even though we had an override rules, they don't have any effect when the parent directory is ignored. Per the docs:

>  It is not possible to re-include a file if a parent directory of that file is excluded.