### PR TITLE
Update e2e status table

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ On top of our classic integration tests, we also run Yarn every day against the 
 | Toolchain | E2E Tests | Tooling | E2E Tests |
 | --- | --- | --- | --- |
 | [Create-React-App](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-cra-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20CRA/badge.svg)]() | [ESLint](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-eslint-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20ESLint/badge.svg)]() |
-| [Gatsby](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gatsby-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Gatsby/badge.svg)]() | [Husky](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-husky-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Husky/badge.svg)]() |
-| | | [Prettier](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-prettier-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Prettier/badge.svg)]() |
+| [Gatsby](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gatsby-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Gatsby/badge.svg)]() | [Prettier](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-prettier-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Prettier/badge.svg)]() |
 | | | [Jest](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-jest-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Jest/badge.svg)]() |
+| | | [Mocha](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-mocha-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Mocha/badge.svg)]() |
+| | | [Husky](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-husky-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20Husky/badge.svg)]() |
 | | | [TypeScript](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-typescript-workflow.yml) | [![](https://github.com/yarnpkg/berry/workflows/E2E%20TypeScript/badge.svg)]() |
 
 ## Build your own bundle


### PR DESCRIPTION
**What's the problem this PR addresses?**

Add mocha, husky and typescript to the status table.
