### PR TITLE
fix(docs): Missing page titles

### DIFF
--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -2,8 +2,7 @@ module.exports = {
   pathPrefix: process.env.NETLIFY ? `/` : `/berry`,
   siteMetadata: {
     title: `Yarn - Package Manager`,
-    description: `Foo`,
-    author: ``,
+    description: `Fast, reliable, and secure dependency management.`,
     menuLinks: [{
       name: `Home`,
       link: `/`,

--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = {
   siteMetadata: {
     title: `Yarn - Package Manager`,
     description: `Fast, reliable, and secure dependency management.`,
+    author: `yarnpkg`,
     menuLinks: [{
       name: `Home`,
       link: `/`,

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -4,9 +4,11 @@ import {JsonContainer, JsonMain, JsonScalar}   from '../../components/json';
 import {JsonArrayProperty, JsonObjectProperty} from '../../components/json';
 import {JsonScalarProperty}                    from '../../components/json';
 import Layout                                  from '../../components/layout-configuration';
+import SEO                                     from '../../components/seo';
 
 const PackageJsonDoc = () => <>
   <Layout>
+    <SEO description="Available fields in manifest (package.json)" keywords={['package manager, yarn, configuration']} title="Manifest" />
     <JsonContainer>
       <JsonMain>
         Manifest files (also called <code>package.json</code> because of their name) contain everything needed to describe the settings unique to one particular package. Project will contain multiple such manifests if they use the workspace feature, as each workspace is described through its own manifest.

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -8,7 +8,11 @@ import SEO                                     from '../../components/seo';
 
 const PackageJsonDoc = () => <>
   <Layout>
-    <SEO description="Available fields in manifest (package.json)" keywords={['package manager, yarn, configuration']} title="Manifest" />
+    <SEO
+      title={`Manifest fields`}
+      description={`List of all the supported fields for a Yarn project manifest (package.json files)`}
+      keywords={[`package manager`, `yarn`, `yarnpkg`, `configuration`, `package.json`]}
+    />
     <JsonContainer>
       <JsonMain>
         Manifest files (also called <code>package.json</code> because of their name) contain everything needed to describe the settings unique to one particular package. Project will contain multiple such manifests if they use the workspace feature, as each workspace is described through its own manifest.

--- a/packages/gatsby/src/pages/configuration/yarnrc.js
+++ b/packages/gatsby/src/pages/configuration/yarnrc.js
@@ -7,7 +7,11 @@ import SEO                                      from '../../components/seo';
 
 const YarnrcDoc = () => <>
   <Layout>
-    <SEO description="Configuration options for yarn" keywords={['package manager, yarn, configuration']} title="Configuration options" />
+    <SEO
+      title={`Configuration options`}
+      description={`List of all the configuration option for Yarn (yarnrc files)`}
+      keywords={[`package manager`, `yarn`, `yarnpkg`, `configuration`, `yarnrc`]}
+    />
     <SymlContainer>
       <SymlMain>
         <p>Yarnrc files (named this way because they must be called <code>.yarnrc.yml</code>) are the one place where you'll be able to configure Yarn's internal settings. While Yarn will automatically find them in the parent directories, they should usually be kept at the root of your project (often your repository). Starting from the v2, they <b>must</b> be written in valid Yaml and have the right extension (simply calling your file <code>.yarnrc</code> won't do).</p>

--- a/packages/gatsby/src/pages/configuration/yarnrc.js
+++ b/packages/gatsby/src/pages/configuration/yarnrc.js
@@ -3,9 +3,11 @@ import React                                    from 'react';
 import Layout                                   from '../../components/layout-configuration';
 import {SymlContainer, SymlMain}                from '../../components/syml';
 import {SymlObjectProperty, SymlScalarProperty} from '../../components/syml';
+import SEO                                      from '../../components/seo';
 
 const YarnrcDoc = () => <>
   <Layout>
+    <SEO description="Configuration options for yarn" keywords={['package manager, yarn, configuration']} title="Configuration options" />
     <SymlContainer>
       <SymlMain>
         <p>Yarnrc files (named this way because they must be called <code>.yarnrc.yml</code>) are the one place where you'll be able to configure Yarn's internal settings. While Yarn will automatically find them in the parent directories, they should usually be kept at the root of your project (often your repository). Starting from the v2, they <b>must</b> be written in valid Yaml and have the right extension (simply calling your file <code>.yarnrc</code> won't do).</p>

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -14,7 +14,10 @@ export default function Template({data, pageContext: {category}}) {
       to: node.frontmatter.path,
       name: node.frontmatter.title,
     }))}>
-      <SEO keywords={['package manager', 'yarn', frontmatter.path.split('/').reverse()[0]]} title={frontmatter.title} />
+      <SEO
+        title={frontmatter.title}
+        keywords={[`package manager`, `yarn`, `yarnpkg`, frontmatter.path.split('/').reverse()[0]]}
+      />
       <PrerenderedMarkdown title={frontmatter.title}>
         {html}
       </PrerenderedMarkdown>

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -3,6 +3,7 @@ import React                 from 'react';
 
 import {LayoutContentNav}    from '../components/layout-content-nav';
 import {PrerenderedMarkdown} from '../components/markdown';
+import SEO                   from '../components/seo';
 
 export default function Template({data, pageContext: {category}}) {
   const {allMarkdownRemark, markdownRemark} = data;
@@ -13,6 +14,7 @@ export default function Template({data, pageContext: {category}}) {
       to: node.frontmatter.path,
       name: node.frontmatter.title,
     }))}>
+      <SEO keywords={['package manager', 'yarn', frontmatter.path.split('/').reverse()[0]]} title={frontmatter.title} />
       <PrerenderedMarkdown title={frontmatter.title}>
         {html}
       </PrerenderedMarkdown>


### PR DESCRIPTION
**What's the problem this PR 

E.g. https://yarnpkg.github.io/berry/features/offline-cache has no title when landing or `Home` when navigating from homepage.

**How did you fix it?**

Populate title by using `SEO` where necessary

**Which packages would need a new release (if any)?**

- deploy docs

**Have you run `yarn version prerelease` in those packages?**

- ~[ ] Yes~
