### PR TITLE
Whitelists the full folder when packing

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -77,6 +77,24 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should support excluding folders from the "files" field`,
+      makeTemporaryEnv({
+        files: [
+          `/lib`,
+        ],
+      }, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/lib/a.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/lib/b.js`, `module.exports = 42;\n`);
+
+        await run(`install`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        await expect(stdout).toMatch(/lib\/a\.js/);
+        await expect(stdout).toMatch(/lib\/b\.js/);
+      }),
+    );
+
+    test(
       `it shouldn't add .gitignore files to the package files`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await fsUtils.writeFile(`${path}/.gitignore`, ``);

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -10,6 +10,10 @@
     "tmp": "^0.0.33"
   },
   "version": "2.0.0-rc.2",
+  "nextVersion": {
+    "semver": "2.0.0-rc.3",
+    "nonce": "1049948467937999"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-git/sources/constants.ts
+++ b/packages/plugin-git/sources/constants.ts
@@ -1,1 +1,1 @@
-export const GIT_REGEXP = /^(git:|git\+.+:|ssh:|https?:.+\.git#.+|https?:.+\.git)/;
+export const GIT_REGEXP = /^(git:|git\+.+:|ssh:|https?:.+\.git#.+|https?:.+\.git|git@.+\.git)/;

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -13,7 +13,8 @@
   },
   "version": "2.0.0-rc.2",
   "nextVersion": {
-    "nonce": "3457249053533299"
+    "semver": "2.0.0-rc.3",
+    "nonce": "6197884979378345"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -205,7 +205,7 @@ export async function genPackList(workspace: Workspace) {
     ignoreList.accept.push(ppath.resolve(PortablePath.root, workspace.manifest.module));
 
   if (workspace.manifest.files !== null) {
-    ignoreList.reject.push(`*`);
+    ignoreList.reject.push(`/*`);
 
     for (const pattern of workspace.manifest.files) {
       addIgnorePattern(ignoreList.accept, pattern, {cwd: PortablePath.root});

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.7",
   "nextVersion": {
     "semver": "2.0.0-rc.8",
-    "nonce": "5819675619623909"
+    "nonce": "80104024546207"
   },
   "main": "./sources/index.ts",
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Listing `lib` into the `files` field didn't include the children of `lib` (you needed to put `lib/**/*`). This was mildly annoying for migration purposes (mostly annoying to find out), so I fixed it.

**How did you fix it?**

The previous pattern was blacklisting all files by default when a `files` entry was set. I've changed it to instead only blacklist the root entries (so once you override the rule with another one that allows a specific directory you don't need to whitelist the files, since they won't match the `/*` anymore). All tests seem to pass.
