### PR TITLE
Prevents infinite loops with --cwd

### DIFF
--- a/packages/berry-cli/package.json
+++ b/packages/berry-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.0",
   "nextVersion": {
     "semver": "2.0.0-rc.1",
-    "nonce": "8021498693890085"
+    "nonce": "1700652149343941"
   },
   "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn was running in an infinite loop when the `--cwd` option was pointing to the `/tmp` folder on OSX, which is a symlink to `/private/tmp`. I'm not 100% sure why it was doing that as we were doing a `chdir` to `/tmp`, not `/private/tmp`, so I'd have expected `process.cwd()` to return the same path, but it's not what happens (reproduced in the Node repl).

**How did you fix it?**

We'll now compare the realpath'd cwds rather than the virtual ones. This isn't a big deal anyway as this will only affect the few commands that use `--cwd`.

**Which packages would need a new release (if any)?**

berry-cli

**Have you run `yarn version [major|minor|patch] --deferred` in those packages?**

- [ ] Yes
