### PR TITLE
Prevents the same file from appearing twice in the list

### DIFF
--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -481,7 +481,7 @@ async function fetchChangedFiles(root: PortablePath, {base}: {base: string}) {
   const {stdout: untrackedStdout} = await execUtils.execvp(`git`, [`ls-files`, `--others`, `--exclude-standard`], {cwd: root, strict: true});
   const untrackedFiles = untrackedStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
 
-  return [...branchFiles, ...localFiles, ...untrackedFiles].sort();
+  return [...new Set([...branchFiles, ...localFiles, ...untrackedFiles].sort())];
 }
 
 async function fetchPreviousNonce(workspace: Workspace, {root, base}: {root: PortablePath, base: string}) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Since we get the file list from multiple sources, it sometimes happens that we get the same file multiple times. That breaks React, which expects unique keys.

**How did you fix it?**

We simply ensure unicity by converting back-and-forth with a `Set`.

