### PR TITLE
Prevents gitignore files from being read when files is used

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -119,6 +119,24 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should ignore root .gitignore files when using the 'files' field`,
+      makeTemporaryEnv({
+        files: [
+          `lib`,
+        ],
+      }, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/.gitignore`, `lib`);
+
+        await run(`install`);
+
+        await fsUtils.writeFile(`${path}/lib/foo.js`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        await expect(stdout).toMatch(/lib\/foo\.js/);
+      }),
+    );
+
+    test(
       `it shouldn't add the cache to the package files`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`install`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `files` field overrides any `gitignore` or `npmignore` at the root, but it wasn't the case until now.

