### PR TITLE
Implements unsafeHttpWhitelist

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -4862,6 +4862,7 @@ function $$SETUP_STATE(hydrateRuntimeState) {
           "packageLocation": "./packages/yarnpkg-core/",
           "packageDependencies": [
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
+            ["@types/micromatch", "npm:3.1.0"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
@@ -4879,6 +4880,7 @@ function $$SETUP_STATE(hydrateRuntimeState) {
             ["got", "npm:9.6.0"],
             ["json-file-plus", "npm:3.3.1"],
             ["logic-solver", "npm:2.0.1"],
+            ["micromatch", "npm:4.0.2"],
             ["mkdirp", "npm:0.5.1"],
             ["p-limit", "npm:2.2.0"],
             ["pluralize", "npm:7.0.0"],

--- a/.pnp.js
+++ b/.pnp.js
@@ -4862,7 +4862,6 @@ function $$SETUP_STATE(hydrateRuntimeState) {
           "packageLocation": "./packages/yarnpkg-core/",
           "packageDependencies": [
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@types/micromatch", "npm:3.1.0"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/unsafeHttpWhitelist.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/unsafeHttpWhitelist.test.js
@@ -1,0 +1,18 @@
+describe(`Features`, () => {
+  describe(`unsafeHttpWhitelist`, () => {
+    test(
+      `it should prevent Yarn from using http by default`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, {
+        unsafeHttpWhitelist: undefined,
+      }, async ({path, run, source}) => {
+        await expect((async () => {
+          await run(`install`);
+        })()).rejects.toThrow(/Unsafe http requests must be explicitly whitelisted in your configuration/);
+      }),
+    );
+  });
+});

--- a/packages/acceptance-tests/yarn.setup.js
+++ b/packages/acceptance-tests/yarn.setup.js
@@ -2,6 +2,7 @@
 
 const {delimiter} = require(`path`);
 const isWsl = require(`is-wsl`);
+const {URL} = require(`url`);
 
 const {
   tests: {generatePkgDriver, startPackageServer, getPackageRegistry},

--- a/packages/acceptance-tests/yarn.setup.js
+++ b/packages/acceptance-tests/yarn.setup.js
@@ -39,14 +39,15 @@ global.makeTemporaryEnv = generatePkgDriver({
         [`TEST_ENV`]: `true`,
         [`YARN_GLOBAL_FOLDER`]: `${nativePath}/.yarn/global`,
         [`YARN_NPM_REGISTRY_SERVER`]: registryUrl,
+        [`YARN_UNSAFE_HTTP_WHITELIST`]: new URL(registryUrl).hostname,
         // Otherwise the tests would break when C:\tmp is on a different drive than the repo
         [`YARN_ENABLE_ABSOLUTE_VIRTUALS`]: `true`,
         // Otherwise the output isn't stable between runs
         [`YARN_ENABLE_TIMERS`]: `false`,
         // Otherwise we would more often test the fallback rather than the real logic
         [`YARN_PNP_FALLBACK_MODE`]: `none`,
-        ... rcEnv,
-        ... env,
+        ...rcEnv,
+        ...env,
       },
     });
 
@@ -61,9 +62,9 @@ global.makeTemporaryEnv = generatePkgDriver({
   },
 });
 
-if (process.platform === `win32` || isWsl || process.platform === `darwin`) {
+if (process.platform === `win32` || isWsl || process.platform === `darwin`)
   jest.setTimeout(10000);
-}
+
 
 beforeEach(async () => {
   await startPackageServer();

--- a/packages/gatsby/src/pages/configuration/yarnrc.js
+++ b/packages/gatsby/src/pages/configuration/yarnrc.js
@@ -1,7 +1,7 @@
 import React                                    from 'react';
 
 import Layout                                   from '../../components/layout-configuration';
-import {SymlContainer, SymlMain}                from '../../components/syml';
+import {SymlContainer, SymlMain, SymlArrayProperty, SymlScalar}                from '../../components/syml';
 import {SymlObjectProperty, SymlScalarProperty} from '../../components/syml';
 import SEO                                      from '../../components/seo';
 
@@ -299,6 +299,19 @@ const YarnrcDoc = () => <>
           This setting defines the name of the files that Yarn looks for when resolving the rc files. For obvious reasons this settings cannot be set within rc files, and must be defined in the environment using the <code>YARN_RC_FILENAME</code> variable.
         </>}
       />
+      <SymlArrayProperty
+        name={`unsafeHttpWhitelist`}
+        description={<>
+          This setting lists the hostnames for which using the HTTP protocol is allowed. Any other hostname will be required to use HTTPS instead.
+        </>}
+      >
+        <SymlScalar
+          placeholder={`*.example.org`}
+        />
+        <SymlScalar
+          placeholder={`example.org`}
+        />
+      </SymlArrayProperty>
       <SymlScalarProperty
         name={`virtualFolder`}
         placeholder={`./.yarn/virtual`}

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "nextVersion": {
     "semver": "2.0.0-rc.2",
-    "nonce": "6058645158869275"
+    "nonce": "5824009610285795"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "nextVersion": {
     "semver": "2.0.0-rc.2",
-    "nonce": "6399894823901459"
+    "nonce": "7301700723742963"
   },
   "main": "./sources/index.ts",
   "bin": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -36,7 +36,6 @@
     "tunnel": "^0.0.6"
   },
   "devDependencies": {
-    "@types/micromatch": "3.1.0",
     "@yarnpkg/plugin-link": "workspace:2.0.0-rc.0",
     "@yarnpkg/plugin-pnp": "workspace:2.0.0-rc.0",
     "@yarnpkg/pnpify": "workspace:2.0.0-rc.1",

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -23,6 +23,7 @@
     "got": "^9.2.2",
     "json-file-plus": "^3.3.1",
     "logic-solver": "^2.0.1",
+    "micromatch": "^4.0.2",
     "mkdirp": "^0.5.1",
     "p-limit": "^2.2.0",
     "pluralize": "^7.0.0",
@@ -35,6 +36,7 @@
     "tunnel": "^0.0.6"
   },
   "devDependencies": {
+    "@types/micromatch": "3.1.0",
     "@yarnpkg/plugin-link": "workspace:2.0.0-rc.0",
     "@yarnpkg/plugin-pnp": "workspace:2.0.0-rc.0",
     "@yarnpkg/pnpify": "workspace:2.0.0-rc.1",

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "nextVersion": {
     "semver": "2.0.0-rc.2",
-    "nonce": "6170104992265521"
+    "nonce": "1237830869746545"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -251,6 +251,12 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.STRING,
     default: null,
   },
+  unsafeHttpWhitelist: {
+    description: `List of the hostnames for which http queries are allowed (glob patterns are supported)`,
+    type: SettingsType.STRING,
+    default: [],
+    isArray: true,
+  },
 
   // Settings related to security
   enableScripts: {

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -1,5 +1,6 @@
 import HttpAgent, {HttpsAgent} from 'agentkeepalive';
 import got, {GotOptions}       from 'got';
+import micromatch              from 'micromatch';
 import tunnel, {ProxyOptions}  from 'tunnel';
 import {URL}                   from 'url';
 
@@ -44,6 +45,9 @@ async function request(target: string, body: Body, {configuration, headers, json
     throw new Error(`Network access have been disabled by configuration (${method} ${target})`);
 
   const url = new URL(target);
+  if (url.protocol === `http:` && !micromatch.isMatch(url.hostname, configuration.get(`unsafeHttpWhitelist`)))
+    throw new Error(`Unsafe http requests must be explicitly whitelisted in your configuration (${url.hostname})`);
+
   let agent;
 
   const httpProxy = configuration.get(`httpProxy`);

--- a/packages/yarnpkg-parsers/sources/resolution.ts
+++ b/packages/yarnpkg-parsers/sources/resolution.ts
@@ -14,7 +14,7 @@ export type Resolution = {
 export function parseResolution(source: string): Resolution {
   const legacyResolution = source.match(/^\*{1,2}\/(.*)/);
   if (legacyResolution)
-    throw new Error(`The override for '${source}' includes a glob pattern. Glob patterns have been removed since their behaviours don't match what you'd expect. Set the override to '${legacyResolution[1]}' instead.`)
+    throw new Error(`The override for '${source}' includes a glob pattern. Glob patterns have been removed since their behaviours don't match what you'd expect. Set the override to '${legacyResolution[1]}' instead.`);
 
   try {
     return parse(source) as Resolution;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,7 +2969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/micromatch@npm:3.1.0, @types/micromatch@npm:^3.1.0":
+"@types/micromatch@npm:^3.1.0":
   version: 3.1.0
   resolution: "@types/micromatch@npm:3.1.0"
   dependencies:
@@ -3763,7 +3763,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/core@workspace:packages/yarnpkg-core"
   dependencies:
-    "@types/micromatch": "npm:3.1.0"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.1"
     "@yarnpkg/json-proxy": "workspace:2.0.0-rc.0"
     "@yarnpkg/parsers": "workspace:2.0.0-rc.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,7 +2969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/micromatch@npm:^3.1.0":
+"@types/micromatch@npm:3.1.0, @types/micromatch@npm:^3.1.0":
   version: 3.1.0
   resolution: "@types/micromatch@npm:3.1.0"
   dependencies:
@@ -3763,6 +3763,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/core@workspace:packages/yarnpkg-core"
   dependencies:
+    "@types/micromatch": "npm:3.1.0"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.1"
     "@yarnpkg/json-proxy": "workspace:2.0.0-rc.0"
     "@yarnpkg/parsers": "workspace:2.0.0-rc.1"
@@ -3780,6 +3781,7 @@ __metadata:
     got: "npm:^9.2.2"
     json-file-plus: "npm:^3.3.1"
     logic-solver: "npm:^2.0.1"
+    micromatch: "npm:^4.0.2"
     mkdirp: "npm:^0.5.1"
     p-limit: "npm:^2.2.0"
     pluralize: "npm:^7.0.0"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Although it's harder to exploit now than it was in the v1 (because we ignore by default what the registry tells us, and instead rely on the path convention), there is a potential attack vector where an attacker would surreptitiously insert an http url for a scoped package within the lockfile. This would cause Yarn to send the authentication token in clear, leading to all sorts of problem (remote code execution, session hijacking).

**How did you fix it?**

Yarn will now by default refuse to make any query to an http url. This behaviour can be overruled on a by-hostname basis thanks to the new `unsafeHttpWhitelist` field, which accepts a list of glob patterns. If a domain matches the rules listed there, http is allowed.

**Which packages would need a new release (if any)?**

yarnpkg-core, yarnpkg-cli

**Have you run `yarn version prerelease` in those packages?**

- [x] Yes
