### PR TITLE
Mael/version

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.6",
+  "nextVersion": {
+    "nonce": "1249689858559711"
+  },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/cli",
   "version": "2.0.0-rc.6",
+  "nextVersion": {
+    "semver": "2.0.0-rc.7",
+    "nonce": "2839545124829267"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/core": "workspace:2.0.0-rc.6",

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/core",
   "version": "2.0.0-rc.6",
+  "nextVersion": {
+    "semver": "2.0.0-rc.7",
+    "nonce": "378806342002957"
+  },
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -9,6 +9,7 @@ import {Project}                                                      from './Pr
 import {StreamReport}                                                 from './StreamReport';
 import {Workspace}                                                    from './Workspace';
 import * as execUtils                                                 from './execUtils';
+import * as miscUtils                                                 from './miscUtils';
 import * as structUtils                                               from './structUtils';
 import {LocatorHash, Locator}                                         from './types';
 
@@ -49,7 +50,11 @@ export async function makeScriptEnv(project: Project, lifecycleScript?: string) 
   scriptEnv.npm_execpath = `${nativeBinFolder}${npath.sep}yarn`;
   scriptEnv.npm_node_execpath = `${nativeBinFolder}${npath.sep}node`;
 
-  scriptEnv.npm_config_user_agent = `yarn/? npm/? node/${process.versions.node} ${process.platform} ${process.arch}`;
+  const version = typeof YARN_VERSION !== `undefined`
+    ? `yarn/${YARN_VERSION}`
+    : `yarn/${miscUtils.dynamicRequire(`@yarnpkg/core`).version}-core`;
+
+  scriptEnv.npm_config_user_agent = `${version} npm/? node/${process.versions.node} ${process.platform} ${process.arch}`;
 
   if (lifecycleScript)
     scriptEnv.npm_lifecycle_event = lifecycleScript;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4495,17 +4495,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/builder@workspace:2.0.0-rc.5, @yarnpkg/builder@workspace:packages/yarnpkg-builder":
+"@yarnpkg/builder@workspace:2.0.0-rc.6, @yarnpkg/builder@workspace:packages/yarnpkg-builder":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/builder@workspace:packages/yarnpkg-builder"
   dependencies:
     "@babel/core": "npm:^7.5.5"
     "@babel/plugin-syntax-class-properties": "npm:^7.2.0"
     "@babel/plugin-syntax-decorators": "npm:^7.2.0"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     "@yarnpkg/monorepo": "workspace:0.0.0"
-    "@yarnpkg/pnpify": "workspace:2.0.0-rc.3"
+    "@yarnpkg/pnpify": "workspace:2.0.0-rc.4"
     babel-loader: "npm:^8.0.6"
     babel-plugin-lazy-import: arcanis/babel-plugin-lazy-import
     chalk: "npm:^2.4.1"
@@ -4525,32 +4525,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/cli@workspace:2.0.0-rc.5, @yarnpkg/cli@workspace:packages/yarnpkg-cli":
+"@yarnpkg/cli@workspace:2.0.0-rc.6, @yarnpkg/cli@workspace:packages/yarnpkg-cli":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/cli@workspace:packages/yarnpkg-cli"
   dependencies:
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     "@yarnpkg/parsers": "workspace:2.0.0-rc.3"
-    "@yarnpkg/plugin-constraints": "workspace:2.0.0-rc.1"
+    "@yarnpkg/plugin-constraints": "workspace:2.0.0-rc.2"
     "@yarnpkg/plugin-dlx": "workspace:2.0.0-rc.1"
     "@yarnpkg/plugin-essentials": "workspace:2.0.0-rc.4"
     "@yarnpkg/plugin-file": "workspace:2.0.0-rc.1"
-    "@yarnpkg/plugin-git": "workspace:2.0.0-rc.1"
+    "@yarnpkg/plugin-git": "workspace:2.0.0-rc.2"
     "@yarnpkg/plugin-github": "workspace:2.0.0-rc.1"
     "@yarnpkg/plugin-http": "workspace:2.0.0-rc.1"
     "@yarnpkg/plugin-init": "workspace:2.0.0-rc.1"
     "@yarnpkg/plugin-link": "workspace:2.0.0-rc.1"
-    "@yarnpkg/plugin-npm": "workspace:2.0.0-rc.2"
+    "@yarnpkg/plugin-npm": "workspace:2.0.0-rc.3"
     "@yarnpkg/plugin-npm-cli": "workspace:2.0.0-rc.2"
     "@yarnpkg/plugin-pack": "workspace:2.0.0-rc.2"
     "@yarnpkg/plugin-pnp": "workspace:2.0.0-rc.1"
-    "@yarnpkg/plugin-typescript": "workspace:2.0.0-rc.2"
+    "@yarnpkg/plugin-typescript": "workspace:2.0.0-rc.3"
     "@yarnpkg/plugin-version": "workspace:2.0.0-rc.3"
-    "@yarnpkg/plugin-workspace-tools": "workspace:2.0.0-rc.2"
+    "@yarnpkg/plugin-workspace-tools": "workspace:2.0.0-rc.3"
     "@yarnpkg/pnp": "workspace:2.0.0-rc.3"
-    "@yarnpkg/pnpify": "workspace:2.0.0-rc.3"
+    "@yarnpkg/pnpify": "workspace:2.0.0-rc.4"
     "@yarnpkg/shell": "workspace:2.0.0-rc.2"
     chalk: "npm:^2.4.1"
     clipanion: "npm:^2.1.1"
@@ -4561,7 +4561,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/core@workspace:2.0.0-rc.5, @yarnpkg/core@workspace:packages/yarnpkg-core":
+"@yarnpkg/core@workspace:2.0.0-rc.6, @yarnpkg/core@workspace:packages/yarnpkg-core":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/core@workspace:packages/yarnpkg-core"
   dependencies:
@@ -4726,7 +4726,7 @@ __metadata:
     "@types/yup": "npm:0.26.12"
     "@typescript-eslint/eslint-plugin": "npm:^1.7.0"
     "@typescript-eslint/parser": "npm:^1.6.0"
-    "@yarnpkg/pnpify": "workspace:2.0.0-rc.3"
+    "@yarnpkg/pnpify": "workspace:2.0.0-rc.4"
     babel-jest: "npm:^24.5.0"
     eslint: "npm:^5.16.0"
     eslint-plugin-arca: "npm:^0.9.0"
@@ -4755,12 +4755,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/plugin-constraints@workspace:2.0.0-rc.1, @yarnpkg/plugin-constraints@workspace:packages/plugin-constraints":
+"@yarnpkg/plugin-constraints@workspace:2.0.0-rc.2, @yarnpkg/plugin-constraints@workspace:packages/plugin-constraints":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-constraints@workspace:packages/plugin-constraints"
   dependencies:
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     clipanion: "npm:^2.1.1"
     inquirer: "npm:^6.2.0"
@@ -4774,8 +4774,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-dlx@workspace:packages/plugin-dlx"
   dependencies:
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     "@yarnpkg/json-proxy": "workspace:2.0.0-rc.2"
     "@yarnpkg/plugin-essentials": "workspace:2.0.0-rc.4"
@@ -4788,8 +4788,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-essentials@workspace:packages/plugin-essentials"
   dependencies:
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     "@yarnpkg/json-proxy": "workspace:2.0.0-rc.2"
     "@yarnpkg/parsers": "workspace:2.0.0-rc.3"
@@ -4806,8 +4806,8 @@ __metadata:
   resolution: "@yarnpkg/plugin-exec@workspace:packages/plugin-exec"
   dependencies:
     "@types/tmp": "npm:^0.0.33"
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     tmp: "npm:^0.0.33"
     typescript: "npm:^3.5.3"
@@ -4818,16 +4818,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-file@workspace:packages/plugin-file"
   dependencies:
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/plugin-git@workspace:2.0.0-rc.1, @yarnpkg/plugin-git@workspace:packages/plugin-git":
+"@yarnpkg/plugin-git@workspace:2.0.0-rc.2, @yarnpkg/plugin-git@workspace:packages/plugin-git":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-git@workspace:packages/plugin-git"
   dependencies:
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     git-url-parse: "npm:11.1.2"
     semver: "npm:^5.6.0"
@@ -4839,7 +4839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-github@workspace:packages/plugin-github"
   dependencies:
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
   languageName: unknown
   linkType: soft
@@ -4848,7 +4848,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-http@workspace:packages/plugin-http"
   dependencies:
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
   languageName: unknown
   linkType: soft
@@ -4857,8 +4857,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-init@workspace:packages/plugin-init"
   dependencies:
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     "@yarnpkg/json-proxy": "workspace:2.0.0-rc.2"
     clipanion: "npm:^2.1.1"
@@ -4869,7 +4869,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-link@workspace:packages/plugin-link"
   dependencies:
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
   languageName: unknown
   linkType: soft
@@ -4878,10 +4878,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-npm-cli@workspace:packages/plugin-npm-cli"
   dependencies:
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
-    "@yarnpkg/plugin-npm": "workspace:2.0.0-rc.2"
+    "@yarnpkg/plugin-npm": "workspace:2.0.0-rc.3"
     "@yarnpkg/plugin-pack": "workspace:2.0.0-rc.2"
     clipanion: "npm:^2.1.1"
     inquirer: "npm:^6.2.0"
@@ -4890,11 +4890,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/plugin-npm@workspace:2.0.0-rc.2, @yarnpkg/plugin-npm@workspace:packages/plugin-npm":
+"@yarnpkg/plugin-npm@workspace:2.0.0-rc.3, @yarnpkg/plugin-npm@workspace:packages/plugin-npm":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-npm@workspace:packages/plugin-npm"
   dependencies:
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     inquirer: "npm:^6.2.0"
     semver: "npm:^5.6.0"
@@ -4906,8 +4906,8 @@ __metadata:
   resolution: "@yarnpkg/plugin-pack@workspace:packages/plugin-pack"
   dependencies:
     "@types/tar-stream": "npm:1.6.0"
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     clipanion: "npm:^2.1.1"
     micromatch: "npm:^4.0.2"
@@ -4919,35 +4919,35 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-pnp@workspace:packages/plugin-pnp"
   dependencies:
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
-    "@yarnpkg/plugin-stage": "workspace:2.0.0-rc.2"
+    "@yarnpkg/plugin-stage": "workspace:2.0.0-rc.3"
     "@yarnpkg/pnp": "workspace:2.0.0-rc.3"
     clipanion: "npm:^2.1.1"
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/plugin-stage@workspace:2.0.0-rc.2, @yarnpkg/plugin-stage@workspace:packages/plugin-stage":
+"@yarnpkg/plugin-stage@workspace:2.0.0-rc.3, @yarnpkg/plugin-stage@workspace:packages/plugin-stage":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-stage@workspace:packages/plugin-stage"
   dependencies:
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     clipanion: "npm:^2.1.1"
     typescript: "npm:^3.5.3"
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/plugin-typescript@workspace:2.0.0-rc.2, @yarnpkg/plugin-typescript@workspace:packages/plugin-typescript":
+"@yarnpkg/plugin-typescript@workspace:2.0.0-rc.3, @yarnpkg/plugin-typescript@workspace:packages/plugin-typescript":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-typescript@workspace:packages/plugin-typescript"
   dependencies:
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/plugin-essentials": "workspace:2.0.0-rc.4"
     "@yarnpkg/plugin-pack": "workspace:2.0.0-rc.2"
     typescript: "npm:^3.5.3"
@@ -4958,9 +4958,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-version@workspace:packages/plugin-version"
   dependencies:
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     "@yarnpkg/plugin-pack": "workspace:2.0.0-rc.2"
     clipanion: "npm:^2.1.1"
@@ -4972,13 +4972,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/plugin-workspace-tools@workspace:2.0.0-rc.2, @yarnpkg/plugin-workspace-tools@workspace:packages/plugin-workspace-tools":
+"@yarnpkg/plugin-workspace-tools@workspace:2.0.0-rc.3, @yarnpkg/plugin-workspace-tools@workspace:packages/plugin-workspace-tools":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-workspace-tools@workspace:packages/plugin-workspace-tools"
   dependencies:
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
-    "@yarnpkg/cli": "workspace:2.0.0-rc.5"
-    "@yarnpkg/core": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
+    "@yarnpkg/cli": "workspace:2.0.0-rc.6"
+    "@yarnpkg/core": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
     clipanion: "npm:^2.1.1"
     p-limit: "npm:^2.2.0"
@@ -4991,9 +4991,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/pnp@workspace:packages/yarnpkg-pnp"
   dependencies:
-    "@yarnpkg/builder": "workspace:2.0.0-rc.5"
+    "@yarnpkg/builder": "workspace:2.0.0-rc.6"
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
-    "@yarnpkg/pnpify": "workspace:2.0.0-rc.3"
+    "@yarnpkg/pnpify": "workspace:2.0.0-rc.4"
     typescript: "npm:^3.5.3"
     webpack: "npm:^4.39.3"
     webpack-cli: "npm:^3.2.1"
@@ -5001,7 +5001,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/pnpify@workspace:2.0.0-rc.3, @yarnpkg/pnpify@workspace:packages/yarnpkg-pnpify":
+"@yarnpkg/pnpify@workspace:2.0.0-rc.4, @yarnpkg/pnpify@workspace:packages/yarnpkg-pnpify":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/pnpify@workspace:packages/yarnpkg-pnpify"
   dependencies:
@@ -24056,7 +24056,7 @@ babel-plugin-lazy-import@arcanis/babel-plugin-lazy-import:
   resolution: "vscode-zipfs@workspace:packages/vscode-zipfs"
   dependencies:
     "@yarnpkg/fslib": "workspace:2.0.0-rc.3"
-    "@yarnpkg/pnpify": "workspace:2.0.0-rc.3"
+    "@yarnpkg/pnpify": "workspace:2.0.0-rc.4"
     pnp-webpack-plugin: "npm:^1.4.3"
     ts-loader: "npm:^5.3.3"
     typescript: "npm:^3.5.3"


### PR DESCRIPTION
**What's the problem this PR addresses?**

The v2 user agent still references `yarn/?`. Since we now have version numbers, they should be properly reflected.

**How did you fix it?**

The user agent will use the CLI version if available (after being bundled). If it isn't, it'll reflect the version for the `@yarnpkg/core` package, with a specific suffix to disambiguate the CLI versions from the core versions.
