### PR TITLE
feat(install): Display validation issues if any

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Commands install displays validation issues of nested workspaces 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: ┌ Validation step
+➤ YN0057: │ unknown: String bin field, but no attached package name
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: Done with warnings
+",
+}
+`;
+
 exports[`Commands install it should print the logs to the standard output when using --inline-builds 1`] = `
 "➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: ┌ Validation step
-➤ YN0057: │ unknown: String bin field, but no attached package name
+➤ YN0057: │ package-a-cafaf2: String bin field, but no attached package name
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -42,7 +42,7 @@ Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: ┌ Validation step
-➤ YN0057: │ unknown: String bin field, but no attached package name
+➤ YN0057: │ root-workspace-988eec: String bin field, but no attached package name
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Commands add it should print the logs to the standard output when using --inline-builds 1`] = `
+exports[`Commands install it should print the logs to the standard output when using --inline-builds 1`] = `
 "➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Fetch step
@@ -17,4 +17,22 @@ exports[`Commands add it should print the logs to the standard output when using
 ➤ YN0000: └ Completed
 ➤ YN0000: Done
 "
+`;
+
+exports[`Commands install reports warning if published binary field is a path but no package name is set 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: ┌ Validation step
+➤ YN0057: │ unknown: String bin field, but no attached package name
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: Done with warnings
+",
+}
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -1,5 +1,9 @@
 import {xfs} from '@yarnpkg/fslib';
 
+const {
+  fs: {writeJson},
+} = require('pkg-tests-core');
+
 describe(`Commands`, () => {
   describe(`install`, () => {
     test(
@@ -128,6 +132,25 @@ describe(`Commands`, () => {
           bin: "./bin/cli.js",
         },
         async ({path, run, source}) => {
+          await expect(run(`install`)).resolves.toMatchSnapshot();
+        }
+      )
+    );
+
+    test(
+      "displays validation issues of nested workspaces",
+      makeTemporaryEnv(
+        {
+          workspaces: ["packages"],
+        },
+        async ({path, run, source}) => {
+          await writeJson(`${path}/packages/package.json`, {
+            workspaces: ["package-a"],
+          });
+          await writeJson(`${path}/packages/package-a/package.json`, {
+            bin: "./bin/cli.js",
+          });
+
           await expect(run(`install`)).resolves.toMatchSnapshot();
         }
       )

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -1,7 +1,7 @@
 import {xfs} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
-  describe(`add`, () => {
+  describe(`install`, () => {
     test(
       `it should print the logs to the standard output when using --inline-builds`,
       makeTemporaryEnv({
@@ -119,6 +119,18 @@ describe(`Commands`, () => {
         // But now, --check-cache should redownload the packages and see that the checksums don't match
         await expect(run(`install`, `--check-cache`)).rejects.toThrow(/YN0018/);
       }),
+    );
+
+    test(
+      "reports warning if published binary field is a path but no package name is set",
+      makeTemporaryEnv(
+        {
+          bin: "./bin/cli.js",
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`)).resolves.toMatchSnapshot();
+        }
+      )
     );
   });
 });

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "6058645158869275"
+  },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@yarnpkg/core": "workspace:2.0.0-rc.1",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "nextVersion": {
     "semver": "2.0.0-rc.2",
-    "nonce": "2740610951748295"
+    "nonce": "6399894823901459"
   },
   "main": "./sources/index.ts",
   "bin": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/core",
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "6170104992265521"
+  },
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -65,6 +65,11 @@ export class Manifest {
 
   public raw: {[key: string]: any} = {};
 
+  /**
+   * errors found in the raw manifest while loading
+   */
+  public readonly errors: Array<Error> = [];
+
   static readonly allDependencies: Array<AllDependencies> = [`dependencies`, `devDependencies`, `peerDependencies`];
   static readonly hardDependencies: Array<HardDependencies> = [`dependencies`, `devDependencies`];
 
@@ -371,7 +376,8 @@ export class Manifest {
       }
     }
 
-    return errors;
+    // @ts-ignore: It's ok to initialize it now
+    this.errors = errors;
   }
 
   getForScope(type: string) {

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -68,7 +68,7 @@ export class Manifest {
   /**
    * errors found in the raw manifest while loading
    */
-  public readonly errors: Array<Error> = [];
+  public errors: ReadonlyArray<Error> = [];
 
   static readonly allDependencies: Array<AllDependencies> = [`dependencies`, `devDependencies`, `peerDependencies`];
   static readonly hardDependencies: Array<HardDependencies> = [`dependencies`, `devDependencies`];
@@ -376,7 +376,6 @@ export class Manifest {
       }
     }
 
-    // @ts-ignore: It's ok to initialize it now
     this.errors = errors;
   }
 

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1133,7 +1133,7 @@ export class Project {
     if (validationErrors.length > 0) {
       await opts.report.startTimerPromise(`Validation step`, async () => {
         for (const validationError of validationErrors) {
-          opts.report.reportWarning(MessageName.INVALID_WORKSPACE, validationError);
+          opts.report.reportWarning(MessageName.INVALID_MANIFEST, validationError);
         }
       });
     }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1125,10 +1125,7 @@ export class Project {
     const validationErrors: Array<string> = [];
     for (const workspace of this.workspaces) {
       for (const manifestError of workspace.manifest.errors) {
-        const workspaceName =
-          workspace.manifest.name === null
-            ? "unknown"
-            : structUtils.stringifyIdent(workspace.manifest.name);
+        const workspaceName = structUtils.prettyWorkspace(this.configuration, workspace);
         validationErrors.push(`${workspaceName}: ${manifestError.message}`);
       }
     }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1136,7 +1136,7 @@ export class Project {
     if (validationErrors.length > 0) {
       await opts.report.startTimerPromise(`Validation step`, async () => {
         for (const validationError of validationErrors) {
-          opts.report.reportWarning(MessageName.INVALID_WORKSPACE, validationError)
+          opts.report.reportWarning(MessageName.INVALID_WORKSPACE, validationError);
         }
       });
     }

--- a/packages/yarnpkg-core/sources/Report.ts
+++ b/packages/yarnpkg-core/sources/Report.ts
@@ -64,6 +64,7 @@ export enum MessageName {
   CACHE_OUTSIDE_PROJECT = 54,
   IMMUTABLE_INSTALL = 55,
   IMMUTABLE_CACHE = 56,
+  INVALID_WORKSPACE = 57
 }
 
 export class ReportError extends Error {

--- a/packages/yarnpkg-core/sources/Report.ts
+++ b/packages/yarnpkg-core/sources/Report.ts
@@ -64,7 +64,7 @@ export enum MessageName {
   CACHE_OUTSIDE_PROJECT = 54,
   IMMUTABLE_INSTALL = 55,
   IMMUTABLE_CACHE = 56,
-  INVALID_WORKSPACE = 57
+  INVALID_MANIFEST = 57
 }
 
 export class ReportError extends Error {


### PR DESCRIPTION
As requested in https://github.com/yarnpkg/berry/pull/403#pullrequestreview-280066376. Picked an error that seemed the most "complex" for testing. Kind of too lazy to write test for every single validation warning :smile: 

**What's the problem this PR addresses?**

Any errors encountered while loading manifests are currently supressed.


**How did you fix it?**
Persist those in the `Manifest` class and display warnings for all workspaces during install


**Which packages would need a new release (if any)?**
* `@yarnpkg/builder`
* `@yarnpkg/cli`
* `@yarnpkg/core`

**Have you run `yarn version prerelease` in those packages?**

- [x] Yes
