### PR TITLE
Fixes support for v-prefixed semver ranges

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -28439,6 +28439,7 @@ exports.hydrateRuntimeState = hydrateRuntimeState;
 
 "use strict";
 
+/// <reference path="../../types/module/index.d.ts"/>
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
@@ -8,9 +8,26 @@ describe(`Protocols`, () => {
         },
         async ({path, run, source}) => {
           await run(`install`);
-  
+
           await expect(source(`require('no-deps')`)).resolves.toMatchObject({
             name: `one-fixed-dep`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should allow prefixing semver ranges with "v"`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `npm:v1.0.0`},
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+            name: `no-deps`,
             version: `1.0.0`,
           });
         },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/semver.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/semver.test.js
@@ -1,0 +1,20 @@
+describe(`Protocols`, () => {
+  describe(`Semver`, () => {
+    test(
+      `it should allow prefixing semver ranges with "v"`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `v1.0.0`},
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+            name: `no-deps`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+  });
+});

--- a/packages/plugin-npm/sources/NpmFetcher.ts
+++ b/packages/plugin-npm/sources/NpmFetcher.ts
@@ -1,6 +1,6 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@berry/core';
 import {structUtils, tgzUtils}                      from '@berry/core';
-import {Locator, MessageName}                       from '@berry/core';
+import {Locator, MessageName, ReportError}          from '@berry/core';
 import {PortablePath}                               from '@berry/fslib';
 import semver                                       from 'semver';
 
@@ -65,7 +65,9 @@ export class NpmFetcher implements Fetcher {
   }
 
   private getLocatorUrl(locator: Locator, opts: FetchOptions) {
-    const version = locator.reference.slice(PROTOCOL.length);
+    const version = semver.clean(locator.reference.slice(PROTOCOL.length));
+    if (version === null)
+      throw new ReportError(MessageName.RESOLVER_NOT_FOUND, `The npm semver resolver got selected, but the version isn't semver`);
 
     return `${npmHttpUtils.getIdentUrl(locator)}/-/${locator.name}-${version}.tgz`;
   }

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -64,7 +64,9 @@ export class NpmSemverResolver implements Resolver {
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {
-    const version = locator.reference.slice(PROTOCOL.length);
+    const version = semver.clean(locator.reference.slice(PROTOCOL.length));
+    if (version === null)
+      throw new ReportError(MessageName.RESOLVER_NOT_FOUND, `The npm semver resolver got selected, but the version isn't semver`);
 
     const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(locator), {
       configuration: opts.project.configuration,


### PR DESCRIPTION
This diff fixes #340 by ensuring that the version ranges are properly cleaned before querying the remote registry.