### PR TITLE
Next.js Supports No-Config PnP

### DIFF
--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -33,8 +33,7 @@ jobs:
         yarn init
 
         # Required
-        yarn add next@^9.0.6-canary.1 react react-dom pnp-webpack-plugin
-        echo 'module.exports = {webpack: config => { config.resolve.plugins = [require("pnp-webpack-plugin")]; config.resolveLoader.plugins = [require("pnp-webpack-plugin")]; return config; }};' | tee next.config.js
+        yarn add next@^9.0.8 react react-dom
 
         # Test itself
         yarn add raw-loader


### PR DESCRIPTION
**What's the problem this PR addresses?**

Newer versions of Next.js support No-Config PnP support.

**How did you fix it?**

Removed the custom Next.js configuration step from the GitHub Workflow.