### PR TITLE
Fixes virtual package generation

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -465,8 +465,8 @@ exports.generatePkgDriver = function generatePkgDriver({
           });
         };
 
-        const source = async script => {
-          return JSON.parse((await run('node', '-p', `JSON.stringify((() => ${script})())`)).stdout.toString());
+        const source = async (script, callDefinition = {}) => {
+          return JSON.parse((await run('node', '-p', `JSON.stringify((() => ${script})())`, callDefinition)).stdout.toString());
         };
 
         try {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
@@ -1,3 +1,5 @@
+import {xfs} from '@yarnpkg/fslib';
+
 const {
   fs: {writeFile, writeJson},
 } = require('pkg-tests-core');
@@ -136,6 +138,52 @@ describe(`Dragon tests`, () => {
         // A, then B, etc, until it eventually runs out of memory.
 
         await run(`install`);
+      },
+    ),
+  );
+
+  test.only(
+    `it should pass the dragon test 4`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        workspaces: [
+          `my-workspace`,
+        ],
+      },
+      async ({path, run, source}) => {
+        // This test assume that we have a workspace that has a dependency listed in both its
+        // peer dependencies and its dev dependencies, and that it itself has a peer
+        // depencency. In those circumstances, we've had issues where the peer dependency
+        // wasn't being properly resolved.
+        
+        await xfs.mkdirpPromise(`${path}/my-workspace`);
+        await xfs.writeJsonPromise(`${path}/my-workspace/package.json`, {
+          name: `my-workspace`,
+          peerDependencies: {
+            [`no-deps`]: `*`,
+            [`peer-deps`]: `*`, 
+          },
+          devDependencies: {
+            [`no-deps`]: `1.0.0`,
+            [`peer-deps`]: `1.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        await expect(source(`require('peer-deps')`, {
+          cwd: `${path}/my-workspace`
+        })).resolves.toMatchObject({
+          name: `peer-deps`,
+          version: `1.0.0`,
+          peerDependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `1.0.0`,
+            },
+          },
+        });
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
@@ -142,7 +142,7 @@ describe(`Dragon tests`, () => {
     ),
   );
 
-  test.only(
+  test(
     `it should pass the dragon test 4`,
     makeTemporaryEnv(
       {

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.3",
+  "nextVersion": {
+    "nonce": "7733017082839951"
+  },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@yarnpkg/core": "workspace:2.0.0-rc.4",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.3",
   "nextVersion": {
     "semver": "2.0.0-rc.4",
-    "nonce": "1822363852510739"
+    "nonce": "2660069579967005"
   },
   "main": "./sources/index.ts",
   "bin": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/core",
   "version": "2.0.0-rc.4",
+  "nextVersion": {
+    "semver": "2.0.0-rc.5",
+    "nonce": "2595254518676891"
+  },
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

When a workspace was depending on a package with a peer dependency (such as `react-dom`) through both `devDependencies` and `peerDependencies`, it wasn't virtualised in the context of the top-level workspace (because the code was incorrectly assuming that it got obtained through a peer dependency, which would require a single instantiation).

**How did you fix it?**

We now pass a flag during the virtualisation which indicates whether the package is a dependency of a top-level workspace. Since they are the only one to be in this situation (peer dependencies override regular dependencies since it doesn't make sense to list them both), a simple flag should be fine.
