### PR TITLE
Describes a bit the project history

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,63 @@
+The people described in this document made significant and/or recurring contributions to Yarn in various aspects. Please don't edit this list as part of a feature or bugfix PR.
+
+Note that it's sometimes hard to keep track of everyone (the v1 trunk has 500+ contributors, and the v2 trunk already 29), so this list is by no means extensive. Still, it provides a decent picture of who to contact for information in case we later lose context over something.
+
+## 2.0.0 - current
+
+### Project lead
+
+- Maël Nison
+
+### Active contributors
+
+- Bram Gotink (Constraints)
+- Daniel Almaguer (Various)
+- Daniel Lo Nigro (Release workflow)
+- Marc-Antoine (Windows support)
+- Sebastian Silbermann (Various)
+- Victor Vlasenko (PnPify)
+- Will Griffiths (Test workflow)
+
+## 1.9.0 - 1.18.0 (~14 months)
+
+### Project lead
+
+- Maël Nison
+
+### Active contributors
+
+- Daniel Lo Nigro (Release workflow)
+- Jeff Valore (Audit)
+
+## 1.0.0 - 1.9.0 (~13 months)
+
+### Project leads
+
+- Burak Yiğit Kaya
+- Maël Nison
+
+### Active contributors
+
+- Daniel Lo Nigro (Release workflow)
+- Kaylie Kwon (Resolution overrides)
+- Jeff Valore (Various)
+
+## 0.20.0 - 0.28.4 (~6 months)
+
+### Project lead
+
+- Konstantin Raev
+
+### Active contributors:
+
+- Daniel Lo Nigro (Release workflow)
+- Jeff Valore (Various)
+- Maël Nison (Various)
+- Simon Vocella (Infra)
+
+## First commit - 0.20.0 (~17 months)
+
+### Project leads
+
+- Sebastian McKenzie
+- Konstantin Raev

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@ Note that it's sometimes hard to keep track of everyone (the v1 trunk has 500+ c
 
 - Daniel Lo Nigro (Release workflow)
 - Jeff Valore (Audit)
+- Haroen Viaene (Website)
 
 ## 1.0.0 - 1.9.0 (~13 months)
 
@@ -39,6 +40,7 @@ Note that it's sometimes hard to keep track of everyone (the v1 trunk has 500+ c
 ### Active contributors
 
 - Daniel Lo Nigro (Release workflow)
+- Haroen Viaene (Website)
 - Kaylie Kwon (Resolution overrides)
 - Jeff Valore (Various)
 
@@ -51,6 +53,7 @@ Note that it's sometimes hard to keep track of everyone (the v1 trunk has 500+ c
 ### Active contributors:
 
 - Daniel Lo Nigro (Release workflow)
+- Haroen Viaene (Website)
 - Jeff Valore (Various)
 - Maël Nison (Various)
 - Simon Vocella (Infra)


### PR DESCRIPTION
**What's the problem this PR addresses?**

The project history is a bit fuzzy at the moment - who works on it, who used to, who to contact for context on some design decisions? Looking at the PRs helsp a bit, the teams as well (although they aren't up-to-date and probably could use a refreshing), but I think it's a good idea to keep track of it in a versioned document.

**How did you fix it?**

I've wrote this document based on what I know about the project (since I joined it, so ~feb 2017). Maybe @bestander, @cpojer, or @sebmck, could help fill the blank before this date if it doesn't match what they remember.
