### PR TITLE
Uses magenta when logging the file path

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,7 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.6",
   "nextVersion": {
-    "nonce": "1249689858559711"
+    "nonce": "7935871209988623"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.6",
   "nextVersion": {
     "semver": "2.0.0-rc.7",
-    "nonce": "2839545124829267"
+    "nonce": "8111905823631191"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.6",
   "nextVersion": {
     "semver": "2.0.0-rc.7",
-    "nonce": "378806342002957"
+    "nonce": "470204799307749"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1288,9 +1288,9 @@ export class Project {
         continue;
 
       if (cache.immutable) {
-        report.reportError(MessageName.IMMUTABLE_CACHE, `${ppath.basename(entryPath)} appears to be unused and would marked for deletion, but the cache is immutable`);
+        report.reportError(MessageName.IMMUTABLE_CACHE, `${this.configuration.format(ppath.basename(entryPath), `magenta`)} appears to be unused and would marked for deletion, but the cache is immutable`);
       } else {
-        report.reportInfo(MessageName.UNUSED_CACHE_ENTRY, `${ppath.basename(entryPath)} appears to be unused - removing`);
+        report.reportInfo(MessageName.UNUSED_CACHE_ENTRY, `${this.configuration.format(ppath.basename(entryPath), `magenta`)} appears to be unused - removing`);
         await xfs.unlinkPromise(entryPath);
       }
     }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The message printed when cleaning unused archives doesn't highlight the file being removed.

**How did you fix it?**

The file name is now properly highlighted.