### PR TITLE
feat(resolve): Accept any workspace version in workspace:*

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/workspace.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/workspace.test.js
@@ -4,7 +4,7 @@ const {fs: {writeJson}} = require('pkg-tests-core');
 describe('Protocols', () => {
   describe('workspace:', () => {
     test(
-      `regcognizes prereleases in wildcard ranges`,
+      `it should recognize prereleases in wildcard ranges`,
       makeTemporaryEnv(
         {
           private: true,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/workspace.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/workspace.test.js
@@ -1,0 +1,31 @@
+
+const {fs: {writeJson}} = require('pkg-tests-core');
+
+describe('Protocols', () => {
+  describe('workspace:', () => {
+    test(
+      `regcognizes prereleases in wildcard ranges`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`docs`, `components`],
+        },
+        async ({path, run, source}) => {
+          await writeJson(`${path}/docs/package.json`, {
+            name: `docs`,
+            private: true,
+            dependencies: {
+              components: `workspace:*`,
+            },
+          });
+          await writeJson(`${path}/components/package.json`, {
+            name: `components`,
+            version: `1.0.0-alpha.0`,
+          });
+
+          await expect(run(`install`)).resolves.toBeTruthy();
+        },
+      ),
+    );
+  });
+});

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.3",
   "nextVersion": {
-    "nonce": "7733017082839951"
+    "semver": "2.0.0-rc.4",
+    "nonce": "7685170686345921"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.3",
   "nextVersion": {
     "semver": "2.0.0-rc.4",
-    "nonce": "2660069579967005"
+    "nonce": "6374202412274785"
   },
   "main": "./sources/index.ts",
   "bin": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.4",
   "nextVersion": {
     "semver": "2.0.0-rc.5",
-    "nonce": "2595254518676891"
+    "nonce": "6238232746607935"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -100,6 +100,9 @@ export class Workspace {
     if (protocol === WorkspaceResolver.protocol && pathname === this.relativeCwd)
       return true;
 
+    if (protocol === WorkspaceResolver.protocol && pathname === `*`)
+      return true;
+
     if (!semver.validRange(pathname))
       return false;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

>  Our current recommendation is to use workspace:*, which will almost always do what you expect.

I expected it to match prerelease versions in the worktree. I'm a bit concerned with overloading semver `*` to work differently in different protocol contexts. I'd be fine with using relative paths but those are marked as experimental.

The use case is dogfeeding a component library to the docs of that library (both living in a monorepo). I never want yarn to look into the registry but strictly in the monorepo. So far I either have to adjust version ranges or use experimental features.

**How did you fix it?**

Add a special case for `workspace:*` that accepts every version. [npm semver `*` does not match prereleases](https://github.com/npm/node-semver/issues/130#issuecomment-120988399).