### PR TITLE
Fixes top-level self-references in PnPify

### DIFF
--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/pnpify",
   "version": "2.0.0-rc.5",
   "nextVersion": {
-    "nonce": "7014347471810219"
+    "semver": "2.0.0-rc.6",
+    "nonce": "5287204389069453"
   },
   "main": "./sources/boot-dev.js",
   "bin": "./sources/boot-cli-dev.js",

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -97,7 +97,7 @@ class PortableNodeModulesFs extends FakeFS<PortablePath> {
 
   private resolveLink(p: PortablePath, op: string, onSymlink: (stats: fs.Stats, targetPath: PortablePath) => any, onRealPath: (targetPath: PortablePath) => any) {
     const pnpPath = this.resolvePath(p);
-      console.log(pnpPath);
+    console.log(pnpPath);
     if (!pnpPath.resolvedPath) {
       throw PortableNodeModulesFs.createFsError('ENOENT', `no such file or directory, ${op} '${p}'`);
     } else {

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -97,18 +97,21 @@ class PortableNodeModulesFs extends FakeFS<PortablePath> {
 
   private resolveLink(p: PortablePath, op: string, onSymlink: (stats: fs.Stats, targetPath: PortablePath) => any, onRealPath: (targetPath: PortablePath) => any) {
     const pnpPath = this.resolvePath(p);
+      console.log(pnpPath);
     if (!pnpPath.resolvedPath) {
       throw PortableNodeModulesFs.createFsError('ENOENT', `no such file or directory, ${op} '${p}'`);
     } else {
       if (pnpPath.resolvedPath !== pnpPath.fullOriginalPath) {
+        let stat;
         try {
-          const stats = this.baseFs.lstatSync(pnpPath.statPath || pnpPath.resolvedPath);
-          if (stats.isDirectory()) {
+          stat = this.baseFs.lstatSync(pnpPath.statPath || pnpPath.resolvedPath);
+        } catch (e) {}
+
+        if (stat) {
+          if (!pnpPath.isSymlink && stat.isDirectory())
             throw PortableNodeModulesFs.createFsError('EINVAL', `invalid argument, ${op} '${p}'`);
-          } else {
-            return onSymlink(stats, this.pathUtils.relative(this.pathUtils.dirname(pnpPath.fullOriginalPath), pnpPath.statPath || pnpPath.resolvedPath));
-          }
-        } catch (e) {
+
+          return onSymlink(stat, this.pathUtils.relative(this.pathUtils.dirname(pnpPath.fullOriginalPath), pnpPath.statPath || pnpPath.resolvedPath));
         }
       }
     }

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -97,7 +97,6 @@ class PortableNodeModulesFs extends FakeFS<PortablePath> {
 
   private resolveLink(p: PortablePath, op: string, onSymlink: (stats: fs.Stats, targetPath: PortablePath) => any, onRealPath: (targetPath: PortablePath) => any) {
     const pnpPath = this.resolvePath(p);
-    console.log(pnpPath);
     if (!pnpPath.resolvedPath) {
       throw PortableNodeModulesFs.createFsError('ENOENT', `no such file or directory, ${op} '${p}'`);
     } else {

--- a/packages/yarnpkg-pnpify/sources/NodePathResolver.ts
+++ b/packages/yarnpkg-pnpify/sources/NodePathResolver.ts
@@ -187,7 +187,11 @@ export class NodePathResolver {
           result.resolvedPath = ppath.join(issuer, request);
 
           if (isSymlink) {
-            result.isSymlink = isSymlink;
+            // We only enforce a symlink if the target is exactly the folder of
+            // the issuer. If it's a file inside it, we just use the actual entry.
+            if (!request) {
+              result.isSymlink = isSymlink;
+            }
           }
         }
       } else {

--- a/packages/yarnpkg-pnpify/sources/NodePathResolver.ts
+++ b/packages/yarnpkg-pnpify/sources/NodePathResolver.ts
@@ -45,7 +45,12 @@ export interface ResolvedPath {
   /**
    * Directory entries list, returned for pathes ending with `/node_modules[/@scope]`
    */
-  dirList?: Set<Filename>
+  dirList?: Set<Filename>;
+
+  /**
+   * If true, the entry is meant to be a symbolic link to the location pointed by resolvedPath.
+   */
+  isSymlink?: boolean;
 }
 
 /**
@@ -124,6 +129,9 @@ export class NodePathResolver {
     // Extract first issuer from the path using PnP API
     let issuer = this.getIssuer(this.pnp, nodePath);
 
+    // Keep track of whether the last component is meant to be a symlink or not
+    let isSymlink = false;
+
     // If we have something left in a path to parse, do that
     if (issuer && nodePath.length > issuer.length) {
       let request: PortablePath = nodePath.slice(issuer.length) as PortablePath;
@@ -144,7 +152,8 @@ export class NodePathResolver {
             if (pkgName.length > 0 && (pkgName[0] !== '@' || pkgName.indexOf(ppath.sep) > 0)) {
               try {
                 let res = this.pnp.resolveToUnqualified(pkgName, ppath.join(issuer, ppath.sep));
-                issuer = res === null || res === issuer ? undefined : res;
+                isSymlink = res === issuer;
+                issuer = res === null ? undefined : res;
               } catch (e) {
                 issuer = undefined;
                 break;
@@ -176,6 +185,10 @@ export class NodePathResolver {
           }
         } else {
           result.resolvedPath = ppath.join(issuer, request);
+
+          if (isSymlink) {
+            result.isSymlink = isSymlink;
+          }
         }
       } else {
         // If we don't have issuer here, it means the path cannot exist in PnP project

--- a/packages/yarnpkg-pnpify/tests/NodePathResolver.test.ts
+++ b/packages/yarnpkg-pnpify/tests/NodePathResolver.test.ts
@@ -25,7 +25,9 @@ const makePnpApiMock = (pkgMap: PkgMap): PnpApi => {
     }),
     getPackageInformation: jest.fn().mockImplementation((info: { package: string }) => pkgMap[info.package]),
     resolveToUnqualified: jest.fn().mockImplementation((request: string, issuer: string) => {
-      if (issuer === `${pkgMap.monorepo.packageLocation}/` && request === 'foo') {
+      if (issuer === `${pkgMap.monorepo.packageLocation}/` && request === 'monorepo') {
+        return pkgMap.monorepo.packageLocation;
+      } else if (issuer === `${pkgMap.monorepo.packageLocation}/` && request === 'foo') {
         return pkgMap.foo.packageLocation;
       } else if (issuer === `${pkgMap.foo.packageLocation}/` && request === 'bar') {
         return pkgMap.bar.packageLocation;
@@ -39,13 +41,16 @@ const makePnpApiMock = (pkgMap: PkgMap): PnpApi => {
 const posixPkgMap: PkgMap = {
   monorepo: {
     packageLocation: '/home/user/proj',
-    packageDependencies: new Map([['foo', '1.0.0'], ['bar', '1.0.0'], ['@scope/baz', '2.0.0']]),
+    packageDependencies: new Map([['monorepo', '1.0.0'], ['foo', '1.0.0'], ['bar', '1.0.0'], ['@scope/baz', '2.0.0']]),
   },
   foo: {
     packageLocation: '/home/user/proj/.cache/foo/node_modules/foo',
     packageDependencies: new Map([['bar', '1.0.0']]),
   },
-  bar: {packageLocation: '/home/user/proj/.cache/bar/node_modules/bar', packageDependencies: new Map()},
+  bar: {
+    packageLocation: '/home/user/proj/.cache/bar/node_modules/bar',
+    packageDependencies: new Map(),
+  },
 };
 
 describe('NodePathResolver', () => {
@@ -81,7 +86,13 @@ describe('NodePathResolver', () => {
   it('should resolve /home/user/proj/node_modules path', () => {
     const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules');
     const pnpPath = resolver.resolvePath(nodePath);
-    expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/node_modules', statPath: '/home/user/proj', dirList: new Set(['foo', 'bar', '@scope'])});
+    expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/node_modules', statPath: '/home/user/proj', dirList: new Set(['monorepo', 'foo', 'bar', '@scope'])});
+  });
+
+  it('should resolve /home/user/proj/node_modules/monorepo path', () => {
+    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/monorepo');
+    const pnpPath = resolver.resolvePath(nodePath);
+    expect(pnpPath).toEqual({resolvedPath: '/home/user/proj', isSymlink: true});
   });
 
   it('should partially resolve /home/user/proj/node_modules/@scope path', () => {

--- a/packages/yarnpkg-pnpify/tests/NodePathResolver.test.ts
+++ b/packages/yarnpkg-pnpify/tests/NodePathResolver.test.ts
@@ -89,10 +89,16 @@ describe('NodePathResolver', () => {
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/node_modules', statPath: '/home/user/proj', dirList: new Set(['monorepo', 'foo', 'bar', '@scope'])});
   });
 
-  it('should resolve /home/user/proj/node_modules/monorepo path', () => {
+  it('should resolve /home/user/proj/node_modules/monorepo path as a symlink to itself', () => {
     const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/monorepo');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj', isSymlink: true});
+  });
+
+  it('should resolve /home/user/proj/node_modules/monorepo/index.js without it being reported a symlink', () => {
+    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/monorepo/index.js');
+    const pnpPath = resolver.resolvePath(nodePath);
+    expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/index.js'});
   });
 
   it('should partially resolve /home/user/proj/node_modules/@scope path', () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

There's an error which occurs when the top-level package refers to itself via its own name. In this case, PnPify was incorrectly reporting the `node_modules/<top level name>` as being a real folder.

**How did you fix it?**

My diff adds a basic capability to PnPify to return explicit folder symlinks. When this specific pattern is found (a package depending on itself), we now return a "proper" symlink.

Note that this doesn't solve the more general case of the `link:` and `portal:` protocols (I think? since they would trigger the same codepath), but those might be solvable through the work in progress at #500 and #470.
