### PR TITLE
Adds a shebang to yarnpkg/builder

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.4",
+  "nextVersion": {
+    "semver": "2.0.0-rc.5",
+    "nonce": "359307347186689"
+  },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/yarnpkg-builder/sources/boot-dev.js
+++ b/packages/yarnpkg-builder/sources/boot-dev.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require(`@yarnpkg/monorepo/scripts/setup-ts-execution`);
 
 require(`./boot`);

--- a/packages/yarnpkg-builder/sources/boot.js
+++ b/packages/yarnpkg-builder/sources/boot.js
@@ -1,2 +1,5 @@
+#!/usr/bin/env node
+
 require(`@yarnpkg/pnpify`).patchFs();
+
 require(`./cli`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current script didn't have a shebang. This isn't a problem for the v2 since all scripts are run via Node by default, but the v1 used a regular `execFile` call which requires a shebang.

**How did you fix it?**

Adds a shebang to the file.
