### PR TITLE
feat(version): Add failed workspace name where apply fails

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.js
@@ -11,7 +11,7 @@ describe(`Commands`, () => {
           name: '@scope/test',
         },
         async ({path, run}) => {
-          await expect(run(`version`, `apply`)).rejects.toThrow(`UsageError: @scope/test@workspace:.: Can't apply the version bump if the resulting version (^2.0.0-rc.0) isn't valid semver`);
+          await expect(run(`version`, `apply`)).rejects.toThrow(`UsageError: Can't apply the version bump if the resulting version (^2.0.0-rc.0) isn't valid semver (in @scope/test@workspace:.)`);
         }
       )
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.js
@@ -1,0 +1,16 @@
+describe(`Commands`, () => {
+  describe(`version apply`, () => {
+    test(
+      `fails if the next version isn't a valid semver`,
+      makeTemporaryEnv(
+        {
+          'version:next': '^2.0.0-rc.0',
+          name: '@scope/test',
+        },
+        async ({path, run}) => {
+          await expect(run(`version`, `apply`)).rejects.toThrow(`UsageError: @scope/test@workspace:.: Can't apply the version bump if the resulting version (^2.0.0-rc.0) isn't valid semver`);
+        }
+      )
+    );
+  });
+});

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.js
@@ -4,7 +4,10 @@ describe(`Commands`, () => {
       `fails if the next version isn't a valid semver`,
       makeTemporaryEnv(
         {
-          'version:next': '^2.0.0-rc.0',
+          nextVersion: {
+            semver: '^2.0.0-rc.0',
+            nonce: '1',
+          },
           name: '@scope/test',
         },
         async ({path, run}) => {

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -18,5 +18,9 @@
   "scripts": {
     "build:plugin-version": "builder build plugin"
   },
-  "version": "2.0.0-rc.1"
+  "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "4797884895321557"
+  }
 }

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -103,7 +103,7 @@ export default class VersionApplyCommand extends BaseCommand {
           throw new Error(`Assertion failed: The nextVersion.semver should have been a string`);
 
         if (!semver.valid(newVersion)) {
-          throw new UsageError(`Can't apply the version bump if the resulting version (${newVersion}) isn't valid semver`);
+          throw new UsageError(`${structUtils.prettyLocator(configuration, workspace.anchoredLocator)}: Can't apply the version bump if the resulting version (${newVersion}) isn't valid semver`);
         }
       };
 

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -103,7 +103,7 @@ export default class VersionApplyCommand extends BaseCommand {
           throw new Error(`Assertion failed: The nextVersion.semver should have been a string`);
 
         if (!semver.valid(newVersion)) {
-          throw new UsageError(`${structUtils.prettyLocator(configuration, workspace.anchoredLocator)}: Can't apply the version bump if the resulting version (${newVersion}) isn't valid semver`);
+          throw new UsageError(`Can't apply the version bump if the resulting version (${newVersion}) isn't valid semver (in ${structUtils.prettyLocator(configuration, workspace.anchoredLocator)})`);
         }
       };
 

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/cli",
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "355232474589399"
+  },
   "main": "./sources/index.ts",
   "bin": {
     "yarn": "./bin/run.js"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn version apply --all` in the berry workspace failed. While adding the malformed version string allows to find the rogue manifest via grep it would help to name the responsible workspace.

**How did you fix it?**
Prefix the usage error with the pretty locator of the workspace to help future debugging and fixed the version in `@berry/plugin-git`

**Which packages would need a new release (if any)?**

* `@berry/cli`
* `@berry/plugin-version`

**Have you run `yarn version prerelease` in those packages?**

- [x] Yes
