### PR TITLE
Implements "yarn set version from sources"

### DIFF
--- a/packages/berry-fslib/sources/index.ts
+++ b/packages/berry-fslib/sources/index.ts
@@ -14,7 +14,7 @@ export {WriteFileOptions}         from './FakeFS';
 
 export {Path, PortablePath, NativePath, Filename} from './path';
 export {ParsedPath, PathUtils, FormatInputPathObject} from './path';
-export {npath, ppath, toFilename} from './path';
+export {npath, ppath, toFilename, fromPortablePath, toPortablePath} from './path';
 
 export {AliasFS}                  from './AliasFS';
 export {FakeFS}                   from './FakeFS';

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -13,13 +13,20 @@ Now that you have Yarn [installed](/getting-started/install), you can start usin
 ### Accessing the list of commands
 
 ```
-yarn --help
+yarn help
 ```
 
 ### Starting a new project
 
 ```
 yarn init
+```
+
+### Installing all the dependencies
+
+```
+yarn
+yarn install
 ```
 
 ### Adding a dependency
@@ -32,11 +39,9 @@ yarn add [package]@[tag]
 
 ### Adding a dependency to different categories of dependencies
 
-Add to respectively [`devDependencies`](/configuration/manifest#devDependencies) or [`peerDependencies`](/configuration/manifest#peerDependencies):
-
 ```
-yarn add [package] --dev
-yarn add [package] --peer
+yarn add [package] --dev  # dev dependencies
+yarn add [package] --peer # peer dependencies
 ```
 
 ### Upgrading a dependency
@@ -52,14 +57,6 @@ yarn up [package]@[tag]
 ```
 yarn remove [package]
 ```
-
-### Installing all the dependencies of project
-
-```
-yarn install
-```
-
-The `install` keyword is optional; just calling `yarn` will have the same effect.
 
 ### Upgrading Yarn itself
 

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -10,51 +10,59 @@ Now that you have Yarn [installed](/getting-started/install), you can start usin
 >
 > We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/advanced/migration). Give it a look and contribute to it if you see things that aren't covered yet!
 
-**Starting a new project**
+### Accessing the list of commands
 
 ```
-$> yarn init
+yarn --help
 ```
 
-**Adding a dependency**
+### Starting a new project
 
 ```
-$> yarn add [package]
-$> yarn add [package]@[version]
-$> yarn add [package]@[tag]
+yarn init
 ```
 
-**Adding a dependency to different categories of dependencies**
+### Adding a dependency
+
+```
+yarn add [package]
+yarn add [package]@[version]
+yarn add [package]@[tag]
+```
+
+### Adding a dependency to different categories of dependencies
 
 Add to respectively [`devDependencies`](/configuration/manifest#devDependencies) or [`peerDependencies`](/configuration/manifest#peerDependencies):
 
 ```
-$> yarn add [package] --dev
-$> yarn add [package] --peer
+yarn add [package] --dev
+yarn add [package] --peer
 ```
 
-**Upgrading a dependency**
+### Upgrading a dependency
 
 ```
-$> yarn up [package]
-$> yarn up [package]@[version]
-$> yarn up [package]@[tag]
+yarn up [package]
+yarn up [package]@[version]
+yarn up [package]@[tag]
 ```
 
-**Removing a dependency**
+### Removing a dependency
 
 ```
-$> yarn remove [package]
+yarn remove [package]
 ```
 
-**Installing all the dependencies of project**
+### Installing all the dependencies of project
 
 ```
-$> yarn
+yarn install
 ```
 
-or
+The `install` keyword is optional; just calling `yarn` will have the same effect.
+
+### Upgrading Yarn itself
 
 ```
-$> yarn install
+yarn set version from sources
 ```

--- a/packages/plugin-essentials/sources/commands/entries/help.ts
+++ b/packages/plugin-essentials/sources/commands/entries/help.ts
@@ -3,6 +3,7 @@ import {Command}        from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class HelpCommand extends Command<CommandContext> {
+  @Command.Path(`help`)
   @Command.Path(`--help`)
   @Command.Path(`-h`)
   async execute() {

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -1,0 +1,112 @@
+import {WorkspaceRequiredError}                                                       from '@berry/cli';
+import {CommandContext, Configuration, MessageName, Project, StreamReport, execUtils} from '@berry/core';
+import {Filename, PortablePath, ppath, toPortablePath, xfs}                           from '@berry/fslib';
+import {Command}                                                                      from 'clipanion';
+import {tmpdir}                                                                       from 'os';
+
+import {setVersion}                                                                   from '../version';
+
+const CLONE_WORKFLOW = ({repository, branch}: {repository: string, branch: string}) => [
+  [`git`, `clone`, repository, `.`],
+  [`git`, `checkout`, branch],
+];
+
+const UPDATE_WORKFLOW = ({branch}: {branch: string}) => [
+  [`git`, `fetch`, `origin`],
+  [`git`, `reset`, `--hard`],
+  [`git`, `clean`, `-dfx`],
+  [`git`, `checkout`, branch],
+];
+
+const BUILD_WORKFLOW = [
+  [`yarn`, `build:cli`],
+];
+
+// eslint-disable-next-line arca/no-default-export
+export default class SetVersionCommand extends Command<CommandContext> {
+  @Command.String(`--path`)
+  installPath?: string;
+
+  @Command.String(`--repository`)
+  repository: string = `git@github.com:yarnpkg/berry`;
+
+  @Command.String(`--branch`)
+  branch: string = `master`;
+
+  static usage = Command.Usage({
+    description: `build Yarn from master`,
+    details: `
+      This command will clone the Yarn repository into a temporary folder, then build it. The resulting bundle will then be copied into the local project.
+    `,
+    examples: [[
+      `Build Yarn from master`,
+      `yarn set version from sources`,
+    ]],
+  });
+
+  @Command.Path(`set`, `version`, `from`, `sources`)
+  async execute() {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
+
+    if (!workspace)
+      throw new WorkspaceRequiredError(this.context.cwd);
+
+    const target = typeof this.installPath !== `undefined`
+      ? ppath.resolve(this.context.cwd, toPortablePath(this.installPath))
+      : ppath.resolve(toPortablePath(tmpdir()), `berry` as Filename);
+
+    const report = await StreamReport.start({
+      configuration,
+      stdout: this.context.stdout,
+    }, async (report: StreamReport) => {
+      await xfs.mkdirpPromise(target);
+
+      let workflow;
+      if (xfs.existsSync(target)) {
+        report.reportInfo(MessageName.UNNAMED, `Fetching the latest commits`);
+        workflow = UPDATE_WORKFLOW(this);
+      } else {
+        report.reportInfo(MessageName.UNNAMED, `Cloning the remote repository`);
+        workflow = CLONE_WORKFLOW(this);
+      }
+
+      report.reportSeparator();
+
+      for (const [fileName, ...args] of workflow) {
+        await execUtils.pipevp(fileName, args, {
+          cwd: target,
+          stdin: this.context.stdin,
+          stdout: this.context.stdout,
+          stderr: this.context.stderr,
+          strict: true,
+        });
+      }
+
+      report.reportSeparator();
+      report.reportInfo(MessageName.UNNAMED, `Building a fresh bundle`);
+      report.reportSeparator();
+
+      for (const [fileName, ...args] of BUILD_WORKFLOW) {
+        await execUtils.pipevp(fileName, args, {
+          cwd: target,
+          stdin: this.context.stdin,
+          stdout: this.context.stdout,
+          stderr: this.context.stderr,
+          strict: true,
+        });
+      }
+
+      report.reportSeparator();
+
+      const bundlePath = ppath.resolve(target, `packages/berry-cli/bundles/berry.js` as PortablePath);
+      const bundleBuffer = await xfs.readFilePromise(bundlePath);
+
+      await setVersion(project, `berry`, bundleBuffer, {
+        report,
+      });
+    });
+
+    return report.exitCode();
+  }
+}

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -20,6 +20,7 @@ import remove                             from './commands/remove';
 import runIndex                           from './commands/runIndex';
 import run                                from './commands/run';
 import setResolutionPolicy                from './commands/set/resolution';
+import setVersionFromSources              from './commands/set/version/sources';
 import setVersionPolicy                   from './commands/set/version';
 import up                                 from './commands/up';
 import why                                from './commands/why';
@@ -61,6 +62,7 @@ const plugin: Plugin = {
     cleanCache,
     setConfig,
     setResolutionPolicy,
+    setVersionFromSources,
     setVersionPolicy,
     listWorkspaces,
     clipanionEntry,


### PR DESCRIPTION
This command implements a new command:

```
yarn set version from sources
```

When run, this command will clone the Yarn repository into a temporary directory and build it there. The resulting will then be copied in the local project. This workflow makes it possible to quickly benefit from our fixes without having to wait for us to formally rebuild the artifacts.