### PR TITLE
Fixes pipevp fd detection

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,7 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.7",
   "nextVersion": {
-    "nonce": "3635459321651403"
+    "nonce": "4184980481175873"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.7",
   "nextVersion": {
     "semver": "2.0.0-rc.8",
-    "nonce": "8465990876668267"
+    "nonce": "8166890150451011"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -92,7 +92,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
         quiet: false,
         stdin: process.stdin,
         stdout: process.stdout,
-        stderr: process.stdout,
+        stderr: process.stderr,
       });
     }
   }

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.7",
   "nextVersion": {
     "semver": "2.0.0-rc.8",
-    "nonce": "7275384005118273"
+    "nonce": "2992847204401525"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current code wasn't detecting properly when the stream sent to `stderr` was `stdout`.

**How did you fix it?**

- We don't alias `stderr` to `stdout` anymore (this isn't our role)
- We now check that the stream has a `fd` rather than just comparing it to a single stream instance