### PR TITLE
Fixes typo in ignore-engines

### DIFF
--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -15,6 +15,10 @@
     "yup": "^0.27.0"
   },
   "version": "2.0.0-rc.6",
+  "nextVersion": {
+    "semver": "2.0.0-rc.7",
+    "nonce": "2865478131811389"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -24,8 +24,8 @@ export default class YarnCommand extends BaseCommand {
   @Command.Boolean(`--prefer-offline`, {hidden: true})
   preferOffline?: boolean;
 
-  @Command.Boolean(`--ignore-engine`, {hidden: true})
-  ignoreEngine?: boolean;
+  @Command.Boolean(`--ignore-engines`, {hidden: true})
+  ignoreEngines?: boolean;
 
   @Command.Boolean(`--inline-builds`)
   inlineBuilds?: boolean;
@@ -96,14 +96,14 @@ export default class YarnCommand extends BaseCommand {
       }
     };
 
-    // The ignoreEngine flag isn't implemented at the moment. I'm still
+    // The ignoreEngines flag isn't implemented at the moment. I'm still
     // considering how it should work in the context of plugins - would it
     // make sense to allow them (or direct dependencies) to define new
     // "engine check"? Since it has implications regarding the architecture,
     // I prefer to postpone the decision to later. Also it wouldn't be a flag,
     // it would definitely be a configuration setting.
-    if (typeof this.ignoreEngine !== `undefined`) {
-      const exitCode = await reportDeprecation(`The --ignore-engine option is deprecated; engine checking isn't a core feature anymore`, {
+    if (typeof this.ignoreEngines !== `undefined`) {
+      const exitCode = await reportDeprecation(`The --ignore-engines option is deprecated; engine checking isn't a core feature anymore`, {
         error: !isZeitNow,
       });
 

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.8",
   "nextVersion": {
     "semver": "2.0.0-rc.9",
-    "nonce": "6922322618928129"
+    "nonce": "6019198471289553"
   },
   "main": "./sources/index.ts",
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I made a typo in #490 by adding support for `ignore-engine` instead of `ignore-engines` (as was the case in the v1). It causes Next deployments to crash.

**How did you fix it?**

Fixed the typo. Since nothing should use that anyway, it's acceptable.
