### PR TITLE
Check eslint and typescript existence before generating sdk

### DIFF
--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/pnpify",
   "version": "2.0.0-rc.3",
   "nextVersion": {
-    "nonce": "817844653480653"
+    "semver": "2.0.0-rc.4",
+    "nonce": "3767137253685023"
   },
   "main": "./sources/boot-dev.js",
   "bin": "./sources/boot-cli-dev.js",

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -81,7 +81,9 @@ export const generateSdk = async (projectRoot: PortablePath): Promise<any> => {
 
   const targetFolder = ppath.join(projectRoot, `.vscode/pnpify` as PortablePath);
 
-  if (hasTypescript || hasEslint)
+  if (!hasTypescript && !hasEslint)
+    console.warn(`Neither 'typescript' nor 'eslint' are installed. Nothing to do.`);
+  else
     await xfs.removePromise(targetFolder);
 
   if (hasTypescript)

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -62,10 +62,32 @@ export const generateEslintWrapper = async (projectRoot: PortablePath, target: P
   await addVSCodeWorkspaceSettings(projectRoot, {'eslint.nodePath': NodeFS.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(eslint)))});
 };
 
-export const generateSdk = async (projectRoot: PortablePath): Promise<any> => {
-  const targetFolder = ppath.join(projectRoot, `.vscode/pnpify` as PortablePath);
-  await xfs.removePromise(targetFolder);
+const isPackageInstalled = (name: string): boolean => {
+  try {
+    dynamicRequire(name);
+    return true;
+  } catch (e) {
+    if (e.code && e.code === 'MODULE_NOT_FOUND') {
+      return false;
+    } else  {
+      throw e;
+    }
+  }
+};
 
-  await generateTypescriptWrapper(projectRoot, targetFolder);
-  await generateEslintWrapper(projectRoot, targetFolder);
+export const generateSdk = async (projectRoot: PortablePath): Promise<any> => {
+  const hasTypescript = isPackageInstalled('typescript');
+  const hasEslint = isPackageInstalled('eslint');
+
+  const targetFolder = ppath.join(projectRoot, `.vscode/pnpify` as PortablePath);
+
+  if (hasTypescript || hasEslint)
+    await xfs.removePromise(targetFolder);
+
+  if (hasTypescript)
+    await generateTypescriptWrapper(projectRoot, targetFolder);
+
+  if (hasEslint) {
+    await generateEslintWrapper(projectRoot, targetFolder);
+  }
 };

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -64,7 +64,7 @@ export const generateEslintWrapper = async (projectRoot: PortablePath, target: P
 
 const isPackageInstalled = (name: string): boolean => {
   try {
-    dynamicRequire(name);
+    dynamicRequire.resolve(name);
     return true;
   } catch (e) {
     if (e.code && e.code === 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Pnpify SDK generation errors out if eslint is not installed #448 

**How did you fix it?**

Typescript and eslint existence checked first before attempt to generate sdk for each of them