### PR TITLE
Enables tests for Node 12

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -48,22 +48,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nodejs_version: [8, 10]
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        node:
+        - 8
+        - 10
+        - 12
+        platform:
+        - ubuntu-latest
+        - windows-latest
+        - macos-latest
         exclude:
-        - platform: windows-latest
-          nodejs_version: 8
+        - node: 8
+          platform: windows-latest
 
-    name: ${{matrix.platform}} w/ Node.js ${{matrix.nodejs_version}}.x
+    name: ${{matrix.platform}} w/ Node.js ${{matrix.node}}.x
     runs-on: ${{matrix.platform}}
 
     steps:
     - uses: actions/checkout@master
 
-    - name: Use Node.js ${{matrix.nodejs_version}}.x
+    - name: Use Node.js ${{matrix.node}}.x
       uses: actions/setup-node@master
       with:
-        version: ${{matrix.nodejs_version}}.x
+        version: ${{matrix.node}}.x
 
     - name: Use Yarn 1.17.2
       run: |


### PR DESCRIPTION
This diff adds support for Node 12 in our integration test pipeline.