### PR TITLE
Adds support for (noop) run --silent

### DIFF
--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -14,5 +14,9 @@
     "treeify": "^1.1.0",
     "yup": "^0.27.0"
   },
-  "version": "2.0.0-rc.1"
+  "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "7743854342989037"
+  }
 }

--- a/packages/plugin-essentials/sources/commands/run.ts
+++ b/packages/plugin-essentials/sources/commands/run.ts
@@ -5,8 +5,18 @@ import {Command, UsageError}               from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class RunCommand extends BaseCommand {
-  @Command.Boolean(`-T,--top-level`)
+  // This flag is mostly used to give users a way to configure node-gyp. They
+  // just have to add it as a top-level workspace.
+  @Command.Boolean(`-T,--top-level`, {hidden: true})
   topLevel: boolean = false;
+
+  // The v1 used to print the Yarn version header when using "yarn run", which
+  // was messing with the output of things like `--version` & co. We don't do
+  // this anymore, but many workflows use `yarn run --silent` to make sure that
+  // they don't get this header, and it makes sense to support it as well (even
+  // if it's a no-op in our case).
+  @Command.Boolean(`--silent`, {hidden: true})
+  silent?: boolean;
 
   @Command.String()
   scriptName!: string;

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/cli",
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "1045035826480495"
+  },
   "main": "./sources/index.ts",
   "bin": {
     "yarn": "./bin/run.js"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Cf the comment - some tools use `yarn run --silent <something>` to make sure that Yarn won't pollute the output with its wrapper text. We don't do this anymore, but it's easier for them if they don't have to feature-detect it.

**How did you fix it?**

The `--silent` flag doesn't cause `yarn run` to crash (note that it *needs* to be between the `run` and the script / binary name - I have to double check because it seems to work even otherwise, but that would be a bug).

The flag is hidden because I don't want people to think it's useful when it doesn't actually do anything (we could document that, but just hiding it is simpler and maybe more effective).

**Which packages would need a new release (if any)?**

plugin-essentials, yarnpkg-cli

**Have you run `yarn version prerelease` in those packages?**

- [x] Yes
