### PR TITLE
fix(builder): List undeclared dependencies

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -3,11 +3,13 @@
   "version": "2.0.0-rc.4",
   "nextVersion": {
     "semver": "2.0.0-rc.5",
-    "nonce": "359307347186689"
+    "nonce": "4374006072980685"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@babel/core": "^7.5.5",
+    "@babel/plugin-syntax-class-properties": "^7.2.0",
+    "@babel/plugin-syntax-decorators": "^7.2.0",
     "@yarnpkg/core": "workspace:2.0.0-rc.5",
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3",
     "@yarnpkg/pnpify": "workspace:2.0.0-rc.3",
@@ -25,8 +27,6 @@
     "webpack-sources": "^1.3.0"
   },
   "devDependencies": {
-    "@babel/plugin-syntax-class-properties": "^7.2.0",
-    "@babel/plugin-syntax-decorators": "^7.2.0",
     "@yarnpkg/monorepo": "workspace:0.0.0",
     "typescript": "^3.5.3"
   },


### PR DESCRIPTION
**What's the problem this PR addresses?**

```
Required package: @babel/plugin-syntax-class-properties (via "@babel/plugin-syntax-class-properties")
Required by: @yarnpkg/builder
```

```
Required package: @babel/plugin-syntax-decorators (via "@babel/plugin-syntax-decorators")
Required by: @yarnpkg/builder
```


**How did you fix it?**

Move dev dependencies to consumer dependencies.

Aside: This should probably be a rule that should be considered in #438 i.e. add a rule that given a list of files collects all import sources and checks if they are declared in a given manifest. In other words: Check that packages are not accidentally added in `devDependencies`.
