### PR TITLE
Improves set version from sources

### DIFF
--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -16,7 +16,8 @@
   },
   "version": "2.0.0-rc.5",
   "nextVersion": {
-    "nonce": "1969982303053681"
+    "semver": "2.0.0-rc.6",
+    "nonce": "7000434455888823"
   },
   "repository": {
     "type": "git",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.7",
   "nextVersion": {
     "semver": "2.0.0-rc.8",
-    "nonce": "4683479104182979"
+    "nonce": "7581474282291295"
   },
   "main": "./sources/index.ts",
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's currently difficult to try out a PR outside of Yarn itself.

**How did you fix it?**

This diff adds a new `--pr` option to `yarn set version from sources`, which will try (best effort) to merge a pull request before building the CLI.

Some notes:

- It cannot be used at the moment to test changes on the non-CLI packages (such as PnPify)
- It's a best effort basis, so in case merge conflicts happen you're on your own for now
- Various misc changes are dropped before the merge (such as package.json or the various checked-in binaries), as they could generate potentially large conflicts with little value.
