### PR TITLE
fix: yarn v1 downloading empty cli

### DIFF
--- a/packages/berry-cli/bin/berry.js
+++ b/packages/berry-cli/bin/berry.js
@@ -1,0 +1,1 @@
+../../yarnpkg-cli/bin/yarn.js


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn policies set-version v2` creates a file with the content `false` since https://github.com/yarnpkg/berry/raw/master/packages/berry-cli/bin/berry.js returns 404. Issue was caused by #395

**How did you fix it?**

Create a symlink from the old cli file to the current location

**Which packages would need a new release (if any)?**

If any then the v1 cli should get a patch. Though this approach has the benefit that it is immediate and backports the fix.

**Have you run `yarn version prerelease` in those packages?**

- ~[ ] Yes~
