### PR TITLE
Runs a real install after yarn version apply

### DIFF
--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -21,6 +21,10 @@
     "build:plugin-version": "builder build plugin"
   },
   "version": "2.0.0-rc.3",
+  "nextVersion": {
+    "semver": "2.0.0-rc.4",
+    "nonce": "864756570755459"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -1,9 +1,9 @@
-import {BaseCommand, WorkspaceRequiredError}                   from '@yarnpkg/cli';
-import {AllDependencies, Configuration, IdentHash, Manifest}   from '@yarnpkg/core';
-import {MessageName, Project, StreamReport, WorkspaceResolver} from '@yarnpkg/core';
-import {Workspace, structUtils}                                from '@yarnpkg/core';
-import {Command, UsageError}                                   from 'clipanion';
-import semver                                                  from 'semver';
+import {BaseCommand, WorkspaceRequiredError}                        from '@yarnpkg/cli';
+import {AllDependencies, Cache, Configuration, IdentHash, Manifest} from '@yarnpkg/core';
+import {MessageName, Project, StreamReport, WorkspaceResolver}      from '@yarnpkg/core';
+import {Workspace, structUtils}                                     from '@yarnpkg/core';
+import {Command, UsageError}                                        from 'clipanion';
+import semver                                                       from 'semver';
 
 // Basically we only support auto-upgrading the ranges that are very simple (^x.y.z, ~x.y.z, >=x.y.z, and of course x.y.z)
 const SUPPORTED_UPGRADE_REGEXP = /^(>=|[~^]|)^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/;
@@ -42,6 +42,7 @@ export default class VersionApplyCommand extends BaseCommand {
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
+    const cache = await Cache.find(configuration);
 
     if (!workspace)
       throw new WorkspaceRequiredError(this.context.cwd);
@@ -188,7 +189,7 @@ export default class VersionApplyCommand extends BaseCommand {
         }
       }
 
-      await project.persist();
+      await project.install({cache, report});
     });
 
     return applyReport.exitCode();

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/cli",
   "version": "2.0.0-rc.6",
+  "nextVersion": {
+    "semver": "2.0.0-rc.7",
+    "nonce": "5783719622303007"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/core": "workspace:2.0.0-rc.6",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn install` is required after running `yarn version apply`, as the lockfile hasn't been updated yet to reflect the changes (only the project manifests have been). This isn't ideal from a user experience point of view.

**How did you fix it?**

A real install will now be run after running `yarn version apply`, and the changes will only be made if the install passed. This ensures that if you commit the result after `yarn version apply` returns, you'll be in a good state with regard to `yarn install --immutable`.
