### PR TITLE
Fixes publishing scoped packages to third-party registries

### DIFF
--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -14,6 +14,10 @@
     "yup": "^0.27.0"
   },
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "2965736026974261"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -63,6 +63,7 @@ export default class NpmPublishCommand extends BaseCommand {
           const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(ident), {
             configuration,
             registry,
+            ident,
             json: true,
           });
 

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -9,6 +9,10 @@
     "semver": "^5.6.0"
   },
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "5986557666077751"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -18,7 +18,7 @@ type AuthOptions = {
 
 type RegistryOptions = {
   ident: Ident,
-  registry?: void,
+  registry?: string,
 } | {
   ident?: void,
   registry: string;
@@ -35,7 +35,7 @@ export function getIdentUrl(ident: Ident) {
 }
 
 export async function get(path: string, {configuration, headers, ident, authType, registry, ...rest}: Options) {
-  if (ident)
+  if (ident && typeof registry === `undefined`)
     registry = npmConfigUtils.getScopeRegistry(ident.scope, {configuration});
   if (ident && ident.scope && typeof authType === `undefined`)
     authType = AuthType.BEST_EFFORT;
@@ -51,7 +51,7 @@ export async function get(path: string, {configuration, headers, ident, authType
 }
 
 export async function put(path: string, body: httpUtils.Body, {configuration, headers, ident, authType = AuthType.ALWAYS_AUTH, registry, ...rest}: Options) {
-  if (ident)
+  if (ident && typeof registry === `undefined`)
     registry = npmConfigUtils.getScopeRegistry(ident.scope, {configuration});
 
   if (typeof registry !== `string`)

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.3",
   "nextVersion": {
     "semver": "2.0.0-rc.4",
-    "nonce": "6374202412274785"
+    "nonce": "1053386781220579"
   },
   "main": "./sources/index.ts",
   "bin": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

When publishing a scoped package to a registry, we were sending a GET requested to the registry to determine whether the version there already existed (when using `--tolerate-republish`). The problem is that we were doing this by passing the publish registry but not the ident, so our request was unauthenticated (and the GitHub Package Registry currently requires auth).

I could have solved that by using `npmAlwaysAuth`, but since the package was scoped the request should have been scoped anyway.

**How did you fix it?**

I relaxed the rules in the `RegistryOptions` so that a registry may now be defined when an ident is explicitly provided (I didn't find the rational why I didn't implement it this way, although I suspect this was before we had `npmPublishRegistry`).