### PR TITLE
Handle duplicate dependencies by `yarn add`

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.js
@@ -88,9 +88,80 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should upgrade the existing development dependency in the current project`,
-      makeTemporaryEnv({}, async ({path, run, source}) => {
-        await run(`add`, `no-deps@1.0.0`, `-D`);
+      `it should upgrade the existing regular dependency in the current project (--prefer-dev)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`add`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should upgrade the existing regular dependency in the current project (implicit)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`add`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should upgrade the existing development dependency in the current project (-D)`,
+      makeTemporaryEnv({
+        devDependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`add`, `no-deps`, `-D`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+          devDependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should upgrade the existing development dependency in the current project (--prefer-dev)`,
+      makeTemporaryEnv({
+        devDependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`add`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+          devDependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should upgrade the existing development dependency in the current project (implicit)`,
+      makeTemporaryEnv({
+        devDependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
         await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
@@ -120,7 +191,7 @@ describe(`Commands`, () => {
         await run(`add`, `no-deps`);
         await expect(
           run(`add`, `no-deps`, `-D`)
-        ).rejects.toThrowError(/already a regular dependency/)
+        ).rejects.toThrowError(/already listed as a regular dependency/);
       }),
     );
 
@@ -130,7 +201,7 @@ describe(`Commands`, () => {
         await run(`add`, `no-deps`);
         await expect(
           run(`add`, `no-deps`, `-P`)
-        ).rejects.toThrowError(/already a regular dependency/)
+        ).rejects.toThrowError(/already listed as a regular dependency/);
       }),
     );
 
@@ -140,7 +211,7 @@ describe(`Commands`, () => {
         await run(`add`, `no-deps`, `-P`);
         await expect(
           run(`add`, `no-deps`)
-        ).rejects.toThrowError(/already a peer dependency/)
+        ).rejects.toThrowError(/already listed as a peer dependency/);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.js
@@ -88,6 +88,20 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should upgrade the existing development dependency in the current project`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps@1.0.0`, `-D`);
+        await run(`add`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+          devDependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
       `it should add a new peer dependency to the current project`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-P`);
@@ -97,6 +111,36 @@ describe(`Commands`, () => {
             [`no-deps`]: `*`,
           },
         });
+      }),
+    );
+
+    test(
+      `it should throw an error when existing regular dependency is added using --dev`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps`);
+        await expect(
+          run(`add`, `no-deps`, `-D`)
+        ).rejects.toThrowError(/already a regular dependency/)
+      }),
+    );
+
+    test(
+      `it should throw an error when existing regular dependency is added using --peer`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps`);
+        await expect(
+          run(`add`, `no-deps`, `-P`)
+        ).rejects.toThrowError(/already a regular dependency/)
+      }),
+    );
+
+    test(
+      `it should throw an error when existing peer dependency is added without --peer|--dev`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps`, `-P`);
+        await expect(
+          run(`add`, `no-deps`)
+        ).rejects.toThrowError(/already a peer dependency/)
       }),
     );
 

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -15,6 +15,10 @@
     "yup": "^0.27.0"
   },
   "version": "2.0.0-rc.2",
+  "nextVersion": {
+    "semver": "2.0.0-rc.3",
+    "nonce": "2611806355438241"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -167,7 +167,7 @@ export default class AddCommand extends BaseCommand {
         ({answer: selected} = await prompt({
           type: `list`,
           name: `answer`,
-          message: `Which range to you want to use?`,
+          message: `Which range do you want to use?`,
           choices: suggestions.map(({descriptor, reason}) => descriptor ? {
             name: reason,
             value: descriptor as Descriptor,

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.3",
   "nextVersion": {
     "semver": "2.0.0-rc.4",
-    "nonce": "5463887435994073"
+    "nonce": "6109060208884871"
   },
   "main": "./sources/index.ts",
   "bin": {


### PR DESCRIPTION
**What's the problem this PR addresses?**
Problem is described in #361.
In short: say `lodash` is already installed as a regular dependency, typing `yarn add lodash --dev` duplicates the dependency entry in both `dependencies` and `devDependencies` within `package.json`.

**How did you fix it?**
As per https://github.com/yarnpkg/berry/issues/361#issuecomment-522326046:
1. Implement new flag `--prefer-dev`.
1. Switch installation target if package is already installed.
1. Throw `UsageError` if explicit flag causes a conflict.

In addition to that, clean up redundant dependency entries from `package.json`.