### PR TITLE
Remove binary name from examples

### DIFF
--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -63,10 +63,10 @@ export default class AddCommand extends BaseCommand {
     `,
     examples: [[
       `Add a regular package to the current workspace`,
-      `yarn add lodash`,
+      `$0 add lodash`,
     ], [
       `Add a specific version for a package to the current workspace`,
-      `yarn add lodash@1.2.3`,
+      `$0 add lodash@1.2.3`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/bin.ts
+++ b/packages/plugin-essentials/sources/commands/bin.ts
@@ -20,10 +20,10 @@ export default class BinCommand extends BaseCommand {
     `,
     examples: [[
       `List all the available binaries`,
-      `yarn bin`,
+      `$0 bin`,
     ], [
       `Print the path to a specific binary`,
-      `yarn bin eslint`,
+      `$0 bin eslint`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/cache/clean.ts
+++ b/packages/plugin-essentials/sources/commands/cache/clean.ts
@@ -29,10 +29,10 @@ export default class CacheCleanCommand extends BaseCommand {
     `,
     examples: [[
       `Remove all the unused cache files from the current project`,
-      `yarn cache clean`,
+      `$0 cache clean`,
     ], [
       `Obtain the list of unused files from the current project`,
-      `yarn cache clean --dry-run --json`,
+      `$0 cache clean --dry-run --json`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/config.ts
+++ b/packages/plugin-essentials/sources/commands/config.ts
@@ -30,7 +30,7 @@ export default class ConfigCommand extends BaseCommand {
     `,
     examples: [[
       `Print the active configuration settings`,
-      `yarn config`,
+      `$0 config`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -60,13 +60,13 @@ export default class YarnCommand extends BaseCommand {
     `,
     examples: [[
       `Install the project`,
-      `yarn install`,
+      `$0 install`,
     ], [
       `Validate a project when using Zero-Installs`,
-      `yarn install --immutable --immutable-cache`,
+      `$0 install --immutable --immutable-cache`,
     ], [
       `Validate a project when using Zero-Installs (slightly safer if you accept external PRs)`,
-      `yarn install --immutable --immutable-cache --check-cache`,
+      `$0 install --immutable --immutable-cache --check-cache`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -28,10 +28,10 @@ export default class LinkCommand extends BaseCommand {
     `,
     examples: [[
       `Register a remote workspace for use in the current project`,
-      `yarn link ~/ts-loader`,
+      `$0 link ~/ts-loader`,
     ], [
       `Register all workspaces from a remote project for use in the current project`,
-      `yarn link ~/jest --all`,
+      `$0 link ~/jest --all`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/node.ts
+++ b/packages/plugin-essentials/sources/commands/node.ts
@@ -17,7 +17,7 @@ export default class NodeCommand extends BaseCommand {
     `,
     examples: [[
       `Run a Node script`,
-      `yarn node ./my-script.js`,
+      `$0 node ./my-script.js`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -28,10 +28,10 @@ export default class PluginDlCommand extends BaseCommand {
     `,
     examples: [[
       `Download and activate the "@yarnpkg/plugin-exec" plugin`,
-      `yarn plugin import @yarnpkg/plugin-exec`,
+      `$0 plugin import @yarnpkg/plugin-exec`,
     ], [
       `Download and activate a community plugin`,
-      `yarn plugin import https://example.org/path/to/plugin.js`,
+      `$0 plugin import https://example.org/path/to/plugin.js`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/plugin/list.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/list.ts
@@ -22,7 +22,7 @@ export default class PluginDlCommand extends BaseCommand {
     `,
     examples: [[
       `List the official plugins`,
-      `yarn plugin list`,
+      `$0 plugin list`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/plugin/runtime.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/runtime.ts
@@ -12,7 +12,7 @@ export default class PluginListCommand extends BaseCommand {
     `,
     examples: [[
       `List the currently active plugins`,
-      `yarn plugin runtime`,
+      `$0 plugin runtime`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -24,10 +24,10 @@ export default class RemoveCommand extends BaseCommand {
     `,
     examples: [[
       `Remove a dependency from the current project`,
-      `yarn remove lodash`,
+      `$0 remove lodash`,
     ], [
       `Remove a dependency from all workspaces at once`,
-      `yarn remove lodash --all`,
+      `$0 remove lodash --all`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/run.ts
+++ b/packages/plugin-essentials/sources/commands/run.ts
@@ -39,10 +39,10 @@ export default class RunCommand extends BaseCommand {
     `,
     examples: [[
       `Run the tests from the local workspace`,
-      `yarn run test`,
+      `$0 run test`,
     ], [
       `Same thing, but without the "run" keyword`,
-      `yarn test`,
+      `$0 test`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/set/resolution.ts
+++ b/packages/plugin-essentials/sources/commands/set/resolution.ts
@@ -25,7 +25,7 @@ export default class SetResolutionCommand extends BaseCommand {
     `,
     examples: [[
       `Force all instances of lodash@^1.2.3 to resolve to 1.5.0`,
-      `yarn set resolution lodash@^1.2.3 1.5.0`,
+      `$0 set resolution lodash@^1.2.3 1.5.0`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -34,16 +34,16 @@ export default class SetVersionCommand extends BaseCommand {
     `,
     examples: [[
       `Download the latest release from the Yarn repository`,
-      `yarn set version latest`,
+      `$0 set version latest`,
     ], [
       `Download the latest nightly release from the Yarn repository`,
-      `yarn set version nightly`,
+      `$0 set version nightly`,
     ], [
       `Switch back to Yarn v1`,
-      `yarn set version ^1`,
+      `$0 set version ^1`,
     ], [
       `Switch back to a specific release`,
-      `yarn set version 1.14.0`,
+      `$0 set version 1.14.0`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -43,7 +43,7 @@ export default class SetVersionCommand extends BaseCommand {
     `,
     examples: [[
       `Build Yarn from master`,
-      `yarn set version from sources`,
+      `$0 set version from sources`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -36,13 +36,13 @@ export default class UpCommand extends BaseCommand {
     `,
     examples: [[
       `Upgrade all instances of lodash to the latest release`,
-      `yarn up lodash`,
+      `$0 up lodash`,
     ], [
       `Upgrade all instances of lodash to the latest release, but ask confirmation for each`,
-      `yarn up lodash -i`,
+      `$0 up lodash -i`,
     ], [
       `Upgrade all instances of lodash to 1.2.3`,
-      `yarn up lodash@1.2.3`,
+      `$0 up lodash@1.2.3`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/why.ts
+++ b/packages/plugin-essentials/sources/commands/why.ts
@@ -30,7 +30,7 @@ export default class WhyCommand extends BaseCommand {
     `,
     examples: [[
       `Explain why lodash is used in your project`,
-      `yarn why lodash`,
+      `$0 why lodash`,
     ]],
   });
 


### PR DESCRIPTION
Closes #478 

Replace `yarn` in examples with `$0`

For some reason this already works even though a new version of clipanion hasn't been published yet. 🤷‍♂ 