### PR TITLE
fix: rsync option in `@yarnpkg/parsers`

### DIFF
--- a/packages/yarnpkg-parsers/package.json
+++ b/packages/yarnpkg-parsers/package.json
@@ -16,7 +16,7 @@
     "grammar:resolution": "run pegjs -o sources/grammars/resolution.js sources/grammars/resolution.pegjs",
     "grammar:syml": "run pegjs -o sources/grammars/syml.js sources/grammars/syml.pegjs",
     "postpack": "rm -rf lib",
-    "prepack": "mkdir -p lib && rsync -a --exclude '*.ts' sources/ lib/ && run build:compile packages/yarnpkg-parsers",
+    "prepack": "mkdir -p lib && rsync -a --include '*.d.ts' --exclude '*.ts' sources/ lib/ && run build:compile packages/yarnpkg-parsers",
     "release": "yarn npm publish",
     "test:parsers": "run test:unit packages/yarnpkg-parsers"
   },


### PR DESCRIPTION

**What's the problem this PR addresses?**

Current `@yarnpkg/parsers` module has no `grammars/*.d.ts` files. It causes `TS7016: Could not find a declaration file` error in a project using this module via `yarn add` .


**How did you fix it?**

That issue is caused by `rsync` option in `prepack` script. Running `yarn workspace @yarnpkg/parsers prepack` creates `lib` directory, but it has no `grammars/*.d.ts` files because of `--exclude '*.ts'` option. So this PR fixed `rsync` option to include `*.d.ts` files. 
