### PR TITLE
Improves fslib

### DIFF
--- a/packages/berry-core/package.json
+++ b/packages/berry-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@berry/core",
   "version": "2.0.0-rc.0",
+  "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/berry-fslib/package.json
+++ b/packages/berry-fslib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@berry/fslib",
   "version": "2.0.0-rc.0",
+  "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/berry-fslib/sources/FakeFS.ts
+++ b/packages/berry-fslib/sources/FakeFS.ts
@@ -92,6 +92,9 @@ export abstract class FakeFS<P extends Path> {
   abstract copyFilePromise(sourceP: P, destP: P, flags?: number): Promise<void>;
   abstract copyFileSync(sourceP: P, destP: P, flags?: number): void;
 
+  abstract appendFilePromise(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
+  abstract appendFileSync(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
+
   abstract writeFilePromise(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
   abstract writeFileSync(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
 

--- a/packages/berry-fslib/sources/FakeFS.ts
+++ b/packages/berry-fslib/sources/FakeFS.ts
@@ -1,7 +1,7 @@
-import {ReadStream, Stats, WriteStream}          from 'fs';
+import {ReadStream, Stats, WriteStream}                  from 'fs';
 
-import {Path, PortablePath, PathUtils, Filename} from './path';
-import {convertPath, ppath}                      from './path';
+import {FSPath, Path, PortablePath, PathUtils, Filename} from './path';
+import {convertPath, ppath}                              from './path';
 
 export type CreateReadStreamOptions = Partial<{
   encoding: string,
@@ -92,8 +92,8 @@ export abstract class FakeFS<P extends Path> {
   abstract copyFilePromise(sourceP: P, destP: P, flags?: number): Promise<void>;
   abstract copyFileSync(sourceP: P, destP: P, flags?: number): void;
 
-  abstract writeFilePromise(p: P, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
-  abstract writeFileSync(p: P, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
+  abstract writeFilePromise(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
+  abstract writeFileSync(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions): void;
 
   abstract unlinkPromise(p: P): Promise<void>;
   abstract unlinkSync(p: P): void;
@@ -101,11 +101,11 @@ export abstract class FakeFS<P extends Path> {
   abstract utimesPromise(p: P, atime: Date | string | number, mtime: Date | string | number): Promise<void>;
   abstract utimesSync(p: P, atime: Date | string | number, mtime: Date | string | number): void;
 
-  abstract readFilePromise(p: P, encoding: 'utf8'): Promise<string>;
-  abstract readFilePromise(p: P, encoding?: string): Promise<Buffer>;
+  abstract readFilePromise(p: FSPath<P>, encoding: 'utf8'): Promise<string>;
+  abstract readFilePromise(p: FSPath<P>, encoding?: string): Promise<Buffer>;
 
-  abstract readFileSync(p: P, encoding: 'utf8'): string;
-  abstract readFileSync(p: P, encoding?: string): Buffer;
+  abstract readFileSync(p: FSPath<P>, encoding: 'utf8'): string;
+  abstract readFileSync(p: FSPath<P>, encoding?: string): Buffer;
 
   abstract readlinkPromise(p: P): Promise<P>;
   abstract readlinkSync(p: P): P;

--- a/packages/berry-fslib/sources/NodeFS.ts
+++ b/packages/berry-fslib/sources/NodeFS.ts
@@ -3,7 +3,7 @@ import fs, {Stats}                                         from 'fs';
 import {CreateReadStreamOptions, CreateWriteStreamOptions} from './FakeFS';
 import {BasePortableFakeFS, WriteFileOptions}              from './FakeFS';
 import {WatchOptions, WatchCallback, Watcher}              from './FakeFS';
-import {PortablePath, NativePath, Filename, Path}          from './path';
+import {FSPath, PortablePath, NativePath, Filename, Path}  from './path';
 import {fromPortablePath, toPortablePath}                  from './path';
 
 export class NodeFS extends BasePortableFakeFS {
@@ -131,21 +131,23 @@ export class NodeFS extends BasePortableFakeFS {
     return this.realFs.copyFileSync(NodeFS.fromPortablePath(sourceP), NodeFS.fromPortablePath(destP), flags);
   }
 
-  async writeFilePromise(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+  async writeFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return await new Promise<void>((resolve, reject) => {
+      const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
       if (opts) {
-        this.realFs.writeFile(NodeFS.fromPortablePath(p), content, opts, this.makeCallback(resolve, reject));
+        this.realFs.writeFile(fsNativePath, content, opts, this.makeCallback(resolve, reject));
       } else {
-        this.realFs.writeFile(NodeFS.fromPortablePath(p), content, this.makeCallback(resolve, reject));
+        this.realFs.writeFile(fsNativePath, content, this.makeCallback(resolve, reject));
       }
     });
   }
 
   writeFileSync(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
     if (opts) {
-      this.realFs.writeFileSync(NodeFS.fromPortablePath(p), content, opts);
+      this.realFs.writeFileSync(fsNativePath, content, opts);
     } else {
-      this.realFs.writeFileSync(NodeFS.fromPortablePath(p), content);
+      this.realFs.writeFileSync(fsNativePath, content);
     }
   }
 
@@ -203,18 +205,20 @@ export class NodeFS extends BasePortableFakeFS {
     return this.realFs.symlinkSync(NodeFS.fromPortablePath(target.replace(/\/+$/, ``) as PortablePath), NodeFS.fromPortablePath(p), type);
   }
 
-  readFilePromise(p: PortablePath, encoding: 'utf8'): Promise<string>;
-  readFilePromise(p: PortablePath, encoding?: string): Promise<Buffer>;
-  async readFilePromise(p: PortablePath, encoding?: string) {
+  readFilePromise(p: FSPath<PortablePath>, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: FSPath<PortablePath>, encoding?: string): Promise<Buffer>;
+  async readFilePromise(p: FSPath<PortablePath>, encoding?: string) {
     return await new Promise<any>((resolve, reject) => {
-      this.realFs.readFile(NodeFS.fromPortablePath(p), encoding, this.makeCallback(resolve, reject));
+      const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+      this.realFs.readFile(fsNativePath, encoding, this.makeCallback(resolve, reject));
     });
   }
 
-  readFileSync(p: PortablePath, encoding: 'utf8'): string;
-  readFileSync(p: PortablePath, encoding?: string): Buffer;
-  readFileSync(p: PortablePath, encoding?: string) {
-    return this.realFs.readFileSync(NodeFS.fromPortablePath(p), encoding);
+  readFileSync(p: FSPath<PortablePath>, encoding: 'utf8'): string;
+  readFileSync(p: FSPath<PortablePath>, encoding?: string): Buffer;
+  readFileSync(p: FSPath<PortablePath>, encoding?: string) {
+    const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+    return this.realFs.readFileSync(fsNativePath, encoding);
   }
 
   async readdirPromise(p: PortablePath) {

--- a/packages/berry-fslib/sources/NodeFS.ts
+++ b/packages/berry-fslib/sources/NodeFS.ts
@@ -131,6 +131,26 @@ export class NodeFS extends BasePortableFakeFS {
     return this.realFs.copyFileSync(NodeFS.fromPortablePath(sourceP), NodeFS.fromPortablePath(destP), flags);
   }
 
+  async appendFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return await new Promise<void>((resolve, reject) => {
+      const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+      if (opts) {
+        this.realFs.appendFile(fsNativePath, content, opts, this.makeCallback(resolve, reject));
+      } else {
+        this.realFs.appendFile(fsNativePath, content, this.makeCallback(resolve, reject));
+      }
+    });
+  }
+
+  appendFileSync(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+    if (opts) {
+      this.realFs.appendFileSync(fsNativePath, content, opts);
+    } else {
+      this.realFs.appendFileSync(fsNativePath, content);
+    }
+  }
+
   async writeFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return await new Promise<void>((resolve, reject) => {
       const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;

--- a/packages/berry-fslib/sources/ProxiedFS.ts
+++ b/packages/berry-fslib/sources/ProxiedFS.ts
@@ -111,6 +111,14 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
     return this.baseFs.copyFileSync(this.mapToBase(sourceP), this.mapToBase(destP), flags);
   }
 
+  appendFilePromise(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.baseFs.appendFilePromise(this.fsMapToBase(p), content, opts);
+  }
+
+  appendFileSync(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.baseFs.appendFileSync(this.fsMapToBase(p), content, opts);
+  }
+
   writeFilePromise(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return this.baseFs.writeFilePromise(this.fsMapToBase(p), content, opts);
   }

--- a/packages/berry-fslib/sources/ProxiedFS.ts
+++ b/packages/berry-fslib/sources/ProxiedFS.ts
@@ -1,6 +1,6 @@
 import {CreateReadStreamOptions, CreateWriteStreamOptions, FakeFS} from './FakeFS';
 import {WriteFileOptions, WatchCallback, WatchOptions, Watcher}    from './FakeFS';
-import {Path}                                                      from './path';
+import {FSPath, Path}                                              from './path';
 
 export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<P> {
   protected abstract readonly baseFs: FakeFS<IP>;
@@ -111,12 +111,12 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
     return this.baseFs.copyFileSync(this.mapToBase(sourceP), this.mapToBase(destP), flags);
   }
 
-  writeFilePromise(p: P, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
-    return this.baseFs.writeFilePromise(this.mapToBase(p), content, opts);
+  writeFilePromise(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.baseFs.writeFilePromise(this.fsMapToBase(p), content, opts);
   }
 
-  writeFileSync(p: P, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
-    return this.baseFs.writeFileSync(this.mapToBase(p), content, opts);
+  writeFileSync(p: FSPath<P>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.baseFs.writeFileSync(this.fsMapToBase(p), content, opts);
   }
 
   unlinkPromise(p: P) {
@@ -159,25 +159,25 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
     return this.baseFs.symlinkSync(this.mapToBase(target), this.mapToBase(p));
   }
 
-  readFilePromise(p: P, encoding: 'utf8'): Promise<string>;
-  readFilePromise(p: P, encoding?: string): Promise<Buffer>;
-  readFilePromise(p: P, encoding?: string) {
+  readFilePromise(p: FSPath<P>, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: FSPath<P>, encoding?: string): Promise<Buffer>;
+  readFilePromise(p: FSPath<P>, encoding?: string) {
     // This weird condition is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
     if (encoding === 'utf8') {
-      return this.baseFs.readFilePromise(this.mapToBase(p), encoding);
+      return this.baseFs.readFilePromise(this.fsMapToBase(p), encoding);
     } else {
-      return this.baseFs.readFilePromise(this.mapToBase(p), encoding);
+      return this.baseFs.readFilePromise(this.fsMapToBase(p), encoding);
     }
   }
 
-  readFileSync(p: P, encoding: 'utf8'): string;
-  readFileSync(p: P, encoding?: string): Buffer;
-  readFileSync(p: P, encoding?: string) {
+  readFileSync(p: FSPath<P>, encoding: 'utf8'): string;
+  readFileSync(p: FSPath<P>, encoding?: string): Buffer;
+  readFileSync(p: FSPath<P>, encoding?: string) {
     // This weird condition is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
     if (encoding === 'utf8') {
-      return this.baseFs.readFileSync(this.mapToBase(p), encoding);
+      return this.baseFs.readFileSync(this.fsMapToBase(p), encoding);
     } else  {
-      return this.baseFs.readFileSync(this.mapToBase(p), encoding);
+      return this.baseFs.readFileSync(this.fsMapToBase(p), encoding);
     }
   }
 
@@ -206,5 +206,13 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
       a,
       b,
     );
+  }
+
+  private fsMapToBase(p: FSPath<P>) {
+    if (typeof p === `number`) {
+      return p;
+    } else {
+      return this.mapToBase(p);
+    }
   }
 }

--- a/packages/berry-fslib/sources/ZipFS.ts
+++ b/packages/berry-fslib/sources/ZipFS.ts
@@ -7,7 +7,7 @@ import {CreateReadStreamOptions, CreateWriteStreamOptions, BasePortableFakeFS} f
 import {FakeFS, WriteFileOptions}                                              from './FakeFS';
 import {WatchOptions, WatchCallback, Watcher}                                  from './FakeFS';
 import {NodeFS}                                                                from './NodeFS';
-import {PortablePath, ppath, Filename}                                         from './path';
+import {FSPath, PortablePath, ppath, Filename}                                 from './path';
 
 const S_IFMT = 0o170000;
 
@@ -158,7 +158,6 @@ export class ZipFS extends BasePortableFakeFS {
 
       if (typeof source === `string` && pathOptions.create)
         flags |= libzip.ZIP_CREATE | libzip.ZIP_TRUNCATE;
-
       if (opts.readOnly)
         flags |= libzip.ZIP_RDONLY;
 
@@ -465,7 +464,6 @@ export class ZipFS extends BasePortableFakeFS {
 
   private registerListing(p: PortablePath) {
     let listing = this.listings.get(p);
-
     if (listing)
       return listing;
 
@@ -490,7 +488,6 @@ export class ZipFS extends BasePortableFakeFS {
       throw Object.assign(new Error(`EBUSY: archive closed, ${reason}`), {code: `EBUSY`});
 
     let resolvedP = ppath.resolve(PortablePath.root, p);
-
     if (resolvedP === `/`)
       return PortablePath.root;
 
@@ -502,12 +499,10 @@ export class ZipFS extends BasePortableFakeFS {
 
       if (!isDir && !doesExist)
         throw Object.assign(new Error(`ENOENT: no such file or directory, ${reason}`), {code: `ENOENT`});
-
       if (!isDir)
         throw Object.assign(new Error(`ENOTDIR: not a directory, ${reason}`), {code: `ENOTDIR`});
 
       resolvedP = ppath.resolve(parentP, ppath.basename(resolvedP));
-
       if (!resolveLastComponent)
         break;
 
@@ -670,8 +665,8 @@ export class ZipFS extends BasePortableFakeFS {
       throw Object.assign(new Error(`ENOSYS: unsupported clone operation, copyfile '${sourceP}' -> ${destP}'`), {code: `ENOSYS`});
 
     const resolvedSourceP = this.resolveFilename(`copyfile '${sourceP} -> ${destP}'`, sourceP);
-    const indexSource = this.entries.get(resolvedSourceP);
 
+    const indexSource = this.entries.get(resolvedSourceP);
     if (typeof indexSource === `undefined`)
       throw Object.assign(new Error(`EINVAL: invalid argument, copyfile '${sourceP}' -> '${destP}'`), {code: `EINVAL`});
 
@@ -689,18 +684,19 @@ export class ZipFS extends BasePortableFakeFS {
     }
   }
 
-  async writeFilePromise(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+  async writeFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return this.writeFileSync(p, content, opts);
   }
 
-  writeFileSync(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
-    const resolvedP = this.resolveFilename(`open '${p}'`, p);
+  writeFileSync(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    if (typeof p !== `string`)
+      throw Object.assign(new Error(`EBADF: bad file descriptor, read`), {code: `EBADF`});
 
+    const resolvedP = this.resolveFilename(`open '${p}'`, p);
     if (this.listings.has(resolvedP))
       throw Object.assign(new Error(`EISDIR: illegal operation on a directory, open '${p}'`), {code: `EISDIR`});
 
     const index = this.entries.get(resolvedP);
-
     if (index !== undefined && typeof opts === `object` && opts.flag && opts.flag.includes(`a`))
       content = Buffer.concat([this.getFileSource(index), Buffer.from(content as any)]);
 
@@ -715,7 +711,6 @@ export class ZipFS extends BasePortableFakeFS {
       content = content.toString(encoding);
 
     const newIndex = this.setFileSource(resolvedP, content);
-
     if (newIndex !== index) {
       this.registerEntry(resolvedP, newIndex);
     }
@@ -805,12 +800,10 @@ export class ZipFS extends BasePortableFakeFS {
 
     if (this.listings.has(resolvedP))
       throw Object.assign(new Error(`EISDIR: illegal operation on a directory, symlink '${target}' -> '${p}'`), {code: `EISDIR`});
-
     if (this.entries.has(resolvedP))
       throw Object.assign(new Error(`EEXIST: file already exists, symlink '${target}' -> '${p}'`), {code: `EEXIST`});
 
     const index = this.setFileSource(resolvedP, target);
-
     this.registerEntry(resolvedP, index);
 
     const rc = libzip.file.setExternalAttributes(this.zip, index, 0, 0, libzip.ZIP_OPSYS_UNIX, (0o120000 | 0o777) << 16);
@@ -819,8 +812,8 @@ export class ZipFS extends BasePortableFakeFS {
     }
   }
 
-  readFilePromise(p: PortablePath, encoding: 'utf8'): Promise<string>;
-  readFilePromise(p: PortablePath, encoding?: string): Promise<Buffer>;
+  readFilePromise(p: FSPath<PortablePath>, encoding: 'utf8'): Promise<string>;
+  readFilePromise(p: FSPath<PortablePath>, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: PortablePath, encoding?: string) {
     // This weird switch is required to tell TypeScript that the signatures are proper (otherwise it thinks that only the generic one is covered)
     switch (encoding) {
@@ -831,16 +824,18 @@ export class ZipFS extends BasePortableFakeFS {
     }
   }
 
-  readFileSync(p: PortablePath, encoding: 'utf8'): string;
-  readFileSync(p: PortablePath, encoding?: string): Buffer;
-  readFileSync(p: PortablePath, encoding?: string) {
+  readFileSync(p: FSPath<PortablePath>, encoding: 'utf8'): string;
+  readFileSync(p: FSPath<PortablePath>, encoding?: string): Buffer;
+  readFileSync(p: FSPath<PortablePath>, encoding?: string) {
+    if (typeof p !== `string`)
+      throw Object.assign(new Error(`EBADF: bad file descriptor, read`), {code: `EBADF`});
+
     // This is messed up regarding the TS signatures
     if (typeof encoding === `object`)
       // @ts-ignore
       encoding = encoding ? encoding.encoding : undefined;
 
     const resolvedP = this.resolveFilename(`open '${p}'`, p);
-
     if (!this.entries.has(resolvedP) && !this.listings.has(resolvedP))
       throw Object.assign(new Error(`ENOENT: no such file or directory, open '${p}'`), {code: `ENOENT`});
 
@@ -866,12 +861,10 @@ export class ZipFS extends BasePortableFakeFS {
 
   readdirSync(p: PortablePath): Array<Filename> {
     const resolvedP = this.resolveFilename(`scandir '${p}'`, p);
-
     if (!this.entries.has(resolvedP) && !this.listings.has(resolvedP))
       throw Object.assign(new Error(`ENOENT: no such file or directory, scandir '${p}'`), {code: `ENOENT`});
 
     const directoryListing = this.listings.get(resolvedP);
-
     if (!directoryListing)
       throw Object.assign(new Error(`ENOTDIR: not a directory, scandir '${p}'`), {code: `ENOTDIR`});
 
@@ -884,7 +877,6 @@ export class ZipFS extends BasePortableFakeFS {
 
   readlinkSync(p: PortablePath): PortablePath {
     const resolvedP = this.resolveFilename(`readlink '${p}'`, p, false);
-
     if (!this.entries.has(resolvedP) && !this.listings.has(resolvedP))
       throw Object.assign(new Error(`ENOENT: no such file or directory, readlink '${p}'`), {code: `ENOENT`});
 
@@ -896,7 +888,6 @@ export class ZipFS extends BasePortableFakeFS {
       throw Object.assign(new Error(`EINVAL: invalid argument, readlink '${p}'`), {code: `EINVAL`});
 
     const entry = this.entries.get(resolvedP);
-
     if (entry === undefined)
       throw new Error(`Unreachable`);
 

--- a/packages/berry-fslib/sources/ZipFS.ts
+++ b/packages/berry-fslib/sources/ZipFS.ts
@@ -684,6 +684,21 @@ export class ZipFS extends BasePortableFakeFS {
     }
   }
 
+  async appendFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.appendFileSync(p, content, opts);
+  }
+
+  appendFileSync(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts: WriteFileOptions = {}) {
+    if (typeof opts === `undefined`)
+      opts = {flag: `a`};
+    else if (typeof opts === `string`)
+      opts = {flag: `a`, encoding: opts};
+    else if (typeof opts.flag === `undefined`)
+      opts = {flag: `a`, ...opts};
+
+    return this.writeFileSync(p, content, opts);
+  }
+
   async writeFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return this.writeFileSync(p, content, opts);
   }

--- a/packages/berry-fslib/sources/ZipOpenFS.ts
+++ b/packages/berry-fslib/sources/ZipOpenFS.ts
@@ -79,7 +79,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async openPromise(p: PortablePath, flags: string, mode?: number) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.openPromise(p, flags, mode);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async () => {
       throw new Error(`Unsupported action (we wouldn't be able to disambiguate the close)`);
     });
   }
@@ -87,7 +87,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   openSync(p: PortablePath, flags: string, mode?: number) {
     return this.makeCallSync(p, () => {
       return this.baseFs.openSync(p, flags, mode);
-    }, (zipFs, {archivePath, subPath}) => {
+    }, () => {
       throw new Error(`Unsupported action (we wouldn't be able to disambiguate the close)`);
     });
   }
@@ -141,7 +141,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async existsPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.existsPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.existsPromise(subPath);
     });
   }
@@ -157,7 +157,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async accessPromise(p: PortablePath, mode?: number) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.accessPromise(p, mode);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.accessPromise(subPath, mode);
     });
   }
@@ -173,7 +173,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async statPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.statPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.statPromise(subPath);
     });
   }
@@ -189,7 +189,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async lstatPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.lstatPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.lstatPromise(subPath);
     });
   }
@@ -205,7 +205,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async chmodPromise(p: PortablePath, mask: number) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.chmodPromise(p, mask);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.chmodPromise(subPath, mask);
     });
   }
@@ -225,10 +225,10 @@ export class ZipOpenFS extends BasePortableFakeFS {
       }, async () => {
         throw Object.assign(new Error(`EEXDEV: cross-device link not permitted`), {code: `EEXDEV`});
       });
-    }, async (zipFsO, {archivePath: archivePathO, subPath: subPathO}) => {
+    }, async (zipFsO, {subPath: subPathO}) => {
       return await this.makeCallPromise(newP, async () => {
         throw Object.assign(new Error(`EEXDEV: cross-device link not permitted`), {code: `EEXDEV`});
-      }, async (zipFsN, {archivePath: archivePathN, subPath: subPathN}) => {
+      }, async (zipFsN, {subPath: subPathN}) => {
         if (zipFsO !== zipFsN) {
           throw Object.assign(new Error(`EEXDEV: cross-device link not permitted`), {code: `EEXDEV`});
         } else {
@@ -245,10 +245,10 @@ export class ZipOpenFS extends BasePortableFakeFS {
       }, async () => {
         throw Object.assign(new Error(`EEXDEV: cross-device link not permitted`), {code: `EEXDEV`});
       });
-    }, (zipFsO, {archivePath: archivePathO, subPath: subPathO}) => {
+    }, (zipFsO, {subPath: subPathO}) => {
       return this.makeCallSync(newP, () => {
         throw Object.assign(new Error(`EEXDEV: cross-device link not permitted`), {code: `EEXDEV`});
-      }, (zipFsN, {archivePath: archivePathN, subPath: subPathN}) => {
+      }, (zipFsN, {subPath: subPathN}) => {
         if (zipFsO !== zipFsN) {
           throw Object.assign(new Error(`EEXDEV: cross-device link not permitted`), {code: `EEXDEV`});
         } else {
@@ -278,13 +278,13 @@ export class ZipOpenFS extends BasePortableFakeFS {
     return await this.makeCallPromise(sourceP, async () => {
       return await this.makeCallPromise(destP, async () => {
         return await this.baseFs.copyFilePromise(sourceP, destP, flags);
-      }, async (zipFsD, {archivePath: archivePathD, subPath: subPathD}) => {
+      }, async (zipFsD, {subPath: subPathD}) => {
         return await fallback(this.baseFs, sourceP, zipFsD, subPathD);
       });
-    }, async (zipFsS, {archivePath: archivePathS, subPath: subPathS}) => {
+    }, async (zipFsS, {subPath: subPathS}) => {
       return await this.makeCallPromise(destP, async () => {
         return await fallback(zipFsS, subPathS, this.baseFs, destP);
-      }, async (zipFsD, {archivePath: archivePathD, subPath: subPathD}) => {
+      }, async (zipFsD, {subPath: subPathD}) => {
         if (zipFsS !== zipFsD) {
           return await fallback(zipFsS, subPathS, zipFsD, subPathD);
         } else {
@@ -314,13 +314,13 @@ export class ZipOpenFS extends BasePortableFakeFS {
     return this.makeCallSync(sourceP, () => {
       return this.makeCallSync(destP, () => {
         return this.baseFs.copyFileSync(sourceP, destP, flags);
-      }, (zipFsD, {archivePath: archivePathD, subPath: subPathD}) => {
+      }, (zipFsD, {subPath: subPathD}) => {
         return fallback(this.baseFs, sourceP, zipFsD, subPathD);
       });
-    }, (zipFsS, {archivePath: archivePathS, subPath: subPathS}) => {
+    }, (zipFsS, {subPath: subPathS}) => {
       return this.makeCallSync(destP, () => {
         return fallback(zipFsS, subPathS, this.baseFs, destP);
-      }, (zipFsD, {archivePath: archivePathD, subPath: subPathD}) => {
+      }, (zipFsD, {subPath: subPathD}) => {
         if (zipFsS !== zipFsD) {
           return fallback(zipFsS, subPathS, zipFsD, subPathD);
         } else {
@@ -330,10 +330,26 @@ export class ZipOpenFS extends BasePortableFakeFS {
     });
   }
 
+  async appendFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return await this.makeCallPromise(p, async () => {
+      return await this.baseFs.appendFilePromise(p, content, opts);
+    }, async (zipFs, {subPath}) => {
+      return await zipFs.appendFilePromise(subPath, content, opts);
+    });
+  }
+
+  appendFileSync(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
+    return this.makeCallSync(p, () => {
+      return this.baseFs.appendFileSync(p, content, opts);
+    }, (zipFs, {subPath}) => {
+      return zipFs.appendFileSync(subPath, content, opts);
+    });
+  }
+
   async writeFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.writeFilePromise(p, content, opts);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.writeFilePromise(subPath, content, opts);
     });
   }
@@ -349,7 +365,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async unlinkPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.unlinkPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.unlinkPromise(subPath);
     });
   }
@@ -381,7 +397,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async mkdirPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.mkdirPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.mkdirPromise(subPath);
     });
   }
@@ -397,7 +413,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async rmdirPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.rmdirPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.rmdirPromise(subPath);
     });
   }
@@ -413,7 +429,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async symlinkPromise(target: PortablePath, p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.symlinkPromise(target, p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.symlinkPromise(target, subPath);
     });
   }
@@ -461,7 +477,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async readdirPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.readdirPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.readdirPromise(subPath);
     }, {
       requireSubpath: false,
@@ -481,7 +497,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
   async readlinkPromise(p: PortablePath) {
     return await this.makeCallPromise(p, async () => {
       return await this.baseFs.readlinkPromise(p);
-    }, async (zipFs, {archivePath, subPath}) => {
+    }, async (zipFs, {subPath}) => {
       return await zipFs.readlinkPromise(subPath);
     });
   }

--- a/packages/berry-fslib/sources/index.ts
+++ b/packages/berry-fslib/sources/index.ts
@@ -12,7 +12,7 @@ export {WatchCallback}            from './FakeFS';
 export {Watcher}                  from './FakeFS';
 export {WriteFileOptions}         from './FakeFS';
 
-export {Path, PortablePath, NativePath, Filename} from './path';
+export {FSPath, Path, PortablePath, NativePath, Filename} from './path';
 export {ParsedPath, PathUtils, FormatInputPathObject} from './path';
 export {npath, ppath, toFilename, fromPortablePath, toPortablePath} from './path';
 

--- a/packages/berry-fslib/sources/index.ts
+++ b/packages/berry-fslib/sources/index.ts
@@ -31,6 +31,7 @@ export {ZipOpenFS}                from './ZipOpenFS';
 export function patchFs(patchedFs: typeof fs, fakeFs: FakeFS<NativePath>): void {
   const SYNC_IMPLEMENTATIONS = new Set([
     `accessSync`,
+    `appendFileSync`,
     `createReadStream`,
     `chmodSync`,
     `copyFileSync`,
@@ -52,6 +53,7 @@ export function patchFs(patchedFs: typeof fs, fakeFs: FakeFS<NativePath>): void 
 
   const ASYNC_IMPLEMENTATIONS = new Set([
     `accessPromise`,
+    `appendFilePromise`,
     `chmodPromise`,
     `copyFilePromise`,
     `lstatPromise`,

--- a/packages/berry-fslib/sources/path.ts
+++ b/packages/berry-fslib/sources/path.ts
@@ -11,6 +11,9 @@ export const PortablePath = {
 export type Filename = (PortablePath & NativePath) & { _filename: false };
 export type Path = PortablePath | NativePath;
 
+// Some of the FS functions support file descriptors
+export type FSPath<T extends Path> = T | number;
+
 export const npath: PathUtils<NativePath> = path as any;
 export const ppath: PathUtils<PortablePath> = path.posix as any;
 

--- a/packages/berry-pnp/package.json
+++ b/packages/berry-pnp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@berry/pnp",
   "version": "2.0.0-rc.0",
+  "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",
   "dependencies": {
     "@berry/fslib": "workspace:2.0.0-rc.0"

--- a/packages/berry-pnpify/sources/NodePathResolver.ts
+++ b/packages/berry-pnpify/sources/NodePathResolver.ts
@@ -1,7 +1,7 @@
-import {PortablePath, Filename, toFilename, ppath} from '@berry/fslib';
-import {PnpApi, PackageInformation}                from '@berry/pnp';
+import {FSPath, PortablePath, Filename, toFilename, ppath} from '@berry/fslib';
+import {PnpApi, PackageInformation}                        from '@berry/pnp';
 
-import {PortablePnPApi}                            from './PortablePnPApi';
+import {PortablePnPApi}                                    from './PortablePnPApi';
 
 /**
  * Regexp for pathname that catches the following paths:
@@ -26,12 +26,12 @@ const NODE_MODULES_REGEXP = /(?:\/node_modules((?:\/@[^\/]+)?(?:\/[^@][^\/]+)?))
  * 2. And we need either fake stats or we can forward underlying fs to stat the issuer dir.
  *    The issuer dir exists on fs. We store issuer dir into `statPath` field
  */
-export interface ResolvedPath {
+export interface ResolvedPath<PathType extends FSPath<PortablePath>> {
   /**
    * Fully resolved path `/node_modules/...` path within PnP project,
    * `null` if path does not exist.
    */
-  resolvedPath: PortablePath | null;
+  resolvedPath: PathType | null;
 
   /**
    * The path that should be used for stats. This field is returned for pathes ending
@@ -107,8 +107,8 @@ export class NodePathResolver {
    *
    * @returns resolved path
    */
-  public resolvePath(nodePath: PortablePath): ResolvedPath {
-    const result: ResolvedPath = {resolvedPath: nodePath};
+  public resolvePath(nodePath: PortablePath): ResolvedPath<PortablePath> {
+    const result: ResolvedPath<PortablePath> = {resolvedPath: nodePath};
 
     const marker = `/node_modules`;
     const index = nodePath.indexOf(marker);
@@ -126,7 +126,7 @@ export class NodePathResolver {
 
     // If we have something left in a path to parse, do that
     if (issuer && nodePath.length > issuer.length) {
-      let request: PortablePath = nodePath.substring(issuer.length) as PortablePath;
+      let request: PortablePath = nodePath.slice(issuer.length) as PortablePath;
 
       let m;
       let rest;


### PR DESCRIPTION
**What's the problem this PR addresses?**

- The fslib didn't account for some families of functions (`appendFile`, `readFile`, `writeFile`) being allowed to consume file descriptors.

- It also didn't implement `appendFile` at all.

**How did you fix it?**

I've added a new type, `FSPath<T>`, which encompasses `T | number`. This type is then used as input for the specific functions referenced above. Since most fake fs layers are abstracted under the `ProxiedFS` abstract, most of them don't have to deal with this as the fds will just be forwarded untransformed.

Of note: TypeScript doesn't prevent a subclass from implementing a subset of an abstract method, meaning that it'll not report it if a subclass of `FakeFS<T>` uses `T` as parameter for the relevant functions rather than `FSPath<T>`. It'll crash at runtime, however, as they'll still receive integers.

**Which packages would need a new release (if any)?**

berry-fslib, berry-pnp, berry-core, berry-cli

**Have you run `yarn version [major|minor|patch] --deferred` in those packages?**

- [x] Yes
