### PR TITLE
fix(version check): Don't consider reverted changes

### DIFF
--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -22,7 +22,8 @@
   },
   "version": "2.0.0-rc.4",
   "nextVersion": {
-    "nonce": "5990857019103789"
+    "semver": "2.0.0-rc.5",
+    "nonce": "6842855244094843"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -472,16 +472,13 @@ async function fetchRoot(initialCwd: PortablePath) {
 }
 
 async function fetchChangedFiles(root: PortablePath, {base}: {base: string}) {
-  const {stdout: branchStdout} = await execUtils.execvp(`git`, [`log`, `--format=`, `--name-only`, `${base}..HEAD`], {cwd: root, strict: true});
-  const branchFiles = branchStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
-
-  const {stdout: localStdout} = await execUtils.execvp(`git`, [`diff`, `HEAD`, `--name-only`], {cwd: root, strict: true});
-  const localFiles = localStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
+  const {stdout: localStdout} = await execUtils.execvp(`git`, [`diff`, `--name-only`, `${base}`], {cwd: root, strict: true});
+  const trackedFiles = localStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
 
   const {stdout: untrackedStdout} = await execUtils.execvp(`git`, [`ls-files`, `--others`, `--exclude-standard`], {cwd: root, strict: true});
   const untrackedFiles = untrackedStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
 
-  return [...new Set([...branchFiles, ...localFiles, ...untrackedFiles].sort())];
+  return [...new Set([...trackedFiles, ...untrackedFiles].sort())];
 }
 
 async function fetchPreviousNonce(workspace: Workspace, {root, base}: {root: PortablePath, base: string}) {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.8",
   "nextVersion": {
     "semver": "2.0.0-rc.9",
-    "nonce": "2511899503671521"
+    "nonce": "6922322618928129"
   },
   "main": "./sources/index.ts",
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Acts as a failing test case for `yarn version check` not considering reverted changes.
 
**How did you fix it?**

Didn't fix it yet. Just want to clarify semantics first. Workaround exists anyway since you can just change the nonce but is this really what we want?