### PR TITLE
Add info to workspace command

### DIFF
--- a/packages/gatsby/src/pages/index.js
+++ b/packages/gatsby/src/pages/index.js
@@ -1,6 +1,5 @@
 import {css}             from '@emotion/core';
 import styled            from '@emotion/styled';
-import {graphql}         from 'gatsby';
 import React, {useState} from 'react';
 
 import Header                                  from '../components/header';

--- a/packages/plugin-workspace-tools/bin/@yarnpkg/plugin-workspace-tools.js
+++ b/packages/plugin-workspace-tools/bin/@yarnpkg/plugin-workspace-tools.js
@@ -352,6 +352,8 @@ module.exports.factory = function (require) {
     category: `Workspace-related commands`,
     description: `run a command on all workspaces`,
     details: `
+        > In order to use this command you need to add \`@yarnpkg/plugin-workspace-tools\` to your plugins.
+
         This command will run a given sub-command on all child workspaces that define it (any workspace that doesn't define it will be just skiped). Various flags can alter the exact behavior of the command:
 
         - If \`-p,--parallel\` is set, the commands will run in parallel; they'll by default be limited to a number of parallel tasks roughly equal to half your core number, but that can be overriden via \`-j,--jobs\`.
@@ -524,6 +526,8 @@ module.exports.factory = function (require) {
     category: `Workspace-related commands`,
     description: `run a command within the specified workspace`,
     details: `
+        > In order to use this command you need to add \`@yarnpkg/plugin-workspace-tools\` to your plugins.
+
         This command will run a given sub-command on a single workspace.
       `,
     examples: [[`Add a package to a single workspace`, `yarn workspace components add -D react`], [`Run build script on a single workspace`, `yarn workspace components run build`]]

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -20,7 +20,8 @@
   },
   "version": "2.0.0-rc.3",
   "nextVersion": {
-    "nonce": "2739312762897529"
+    "semver": "2.0.0-rc.4",
+    "nonce": "6333116070315637"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -78,6 +78,8 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     category: `Workspace-related commands`,
     description: `run a command on all workspaces`,
     details: `
+      > In order to use this command you need to add \`@yarnpkg/plugin-workspace-tools\` to your plugins.
+
       This command will run a given sub-command on all child workspaces that define it (any workspace that doesn't define it will be just skiped). Various flags can alter the exact behavior of the command:
 
       - If \`-p,--parallel\` is set, the commands will run in parallel; they'll by default be limited to a number of parallel tasks roughly equal to half your core number, but that can be overriden via \`-j,--jobs\`.

--- a/packages/plugin-workspace-tools/sources/commands/workspace.ts
+++ b/packages/plugin-workspace-tools/sources/commands/workspace.ts
@@ -18,6 +18,8 @@ export default class WorkspaceCommand extends Command<CommandContext> {
     category: `Workspace-related commands`,
     description: `run a command within the specified workspace`,
     details: `
+      > In order to use this command you need to add \`@yarnpkg/plugin-workspace-tools\` to your plugins.
+
       This command will run a given sub-command on a single workspace.
     `,
     examples: [[

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.7",
   "nextVersion": {
     "semver": "2.0.0-rc.8",
-    "nonce": "80104024546207"
+    "nonce": "1113692372681183"
   },
   "main": "./sources/index.ts",
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I thought it might make sense to let people know that they need to add `@yarnpkg/plugin-workspace-tools` to plugins.

**How did you fix it?**

Added the info to the commands.

I didn't find the workspace **list** command though.

Removed an unused import from gatsby index.js
