### PR TITLE
Improves the release process

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -74,10 +74,6 @@ jobs:
       with:
         version: ${{matrix.node}}.x
 
-    - name: 'Use Yarn 1.17.2'
-      run: |
-        npm install -g yarn@1.17.2
-
     - name: 'Build the standard bundle & plugins'
       run: |
         set -e

--- a/.github/workflows/package-workflow.yml
+++ b/.github/workflows/package-workflow.yml
@@ -2,44 +2,36 @@
 on:
   push:
     branches:
-      - master
+    - master
     paths:
-      - "scripts/actions/build-deb/"
-      - ".github/workflows/package-workflow.yml"
+    - scripts/actions/build-deb
+    - .github/workflows/package-workflow.yml
   pull_request:
     paths:
-      - "scripts/actions/build-deb/"
-      - ".github/workflows/package-workflow.yml"
+    - scripts/actions/build-deb
+    - .github/workflows/package-workflow.yml
 
-name: "Release Packages"
+name: 'Release Packages'
 jobs:
   linux-packages:
-    name: "Linux Packages"
+    name: 'Linux Packages'
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@master
+
     - uses: actions/setup-node@master
       with:
         version: 12.x
 
-    - name: 'Install Yarn 1.17.3'
-      run: |
-        curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-        echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-        sudo apt-get update && sudo apt-get install yarn=1.17.3-1 --no-install-recommends
-
-    - name: 'Build'
+    - name: 'Build the standard bundle'
       run: |
         set -ex
         node ./scripts/run-yarn.js build:cli
+
+    - name: 'Build the dist directory'
+      run: |
         ./scripts/build-dist.sh
 
-    - name: 'Build packages'
+    - name: 'Build the deb archive'
       uses: ./scripts/actions/build-deb
-
-    - name: 'Upload packages'
-      uses: actions/upload-artifact@master
-      with:
-        name: packages
-        path: artifacts

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -18,10 +18,6 @@ jobs:
       with:
         version: 10.x
 
-    - name: 'Apply the new version numbers'
-      run: |
-        node ./scripts/run-yarn.js version apply --all
-
     - name: 'Generate the artifacts'
       run: |
         node ./scripts/run-yarn.js release:all
@@ -35,5 +31,12 @@ jobs:
 
     - name: 'Send the artifacts'
       uses: arcanis/release-action@master
+      env:
+        GITHUB_TOKEN: ${{secrets.YARNBOT_TOKEN}}
+
+    - name: 'Publish the packages'
+      run: |
+        YARN_NPM_PUBLISH_REGISTRY=https://npm.pkg.github.com YARN_NPM_AUTH_TOKEN="${GITHUB_TOKEN}" \
+          node ./scripts/run-yarn.js workspaces foreach npm publish --topological --tolerate-republish
       env:
         GITHUB_TOKEN: ${{secrets.YARNBOT_TOKEN}}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -22,6 +22,17 @@ jobs:
       run: |
         node ./scripts/run-yarn.js release:all
 
+    - id: check-if-deb-is-needed
+      name: 'Check whether the deb package must be rebuilt'
+      run: |
+        compgen -G './artifacts/yarn-*.js' > /dev/null
+      continue-on-error: true
+
+    - id: build-dep
+      name: 'Build the deb archive'
+      uses: ./scripts/actions/build-deb
+      if: job.steps.check-if-deb-is-needed.status == failure
+
     - name: 'Make the commit'
       uses: ./scripts/actions/make-commit
       with:

--- a/packages/berry-cli/package.json
+++ b/packages/berry-cli/package.json
@@ -5,7 +5,6 @@
     "semver": "2.0.0-rc.1",
     "nonce": "5762992896342831"
   },
-  "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",
   "bin": {
     "berry": "./bin/run.js"

--- a/packages/berry-fslib/package.json
+++ b/packages/berry-fslib/package.json
@@ -5,7 +5,6 @@
     "semver": "2.0.0-rc.1",
     "nonce": "6974102271407775"
   },
-  "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/berry-libzip/package.json
+++ b/packages/berry-libzip/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@berry/libzip",
   "version": "2.0.0-rc.0",
+  "nextVersion": {
+    "semver": "2.0.0-rc.1",
+    "nonce": "3168660184001661"
+  },
   "main": "./sources/index.ts",
   "devDependencies": {
     "@berry/pnpify": "workspace:2.0.0-rc.0",

--- a/packages/berry-parsers/package.json
+++ b/packages/berry-parsers/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@berry/parsers",
   "version": "2.0.0-rc.0",
+  "nextVersion": {
+    "semver": "2.0.0-rc.1",
+    "nonce": "3138253992714865"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "js-yaml": "^3.10.0"

--- a/packages/berry-pnp/package.json
+++ b/packages/berry-pnp/package.json
@@ -5,7 +5,6 @@
     "semver": "2.0.0-rc.1",
     "nonce": "4347415775920157"
   },
-  "version:next": "2.0.0-rc.1",
   "main": "./sources/index.ts",
   "dependencies": {
     "@berry/fslib": "workspace:2.0.0-rc.0"

--- a/packages/berry-pnpify/package.json
+++ b/packages/berry-pnpify/package.json
@@ -15,7 +15,8 @@
   "devDependencies": {
     "@berry/monorepo": "workspace:0.0.0",
     "@berry/pnp": "workspace:2.0.0-rc.0",
-    "eslint": "^5.16.0"
+    "eslint": "^5.16.0",
+    "typescript": "^3.3.3333"
   },
   "peerDependencies": {
     "eslint": "*",

--- a/packages/plugin-constraints/sources/commands/constraints/query.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/query.ts
@@ -7,6 +7,9 @@ import {Constraints}            from '../../Constraints';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ConstraintsQueryCommand extends BaseCommand {
+  @Command.Boolean(`--json`)
+  json: boolean = false;
+
   @Command.String()
   query!: string;
 
@@ -15,6 +18,8 @@ export default class ConstraintsQueryCommand extends BaseCommand {
     description: `query the constraints fact database`,
     details: `
       This command will output all matches to the given prolog query.
+
+      If the \`--json\` flag is set the output will follow a JSON-stream output also known as NDJSON (https://github.com/ndjson/ndjson-spec).
     `,
     examples: [[
       `List all dependencies throughout the workspace`,
@@ -34,6 +39,7 @@ export default class ConstraintsQueryCommand extends BaseCommand {
 
     const report = await StreamReport.start({
       configuration,
+      json: this.json,
       stdout: this.context.stdout,
     }, async report => {
       for await (const result of constraints.query(query)) {
@@ -46,6 +52,8 @@ export default class ConstraintsQueryCommand extends BaseCommand {
           const [variableName, value] = lines[i];
           report.reportInfo(null, `${getLinePrefix(i, lineCount)}${variableName.padEnd(maxVariableNameLength, ` `)} = ${valueToString(value)}`);
         }
+
+        report.reportJson(result);
       }
     });
 

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@berry/plugin-git",
-  "version:next": "^2.0.0-rc.0",
+  "nextVersion": {
+    "semver": "2.0.0-rc.0"
+  },
   "private": true,
   "main": "./sources/index.ts",
   "dependencies": {

--- a/scripts/actions/build-deb/build-deb.sh
+++ b/scripts/actions/build-deb/build-deb.sh
@@ -6,6 +6,7 @@ set -ex
 ensureAvailable() {
   command -v "$1" >/dev/null 2>&1 || (echo "You need to install $1" && exit 2)
 }
+
 ensureAvailable dpkg-deb
 ensureAvailable fpm
 ensureAvailable fakeroot
@@ -14,9 +15,9 @@ ensureAvailable rpmbuild
 
 CONTENTS_DIR=./scripts/actions/build-deb/contents
 PACKAGE_TMPDIR=tmp/debian_pkg
-VERSION=`./dist/bin/yarn --version`
+VERSION=$(./dist/bin/yarn --version)
 OUTPUT_DIR=artifacts
-DEB_PACKAGE_NAME=yarn-next_$VERSION'_all.deb'
+DEB_PACKAGE_NAME=yarn-next-$VERSION'.deb'
 
 mkdir -p $OUTPUT_DIR
 # Remove old packages

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,11 +3,59 @@
 set -e
 
 THIS_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR="$THIS_DIR/.."
 
-ARTIFACT_DIR="$THIS_DIR"/../artifacts
+ARTIFACT_DIR="$REPO_DIR"/artifacts
+
+rm -rf "$ARTIFACT_DIR"
 mkdir -p "$ARTIFACT_DIR"
 
-yarn build:cli
-CLI_VERSION=$(yarn --version)
+contains_element() {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
 
-cp packages/berry-cli/bundles/berry.js "$ARTIFACT_DIR"/yarn-"$CLI_VERSION".js
+build_cli() {
+  if contains_element @berry/cli "${PACKAGES_TO_RELEASE[@]}"; then
+    node "$REPO_DIR"/scripts/run-yarn.js build:cli
+    CLI_VERSION=$(node "$REPO_DIR"/scripts/run-yarn.js --version)
+    cp "$REPO_DIR"/packages/berry-cli/bundles/berry.js "$ARTIFACT_DIR"/yarn-"$CLI_VERSION".js
+  fi
+}
+
+build_plugin() {
+  if contains_element @berry/"$1" "${PACKAGES_TO_RELEASE[@]}"; then
+    node "$REPO_DIR"/scripts/run-yarn.js build:"$1"
+    PLUGIN_VERSION=$(jq -r .version packages/$1/package.json)
+    cp "$REPO_DIR"/packages/"$1"/bundles/@berry/"$1".js "$ARTIFACT_DIR"/"$1"-"$PLUGIN_VERSION".js
+  fi
+}
+
+build_package() {
+  if contains_element @berry/"$1" "${PACKAGES_TO_RELEASE[@]}"; then
+    node "$REPO_DIR"/scripts/run-yarn.js packages/berry-"$1" pack -o "$ARTIFACT_DIR"/"%s-%v.tgz"
+  fi
+}
+
+# Bump the packages, and store which ones have been bumped (and thus need to be re-released)
+PACKAGES_TO_RELEASE=( $(node "$REPO_DIR"/scripts/run-yarn.js version apply --all --json | jq -r .ident) )
+
+build_cli
+
+build_plugin plugin-exec
+build_plugin plugin-stage
+build_plugin plugin-typescript
+build_plugin plugin-workspace-tools
+
+build_package builder
+build_package cli
+build_package core
+build_package fslib
+build_package json-proxy
+build_package libzip
+build_package parsers
+build_package pnp
+build_package pnpify
+build_package shell

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,6 +2137,7 @@ __metadata:
     "@berry/pnp": "workspace:2.0.0-rc.0"
     cross-spawn: "npm:^6.0.5"
     eslint: "npm:^5.16.0"
+    typescript: "npm:^3.3.3333"
   peerDependencies:
     eslint: "*"
     typescript: "*"


### PR DESCRIPTION
Warning: hard to test, I'll probably have to commit to master for a few hours after that

**What's the problem this PR addresses?**

We currently only build the CLI JS bundle when doing a release. No plugin, no deb, no packages.

**How did you fix it?**

The `release.sh` script will now build all the artifacts, and I've tried to plug the deb builder wrote by @Daniel15 into the release workflow. I'm not 100% certain of the syntax tho, so it's likely I'll have to make multiple releases to get it right!
