### PR TITLE
Fixes using tarballs w/ the resolution field

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/resolutions.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/resolutions.test.js
@@ -1,5 +1,6 @@
 const {
   fs: {writeFile, writeJson},
+  tests: {getPackageArchivePath, getPackageDirectoryPath}
 } = require('pkg-tests-core');
 
 describe(`Features`, () => {
@@ -29,6 +30,62 @@ describe(`Features`, () => {
             version: `1.0.0`,
             dependencies: {
               [`no-deps`]: 42,
+            },
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should support overriding packages with tarballs`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`one-fixed-dep`]: `1.0.0`,
+          },
+          resolutions: {
+            [`no-deps`]: getPackageArchivePath(`no-deps`, `2.0.0`),
+          },
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+            name: `one-fixed-dep`,
+            version: `1.0.0`,
+            dependencies: {
+              [`no-deps`]: {
+                name: `no-deps`,
+                version: `2.0.0`,
+              },
+            },
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should support overriding packages with directories`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`one-fixed-dep`]: `1.0.0`,
+          },
+          resolutions: {
+            [`no-deps`]: getPackageDirectoryPath(`no-deps`, `2.0.0`),
+          },
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+            name: `one-fixed-dep`,
+            version: `1.0.0`,
+            dependencies: {
+              [`no-deps`]: {
+                name: `no-deps`,
+                version: `2.0.0`,
+              },
             },
           });
         },

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -6,5 +6,9 @@
     "@yarnpkg/core": "workspace:2.0.0-rc.1",
     "@yarnpkg/fslib": "workspace:2.0.0-rc.1"
   },
-  "version": "2.0.0-rc.0"
+  "version": "2.0.0-rc.0",
+  "nextVersion": {
+    "semver": "2.0.0-rc.1",
+    "nonce": "8885593144299849"
+  }
 }

--- a/packages/plugin-file/sources/FileResolver.ts
+++ b/packages/plugin-file/sources/FileResolver.ts
@@ -32,6 +32,9 @@ export class FileResolver implements Resolver {
     if (FILE_REGEXP.test(descriptor.range))
       descriptor = structUtils.makeDescriptor(descriptor, `file:${descriptor.range}`);
 
+    if (descriptor.range.includes(`?`))
+      return descriptor;
+
     return structUtils.bindDescriptor(descriptor, {
       locator: structUtils.stringifyLocator(fromLocator),
     });

--- a/packages/plugin-file/sources/TarballFileResolver.ts
+++ b/packages/plugin-file/sources/TarballFileResolver.ts
@@ -40,7 +40,7 @@ export class TarballFileResolver implements Resolver {
       descriptor = structUtils.makeDescriptor(descriptor, `file:${descriptor.range}`);
 
     if (descriptor.range.includes(`?`))
-      throw new Error(`File-type dependencies cannot contain the character "?"`);
+      return descriptor;
 
     return structUtils.makeDescriptor(descriptor, `${descriptor.range}?${querystring.stringify({
       locator: structUtils.stringifyLocator(fromLocator),

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "nextVersion": {
     "semver": "2.0.0-rc.2",
-    "nonce": "355232474589399"
+    "nonce": "2740610951748295"
   },
   "main": "./sources/index.ts",
   "bin": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using `file:` within the `resolutions` field causes it to be bound to the top-level workspace (so that relative paths get resolved from the right location), but it causes problems when we later try to use that bound locator as a dependency of another one (because Yarn currently prevents rebinding on `file:`).

**How did you fix it?**

Does the same thing as #194, but for `file:` entries. Basically, if we try to rebind something that's already bound, we just ignore the bind call.

**Which packages would need a new release (if any)?**

yarnpkg-cli

**Have you run `yarn version prerelease` in those packages?**

- [x] Yes
