### PR TITLE
Fslib API

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/exec.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/exec.ts
@@ -1,5 +1,5 @@
-import {NodeFS} from '@yarnpkg/fslib';
-import cp       from 'child_process';
+import {npath} from '@yarnpkg/fslib';
+import cp      from 'child_process';
 
 interface Options {
   cwd: string;
@@ -23,7 +23,7 @@ export const execFile = (
   return new Promise((resolve, reject) => {
     cp.execFile(path, args, {
       ...options,
-      cwd: options.cwd ? NodeFS.fromPortablePath(options.cwd) : undefined,
+      cwd: options.cwd ? npath.fromPortablePath(options.cwd) : undefined,
     }, (error, stdout, stderr) => {
       stdout = stdout.replace(/\r\n?/g, `\n`);
       stderr = stderr.replace(/\r\n?/g, `\n`);

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/exec.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/exec.ts
@@ -1,8 +1,8 @@
-import {npath} from '@yarnpkg/fslib';
-import cp      from 'child_process';
+import {PortablePath, npath} from '@yarnpkg/fslib';
+import cp                    from 'child_process';
 
 interface Options {
-  cwd: string;
+  cwd: PortablePath;
   env?: Record<string, string>;
 }
 

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/fs.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/fs.ts
@@ -1,11 +1,11 @@
-import {xfs, NodeFS, PortablePath, ppath, Filename} from '@yarnpkg/fslib';
-import klaw                                         from 'klaw';
-import tarFs                                        from 'tar-fs';
-import tmp                                          from 'tmp';
-import zlib                                         from 'zlib';
-import {Gzip}                                       from 'zlib';
+import {Filename, PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
+import klaw                                        from 'klaw';
+import tarFs                                       from 'tar-fs';
+import tmp                                         from 'tmp';
+import zlib                                        from 'zlib';
+import {Gzip}                                      from 'zlib';
 
-import * as miscUtils                               from './misc';
+import * as miscUtils                              from './misc';
 
 const IS_WIN32 = process.platform === `win32`;
 
@@ -16,12 +16,12 @@ export const walk = (
   return new Promise((resolve) => {
     const paths: PortablePath[] = [];
 
-    const walker = klaw(NodeFS.fromPortablePath(source), {
+    const walker = klaw(npath.fromPortablePath(source), {
       filter: (sourcePath: string) => {
         if (!filter)
           return true;
 
-        const itemPath = NodeFS.toPortablePath(sourcePath);
+        const itemPath = npath.toPortablePath(sourcePath);
         const stat = xfs.statSync(itemPath);
 
         if (stat.isDirectory())
@@ -37,7 +37,7 @@ export const walk = (
     });
 
     walker.on('data', ({path: sourcePath}) => {
-      const itemPath = NodeFS.toPortablePath(sourcePath);
+      const itemPath = npath.toPortablePath(sourcePath);
       const relativePath = ppath.relative(source, itemPath);
 
       if (!filter || miscUtils.filePatternMatch(relativePath, filter))
@@ -67,9 +67,9 @@ export const packToStream = (
 
   const zipperStream = zlib.createGzip();
 
-  const packStream = tarFs.pack(NodeFS.fromPortablePath(source), {
+  const packStream = tarFs.pack(npath.fromPortablePath(source), {
     map: (header: any) => {
-      header.name = NodeFS.toPortablePath(header.name);
+      header.name = npath.toPortablePath(header.name);
 
       if (true) {
         header.name = ppath.resolve(PortablePath.root, header.name);
@@ -118,7 +118,7 @@ export const packToFile = (target: PortablePath, source: PortablePath, options: 
 export const unpackToDirectory = (target: PortablePath, source: PortablePath): Promise<void> => {
   const tarballStream = xfs.createReadStream(source);
   const gunzipStream =  zlib.createUnzip();
-  const extractStream = tarFs.extract(NodeFS.fromPortablePath(target));
+  const extractStream = tarFs.extract(npath.fromPortablePath(target));
 
   tarballStream.pipe(gunzipStream).pipe(extractStream);
 
@@ -147,7 +147,7 @@ export const createTemporaryFolder = (name?: Filename): Promise<PortablePath> =>
       if (error) {
         reject(error);
       } else {
-        let realPath = await xfs.realpathPromise(NodeFS.toPortablePath(dirPath));
+        let realPath = await xfs.realpathPromise(npath.toPortablePath(dirPath));
 
         if (name) {
           realPath = ppath.join(realPath, name as PortablePath);
@@ -173,7 +173,7 @@ export const createTemporaryFile = async (filePath: PortablePath): Promise<Porta
         if (error) {
           reject(error);
         } else {
-          resolve(NodeFS.toPortablePath(filePath));
+          resolve(npath.toPortablePath(filePath));
         }
       });
     });

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -1,4 +1,4 @@
-import {NodeFS}    from '@yarnpkg/fslib';
+import {npath}     from '@yarnpkg/fslib';
 import {delimiter} from 'path';
 
 import {URL}       from 'url';
@@ -24,8 +24,8 @@ const mte = generatePkgDriver({
     for (const key of Object.keys(config))
       rcEnv[`YARN_${key.replace(/([A-Z])/g, `_$1`).toUpperCase()}`] = config[key];
 
-    const nativePath = NodeFS.fromPortablePath(path);
-    const tempHomeFolder = NodeFS.fromPortablePath(await createTemporaryFolder());
+    const nativePath = npath.fromPortablePath(path);
+    const tempHomeFolder = npath.fromPortablePath(await createTemporaryFolder());
 
     const cwdArgs = typeof projectFolder !== `undefined`
       ? [projectFolder]

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -1,4 +1,4 @@
-import {NodeFS, toFilename}              from '@yarnpkg/fslib';
+import {npath, toFilename}               from '@yarnpkg/fslib';
 import crypto                            from 'crypto';
 import {IncomingMessage, ServerResponse} from 'http';
 import http                              from 'http';
@@ -50,7 +50,7 @@ export const getPackageRegistry = (): Promise<PackageRegistry> => {
 
   return (packageRegistryPromise = (async () => {
     const packageRegistry = new Map();
-    for (const packageFile of await fsUtils.walk(NodeFS.toPortablePath(`${require(`pkg-tests-fixtures`)}/packages`), {
+    for (const packageFile of await fsUtils.walk(npath.toPortablePath(`${require(`pkg-tests-fixtures`)}/packages`), {
       filter: ['package.json'],
     })) {
       const packageJson = await fsUtils.readJson(packageFile);
@@ -88,8 +88,8 @@ export const getPackageArchiveStream = async (name: string, version: string): Pr
   if (!packageVersionEntry)
     throw new Error(`Unknown version "${version}" for package "${name}"`);
 
-  return fsUtils.packToStream(NodeFS.toPortablePath(packageVersionEntry.path), {
-    virtualPath: NodeFS.toPortablePath('/package'),
+  return fsUtils.packToStream(npath.toPortablePath(packageVersionEntry.path), {
+    virtualPath: npath.toPortablePath('/package'),
   });
 };
 
@@ -104,8 +104,8 @@ export const getPackageArchivePath = async (name: string, version: string): Prom
 
   const archivePath = await fsUtils.createTemporaryFile(toFilename(`${name}-${version}.tar.gz`));
 
-  await fsUtils.packToFile(archivePath, NodeFS.toPortablePath(packageVersionEntry.path), {
-    virtualPath: NodeFS.toPortablePath('/package'),
+  await fsUtils.packToFile(archivePath, npath.toPortablePath(packageVersionEntry.path), {
+    virtualPath: npath.toPortablePath('/package'),
   });
 
   return archivePath;
@@ -266,7 +266,7 @@ export const startPackageServer = (): Promise<string> => {
         ['Transfer-Encoding']: 'chunked',
       });
 
-      const packStream = fsUtils.packToStream(NodeFS.toPortablePath(packageVersionEntry.path), {virtualPath: NodeFS.toPortablePath('/package')});
+      const packStream = fsUtils.packToStream(npath.toPortablePath(packageVersionEntry.path), {virtualPath: npath.toPortablePath('/package')});
       packStream.pipe(response);
     },
 
@@ -504,7 +504,7 @@ export const generatePkgDriver = ({
         const registryUrl = await startPackageServer();
 
         // Writes a new package.json file into our temporary directory
-        await fsUtils.writeJson(NodeFS.toPortablePath(`${path}/package.json`), await deepResolve(packageJson));
+        await fsUtils.writeJson(npath.toPortablePath(`${path}/package.json`), await deepResolve(packageJson));
 
         const run = (...args: any[]) => {
           let callDefinition = {};

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -1,4 +1,4 @@
-import {npath, toFilename}               from '@yarnpkg/fslib';
+import {PortablePath, npath, toFilename} from '@yarnpkg/fslib';
 import crypto                            from 'crypto';
 import {IncomingMessage, ServerResponse} from 'http';
 import http                              from 'http';
@@ -16,14 +16,14 @@ export type PackageEntry = Map<string, {path: string, packageJson: Object}>;
 export type PackageRegistry = Map<string, PackageEntry>;
 
 interface RunDriverOptions extends Record<string, any> {
-  cwd?: string;
-  projectFolder?: string;
+  cwd?: PortablePath;
+  projectFolder?: PortablePath;
   registryUrl: string;
   env?: Record<string, string>;
 }
 
 export type PackageRunDriver = (
-  command: string,
+  path: PortablePath,
   args: Array<string>,
   opts: RunDriverOptions,
 ) => Promise<ExecResult>;

--- a/packages/acceptance-tests/pkg-tests-fixtures/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/index.js
@@ -1,3 +1,3 @@
-const {NodeFS} = require('@yarnpkg/fslib');
+const {npath} = require('@yarnpkg/fslib');
 
-module.exports = NodeFS.toPortablePath(__dirname);
+module.exports = npath.toPortablePath(__dirname);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/link.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/link.test.js
@@ -1,4 +1,4 @@
-import {NodeFS} from '@yarnpkg/fslib';
+import {npath} from '@yarnpkg/fslib';
 
 const {
   fs: {createTemporaryFolder, readJson, writeJson},
@@ -19,7 +19,7 @@ describe(`Commands`, () => {
 
         await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
           resolutions: {
-            [`my-package`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-package`)}`,
+            [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
           },
         });
       }),
@@ -49,7 +49,7 @@ describe(`Commands`, () => {
 
           await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
             resolutions: {
-              [`my-package`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-package`)}`,
+              [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
             },
           });
         },
@@ -78,8 +78,8 @@ describe(`Commands`, () => {
 
         await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
           resolutions: {
-            [`workspace-a`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
-            [`workspace-b`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
+            [`workspace-a`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+            [`workspace-b`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
           },
         });
       }),
@@ -108,7 +108,7 @@ describe(`Commands`, () => {
 
         await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
           resolutions: {
-            [`workspace-a`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+            [`workspace-a`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
           },
         });
 
@@ -143,8 +143,8 @@ describe(`Commands`, () => {
 
         await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
           resolutions: {
-            [`workspace-a`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
-            [`workspace-b`]: `portal:${NodeFS.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
+            [`workspace-a`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+            [`workspace-b`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
           },
         });
       }),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/stage.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/stage.test.js
@@ -1,4 +1,4 @@
-const {NodeFS, xfs} = require(`@yarnpkg/fslib`);
+const {npath, xfs} = require(`@yarnpkg/fslib`);
 const {
   exec: {execFile},
   fs: {writeFile, writeJson, mkdirp},
@@ -14,8 +14,8 @@ describe(`Commands`, () => {
 
         await expect(run(`stage`, `-n`, {cwd: path})).resolves.toMatchObject({
           stdout: [
-            `${NodeFS.fromPortablePath(`${path}/.yarnrc.yml`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/package.json`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarnrc.yml`)}\n`,
+            `${npath.fromPortablePath(`${path}/package.json`)}\n`,
           ].join(``),
         });
       }),
@@ -31,8 +31,8 @@ describe(`Commands`, () => {
 
         await expect(run(`stage`, `-n`, {cwd: path})).resolves.toMatchObject({
           stdout: [
-            `${NodeFS.fromPortablePath(`${path}/.yarnrc.yml`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/package.json`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarnrc.yml`)}\n`,
+            `${npath.fromPortablePath(`${path}/package.json`)}\n`,
           ].join(``),
         });
       }),
@@ -52,13 +52,13 @@ describe(`Commands`, () => {
 
         await expect(run(`stage`, `-n`, {cwd: path})).resolves.toMatchObject({
           stdout: [
-            `${NodeFS.fromPortablePath(`${path}/.pnp.js`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/.yarn/global/cache/no-deps-npm-1.0.0-cf533b267a-1.zip`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/.yarn/cache/.gitignore`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/.yarn/cache/no-deps-npm-1.0.0-cf533b267a-1.zip`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/.yarnrc.yml`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/package.json`)}\n`,
-            `${NodeFS.fromPortablePath(`${path}/yarn.lock`)}\n`,
+            `${npath.fromPortablePath(`${path}/.pnp.js`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarn/global/cache/no-deps-npm-1.0.0-cf533b267a-1.zip`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarn/cache/.gitignore`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarn/cache/no-deps-npm-1.0.0-cf533b267a-1.zip`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarnrc.yml`)}\n`,
+            `${npath.fromPortablePath(`${path}/package.json`)}\n`,
+            `${npath.fromPortablePath(`${path}/yarn.lock`)}\n`,
           ].join(``),
         });
       }),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1,4 +1,4 @@
-const {NodeFS, ppath, xfs} = require(`@yarnpkg/fslib`);
+const {npath, ppath, xfs} = require(`@yarnpkg/fslib`);
 const cp = require(`child_process`);
 const {satisfies} = require(`semver`);
 
@@ -452,8 +452,8 @@ describe(`Plug'n'Play`, () => {
         await expect(
           source(
             `require(require.resolve('no-deps', {paths: ${JSON.stringify([
-              `${NodeFS.fromPortablePath(path)}/workspace-a`,
-              `${NodeFS.fromPortablePath(path)}/workspace-b`,
+              `${npath.fromPortablePath(path)}/workspace-a`,
+              `${npath.fromPortablePath(path)}/workspace-b`,
             ])}}))`,
           ),
         ).resolves.toMatchObject({
@@ -547,7 +547,7 @@ describe(`Plug'n'Play`, () => {
         await writeFile(`${tmp}/index.js`, `require(process.argv[2])`);
         await writeFile(`${path}/index.js`, `require('no-deps')`);
 
-        await run(`node`, `${NodeFS.fromPortablePath(tmp)}/index.js`, `${path}/index.js`);
+        await run(`node`, `${npath.fromPortablePath(tmp)}/index.js`, `${path}/index.js`);
       },
     ),
   );
@@ -1092,7 +1092,7 @@ describe(`Plug'n'Play`, () => {
         await expect(
           source(
             `JSON.parse(require('child_process').execFileSync(process.execPath, [${JSON.stringify(
-              `${NodeFS.fromPortablePath(path)}/script.js`,
+              `${npath.fromPortablePath(path)}/script.js`,
             )}]).toString())`,
           ),
         ).resolves.toMatchObject({
@@ -1117,7 +1117,7 @@ describe(`Plug'n'Play`, () => {
         await writeFile(
           `${path}/main.js`,
           `console.log(require('child_process').execFileSync(process.execPath, [${JSON.stringify(
-            `${NodeFS.fromPortablePath(path)}/sub.js`,
+            `${npath.fromPortablePath(path)}/sub.js`,
           )}]).toString())`,
         );
 
@@ -1137,7 +1137,7 @@ describe(`Plug'n'Play`, () => {
       await writeFile(`${path}/foo.js`, `console.log(42);`);
 
       await expect(
-        run(`node`, `-e`, `console.log(21);`, {env: {NODE_OPTIONS: `--require ${NodeFS.fromPortablePath(path)}/foo`}}),
+        run(`node`, `-e`, `console.log(21);`, {env: {NODE_OPTIONS: `--require ${npath.fromPortablePath(path)}/foo`}}),
       ).resolves.toMatchObject({
         // Note that '42' is present twice: the first one because Node executes Yarn, and the second one because Yarn spawns Node
         stdout: `42\n42\n21\n`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
@@ -1,4 +1,4 @@
-const {NodeFS, xfs} = require(`@yarnpkg/fslib`);
+const {npath, xfs} = require(`@yarnpkg/fslib`);
 const {
   fs: {writeFile, writeJson},
 } = require('pkg-tests-core');
@@ -80,9 +80,9 @@ describe(`Plug'n'Play API`, () => {
           await run(`install`);
 
           await expect(
-            source(`require('pnpapi').resolveRequest('pnpapi', ${JSON.stringify(`${NodeFS.fromPortablePath(path)}/`)})`),
+            source(`require('pnpapi').resolveRequest('pnpapi', ${JSON.stringify(`${npath.fromPortablePath(path)}/`)})`),
           ).resolves.toEqual(
-            NodeFS.fromPortablePath(`${path}/.pnp.js`),
+            npath.fromPortablePath(`${path}/.pnp.js`),
           );
         }),
       );
@@ -93,7 +93,7 @@ describe(`Plug'n'Play API`, () => {
           await run(`install`);
 
           await expect(
-            source(`require('pnpapi').resolveRequest('fs', ${JSON.stringify(`${NodeFS.fromPortablePath(path)}/`)})`)
+            source(`require('pnpapi').resolveRequest('fs', ${JSON.stringify(`${npath.fromPortablePath(path)}/`)})`)
           ).resolves.toEqual(
             null,
           );
@@ -119,9 +119,9 @@ describe(`Plug'n'Play API`, () => {
             await run(`install`);
 
             await expect(
-              source(`require('pnpapi').resolveRequest('fs', ${JSON.stringify(`${NodeFS.fromPortablePath(path)}/`)}, {considerBuiltins: false})`),
+              source(`require('pnpapi').resolveRequest('fs', ${JSON.stringify(`${npath.fromPortablePath(path)}/`)}, {considerBuiltins: false})`),
             ).resolves.toEqual(
-              NodeFS.fromPortablePath(`${path}/fs/index.js`),
+              npath.fromPortablePath(`${path}/fs/index.js`),
             );
           },
         ),
@@ -137,9 +137,9 @@ describe(`Plug'n'Play API`, () => {
           await run(`install`);
 
           await expect(
-            source(`require('pnpapi').resolveRequest('./foo', ${JSON.stringify(`${NodeFS.fromPortablePath(path)}/`)}, {extensions: ['.bar']})`),
+            source(`require('pnpapi').resolveRequest('./foo', ${JSON.stringify(`${npath.fromPortablePath(path)}/`)}, {extensions: ['.bar']})`),
           ).resolves.toEqual(
-            NodeFS.fromPortablePath(`${path}/foo.bar`),
+            npath.fromPortablePath(`${path}/foo.bar`),
           );
         }),
       );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/require.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/require.test.js
@@ -1,4 +1,4 @@
-const {NodeFS} = require(`@yarnpkg/fslib`);
+const {npath} = require(`@yarnpkg/fslib`);
 const {satisfies} = require(`semver`);
 
 const {
@@ -137,7 +137,7 @@ describe(`Require tests`, () => {
 
       await writeFile(`${tmp}/file.js`, `module.exports = 42;`);
 
-      await expect(source(`require(${JSON.stringify(NodeFS.fromPortablePath(tmp))} + "/file")`)).resolves.toEqual(42);
+      await expect(source(`require(${JSON.stringify(npath.fromPortablePath(tmp))} + "/file")`)).resolves.toEqual(42);
     }),
   );
 
@@ -216,8 +216,8 @@ describe(`Require tests`, () => {
         await expect(
           source(
             `require(require.resolve('no-deps', {paths: ${JSON.stringify([
-              `${NodeFS.fromPortablePath(path)}/workspace-a`,
-              `${NodeFS.fromPortablePath(path)}/workspace-b`,
+              `${npath.fromPortablePath(path)}/workspace-a`,
+              `${npath.fromPortablePath(path)}/workspace-b`,
             ])}}))`,
           ),
         ).resolves.toMatchObject({

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -1,4 +1,4 @@
-const {NodeFS, xfs} = require(`@yarnpkg/fslib`);
+const {npath, xfs} = require(`@yarnpkg/fslib`);
 const {isAbsolute, resolve} = require('path');
 
 const {
@@ -252,7 +252,7 @@ describe(`Scripts tests`, () => {
         expect(itemPath).toBeDefined();
 
         const content = await readFile(itemPath, 'utf8');
-        await expect(content).toEqual(NodeFS.fromPortablePath(itemPath));
+        await expect(content).toEqual(npath.fromPortablePath(itemPath));
       },
     ),
   );

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -13,7 +13,8 @@
   },
   "version": "2.0.0-rc.1",
   "nextVersion": {
-    "nonce": "5028875255691919"
+    "semver": "2.0.0-rc.2",
+    "nonce": "2136862638378481"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -1,9 +1,9 @@
-import {BaseCommand, WorkspaceRequiredError}                    from '@yarnpkg/cli';
-import {Configuration, Project}                                 from '@yarnpkg/core';
-import {scriptUtils, structUtils}                               from '@yarnpkg/core';
-import {NodeFS, xfs, PortablePath, ppath, Filename, toFilename} from '@yarnpkg/fslib';
-import {Command}                                                from 'clipanion';
-import tmp                                                      from 'tmp';
+import {BaseCommand, WorkspaceRequiredError}                   from '@yarnpkg/cli';
+import {Configuration, Project}                                from '@yarnpkg/core';
+import {scriptUtils, structUtils}                              from '@yarnpkg/core';
+import {Filename, PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
+import {Command}                                               from 'clipanion';
+import tmp                                                     from 'tmp';
 
 // eslint-disable-next-line arca/no-default-export
 export default class DlxCommand extends BaseCommand {
@@ -82,7 +82,7 @@ function createTemporaryDirectory(name?: Filename) {
       if (error) {
         reject(error);
       } else {
-        resolve(NodeFS.toPortablePath(dirPath));
+        resolve(npath.toPortablePath(dirPath));
       }
     });
   }).then(async dirPath => {

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -15,6 +15,10 @@
     "yup": "^0.27.0"
   },
   "version": "2.0.0-rc.7",
+  "nextVersion": {
+    "semver": "2.0.0-rc.8",
+    "nonce": "2928827852983397"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-essentials/sources/commands/cache/clean.ts
+++ b/packages/plugin-essentials/sources/commands/cache/clean.ts
@@ -1,6 +1,6 @@
 import {BaseCommand}                        from '@yarnpkg/cli';
 import {Configuration, Cache, StreamReport} from '@yarnpkg/core';
-import {PortablePath, xfs}                  from '@yarnpkg/fslib';
+import {xfs}                                from '@yarnpkg/fslib';
 import {Command}                            from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-essentials/sources/commands/entries/run.ts
+++ b/packages/plugin-essentials/sources/commands/entries/run.ts
@@ -1,5 +1,5 @@
 import {CommandContext, structUtils} from '@yarnpkg/core';
-import {NodeFS, ppath}               from '@yarnpkg/fslib';
+import {npath, ppath}                from '@yarnpkg/fslib';
 import {Command}                     from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
@@ -12,7 +12,7 @@ export default class EntryCommand extends Command<CommandContext> {
 
   async execute() {
     if (this.leadingArgument.match(/[\\\/]/) && !structUtils.tryParseIdent(this.leadingArgument)) {
-      const newCwd = ppath.resolve(this.context.cwd, NodeFS.toPortablePath(this.leadingArgument));
+      const newCwd = ppath.resolve(this.context.cwd, npath.toPortablePath(this.leadingArgument));
       return await this.cli.run(this.args, {cwd: newCwd});
     } else {
       return await this.cli.run([`run`, this.leadingArgument, ...this.args]);

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -1,6 +1,6 @@
 import {BaseCommand, WorkspaceRequiredError}                      from '@yarnpkg/cli';
 import {Cache, Configuration, Project, StreamReport, structUtils} from '@yarnpkg/core';
-import {NodeFS, ppath}                                            from '@yarnpkg/fslib';
+import {npath, ppath}                                             from '@yarnpkg/fslib';
 import {Command, UsageError}                                      from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
@@ -44,7 +44,7 @@ export default class LinkCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(this.context.cwd);
 
-    const absoluteDestination = ppath.resolve(this.context.cwd, NodeFS.toPortablePath(this.destination));
+    const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
 
     const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins);
     const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                                                    from '@yarnpkg/cli';
 import {Configuration, MessageName, Project, ReportError, StreamReport} from '@yarnpkg/core';
 import {httpUtils, structUtils}                                         from '@yarnpkg/core';
-import {xfs, NodeFS, PortablePath, ppath}                               from '@yarnpkg/fslib';
+import {PortablePath, npath, ppath, xfs}                                from '@yarnpkg/fslib';
 import {Command}                                                        from 'clipanion';
 import {runInNewContext}                                                from 'vm';
 
@@ -46,7 +46,7 @@ export default class PluginDlCommand extends BaseCommand {
       const {project} = await Project.find(configuration, this.context.cwd);
 
       const name = this.name!;
-      const candidatePath = ppath.resolve(this.context.cwd, NodeFS.toPortablePath(name));
+      const candidatePath = ppath.resolve(this.context.cwd, npath.toPortablePath(name));
 
       let pluginBuffer;
 

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -1,11 +1,11 @@
-import {BaseCommand}                                                          from '@yarnpkg/cli';
-import {WorkspaceRequiredError}                                               from '@yarnpkg/cli';
-import {Configuration, MessageName, Project, StreamReport, execUtils}         from '@yarnpkg/core';
-import {Filename, PortablePath, ppath, toPortablePath, xfs, fromPortablePath} from '@yarnpkg/fslib';
-import {Command}                                                              from 'clipanion';
-import {tmpdir}                                                               from 'os';
+import {BaseCommand}                                                  from '@yarnpkg/cli';
+import {WorkspaceRequiredError}                                       from '@yarnpkg/cli';
+import {Configuration, MessageName, Project, StreamReport, execUtils} from '@yarnpkg/core';
+import {Filename, PortablePath, npath, ppath, xfs}                    from '@yarnpkg/fslib';
+import {Command}                                                      from 'clipanion';
+import {tmpdir}                                                       from 'os';
 
-import {setVersion}                                                           from '../version';
+import {setVersion}                                                   from '../version';
 
 const PR_REGEXP = /^[0-9]+$/;
 
@@ -18,7 +18,7 @@ function getBranchRef(branch: string) {
 }
 
 const CLONE_WORKFLOW = ({repository, branch}: {repository: string, branch: string}, target: PortablePath) => [
-  [`git`, `init`, fromPortablePath(target)],
+  [`git`, `init`, npath.fromPortablePath(target)],
   [`git`, `remote`, `add`, `origin`, repository],
   [`git`, `fetch`, `origin`, getBranchRef(branch)],
   [`git`, `reset`, `--hard`, `FETCH_HEAD`],
@@ -71,8 +71,8 @@ export default class SetVersionCommand extends BaseCommand {
       throw new WorkspaceRequiredError(this.context.cwd);
 
     const target = typeof this.installPath !== `undefined`
-      ? ppath.resolve(this.context.cwd, toPortablePath(this.installPath))
-      : ppath.resolve(toPortablePath(tmpdir()), `yarnpkg-sources` as Filename);
+      ? ppath.resolve(this.context.cwd, npath.toPortablePath(this.installPath))
+      : ppath.resolve(npath.toPortablePath(tmpdir()), `yarnpkg-sources` as Filename);
 
     const report = await StreamReport.start({
       configuration,

--- a/packages/plugin-exec/package.json
+++ b/packages/plugin-exec/package.json
@@ -16,6 +16,10 @@
     "update-local": "yarn build:plugin-exec && rsync -a --delete bundles/ bin/"
   },
   "version": "2.0.0-rc.4",
+  "nextVersion": {
+    "semver": "2.0.0-rc.5",
+    "nonce": "5769576455319063"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -1,11 +1,11 @@
-import {Fetcher, FetchOptions, MinimalFetchOptions}    from '@yarnpkg/core';
-import {Locator, MessageName}                          from '@yarnpkg/core';
-import {execUtils, scriptUtils, structUtils, tgzUtils} from '@yarnpkg/core';
-import {NodeFS, xfs, ppath, PortablePath, toFilename}  from '@yarnpkg/fslib';
-import querystring                                     from 'querystring';
-import {dirSync, tmpNameSync}                          from 'tmp';
+import {Fetcher, FetchOptions, MinimalFetchOptions}          from '@yarnpkg/core';
+import {Locator, MessageName}                                from '@yarnpkg/core';
+import {execUtils, scriptUtils, structUtils, tgzUtils}       from '@yarnpkg/core';
+import {NodeFS, PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
+import querystring                                           from 'querystring';
+import {dirSync, tmpNameSync}                                from 'tmp';
 
-import {PROTOCOL}                                      from './constants';
+import {PROTOCOL}                                            from './constants';
 
 export class ExecFetcher implements Fetcher {
   supports(locator: Locator, opts: MinimalFetchOptions) {
@@ -86,10 +86,10 @@ export class ExecFetcher implements Fetcher {
   }
 
   private async generatePackage(locator: Locator, generatorPath: PortablePath, opts: FetchOptions) {
-    const cwd = NodeFS.toPortablePath(dirSync().name);
+    const cwd = npath.toPortablePath(dirSync().name);
     const env = await scriptUtils.makeScriptEnv({project: opts.project});
 
-    const logFile = NodeFS.toPortablePath(tmpNameSync({
+    const logFile = npath.toPortablePath(tmpNameSync({
       prefix: `buildfile-`,
       postfix: `.log`,
     }));
@@ -101,7 +101,7 @@ export class ExecFetcher implements Fetcher {
     stdout.write(`# This file contains the result of Yarn generating a package (${structUtils.stringifyLocator(locator)})\n`);
     stdout.write(`\n`);
 
-    const {code} = await execUtils.pipevp(process.execPath, [NodeFS.fromPortablePath(generatorPath), structUtils.stringifyIdent(locator)], {cwd, env, stdin, stdout, stderr});
+    const {code} = await execUtils.pipevp(process.execPath, [npath.fromPortablePath(generatorPath), structUtils.stringifyIdent(locator)], {cwd, env, stdin, stdout, stderr});
     if (code !== 0)
       throw new Error(`Package generation failed (exit code ${code}, logs can be found here: ${logFile})`);
 

--- a/packages/plugin-exec/sources/ExecResolver.ts
+++ b/packages/plugin-exec/sources/ExecResolver.ts
@@ -2,7 +2,7 @@ import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {miscUtils, structUtils}                          from '@yarnpkg/core';
-import {NodeFS}                                          from '@yarnpkg/fslib';
+import {npath}                                           from '@yarnpkg/fslib';
 import querystring                                       from 'querystring';
 
 import {PROTOCOL}                                        from './constants';
@@ -41,7 +41,7 @@ export class ExecResolver implements Resolver {
     if (path.startsWith(PROTOCOL))
       path = path.slice(PROTOCOL.length);
 
-    return [structUtils.makeLocator(descriptor, `${PROTOCOL}${NodeFS.toPortablePath(path)}`)];
+    return [structUtils.makeLocator(descriptor, `${PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -7,6 +7,10 @@
     "@yarnpkg/fslib": "workspace:2.0.0-rc.5"
   },
   "version": "2.0.0-rc.2",
+  "nextVersion": {
+    "semver": "2.0.0-rc.3",
+    "nonce": "1092319637125435"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-file/sources/FileResolver.ts
+++ b/packages/plugin-file/sources/FileResolver.ts
@@ -2,7 +2,7 @@ import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {miscUtils, structUtils}                          from '@yarnpkg/core';
-import {NodeFS}                                          from '@yarnpkg/fslib';
+import {npath}                                           from '@yarnpkg/fslib';
 
 import {FILE_REGEXP, PROTOCOL}                           from './constants';
 
@@ -46,7 +46,7 @@ export class FileResolver implements Resolver {
     if (path.startsWith(PROTOCOL))
       path = path.slice(PROTOCOL.length);
 
-    return [structUtils.makeLocator(descriptor, `${PROTOCOL}${NodeFS.toPortablePath(path)}`)];
+    return [structUtils.makeLocator(descriptor, `${PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-file/sources/TarballFileResolver.ts
+++ b/packages/plugin-file/sources/TarballFileResolver.ts
@@ -2,7 +2,7 @@ import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {miscUtils, structUtils}                          from '@yarnpkg/core';
-import {NodeFS}                                          from '@yarnpkg/fslib';
+import {npath}                                           from '@yarnpkg/fslib';
 import querystring                                       from 'querystring';
 
 import {FILE_REGEXP, TARBALL_REGEXP, PROTOCOL}           from './constants';
@@ -53,7 +53,7 @@ export class TarballFileResolver implements Resolver {
     if (path.startsWith(PROTOCOL))
       path = path.slice(PROTOCOL.length);
 
-    return [structUtils.makeLocator(descriptor, `${PROTOCOL}${NodeFS.toPortablePath(path)}`)];
+    return [structUtils.makeLocator(descriptor, `${PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -10,6 +10,10 @@
     "tmp": "^0.0.33"
   },
   "version": "2.0.0-rc.4",
+  "nextVersion": {
+    "semver": "2.0.0-rc.5",
+    "nonce": "2726395786787317"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -1,5 +1,5 @@
 import {execUtils, Configuration} from '@yarnpkg/core';
-import {fromPortablePath, xfs}    from '@yarnpkg/fslib';
+import {npath, xfs}               from '@yarnpkg/fslib';
 import semver                     from 'semver';
 
 function makeGitEnvironment() {
@@ -182,7 +182,7 @@ export async function clone(url: string, configuration: Configuration) {
   const execOpts = {cwd: directory, env: makeGitEnvironment(), strict: true};
 
   try {
-    await execUtils.execvp(`git`, [`clone`, `${repo}`, fromPortablePath(directory)], execOpts);
+    await execUtils.execvp(`git`, [`clone`, `${repo}`, npath.fromPortablePath(directory)], execOpts);
     await execUtils.execvp(`git`, [`checkout`, `${request}`], execOpts);
   } catch (error) {
     error.message = `Repository clone failed`;

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -15,6 +15,10 @@
     "/lib"
   ],
   "version": "2.0.0-rc.2",
+  "nextVersion": {
+    "semver": "2.0.0-rc.3",
+    "nonce": "8002006925326491"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-github/sources/GithubFetcher.ts
+++ b/packages/plugin-github/sources/GithubFetcher.ts
@@ -1,10 +1,10 @@
-import {Fetcher, FetchOptions, MinimalFetchOptions}      from '@yarnpkg/core';
-import {Locator, MessageName}                            from '@yarnpkg/core';
-import {httpUtils, scriptUtils, structUtils, tgzUtils}   from '@yarnpkg/core';
-import {PortablePath, CwdFS, ppath, xfs, toPortablePath} from '@yarnpkg/fslib';
-import {tmpNameSync}                                     from 'tmp';
+import {Fetcher, FetchOptions, MinimalFetchOptions}    from '@yarnpkg/core';
+import {Locator, MessageName}                          from '@yarnpkg/core';
+import {httpUtils, scriptUtils, structUtils, tgzUtils} from '@yarnpkg/core';
+import {PortablePath, CwdFS, npath, ppath, xfs}        from '@yarnpkg/fslib';
+import {tmpNameSync}                                   from 'tmp';
 
-import * as githubUtils                                  from './githubUtils';
+import * as githubUtils                                from './githubUtils';
 
 export class GithubFetcher implements Fetcher {
   supports(locator: Locator, opts: MinimalFetchOptions) {
@@ -43,7 +43,7 @@ export class GithubFetcher implements Fetcher {
       configuration: opts.project.configuration,
     });
 
-    const extractPath = toPortablePath(tmpNameSync());
+    const extractPath = npath.toPortablePath(tmpNameSync());
     const extractTarget = new CwdFS(extractPath);
 
     await tgzUtils.extractArchiveTo(sourceBuffer, extractTarget, {

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -7,6 +7,10 @@
     "@yarnpkg/fslib": "workspace:2.0.0-rc.5"
   },
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "5488293046904949"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-link/sources/LinkResolver.ts
+++ b/packages/plugin-link/sources/LinkResolver.ts
@@ -2,7 +2,7 @@ import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest, Package}          from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {miscUtils, structUtils}                          from '@yarnpkg/core';
-import {NodeFS}                                          from '@yarnpkg/fslib';
+import {npath}                                           from '@yarnpkg/fslib';
 
 import {LINK_PROTOCOL}                                   from './constants';
 
@@ -34,7 +34,7 @@ export class LinkResolver implements Resolver {
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {
     const path = descriptor.range.slice(LINK_PROTOCOL.length);
 
-    return [structUtils.makeLocator(descriptor, `${LINK_PROTOCOL}${NodeFS.toPortablePath(path)}`)];
+    return [structUtils.makeLocator(descriptor, `${LINK_PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
   async resolve(locator: Locator, opts: ResolveOptions): Promise<Package> {

--- a/packages/plugin-link/sources/RawLinkResolver.ts
+++ b/packages/plugin-link/sources/RawLinkResolver.ts
@@ -2,7 +2,7 @@ import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator}                             from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {structUtils}                                     from '@yarnpkg/core';
-import {NodeFS}                                          from '@yarnpkg/fslib';
+import {npath}                                           from '@yarnpkg/fslib';
 
 import {RAW_LINK_PROTOCOL}                               from './constants';
 
@@ -34,7 +34,7 @@ export class RawLinkResolver implements Resolver {
   async getCandidates(descriptor: Descriptor, opts: ResolveOptions) {
     const path = descriptor.range.slice(RAW_LINK_PROTOCOL.length);
 
-    return [structUtils.makeLocator(descriptor, `${RAW_LINK_PROTOCOL}${NodeFS.toPortablePath(path)}`)];
+    return [structUtils.makeLocator(descriptor, `${RAW_LINK_PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -9,6 +9,10 @@
     "semver": "^5.6.0"
   },
   "version": "2.0.0-rc.4",
+  "nextVersion": {
+    "semver": "2.0.0-rc.5",
+    "nonce": "6446592163508797"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -1,5 +1,4 @@
-import {Configuration, Ident, Manifest, structUtils} from '@yarnpkg/core';
-import {PortablePath}                                from '@yarnpkg/fslib';
+import {Configuration, Manifest} from '@yarnpkg/core';
 
 export enum RegistryType {
   FETCH_REGISTRY = 'npmRegistryServer',

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -15,7 +15,7 @@
   "version": "2.0.0-rc.4",
   "nextVersion": {
     "semver": "2.0.0-rc.5",
-    "nonce": "3390682135047771"
+    "nonce": "402525575272699"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -1,6 +1,6 @@
 import {BaseCommand, WorkspaceRequiredError}                                       from '@yarnpkg/cli';
 import {Configuration, MessageName, Project, StreamReport, Workspace, structUtils} from '@yarnpkg/core';
-import {Filename, xfs, ppath, toPortablePath}                                      from '@yarnpkg/fslib';
+import {Filename, npath, ppath, xfs}                                               from '@yarnpkg/fslib';
 import {Command}                                                                   from 'clipanion';
 
 import * as packUtils                                                              from '../packUtils';
@@ -94,7 +94,7 @@ function interpolateOutputName(name: string, {workspace}: {workspace: Workspace}
     .replace(`%s`, prettyWorkspaceIdent(workspace))
     .replace(`%v`, prettyWorkspaceVersion(workspace));
 
-  return toPortablePath(interpolated);
+  return npath.toPortablePath(interpolated);
 }
 
 function prettyWorkspaceIdent(workspace: Workspace) {

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -13,6 +13,10 @@
     "@yarnpkg/plugin-stage": "workspace:2.0.0-rc.3"
   },
   "version": "2.0.0-rc.3",
+  "nextVersion": {
+    "semver": "2.0.0-rc.4",
+    "nonce": "1221069532787633"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -1,7 +1,7 @@
 import {Installer, Linker, LinkOptions, MinimalLinkOptions, Manifest, LinkType, MessageName, DependencyMeta} from '@yarnpkg/core';
 import {FetchResult, Descriptor, Ident, Locator, Package, BuildDirective, BuildType}                         from '@yarnpkg/core';
 import {miscUtils, structUtils}                                                                              from '@yarnpkg/core';
-import {CwdFS, FakeFS, NodeFS, xfs, PortablePath, ppath, toFilename}                                         from '@yarnpkg/fslib';
+import {CwdFS, FakeFS, PortablePath, npath, ppath, toFilename, xfs}                                          from '@yarnpkg/fslib';
 import {PackageRegistry, generateInlinedScript, generateSplitScript}                                         from '@yarnpkg/pnp';
 import {UsageError}                                                                                          from 'clipanion';
 
@@ -27,7 +27,7 @@ export class PnpLinker implements Linker {
     if (!xfs.existsSync(pnpPath))
       throw new UsageError(`The project in ${opts.project.cwd}/package.json doesn't seem to have been installed - running an install there might help`);
 
-    const physicalPath = NodeFS.fromPortablePath(pnpPath);
+    const physicalPath = npath.fromPortablePath(pnpPath);
     const pnpFile = miscUtils.dynamicRequire(physicalPath);
     delete require.cache[physicalPath];
 
@@ -37,7 +37,7 @@ export class PnpLinker implements Linker {
     if (!packageInformation)
       throw new UsageError(`Couldn't find ${structUtils.prettyLocator(opts.project.configuration, locator)} in the currently installed PnP map - running an install might help`);
 
-    return NodeFS.toPortablePath(packageInformation.packageLocation);
+    return npath.toPortablePath(packageInformation.packageLocation);
   }
 
   async findPackageLocator(location: PortablePath, opts: LinkOptions) {
@@ -45,11 +45,11 @@ export class PnpLinker implements Linker {
     if (!xfs.existsSync(pnpPath))
       throw new UsageError(`The project in ${opts.project.cwd}/package.json doesn't seem to have been installed - running an install there might help`);
 
-    const physicalPath = NodeFS.fromPortablePath(pnpPath);
+    const physicalPath = npath.fromPortablePath(pnpPath);
     const pnpFile = miscUtils.dynamicRequire(physicalPath);
     delete require.cache[physicalPath];
 
-    const locator = pnpFile.findPackageLocator(NodeFS.fromPortablePath(location));
+    const locator = pnpFile.findPackageLocator(npath.fromPortablePath(location));
     if (!locator)
       return null;
 

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -1,5 +1,5 @@
 import {Hooks as CoreHooks, Plugin, Project, SettingsType} from '@yarnpkg/core';
-import {Filename, NodeFS, PortablePath, ppath, xfs}        from '@yarnpkg/fslib';
+import {Filename, PortablePath, npath, ppath, xfs}         from '@yarnpkg/fslib';
 import {Hooks as StageHooks}                               from '@yarnpkg/plugin-stage';
 
 import {PnpLinker}                                         from './PnpLinker';
@@ -9,7 +9,7 @@ export const getPnpPath = (project: Project) => ppath.join(project.cwd, `.pnp.js
 
 async function setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>) {
   const pnpPath: PortablePath = getPnpPath(project);
-  const pnpRequire = `--require ${NodeFS.fromPortablePath(pnpPath)}`;
+  const pnpRequire = `--require ${npath.fromPortablePath(pnpPath)}`;
 
   if (xfs.existsSync(pnpPath)) {
     let nodeOptions = env.NODE_OPTIONS || ``;

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -18,7 +18,8 @@
   },
   "version": "2.0.0-rc.3",
   "nextVersion": {
-    "nonce": "5030865929643279"
+    "semver": "2.0.0-rc.4",
+    "nonce": "2405920880030031"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-stage/sources/commands/stage.ts
+++ b/packages/plugin-stage/sources/commands/stage.ts
@@ -1,11 +1,11 @@
-import {BaseCommand}                      from '@yarnpkg/cli';
-import {Configuration, Project}           from '@yarnpkg/core';
-import {NodeFS, xfs, PortablePath, ppath} from '@yarnpkg/fslib';
-import {Command, UsageError}              from 'clipanion';
+import {BaseCommand}                     from '@yarnpkg/cli';
+import {Configuration, Project}          from '@yarnpkg/core';
+import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
+import {Command, UsageError}             from 'clipanion';
 
-import {Driver as GitDriver}              from '../drivers/GitDriver';
-import {Driver as MercurialDriver}        from '../drivers/MercurialDriver';
-import {Hooks}                            from '..';
+import {Driver as GitDriver}             from '../drivers/GitDriver';
+import {Driver as MercurialDriver}       from '../drivers/MercurialDriver';
+import {Hooks}                           from '..';
 
 const ALL_DRIVERS = [
   GitDriver,
@@ -87,7 +87,7 @@ export default class StageCommand extends BaseCommand {
         this.context.stdout.write(`${commitMessage}\n`);
       } else {
         for (const file of changeList) {
-          this.context.stdout.write(`${NodeFS.fromPortablePath(file.path)}\n`);
+          this.context.stdout.write(`${npath.fromPortablePath(file.path)}\n`);
         }
       }
     } else {

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -1,5 +1,5 @@
 import {execUtils, Manifest, structUtils, IdentHash, Descriptor} from '@yarnpkg/core';
-import {NodeFS, PortablePath, ppath, toFilename}                 from '@yarnpkg/fslib';
+import {PortablePath, npath, ppath, toFilename}                  from '@yarnpkg/fslib';
 
 import * as stageUtils                                           from '../stageUtils';
 
@@ -146,14 +146,14 @@ export const Driver = {
   },
 
   async makeCommit(cwd: PortablePath, changeList: Array<stageUtils.FileAction>, commitMessage: string) {
-    const localPaths = changeList.map(file => NodeFS.fromPortablePath(file.path));
+    const localPaths = changeList.map(file => npath.fromPortablePath(file.path));
 
     await execUtils.execvp(`git`, [`add`, `-N`, `--`, ...localPaths], {cwd, strict: true});
     await execUtils.execvp(`git`, [`commit`, `-m`, `${commitMessage}\n\n${MESSAGE_MARKER}\n`, `--`, ...localPaths], {cwd, strict: true});
   },
 
   async makeReset(cwd: PortablePath, changeList: Array<stageUtils.FileAction>) {
-    const localPaths = changeList.map(path => NodeFS.fromPortablePath(path.path));
+    const localPaths = changeList.map(path => npath.fromPortablePath(path.path));
 
     await execUtils.execvp(`git`, [`reset`, `HEAD`, `--`, ...localPaths], {cwd, strict: true});
   },

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -21,6 +21,10 @@
     "build:plugin-version": "builder build plugin"
   },
   "version": "2.0.0-rc.5",
+  "nextVersion": {
+    "semver": "2.0.0-rc.6",
+    "nonce": "2482302254186549"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -1,6 +1,6 @@
 import {WorkspaceRequiredError}                                                                                                      from '@yarnpkg/cli';
 import {CommandContext, Configuration, MessageName, Project, StreamReport, Workspace, execUtils, structUtils, Manifest, LocatorHash} from '@yarnpkg/core';
-import {Filename, PortablePath, fromPortablePath, ppath, toPortablePath, xfs}                                                        from '@yarnpkg/fslib';
+import {Filename, PortablePath, npath, ppath, xfs}                                                        from '@yarnpkg/fslib';
 import {Command, UsageError}                                                                                                         from 'clipanion';
 import {AppContext, Box, Color, StdinContext, render}                                                                                from 'ink';
 import React, {useCallback, useContext, useEffect, useState}                                                                         from 'react';
@@ -473,16 +473,16 @@ async function fetchRoot(initialCwd: PortablePath) {
 
 async function fetchChangedFiles(root: PortablePath, {base}: {base: string}) {
   const {stdout: localStdout} = await execUtils.execvp(`git`, [`diff`, `--name-only`, `${base}`], {cwd: root, strict: true});
-  const trackedFiles = localStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
+  const trackedFiles = localStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, npath.toPortablePath(file)));
 
   const {stdout: untrackedStdout} = await execUtils.execvp(`git`, [`ls-files`, `--others`, `--exclude-standard`], {cwd: root, strict: true});
-  const untrackedFiles = untrackedStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, toPortablePath(file)));
+  const untrackedFiles = untrackedStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, npath.toPortablePath(file)));
 
   return [...new Set([...trackedFiles, ...untrackedFiles].sort())];
 }
 
 async function fetchPreviousNonce(workspace: Workspace, {root, base}: {root: PortablePath, base: string}) {
-  const {code, stdout} = await execUtils.execvp(`git`, [`show`, `${base}:${fromPortablePath(ppath.relative(root, ppath.join(workspace.cwd, `package.json` as Filename)))}`], {cwd: workspace.cwd});
+  const {code, stdout} = await execUtils.execvp(`git`, [`show`, `${base}:${npath.fromPortablePath(ppath.relative(root, ppath.join(workspace.cwd, `package.json` as Filename)))}`], {cwd: workspace.cwd});
 
   if (code === 0) {
     return getNonce(Manifest.fromText(stdout));

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.8",
+  "nextVersion": {
+    "nonce": "6492942287603617"
+  },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/yarnpkg-builder/sources/commands/new/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/new/plugin.ts
@@ -1,7 +1,7 @@
-import {Filename, NodeFS, ppath, xfs} from '@yarnpkg/fslib';
-import chalk                          from 'chalk';
-import {Command, UsageError}          from 'clipanion';
-import path                           from 'path';
+import {Filename, npath, ppath, xfs} from '@yarnpkg/fslib';
+import chalk                         from 'chalk';
+import {Command, UsageError}         from 'clipanion';
+import path                          from 'path';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NewPluginCommand extends Command {
@@ -14,7 +14,7 @@ export default class NewPluginCommand extends Command {
 
   @Command.Path(`new`, `plugin`)
   async execute() {
-    const target = NodeFS.toPortablePath(path.resolve(this.target));
+    const target = npath.toPortablePath(path.resolve(this.target));
     if (await xfs.existsPromise(target)) {
       const listing = await xfs.readdirPromise(target);
       if (listing.length !== 0) {
@@ -80,6 +80,6 @@ export default class NewPluginCommand extends Command {
       ],
     }, null, 2));
 
-    this.context.stdout.write(`Scaffolding done! Just go into ${chalk.magenta(NodeFS.fromPortablePath(target))} and run ${chalk.cyan(`yarn && yarn build`)} 🙂\n`);
+    this.context.stdout.write(`Scaffolding done! Just go into ${chalk.magenta(npath.fromPortablePath(target))} and run ${chalk.cyan(`yarn && yarn build`)} 🙂\n`);
   }
 }

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.9",
   "nextVersion": {
     "semver": "2.0.0-rc.10",
-    "nonce": "3585046797413477"
+    "nonce": "736442921407729"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -1,11 +1,11 @@
 import {Configuration, CommandContext, PluginConfiguration} from '@yarnpkg/core';
-import {xfs, NodeFS, PortablePath}                          from '@yarnpkg/fslib';
+import {PortablePath, npath, xfs}                           from '@yarnpkg/fslib';
 import {execFileSync}                                       from 'child_process';
 import {Cli}                                                from 'clipanion';
 import {realpathSync}                                       from 'fs';
 
 function runBinary(path: PortablePath) {
-  const physicalPath = NodeFS.fromPortablePath(path);
+  const physicalPath = npath.fromPortablePath(path);
 
   if (physicalPath) {
     execFileSync(process.execPath, [physicalPath, ...process.argv.slice(2)], {
@@ -45,7 +45,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
   async function exec(cli: Cli<CommandContext>): Promise<void> {
     // Since we only care about a few very specific settings (yarn-path and ignore-path) we tolerate extra configuration key.
     // If we didn't, we wouldn't even be able to run `yarn config` (which is recommended in the invalid config error message)
-    const configuration = await Configuration.find(NodeFS.toPortablePath(process.cwd()), pluginConfiguration, {
+    const configuration = await Configuration.find(npath.toPortablePath(process.cwd()), pluginConfiguration, {
       strict: false,
     });
 
@@ -87,7 +87,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
       }
 
       cli.runExit(command, {
-        cwd: NodeFS.toPortablePath(process.cwd()),
+        cwd: npath.toPortablePath(process.cwd()),
         plugins: pluginConfiguration,
         quiet: false,
         stdin: process.stdin,

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/core",
   "version": "2.0.0-rc.9",
+  "nextVersion": {
+    "semver": "2.0.0-rc.10",
+    "nonce": "6523673158838445"
+  },
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -1,13 +1,13 @@
-import {FakeFS, LazyFS, NodeFS, ZipFS, PortablePath, Filename, toPortablePath} from '@yarnpkg/fslib';
-import {xfs, ppath, toFilename}                                                from '@yarnpkg/fslib';
-import fs                                                                      from 'fs';
-import {tmpNameSync}                                                           from 'tmp';
+import {FakeFS, LazyFS, NodeFS, ZipFS, PortablePath, Filename} from '@yarnpkg/fslib';
+import {npath, ppath, toFilename, xfs}                         from '@yarnpkg/fslib';
+import fs                                                      from 'fs';
+import {tmpNameSync}                                           from 'tmp';
 
-import {Configuration}                                                         from './Configuration';
-import {MessageName, ReportError}                                              from './Report';
-import * as hashUtils                                                          from './hashUtils';
-import * as structUtils                                                        from './structUtils';
-import {LocatorHash, Locator}                                                  from './types';
+import {Configuration}                                         from './Configuration';
+import {MessageName, ReportError}                              from './Report';
+import * as hashUtils                                          from './hashUtils';
+import * as structUtils                                        from './structUtils';
+import {LocatorHash, Locator}                                  from './types';
 
 // Each time we'll bump this number the cache hashes will change, which will
 // cause all files to be fetched again. Use with caution.
@@ -146,7 +146,7 @@ export class Cache {
       if (mirrorPath === null || !xfs.existsSync(mirrorPath))
         return await loader!();
 
-      const tempPath = toPortablePath(tmpNameSync());
+      const tempPath = npath.toPortablePath(tmpNameSync());
       await xfs.copyFilePromise(mirrorPath, tempPath, fs.constants.COPYFILE_FICLONE);
       return new ZipFS(tempPath);
     };

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1,27 +1,27 @@
-import {xfs, NodeFS, PortablePath, ppath, Filename, toFilename} from '@yarnpkg/fslib';
-import {parseSyml, stringifySyml}                               from '@yarnpkg/parsers';
-import camelcase                                                from 'camelcase';
-import chalk                                                    from 'chalk';
-import {UsageError}                                             from 'clipanion';
-import isCI                                                     from 'is-ci';
-import {PassThrough, Writable}                                  from 'stream';
-import supportsColor                                            from 'supports-color';
-import {tmpNameSync}                                            from 'tmp';
+import {Filename, PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
+import {parseSyml, stringifySyml}                              from '@yarnpkg/parsers';
+import camelcase                                               from 'camelcase';
+import chalk                                                   from 'chalk';
+import {UsageError}                                            from 'clipanion';
+import isCI                                                    from 'is-ci';
+import {PassThrough, Writable}                                 from 'stream';
+import supportsColor                                           from 'supports-color';
+import {tmpNameSync}                                           from 'tmp';
 
-import {MultiFetcher}                                           from './MultiFetcher';
-import {MultiResolver}                                          from './MultiResolver';
-import {Plugin, Hooks}                                          from './Plugin';
-import {Report}                                                 from './Report';
-import {SemverResolver}                                         from './SemverResolver';
-import {TagResolver}                                            from './TagResolver';
-import {VirtualFetcher}                                         from './VirtualFetcher';
-import {VirtualResolver}                                        from './VirtualResolver';
-import {WorkspaceFetcher}                                       from './WorkspaceFetcher';
-import {WorkspaceResolver}                                      from './WorkspaceResolver';
-import * as folderUtils                                         from './folderUtils';
-import * as miscUtils                                           from './miscUtils';
-import * as nodeUtils                                           from './nodeUtils';
-import * as structUtils                                         from './structUtils';
+import {MultiFetcher}                                          from './MultiFetcher';
+import {MultiResolver}                                         from './MultiResolver';
+import {Plugin, Hooks}                                         from './Plugin';
+import {Report}                                                from './Report';
+import {SemverResolver}                                        from './SemverResolver';
+import {TagResolver}                                           from './TagResolver';
+import {VirtualFetcher}                                        from './VirtualFetcher';
+import {VirtualResolver}                                       from './VirtualResolver';
+import {WorkspaceFetcher}                                      from './WorkspaceFetcher';
+import {WorkspaceResolver}                                     from './WorkspaceResolver';
+import * as folderUtils                                        from './folderUtils';
+import * as miscUtils                                          from './miscUtils';
+import * as nodeUtils                                          from './nodeUtils';
+import * as structUtils                                        from './structUtils';
 
 // @ts-ignore
 const ctx: any = new chalk.constructor({enabled: true});
@@ -355,7 +355,7 @@ function parseSingleValue(configuration: Configuration, path: string, value: unk
 
   switch (definition.type) {
     case SettingsType.ABSOLUTE_PATH:
-      return ppath.resolve(folder, NodeFS.toPortablePath(value));
+      return ppath.resolve(folder, npath.toPortablePath(value));
     case SettingsType.LOCATOR_LOOSE:
       return structUtils.parseLocator(value, false);
     case SettingsType.LOCATOR:
@@ -532,8 +532,8 @@ export class Configuration {
           continue;
 
         for (const userProvidedPath of data.plugins) {
-          const pluginPath = ppath.resolve(cwd, NodeFS.toPortablePath(userProvidedPath));
-          const {factory, name} = nodeUtils.dynamicRequire(NodeFS.fromPortablePath(pluginPath));
+          const pluginPath = ppath.resolve(cwd, npath.toPortablePath(userProvidedPath));
+          const {factory, name} = nodeUtils.dynamicRequire(npath.fromPortablePath(pluginPath));
 
           // Prevent plugin redefinition so that the ones declared deeper in the
           // filesystem always have precedence over the ones below.
@@ -789,7 +789,7 @@ export class Configuration {
     let stdout: Writable;
     let stderr: Writable;
 
-    const logFile = NodeFS.toPortablePath(tmpNameSync({prefix: `logfile-`, postfix: `.log`}));
+    const logFile = npath.toPortablePath(tmpNameSync({prefix: `logfile-`, postfix: `.log`}));
     const logStream = xfs.createWriteStream(logFile);
 
     if (this.get(`enableInlineBuilds`)) {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1,33 +1,33 @@
-import {xfs, NodeFS, PortablePath, ppath, toFilename} from '@yarnpkg/fslib';
-import {parseSyml, stringifySyml}                     from '@yarnpkg/parsers';
-import {createHash}                                   from 'crypto';
+import {PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
+import {parseSyml, stringifySyml}                    from '@yarnpkg/parsers';
+import {createHash}                                  from 'crypto';
 // @ts-ignore
-import Logic                                          from 'logic-solver';
-import pLimit                                         from 'p-limit';
-import semver                                         from 'semver';
-import {tmpNameSync}                                  from 'tmp';
+import Logic                                         from 'logic-solver';
+import pLimit                                        from 'p-limit';
+import semver                                        from 'semver';
+import {tmpNameSync}                                 from 'tmp';
 
-import {AliasResolver}                                from './AliasResolver';
-import {Cache}                                        from './Cache';
-import {Configuration}                                from './Configuration';
-import {Fetcher}                                      from './Fetcher';
-import {Installer, BuildDirective, BuildType}         from './Installer';
-import {Linker}                                       from './Linker';
-import {LockfileResolver}                             from './LockfileResolver';
-import {DependencyMeta, Manifest}                     from './Manifest';
-import {MultiResolver}                                from './MultiResolver';
-import {Report, ReportError, MessageName}             from './Report';
-import {RunInstallPleaseResolver}                     from './RunInstallPleaseResolver';
-import {ThrowReport}                                  from './ThrowReport';
-import {Workspace}                                    from './Workspace';
-import {YarnResolver}                                 from './YarnResolver';
-import {isFolderInside}                               from './folderUtils';
-import * as miscUtils                                 from './miscUtils';
-import * as scriptUtils                               from './scriptUtils';
-import * as structUtils                               from './structUtils';
-import {IdentHash, DescriptorHash, LocatorHash}       from './types';
-import {Descriptor, Ident, Locator, Package}          from './types';
-import {LinkType}                                     from './types';
+import {AliasResolver}                               from './AliasResolver';
+import {Cache}                                       from './Cache';
+import {Configuration}                               from './Configuration';
+import {Fetcher}                                     from './Fetcher';
+import {Installer, BuildDirective, BuildType}        from './Installer';
+import {Linker}                                      from './Linker';
+import {LockfileResolver}                            from './LockfileResolver';
+import {DependencyMeta, Manifest}                    from './Manifest';
+import {MultiResolver}                               from './MultiResolver';
+import {Report, ReportError, MessageName}            from './Report';
+import {RunInstallPleaseResolver}                    from './RunInstallPleaseResolver';
+import {ThrowReport}                                 from './ThrowReport';
+import {Workspace}                                   from './Workspace';
+import {YarnResolver}                                from './YarnResolver';
+import {isFolderInside}                              from './folderUtils';
+import * as miscUtils                                from './miscUtils';
+import * as scriptUtils                              from './scriptUtils';
+import * as structUtils                              from './structUtils';
+import {IdentHash, DescriptorHash, LocatorHash}      from './types';
+import {Descriptor, Ident, Locator, Package}         from './types';
+import {LinkType}                                    from './types';
 
 // When upgraded, the lockfile entries have to be resolved again (but the specific
 // versions are still pinned, no worry). Bump it when you change the fields within
@@ -1342,7 +1342,7 @@ function applyVirtualResolutionMutations({
   const resolutionStack: Array<Locator> = [];
 
   const reportStackOverflow = (): never => {
-    const logFile = NodeFS.toPortablePath(
+    const logFile = npath.toPortablePath(
       tmpNameSync({
         prefix: `stacktrace-`,
         postfix: `.log`,

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -1,14 +1,14 @@
-import {xfs, NodeFS, PortablePath, ppath, toFilename} from '@yarnpkg/fslib';
-import globby                                         from 'globby';
-import semver                                         from 'semver';
+import {PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
+import globby                                        from 'globby';
+import semver                                        from 'semver';
 
-import {Manifest}                                     from './Manifest';
-import {Project}                                      from './Project';
-import {WorkspaceResolver}                            from './WorkspaceResolver';
-import * as hashUtils                                 from './hashUtils';
-import * as structUtils                               from './structUtils';
-import {IdentHash}                                    from './types';
-import {Descriptor, Locator}                          from './types';
+import {Manifest}                                    from './Manifest';
+import {Project}                                     from './Project';
+import {WorkspaceResolver}                           from './WorkspaceResolver';
+import * as hashUtils                                from './hashUtils';
+import * as structUtils                              from './structUtils';
+import {IdentHash}                                   from './types';
+import {Descriptor, Locator}                         from './types';
 
 export class Workspace {
   public readonly project: Project;
@@ -63,7 +63,7 @@ export class Workspace {
     for (const definition of this.manifest.workspaceDefinitions) {
       const relativeCwds = await globby(definition.pattern, {
         absolute: true,
-        cwd: NodeFS.fromPortablePath(this.cwd),
+        cwd: npath.fromPortablePath(this.cwd),
         expandDirectories: false,
         onlyDirectories: true,
         onlyFiles: false,
@@ -73,7 +73,7 @@ export class Workspace {
       relativeCwds.sort();
 
       for (const relativeCwd of relativeCwds) {
-        const candidateCwd = ppath.resolve(this.cwd, NodeFS.toPortablePath(relativeCwd));
+        const candidateCwd = ppath.resolve(this.cwd, npath.toPortablePath(relativeCwd));
 
         if (xfs.existsSync(ppath.join(candidateCwd, toFilename(`package.json`)))) {
           this.workspacesCwds.add(candidateCwd);

--- a/packages/yarnpkg-core/sources/execUtils.ts
+++ b/packages/yarnpkg-core/sources/execUtils.ts
@@ -1,6 +1,6 @@
-import {NodeFS, PortablePath} from '@yarnpkg/fslib';
-import crossSpawn             from 'cross-spawn';
-import {Readable, Writable}   from 'stream';
+import {PortablePath, npath} from '@yarnpkg/fslib';
+import crossSpawn            from 'cross-spawn';
+import {Readable, Writable}  from 'stream';
 
 export type PipevpOptions = {
   cwd: PortablePath,
@@ -30,7 +30,7 @@ export async function pipevp(fileName: string, args: Array<string>, {cwd, env = 
     stdio[2] = stderr;
 
   const subprocess = crossSpawn(fileName, args, {
-    cwd: NodeFS.fromPortablePath(cwd),
+    cwd: npath.fromPortablePath(cwd),
     env,
     stdio,
   });
@@ -72,7 +72,7 @@ export async function execvp(fileName: string, args: Array<string>, {cwd, env = 
   const stderrChunks: Array<Buffer> = [];
 
   const subprocess = crossSpawn(fileName, args, {
-    cwd: NodeFS.fromPortablePath(cwd),
+    cwd: npath.fromPortablePath(cwd),
     env,
     stdio,
   });

--- a/packages/yarnpkg-core/sources/folderUtils.ts
+++ b/packages/yarnpkg-core/sources/folderUtils.ts
@@ -1,14 +1,14 @@
-import {NodeFS, PortablePath, ppath, npath} from '@yarnpkg/fslib';
-import {homedir}                            from 'os';
+import {PortablePath, npath, ppath} from '@yarnpkg/fslib';
+import {homedir}                    from 'os';
 
 export function getDefaultGlobalFolder() {
   if (process.platform === `win32`) {
-    const base = NodeFS.toPortablePath(process.env.LOCALAPPDATA || npath.join(homedir(), 'AppData', 'Local'));
+    const base = npath.toPortablePath(process.env.LOCALAPPDATA || npath.join(homedir(), 'AppData', 'Local'));
     return ppath.resolve(base, `Yarn/Berry` as PortablePath);
   }
 
   if (process.env.XDG_DATA_HOME) {
-    const base = NodeFS.toPortablePath(process.env.XDG_DATA_HOME);
+    const base = npath.toPortablePath(process.env.XDG_DATA_HOME);
     return ppath.resolve(base, `yarn/berry` as PortablePath);
   }
 
@@ -16,7 +16,7 @@ export function getDefaultGlobalFolder() {
 }
 
 export function getHomeFolder() {
-  return NodeFS.toPortablePath(homedir() || '/usr/local/share');
+  return npath.toPortablePath(homedir() || '/usr/local/share');
 }
 
 export function isFolderInside(target: PortablePath, parent: PortablePath) {

--- a/packages/yarnpkg-core/sources/tgzUtils.ts
+++ b/packages/yarnpkg-core/sources/tgzUtils.ts
@@ -1,6 +1,6 @@
-import {FakeFS, PortablePath, ZipFS, NodeFS, ppath} from '@yarnpkg/fslib';
-import {Parse}                                      from 'tar';
-import {tmpNameSync}                                from 'tmp';
+import {FakeFS, PortablePath, ZipFS, NodeFS, npath, ppath} from '@yarnpkg/fslib';
+import {Parse}                                             from 'tar';
+import {tmpNameSync}                                       from 'tmp';
 
 interface MakeArchiveFromDirectoryOptions {
   baseFs?: FakeFS<PortablePath>,
@@ -8,7 +8,7 @@ interface MakeArchiveFromDirectoryOptions {
 };
 
 export async function makeArchiveFromDirectory(source: PortablePath, {baseFs = new NodeFS(), prefixPath = PortablePath.root}: MakeArchiveFromDirectoryOptions = {}): Promise<ZipFS> {
-  const zipFs = new ZipFS(NodeFS.toPortablePath(tmpNameSync()), {create: true});
+  const zipFs = new ZipFS(npath.toPortablePath(tmpNameSync()), {create: true});
   const target = ppath.resolve(PortablePath.root, prefixPath!);
 
   await zipFs.copyPromise(target, source, {baseFs});
@@ -22,7 +22,7 @@ interface ExtractBufferOptions {
 };
 
 export async function convertToZip(tgz: Buffer, opts: ExtractBufferOptions) {
-  return await extractArchiveTo(tgz, new ZipFS(NodeFS.toPortablePath(tmpNameSync()), {create: true}), opts);
+  return await extractArchiveTo(tgz, new ZipFS(npath.toPortablePath(tmpNameSync()), {create: true}), opts);
 }
 
 export async function extractArchiveTo<T extends FakeFS<PortablePath>>(tgz: Buffer, targetFs: T, {stripComponents = 0, prefixPath = PortablePath.dot}: ExtractBufferOptions = {}): Promise<T> {

--- a/packages/yarnpkg-fslib/package.json
+++ b/packages/yarnpkg-fslib/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/fslib",
   "version": "2.0.0-rc.5",
+  "nextVersion": {
+    "semver": "2.0.0-rc.6",
+    "nonce": "2946411982127801"
+  },
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/packages/yarnpkg-fslib/sources/NoFS.ts
+++ b/packages/yarnpkg-fslib/sources/NoFS.ts
@@ -1,0 +1,206 @@
+import {FakeFS}              from './FakeFS';
+import {PortablePath, ppath} from './path';
+
+const makeError = () => Object.assign(new Error(`ENOSYS: unsupported filesystem access`), {code: `ENOSYS`});
+
+export class NoFS extends FakeFS<PortablePath> {
+  constructor() {
+    super(ppath);
+  }
+
+  getRealPath(): never {
+    throw makeError();
+  }
+
+  resolve(): never {
+    throw makeError();
+  }
+
+  async openPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  openSync(): never {
+    throw makeError();
+  }
+
+  async readPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  readSync(): never {
+    throw makeError();
+  }
+
+  async writePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  writeSync(): never {
+    throw makeError();
+  }
+
+  async closePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  closeSync(): never {
+    throw makeError();
+  }
+
+  createWriteStream(): never {
+    throw makeError();
+  }
+
+  createReadStream(): never {
+    throw makeError();
+  }
+
+  async realpathPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  realpathSync(): never {
+    throw makeError();
+  }
+
+  async readdirPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  readdirSync(): never {
+    throw makeError();
+  }
+
+  async existsPromise(p: PortablePath): Promise<never> {
+    throw makeError();
+  }
+
+  existsSync(p: PortablePath): never {
+    throw makeError();
+  }
+
+  async accessPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  accessSync(): never {
+    throw makeError();
+  }
+
+  async statPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  statSync(): never {
+    throw makeError();
+  }
+
+  async lstatPromise(p: PortablePath): Promise<never> {
+    throw makeError();
+  }
+
+  lstatSync(p: PortablePath): never {
+    throw makeError();
+  }
+
+  async chmodPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  chmodSync(): never {
+    throw makeError();
+  }
+
+  async mkdirPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  mkdirSync(): never {
+    throw makeError();
+  }
+
+  async rmdirPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  rmdirSync(): never {
+    throw makeError();
+  }
+
+  async symlinkPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  symlinkSync(): never {
+    throw makeError();
+  }
+
+  async renamePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  renameSync(): never {
+    throw makeError();
+  }
+
+  async copyFilePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  copyFileSync(): never {
+    throw makeError();
+  }
+
+  async appendFilePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  appendFileSync(): never {
+    throw makeError();
+  }
+
+  async writeFilePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  writeFileSync(): never {
+    throw makeError();
+  }
+
+  async unlinkPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  unlinkSync(): never {
+    throw makeError();
+  }
+
+  async utimesPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  utimesSync(): never {
+    throw makeError();
+  }
+
+  async readFilePromise(): Promise<never> {
+    throw makeError();
+  }
+
+  readFileSync(): never {
+    throw makeError();
+  }
+
+  async readlinkPromise(): Promise<never> {
+    throw makeError();
+  }
+
+  readlinkSync(): never {
+    throw makeError();
+  }
+
+  watch(): never {
+    throw makeError();
+  }
+}

--- a/packages/yarnpkg-fslib/sources/NodeFS.ts
+++ b/packages/yarnpkg-fslib/sources/NodeFS.ts
@@ -3,8 +3,7 @@ import fs, {Stats}                                         from 'fs';
 import {CreateReadStreamOptions, CreateWriteStreamOptions} from './FakeFS';
 import {BasePortableFakeFS, WriteFileOptions}              from './FakeFS';
 import {WatchOptions, WatchCallback, Watcher}              from './FakeFS';
-import {FSPath, PortablePath, NativePath, Filename, Path}  from './path';
-import {fromPortablePath, toPortablePath}                  from './path';
+import {FSPath, PortablePath, Filename, npath}             from './path';
 
 export class NodeFS extends BasePortableFakeFS {
   private readonly realFs: typeof fs;
@@ -21,12 +20,12 @@ export class NodeFS extends BasePortableFakeFS {
 
   async openPromise(p: PortablePath, flags: string, mode?: number) {
     return await new Promise<number>((resolve, reject) => {
-      this.realFs.open(NodeFS.fromPortablePath(p), flags, mode, this.makeCallback(resolve, reject));
+      this.realFs.open(npath.fromPortablePath(p), flags, mode, this.makeCallback(resolve, reject));
     });
   }
 
   openSync(p: PortablePath, flags: string, mode?: number) {
-    return this.realFs.openSync(NodeFS.fromPortablePath(p), flags, mode);
+    return this.realFs.openSync(npath.fromPortablePath(p), flags, mode);
   }
 
   async readPromise(fd: number, buffer: Buffer, offset: number = 0, length: number = 0, position: number | null = -1) {
@@ -78,100 +77,100 @@ export class NodeFS extends BasePortableFakeFS {
   }
 
   createReadStream(p: PortablePath | null, opts?: CreateReadStreamOptions) {
-    const realPath = (p !== null ? NodeFS.fromPortablePath(p) : p) as fs.PathLike;
+    const realPath = (p !== null ? npath.fromPortablePath(p) : p) as fs.PathLike;
     return this.realFs.createReadStream(realPath, opts);
   }
 
   createWriteStream(p: PortablePath | null, opts?: CreateWriteStreamOptions) {
-    const realPath = (p !== null ? NodeFS.fromPortablePath(p) : p) as fs.PathLike;
+    const realPath = (p !== null ? npath.fromPortablePath(p) : p) as fs.PathLike;
     return this.realFs.createWriteStream(realPath, opts);
   }
 
   async realpathPromise(p: PortablePath) {
     return await new Promise<string>((resolve, reject) => {
-      this.realFs.realpath(NodeFS.fromPortablePath(p), {}, this.makeCallback(resolve, reject));
+      this.realFs.realpath(npath.fromPortablePath(p), {}, this.makeCallback(resolve, reject));
     }).then(path => {
-      return NodeFS.toPortablePath(path);
+      return npath.toPortablePath(path);
     });
   }
 
   realpathSync(p: PortablePath) {
-    return NodeFS.toPortablePath(this.realFs.realpathSync(NodeFS.fromPortablePath(p), {}));
+    return npath.toPortablePath(this.realFs.realpathSync(npath.fromPortablePath(p), {}));
   }
 
   async existsPromise(p: PortablePath) {
     return await new Promise<boolean>(resolve => {
-      this.realFs.exists(NodeFS.fromPortablePath(p), resolve);
+      this.realFs.exists(npath.fromPortablePath(p), resolve);
     });
   }
 
   accessSync(p: PortablePath, mode?: number) {
-    return this.realFs.accessSync(NodeFS.fromPortablePath(p), mode);
+    return this.realFs.accessSync(npath.fromPortablePath(p), mode);
   }
 
   async accessPromise(p: PortablePath, mode?: number) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.access(NodeFS.fromPortablePath(p), mode, this.makeCallback(resolve, reject));
+      this.realFs.access(npath.fromPortablePath(p), mode, this.makeCallback(resolve, reject));
     });
   }
 
   existsSync(p: PortablePath) {
-    return this.realFs.existsSync(NodeFS.fromPortablePath(p));
+    return this.realFs.existsSync(npath.fromPortablePath(p));
   }
 
   async statPromise(p: PortablePath) {
     return await new Promise<Stats>((resolve, reject) => {
-      this.realFs.stat(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.stat(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     });
   }
 
   statSync(p: PortablePath) {
-    return this.realFs.statSync(NodeFS.fromPortablePath(p));
+    return this.realFs.statSync(npath.fromPortablePath(p));
   }
 
   async lstatPromise(p: PortablePath) {
     return await new Promise<Stats>((resolve, reject) => {
-      this.realFs.lstat(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.lstat(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     });
   }
 
   lstatSync(p: PortablePath) {
-    return this.realFs.lstatSync(NodeFS.fromPortablePath(p));
+    return this.realFs.lstatSync(npath.fromPortablePath(p));
   }
 
   async chmodPromise(p: PortablePath, mask: number) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.chmod(NodeFS.fromPortablePath(p), mask, this.makeCallback(resolve, reject));
+      this.realFs.chmod(npath.fromPortablePath(p), mask, this.makeCallback(resolve, reject));
     });
   }
 
   chmodSync(p: PortablePath, mask: number) {
-    return this.realFs.chmodSync(NodeFS.fromPortablePath(p), mask);
+    return this.realFs.chmodSync(npath.fromPortablePath(p), mask);
   }
 
   async renamePromise(oldP: PortablePath, newP: PortablePath) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.rename(NodeFS.fromPortablePath(oldP), NodeFS.fromPortablePath(newP), this.makeCallback(resolve, reject));
+      this.realFs.rename(npath.fromPortablePath(oldP), npath.fromPortablePath(newP), this.makeCallback(resolve, reject));
     });
   }
 
   renameSync(oldP: PortablePath, newP: PortablePath) {
-    return this.realFs.renameSync(NodeFS.fromPortablePath(oldP), NodeFS.fromPortablePath(newP));
+    return this.realFs.renameSync(npath.fromPortablePath(oldP), npath.fromPortablePath(newP));
   }
 
   async copyFilePromise(sourceP: PortablePath, destP: PortablePath, flags: number = 0) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.copyFile(NodeFS.fromPortablePath(sourceP), NodeFS.fromPortablePath(destP), flags, this.makeCallback(resolve, reject));
+      this.realFs.copyFile(npath.fromPortablePath(sourceP), npath.fromPortablePath(destP), flags, this.makeCallback(resolve, reject));
     });
   }
 
   copyFileSync(sourceP: PortablePath, destP: PortablePath, flags: number = 0) {
-    return this.realFs.copyFileSync(NodeFS.fromPortablePath(sourceP), NodeFS.fromPortablePath(destP), flags);
+    return this.realFs.copyFileSync(npath.fromPortablePath(sourceP), npath.fromPortablePath(destP), flags);
   }
 
   async appendFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return await new Promise<void>((resolve, reject) => {
-      const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+      const fsNativePath = typeof p === `string` ? npath.fromPortablePath(p) : p;
       if (opts) {
         this.realFs.appendFile(fsNativePath, content, opts, this.makeCallback(resolve, reject));
       } else {
@@ -181,7 +180,7 @@ export class NodeFS extends BasePortableFakeFS {
   }
 
   appendFileSync(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
-    const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+    const fsNativePath = typeof p === `string` ? npath.fromPortablePath(p) : p;
     if (opts) {
       this.realFs.appendFileSync(fsNativePath, content, opts);
     } else {
@@ -191,7 +190,7 @@ export class NodeFS extends BasePortableFakeFS {
 
   async writeFilePromise(p: FSPath<PortablePath>, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
     return await new Promise<void>((resolve, reject) => {
-      const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+      const fsNativePath = typeof p === `string` ? npath.fromPortablePath(p) : p;
       if (opts) {
         this.realFs.writeFile(fsNativePath, content, opts, this.makeCallback(resolve, reject));
       } else {
@@ -201,7 +200,7 @@ export class NodeFS extends BasePortableFakeFS {
   }
 
   writeFileSync(p: PortablePath, content: string | Buffer | ArrayBuffer | DataView, opts?: WriteFileOptions) {
-    const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+    const fsNativePath = typeof p === `string` ? npath.fromPortablePath(p) : p;
     if (opts) {
       this.realFs.writeFileSync(fsNativePath, content, opts);
     } else {
@@ -211,63 +210,63 @@ export class NodeFS extends BasePortableFakeFS {
 
   async unlinkPromise(p: PortablePath) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.unlink(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.unlink(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     });
   }
 
   unlinkSync(p: PortablePath) {
-    return this.realFs.unlinkSync(NodeFS.fromPortablePath(p));
+    return this.realFs.unlinkSync(npath.fromPortablePath(p));
   }
 
   async utimesPromise(p: PortablePath, atime: Date | string | number, mtime: Date | string | number) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.utimes(NodeFS.fromPortablePath(p), atime, mtime, this.makeCallback(resolve, reject));
+      this.realFs.utimes(npath.fromPortablePath(p), atime, mtime, this.makeCallback(resolve, reject));
     });
   }
 
   utimesSync(p: PortablePath, atime: Date | string | number, mtime: Date | string | number) {
-    this.realFs.utimesSync(NodeFS.fromPortablePath(p), atime, mtime);
+    this.realFs.utimesSync(npath.fromPortablePath(p), atime, mtime);
   }
 
   async mkdirPromise(p: PortablePath) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.mkdir(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.mkdir(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     });
   }
 
   mkdirSync(p: PortablePath) {
-    return this.realFs.mkdirSync(NodeFS.fromPortablePath(p));
+    return this.realFs.mkdirSync(npath.fromPortablePath(p));
   }
 
   async rmdirPromise(p: PortablePath) {
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.rmdir(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.rmdir(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     });
   }
 
   rmdirSync(p: PortablePath) {
-    return this.realFs.rmdirSync(NodeFS.fromPortablePath(p));
+    return this.realFs.rmdirSync(npath.fromPortablePath(p));
   }
 
   async symlinkPromise(target: PortablePath, p: PortablePath) {
     const type: 'dir' | 'file' = target.endsWith(`/`) ? `dir` : `file`;
 
     return await new Promise<void>((resolve, reject) => {
-      this.realFs.symlink(NodeFS.fromPortablePath(target.replace(/\/+$/, ``) as PortablePath), NodeFS.fromPortablePath(p), type, this.makeCallback(resolve, reject));
+      this.realFs.symlink(npath.fromPortablePath(target.replace(/\/+$/, ``) as PortablePath), npath.fromPortablePath(p), type, this.makeCallback(resolve, reject));
     });
   }
 
   symlinkSync(target: PortablePath, p: PortablePath) {
     const type: 'dir' | 'file' = target.endsWith(`/`) ? `dir` : `file`;
 
-    return this.realFs.symlinkSync(NodeFS.fromPortablePath(target.replace(/\/+$/, ``) as PortablePath), NodeFS.fromPortablePath(p), type);
+    return this.realFs.symlinkSync(npath.fromPortablePath(target.replace(/\/+$/, ``) as PortablePath), npath.fromPortablePath(p), type);
   }
 
   readFilePromise(p: FSPath<PortablePath>, encoding: 'utf8'): Promise<string>;
   readFilePromise(p: FSPath<PortablePath>, encoding?: string): Promise<Buffer>;
   async readFilePromise(p: FSPath<PortablePath>, encoding?: string) {
     return await new Promise<any>((resolve, reject) => {
-      const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+      const fsNativePath = typeof p === `string` ? npath.fromPortablePath(p) : p;
       this.realFs.readFile(fsNativePath, encoding, this.makeCallback(resolve, reject));
     });
   }
@@ -275,37 +274,37 @@ export class NodeFS extends BasePortableFakeFS {
   readFileSync(p: FSPath<PortablePath>, encoding: 'utf8'): string;
   readFileSync(p: FSPath<PortablePath>, encoding?: string): Buffer;
   readFileSync(p: FSPath<PortablePath>, encoding?: string) {
-    const fsNativePath = typeof p === `string` ? NodeFS.fromPortablePath(p) : p;
+    const fsNativePath = typeof p === `string` ? npath.fromPortablePath(p) : p;
     return this.realFs.readFileSync(fsNativePath, encoding);
   }
 
   async readdirPromise(p: PortablePath) {
     return await new Promise<Array<string>>((resolve, reject) => {
-      this.realFs.readdir(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.readdir(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     }) as Filename[];
   }
 
   readdirSync(p: PortablePath) {
-    return this.realFs.readdirSync(NodeFS.fromPortablePath(p)) as Filename[];
+    return this.realFs.readdirSync(npath.fromPortablePath(p)) as Filename[];
   }
 
   async readlinkPromise(p: PortablePath) {
     return await new Promise<string>((resolve, reject) => {
-      this.realFs.readlink(NodeFS.fromPortablePath(p), this.makeCallback(resolve, reject));
+      this.realFs.readlink(npath.fromPortablePath(p), this.makeCallback(resolve, reject));
     }).then(path => {
-      return NodeFS.toPortablePath(path);
+      return npath.toPortablePath(path);
     });
   }
 
   readlinkSync(p: PortablePath) {
-    return NodeFS.toPortablePath(this.realFs.readlinkSync(NodeFS.fromPortablePath(p)));
+    return npath.toPortablePath(this.realFs.readlinkSync(npath.fromPortablePath(p)));
   }
 
   watch(p: PortablePath, cb?: WatchCallback): Watcher;
   watch(p: PortablePath, opts: WatchOptions, cb?: WatchCallback): Watcher;
   watch(p: PortablePath, a?: WatchOptions | WatchCallback, b?: WatchCallback) {
     return this.realFs.watch(
-      NodeFS.fromPortablePath(p),
+      npath.fromPortablePath(p),
       // @ts-ignore
       a,
       b,
@@ -320,13 +319,5 @@ export class NodeFS extends BasePortableFakeFS {
         resolve(result);
       }
     };
-  }
-
-  static fromPortablePath(p: Path): NativePath {
-    return fromPortablePath(p);
-  }
-
-  static toPortablePath(p: Path): PortablePath {
-    return toPortablePath(p);
   }
 }

--- a/packages/yarnpkg-fslib/sources/PosixFS.ts
+++ b/packages/yarnpkg-fslib/sources/PosixFS.ts
@@ -1,5 +1,4 @@
 import {FakeFS}                          from './FakeFS';
-import {NodeFS}                          from './NodeFS';
 import {ProxiedFS}                       from './ProxiedFS';
 import {npath, NativePath, PortablePath} from './path';
 
@@ -13,10 +12,10 @@ export class PosixFS extends ProxiedFS<NativePath, PortablePath> {
   }
 
   protected mapFromBase(path: PortablePath) {
-    return NodeFS.fromPortablePath(path);
+    return npath.fromPortablePath(path);
   }
 
   protected mapToBase(path: NativePath) {
-    return NodeFS.toPortablePath(path);
+    return npath.toPortablePath(path);
   }
 }

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -7,7 +7,7 @@ import {CreateReadStreamOptions, CreateWriteStreamOptions, BasePortableFakeFS} f
 import {FakeFS, WriteFileOptions}                                              from './FakeFS';
 import {WatchOptions, WatchCallback, Watcher}                                  from './FakeFS';
 import {NodeFS}                                                                from './NodeFS';
-import {FSPath, PortablePath, ppath, Filename}                                 from './path';
+import {FSPath, PortablePath, npath, ppath, Filename}                          from './path';
 
 const S_IFMT = 0o170000;
 
@@ -165,7 +165,7 @@ export class ZipFS extends BasePortableFakeFS {
         flags |= libzip.ZIP_RDONLY;
 
       if (typeof source === `string`) {
-        this.zip = libzip.open(NodeFS.fromPortablePath(source), flags, errPtr);
+        this.zip = libzip.open(npath.fromPortablePath(source), flags, errPtr);
       } else {
         const lzSource = this.allocateUnattachedSource(source);
 

--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -1,9 +1,9 @@
-import fs                         from 'fs';
-import tmp                        from 'tmp';
+import fs                                from 'fs';
+import tmp                               from 'tmp';
 
-import {FakeFS}                   from './FakeFS';
-import {NodeFS}                   from './NodeFS';
-import {PortablePath, NativePath} from './path';
+import {FakeFS}                          from './FakeFS';
+import {NodeFS}                          from './NodeFS';
+import {PortablePath, NativePath, npath} from './path';
 
 export {CreateReadStreamOptions}  from './FakeFS';
 export {CreateWriteStreamOptions} from './FakeFS';
@@ -14,13 +14,14 @@ export {WriteFileOptions}         from './FakeFS';
 
 export {FSPath, Path, PortablePath, NativePath, Filename} from './path';
 export {ParsedPath, PathUtils, FormatInputPathObject} from './path';
-export {npath, ppath, toFilename, fromPortablePath, toPortablePath} from './path';
+export {npath, ppath, toFilename} from './path';
 
 export {AliasFS}                  from './AliasFS';
 export {FakeFS}                   from './FakeFS';
 export {CwdFS}                    from './CwdFS';
 export {JailFS}                   from './JailFS';
 export {LazyFS}                   from './LazyFS';
+export {NoFS}                     from './NoFS';
 export {NodeFS}                   from './NodeFS';
 export {PosixFS}                  from './PosixFS';
 export {ProxiedFS}                from './ProxiedFS';
@@ -159,10 +160,10 @@ export const xfs: XFS = Object.assign(new NodeFS(), {
   mktempSync<T>(cb?: (p: PortablePath) => T) {
     const {name, removeCallback} = tmp.dirSync({unsafeCleanup: true});
     if (typeof cb === `undefined`) {
-      return NodeFS.toPortablePath(name);
+      return npath.toPortablePath(name);
     } else {
       try {
-        return cb(NodeFS.toPortablePath(name));
+        return cb(npath.toPortablePath(name));
       } finally {
         removeCallback();
       }
@@ -175,7 +176,7 @@ export const xfs: XFS = Object.assign(new NodeFS(), {
           if (err) {
             reject(err);
           } else {
-            resolve(NodeFS.toPortablePath(path));
+            resolve(npath.toPortablePath(path));
           }
         });
       });
@@ -185,7 +186,7 @@ export const xfs: XFS = Object.assign(new NodeFS(), {
           if (err) {
             reject(err);
           } else {
-            Promise.resolve(NodeFS.toPortablePath(path)).then(cb).then(result => {
+            Promise.resolve(npath.toPortablePath(path)).then(cb).then(result => {
               cleanup();
               resolve(result);
             }, error => {

--- a/packages/yarnpkg-fslib/tests/VirtualFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/VirtualFS.test.ts
@@ -1,17 +1,17 @@
-import {VirtualFS}                       from '../sources/VirtualFS';
-import {Filename, ppath, toPortablePath} from '../sources/path';
-import {xfs}                             from '../sources';
+import {VirtualFS}              from '../sources/VirtualFS';
+import {Filename, npath, ppath} from '../sources/path';
+import {xfs}                    from '../sources';
 
 describe(`VirtualFS`, () => {
   it(`should allow access to a directory through its virtual subfolder`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
     expect(virtualFs.readdirSync(virtualPath)).toContain(`VirtualFS.test.ts`);
   });
 
   it(`should allow access to a directory through its virtual components`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -19,7 +19,7 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should allow access to a directory through its depth marker`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename, `0` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -27,7 +27,7 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should allow access to a directory parent through its depth marker`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename, `1` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -35,7 +35,7 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should allow reading a file through its virtual path (depth=0)`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename, `0` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -47,7 +47,7 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should allow reading a file through its virtual path (depth=1)`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename, `1` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -59,14 +59,14 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should preserve the virtual path across realpath (virtual directory)`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
     expect(virtualFs.realpathSync(virtualPath)).toEqual(virtualPath);
   });
 
   it(`should preserve the virtual path across realpath (virtual component)`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -74,7 +74,7 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should preserve the virtual path across realpath (depth marker)`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename, `0` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);
@@ -82,7 +82,7 @@ describe(`VirtualFS`, () => {
   });
 
   it(`should preserve the virtual path across realpath (virtual file)`, () => {
-    const virtualPath = ppath.join(toPortablePath(__dirname), `virtual` as Filename);
+    const virtualPath = ppath.join(npath.toPortablePath(__dirname), `virtual` as Filename);
     const virtualEntry = ppath.join(virtualPath, `12345` as Filename, `0` as Filename, `VirtualFS.test.ts` as Filename);
 
     const virtualFs = new VirtualFS(virtualPath);

--- a/packages/yarnpkg-fslib/tests/npath.test.ts
+++ b/packages/yarnpkg-fslib/tests/npath.test.ts
@@ -1,4 +1,4 @@
-import {NodeFS} from '../sources/NodeFS';
+import {npath} from '../sources/paths';
 
 describe(`Portable paths`, () => {
   for (const platform of [`darwin`, `win32`]) {
@@ -25,55 +25,55 @@ describe(`Portable paths`, () => {
           it(`shouldn't change paths on non-Windows platform`, () => {
             const inputPath = 'C:\\Users\\user\\proj';
             const outputPath = inputPath;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
         } else {
           it(`shouldn't change absolute posix paths when producing portable path`, () => {
             const inputPath = '/home/user/proj';
             const outputPath = inputPath;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`shouldn't change absolute paths that are already portable`, () => {
             const inputPath = '/c:/Users/user/proj';
             const outputPath = '/c:/Users/user/proj';
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should normalize the slashes in relative Windows paths`, () => {
             const inputPath = '..\\Users\\user/proj';
             const outputPath = '../Users/user/proj';
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform Windows paths into their posix counterparts (uppercase drive)`, () => {
             const inputPath = 'C:\\Users\\user\\proj';
             const outputPath = `/C:/Users/user/proj`;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform Windows paths into their posix counterparts (lowercase drive)`, () => {
             const inputPath = 'c:\\Users\\user\\proj';
             const outputPath = `/c:/Users/user/proj`;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform Windows paths into their posix counterparts (forward slashes)`, () => {
             const inputPath = 'C:/Users/user/proj';
             const outputPath = `/C:/Users/user/proj`;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should support Windows paths that contain both backslashes and forward slashes`, () => {
             const inputPath = 'C:/Users\\user/proj';
             const outputPath = `/C:/Users/user/proj`;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should support drive: Windows paths`, () => {
             const inputPath = 'C:';
             const outputPath = `/C:`;
-            expect(NodeFS.toPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.toPortablePath(inputPath)).toEqual(outputPath);
           });
         }
       });
@@ -83,49 +83,49 @@ describe(`Portable paths`, () => {
           it(`shouldn't change portable paths on non-Windows platforms`, () => {
             const inputPath = '/c:/Users/user/proj';
             const outputPath = inputPath;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
         } else {
           it(`shouldn't change absolute posix paths when producing native path`, () => {
             const inputPath = '/home/user/proj';
             const outputPath = '/home/user/proj';
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`shouldn't change relative posix paths when producing native paths`, () => {
             const inputPath = '../Users/user/proj';
             const outputPath = inputPath;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`shouldn't change absolute path when it is already Windows`, () => {
             const inputPath = `c:\\Users\\user\\proj`;
             const outputPath = inputPath;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform back Windows paths on Windows platforms (lowercase drive)`, () => {
             const inputPath = `/c:/Users/user/proj`;
             const outputPath = `c:\\Users\\user\\proj`;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform back Windows paths on Windows platforms (uppercase drive)`, () => {
             const inputPath = `/C:/Users/user/proj`;
             const outputPath = `C:\\Users\\user\\proj`;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform back Windows paths on Windows platforms (mixed path)`, () => {
             const inputPath = `/c:/Users\\user/proj`;
             const outputPath = `c:\\Users\\user\\proj`;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
 
           it(`should transform back drive: on Windows platforms`, () => {
             const inputPath = `/C:`;
             const outputPath = `C:`;
-            expect(NodeFS.fromPortablePath(inputPath)).toEqual(outputPath);
+            expect(npath.fromPortablePath(inputPath)).toEqual(outputPath);
           });
         }
       });

--- a/packages/yarnpkg-fslib/tests/npath.test.ts
+++ b/packages/yarnpkg-fslib/tests/npath.test.ts
@@ -1,4 +1,4 @@
-import {npath} from '../sources/paths';
+import {npath} from '../sources/path';
 
 describe(`Portable paths`, () => {
   for (const platform of [`darwin`, `win32`]) {

--- a/packages/yarnpkg-json-proxy/package.json
+++ b/packages/yarnpkg-json-proxy/package.json
@@ -2,7 +2,7 @@
   "name": "@yarnpkg/json-proxy",
   "version": "2.0.0-rc.2",
   "nextVersion": {
-    "nonce": "5385708061506495"
+    "nonce": "5574339745259021"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/pnp",
   "version": "2.0.0-rc.6",
+  "nextVersion": {
+    "nonce": "9003835310538527"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:2.0.0-rc.5"

--- a/packages/yarnpkg-pnp/sources/loader/applyPatch.ts
+++ b/packages/yarnpkg-pnp/sources/loader/applyPatch.ts
@@ -1,11 +1,11 @@
-import {FakeFS, NodeFS, PosixFS, patchFs, PortablePath} from '@yarnpkg/fslib';
-import fs                                               from 'fs';
-import Module                                           from 'module';
-import path                                             from 'path';
+import {FakeFS, PosixFS, npath, patchFs, PortablePath} from '@yarnpkg/fslib';
+import fs                                              from 'fs';
+import Module                                          from 'module';
+import path                                            from 'path';
 
-import {PackageLocator, PnpApi}                         from '../types';
+import {PackageLocator, PnpApi}                        from '../types';
 
-import {ErrorCode, makeError, getIssuerModule}          from './internalTools';
+import {ErrorCode, makeError, getIssuerModule}         from './internalTools';
 
 export type ApplyPatchOptions = {
   compatibilityMode?: boolean,
@@ -210,7 +210,7 @@ export function applyPatch(pnpapi: PnpApi, opts: ApplyPatchOptions) {
 
     if (!issuers) {
       const issuerModule = getIssuerModule(parent);
-      const issuer = issuerModule ? issuerModule.filename : `${NodeFS.toPortablePath(process.cwd())}/`;
+      const issuer = issuerModule ? issuerModule.filename : `${npath.toPortablePath(process.cwd())}/`;
 
       issuers = [issuer];
     }
@@ -220,7 +220,7 @@ export function applyPatch(pnpapi: PnpApi, opts: ApplyPatchOptions) {
     // We test it for an absolute Windows path and convert it to a portable path.
     // We should probably always call toPortablePath and check for this directly
     if (/^[A-Z]:.*/.test(request))
-      request = NodeFS.toPortablePath(request);
+      request = npath.toPortablePath(request);
 
     let firstError;
 

--- a/packages/yarnpkg-pnp/sources/loader/hydrateRuntimeState.ts
+++ b/packages/yarnpkg-pnp/sources/loader/hydrateRuntimeState.ts
@@ -1,4 +1,4 @@
-import {NodeFS, ppath, PortablePath}                                                     from '@yarnpkg/fslib';
+import {PortablePath, npath, ppath}                                                      from '@yarnpkg/fslib';
 
 import {PackageInformation, PackageLocator, PackageStore, RuntimeState, SerializedState} from '../types';
 
@@ -7,7 +7,7 @@ export type HydrateRuntimeStateOptions = {
 };
 
 export function hydrateRuntimeState(data: SerializedState, {basePath}: HydrateRuntimeStateOptions): RuntimeState {
-  const portablePath = NodeFS.toPortablePath(basePath);
+  const portablePath = npath.toPortablePath(basePath);
 
   const ignorePattern = data.ignorePatternData !== null
     ? new RegExp(data.ignorePatternData)

--- a/packages/yarnpkg-pnp/sources/loader/makeApi.ts
+++ b/packages/yarnpkg-pnp/sources/loader/makeApi.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../types/module/index.d.ts"/>
 
-import {FakeFS, NodeFS, PortablePath, NativePath, Path}           from '@yarnpkg/fslib';
+import {FakeFS, NativePath, Path, PortablePath, npath}            from '@yarnpkg/fslib';
 import {ppath, toFilename}                                        from '@yarnpkg/fslib';
 import Module                                                     from 'module';
 
@@ -272,7 +272,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
    */
 
   function normalizePath(p: Path) {
-    return NodeFS.toPortablePath(p);
+    return npath.toPortablePath(p);
   }
 
   /**
@@ -287,7 +287,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
     // would give us the paths to give to _resolveFilename), we can as well not use
     // the {paths} option at all, since it internally makes _resolveFilename create another
     // fake module anyway.
-    return Module._resolveFilename(request, makeFakeModule(NodeFS.fromPortablePath(issuer)), false, {plugnplay: false});
+    return Module._resolveFilename(request, makeFakeModule(npath.fromPortablePath(issuer)), false, {plugnplay: false});
   }
 
   /**
@@ -395,7 +395,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
     // The 'pnpapi' request is reserved and will always return the path to the PnP file, from everywhere
 
     if (request === `pnpapi`)
-      return NodeFS.toPortablePath(opts.pnpapiResolution);
+      return npath.toPortablePath(opts.pnpapiResolution);
 
     // Bailout if the request is a native module
 
@@ -417,7 +417,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
         );
       }
 
-      return NodeFS.toPortablePath(result);
+      return npath.toPortablePath(result);
     }
 
     let unqualifiedPath: PortablePath;
@@ -479,7 +479,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
           );
         }
 
-        return NodeFS.toPortablePath(result);
+        return npath.toPortablePath(result);
       }
 
       const issuerInformation = getPackageInformationSafe(issuerLocator);
@@ -631,38 +631,38 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
       if (info === null)
         return null;
 
-      const packageLocation = NodeFS.fromPortablePath(info.packageLocation);
+      const packageLocation = npath.fromPortablePath(info.packageLocation);
       const nativeInfo = {...info, packageLocation};
 
       return nativeInfo;
     },
 
     findPackageLocator: (path: string) => {
-      return findPackageLocator(NodeFS.toPortablePath(path));
+      return findPackageLocator(npath.toPortablePath(path));
     },
 
     resolveToUnqualified: maybeLog(`resolveToUnqualified`, (request: NativePath, issuer: NativePath | null, opts?: ResolveToUnqualifiedOptions) => {
-      const portableIssuer = issuer !== null ?  NodeFS.toPortablePath(issuer) : null;
+      const portableIssuer = issuer !== null ?  npath.toPortablePath(issuer) : null;
 
-      const resolution = resolveToUnqualified(NodeFS.toPortablePath(request), portableIssuer, opts);
+      const resolution = resolveToUnqualified(npath.toPortablePath(request), portableIssuer, opts);
       if (resolution === null)
         return null;
 
-      return NodeFS.fromPortablePath(resolution);
+      return npath.fromPortablePath(resolution);
     }),
 
     resolveUnqualified: maybeLog(`resolveUnqualified`, (unqualifiedPath: NativePath, opts?: ResolveUnqualifiedOptions) => {
-      return NodeFS.fromPortablePath(resolveUnqualified(NodeFS.toPortablePath(unqualifiedPath), opts));
+      return npath.fromPortablePath(resolveUnqualified(npath.toPortablePath(unqualifiedPath), opts));
     }),
 
     resolveRequest: maybeLog(`resolveRequest`, (request: NativePath, issuer: NativePath | null, opts?: ResolveRequestOptions) => {
-      const portableIssuer = issuer !== null ? NodeFS.toPortablePath(issuer) : null;
+      const portableIssuer = issuer !== null ? npath.toPortablePath(issuer) : null;
 
-      const resolution = resolveRequest(NodeFS.toPortablePath(request), portableIssuer, opts);
+      const resolution = resolveRequest(npath.toPortablePath(request), portableIssuer, opts);
       if (resolution === null)
         return null;
 
-      return NodeFS.fromPortablePath(resolution);
+      return npath.fromPortablePath(resolution);
     }),
   };
 }

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/pnpify",
   "version": "2.0.0-rc.7",
+  "nextVersion": {
+    "nonce": "4709835541163491"
+  },
   "main": "./sources/boot-dev.js",
   "bin": "./sources/boot-cli-dev.js",
   "sideEffects": false,

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -23,11 +23,11 @@ export class NodeModulesFS extends ProxiedFS<NativePath, PortablePath> {
   }
 
   protected mapFromBase(path: PortablePath) {
-    return NodeFS.fromPortablePath(path);
+    return npath.fromPortablePath(path);
   }
 
   protected mapToBase(path: NativePath) {
-    return NodeFS.toPortablePath(path);
+    return npath.toPortablePath(path);
   }
 }
 
@@ -47,7 +47,7 @@ class PortableNodeModulesFs extends FakeFS<PortablePath> {
     this.pathResolver = new NodePathResolver(pnp);
     this.watchManager = new WatchManager();
 
-    const pnpRootPath = NodeFS.toPortablePath(pnp.getPackageInformation(pnp.topLevel)!.packageLocation);
+    const pnpRootPath = npath.toPortablePath(pnp.getPackageInformation(pnp.topLevel)!.packageLocation);
     this.watchPnpFile(pnpRootPath);
   }
 

--- a/packages/yarnpkg-pnpify/sources/PortablePnPApi.ts
+++ b/packages/yarnpkg-pnpify/sources/PortablePnPApi.ts
@@ -1,4 +1,4 @@
-import {PortablePath, NodeFS}                       from '@yarnpkg/fslib';
+import {PortablePath, npath}                        from '@yarnpkg/fslib';
 import {PnpApi, PackageInformation, PackageLocator} from '@yarnpkg/pnp';
 
 /**
@@ -21,7 +21,7 @@ export class PortablePnPApi {
     let portableInfo: PackageInformation<PortablePath> | null = null;
     if (nativeInfo) {
       portableInfo = {
-        packageLocation: NodeFS.toPortablePath(nativeInfo.packageLocation),
+        packageLocation: npath.toPortablePath(nativeInfo.packageLocation),
         packageDependencies: nativeInfo.packageDependencies,
         linkType: nativeInfo.linkType,
       };
@@ -30,20 +30,20 @@ export class PortablePnPApi {
   }
 
   public findPackageLocator(location: PortablePath): PackageLocator | null {
-    return this.pnp.findPackageLocator(NodeFS.fromPortablePath(location));
+    return this.pnp.findPackageLocator(npath.fromPortablePath(location));
   }
 
   public resolveToUnqualified(request: string, issuer: PortablePath | null, opts?: {considerBuiltins?: boolean}): PortablePath | null {
-    const result = this.pnp.resolveToUnqualified(request, !issuer ? null : NodeFS.fromPortablePath(issuer), opts);
-    return !result ? null : NodeFS.toPortablePath(result);
+    const result = this.pnp.resolveToUnqualified(request, !issuer ? null : npath.fromPortablePath(issuer), opts);
+    return !result ? null : npath.toPortablePath(result);
   }
 
   public resolveUnqualified(unqualified: PortablePath, opts?: {extensions?: Array<string>}): PortablePath {
-    return NodeFS.toPortablePath(this.pnp.resolveUnqualified(NodeFS.fromPortablePath(unqualified), opts));
+    return npath.toPortablePath(this.pnp.resolveUnqualified(npath.fromPortablePath(unqualified), opts));
   }
 
   public resolveRequest(request: string, issuer: PortablePath | null, opts?: {considerBuiltins?: boolean, extensions?: Array<string>}): PortablePath | null {
-    const result = this.pnp.resolveRequest(request, !issuer ? null : NodeFS.fromPortablePath(issuer), opts);
-    return !result ? null : NodeFS.toPortablePath(result);
+    const result = this.pnp.resolveRequest(request, !issuer ? null : npath.fromPortablePath(issuer), opts);
+    return !result ? null : npath.toPortablePath(result);
   }
 }

--- a/packages/yarnpkg-pnpify/sources/cli.ts
+++ b/packages/yarnpkg-pnpify/sources/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import {NodeFS}         from '@yarnpkg/fslib';
+import {npath}          from '@yarnpkg/fslib';
 import crossSpawn       from 'cross-spawn';
 
 import {dynamicRequire} from './dynamicRequire';
@@ -33,7 +33,7 @@ function sdk() {
   const {getPackageInformation, topLevel} = dynamicRequire(`pnpapi`);
   const {packageLocation} = getPackageInformation(topLevel);
 
-  const projectRoot = NodeFS.toPortablePath(packageLocation);
+  const projectRoot = npath.toPortablePath(packageLocation);
 
   generateSdk(projectRoot).catch(error => {
     console.error(error.stack);

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -1,10 +1,10 @@
-import {Filename, NodeFS, PortablePath, xfs, ppath} from '@yarnpkg/fslib';
-import json5                                        from 'json5';
+import {Filename, PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
+import json5                                       from 'json5';
 
-import {dynamicRequire}                             from './dynamicRequire';
+import {dynamicRequire}                            from './dynamicRequire';
 
 const TEMPLATE = (relPnpApiPath: string, module: string, {usePnpify}: {usePnpify: boolean}) => [
-  `const relPnpApiPath = ${JSON.stringify(NodeFS.toPortablePath(relPnpApiPath))};\n`,
+  `const relPnpApiPath = ${JSON.stringify(npath.toPortablePath(relPnpApiPath))};\n`,
   `const absPnpApiPath = require(\`path\`).resolve(__dirname, relPnpApiPath);\n`,
   `\n`,
   `// Setup the environment to be able to require ${module}\n`,
@@ -46,7 +46,7 @@ const generateTypescriptWrapper = async (projectRoot: PortablePath, target: Port
   await xfs.writeFilePromise(manifest, JSON.stringify({name: 'typescript', version: `${dynamicRequire('typescript/package.json').version}-pnpify`}, null, 2));
   await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath, "typescript/lib/tsserver", {usePnpify: true}));
 
-  await addVSCodeWorkspaceSettings(projectRoot, {'typescript.tsdk': NodeFS.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver)))});
+  await addVSCodeWorkspaceSettings(projectRoot, {'typescript.tsdk': npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver)))});
 };
 
 export const generateEslintWrapper = async (projectRoot: PortablePath, target: PortablePath) => {
@@ -60,7 +60,7 @@ export const generateEslintWrapper = async (projectRoot: PortablePath, target: P
   await xfs.writeFilePromise(manifest, JSON.stringify({name: 'eslint', version: `${dynamicRequire('eslint/package.json').version}-pnpify`, main: 'lib/api.js'}, null, 2));
   await xfs.writeFilePromise(api, TEMPLATE(relPnpApiPath, "eslint", {usePnpify: false}));
 
-  await addVSCodeWorkspaceSettings(projectRoot, {'eslint.nodePath': NodeFS.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(eslint)))});
+  await addVSCodeWorkspaceSettings(projectRoot, {'eslint.nodePath': npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(eslint)))});
 };
 
 const isPackageInstalled = (name: string): boolean => {

--- a/packages/yarnpkg-pnpify/tests/NodePathResolver.test.ts
+++ b/packages/yarnpkg-pnpify/tests/NodePathResolver.test.ts
@@ -1,4 +1,4 @@
-import {NodeFS}           from '@yarnpkg/fslib';
+import {npath}            from '@yarnpkg/fslib';
 import {PnpApi}           from '@yarnpkg/pnp';
 
 import {NodePathResolver} from '../sources/NodePathResolver';
@@ -61,84 +61,84 @@ describe('NodePathResolver', () => {
   });
 
   it('should not change paths outside of pnp project', () => {
-    const pnpPath = resolver.resolvePath(NodeFS.toPortablePath('/home/user/node_modules/a/b/c'));
+    const pnpPath = resolver.resolvePath(npath.toPortablePath('/home/user/node_modules/a/b/c'));
     expect(pnpPath.resolvedPath).toEqual('/home/user/node_modules/a/b/c');
   });
 
   it('should not try to alter paths without node_modules inside pnp project', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/.cache/foo');
+    const nodePath = npath.toPortablePath('/home/user/proj/.cache/foo');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: nodePath});
   });
 
   it('should not try to alter paths from a dotted node_modules entry', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/.foo/bar');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/.foo/bar');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: nodePath});
   });
 
   it('should resolve /home/user/proj path', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj');
+    const nodePath = npath.toPortablePath('/home/user/proj');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj'});
   });
 
   it('should resolve /home/user/proj/node_modules path', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/node_modules', statPath: '/home/user/proj', dirList: new Set(['monorepo', 'foo', 'bar', '@scope'])});
   });
 
   it('should resolve /home/user/proj/node_modules/monorepo path as a symlink to itself', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/monorepo');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/monorepo');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj', isSymlink: true});
   });
 
   it('should resolve /home/user/proj/node_modules/monorepo/index.js without it being reported a symlink', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/monorepo/index.js');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/monorepo/index.js');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/index.js'});
   });
 
   it('should partially resolve /home/user/proj/node_modules/@scope path', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/@scope');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/@scope');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/node_modules/@scope', statPath: '/home/user/proj', dirList: new Set(['baz'])});
   });
 
   it('should not change path inside pnp dependency', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/.cache/foo/node_modules/foo');
+    const nodePath = npath.toPortablePath('/home/user/proj/.cache/foo/node_modules/foo');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: nodePath});
   });
 
   it('should resolve /home/user/proj/node_modules/foo path', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/foo');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/foo');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/.cache/foo/node_modules/foo'});
   });
 
   it('should enter resolve package and leave request intact in /home/user/proj/node_modules/foo/a/b/c/index.js', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/foo/a/b/c/index.js');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/foo/a/b/c/index.js');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/.cache/foo/node_modules/foo/a/b/c/index.js'});
   });
 
   it('should enter into two packages in a path and leave request intact', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/foo/node_modules/bar/a/b/c/index.js');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/foo/node_modules/bar/a/b/c/index.js');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: '/home/user/proj/.cache/bar/node_modules/bar/a/b/c/index.js'});
   });
 
   it('should return null if issuer has no given dependency', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/bar');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/bar');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: null});
   });
 
   it('should return null if packages dependends on itself', () => {
-    const nodePath = NodeFS.toPortablePath('/home/user/proj/node_modules/foo/node_modules/foo');
+    const nodePath = npath.toPortablePath('/home/user/proj/node_modules/foo/node_modules/foo');
     const pnpPath = resolver.resolvePath(nodePath);
     expect(pnpPath).toEqual({resolvedPath: null});
   });

--- a/packages/yarnpkg-pnpify/tests/WatchManager.test.ts
+++ b/packages/yarnpkg-pnpify/tests/WatchManager.test.ts
@@ -1,12 +1,12 @@
-import {NodeFS, toFilename} from '@yarnpkg/fslib';
+import {npath, toFilename} from '@yarnpkg/fslib';
 
-import {WatchManager}       from '../sources/WatchManager';
+import {WatchManager}      from '../sources/WatchManager';
 
 describe('WatchManager', () => {
   const manager = new WatchManager();
 
   it('should trigger callback when dir entries added', () => {
-    const dirPath = NodeFS.toPortablePath('/abc');
+    const dirPath = npath.toPortablePath('/abc');
     const dirList = new Set(['file1.ts', 'file2.ts'].map(x => toFilename(x)));
     const callback = jest.fn();
     const watcherCallback = jest.fn();
@@ -32,7 +32,7 @@ describe('WatchManager', () => {
 
   it('should trigger callback when dir entries removed', () => {
     const manager = new WatchManager();
-    const dirPath = NodeFS.toPortablePath('/abc');
+    const dirPath = npath.toPortablePath('/abc');
     const dirList = new Set(['file1.ts', 'file2.ts', 'file3.ts', 'file4.ts'].map(x => toFilename(x)));
     const callback = jest.fn();
     const watcherCallback = jest.fn();
@@ -56,7 +56,7 @@ describe('WatchManager', () => {
   });
 
   it('should not trigger closed callback', () => {
-    const dirPath = NodeFS.toPortablePath('/abc');
+    const dirPath = npath.toPortablePath('/abc');
     const dirList = new Set(['file1.ts'].map(x => toFilename(x)));
     const callback = jest.fn();
     const watcherCallback = jest.fn();

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -2,7 +2,7 @@
   "name": "@yarnpkg/shell",
   "version": "2.0.0-rc.2",
   "nextVersion": {
-    "nonce": "6735137093494127"
+    "nonce": "8104897074983453"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -1,4 +1,4 @@
-import {xfs, NodeFS, ppath, PortablePath}                                            from '@yarnpkg/fslib';
+import {PortablePath, npath, ppath, xfs}                                             from '@yarnpkg/fslib';
 import {Argument, ArgumentSegment, CommandChain, CommandLine, ShellLine, parseShell} from '@yarnpkg/parsers';
 import {EnvSegment}                                                                  from '@yarnpkg/parsers';
 import {PassThrough, Readable, Writable}                                             from 'stream';
@@ -51,7 +51,7 @@ function cloneState(state: ShellState, mergeWith: Partial<ShellState> = {}) {
 
 const BUILTINS = new Map<string, ShellBuiltin>([
   [`cd`, async ([target, ...rest]: Array<string>, opts: ShellOptions, state: ShellState) => {
-    const resolvedTarget = ppath.resolve(state.cwd, NodeFS.toPortablePath(target));
+    const resolvedTarget = ppath.resolve(state.cwd, npath.toPortablePath(target));
     const stat = await xfs.statPromise(resolvedTarget);
 
     if (!stat.isDirectory()) {
@@ -64,7 +64,7 @@ const BUILTINS = new Map<string, ShellBuiltin>([
   }],
 
   [`pwd`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {
-    state.stdout.write(`${NodeFS.fromPortablePath(state.cwd)}\n`);
+    state.stdout.write(`${npath.fromPortablePath(state.cwd)}\n`);
     return 0;
   }],
 
@@ -105,7 +105,7 @@ const BUILTINS = new Map<string, ShellBuiltin>([
         switch (type) {
           case `<`: {
             inputs.push(() => {
-              return xfs.createReadStream(ppath.resolve(state.cwd, NodeFS.toPortablePath(args[u])));
+              return xfs.createReadStream(ppath.resolve(state.cwd, npath.toPortablePath(args[u])));
             });
           } break;
           case `<<<`: {
@@ -119,10 +119,10 @@ const BUILTINS = new Map<string, ShellBuiltin>([
             });
           } break;
           case `>`: {
-            outputs.push(xfs.createWriteStream(ppath.resolve(state.cwd, NodeFS.toPortablePath(args[u]))));
+            outputs.push(xfs.createWriteStream(ppath.resolve(state.cwd, npath.toPortablePath(args[u]))));
           } break;
           case `>>`: {
-            outputs.push(xfs.createWriteStream(ppath.resolve(state.cwd, NodeFS.toPortablePath(args[u])), {flags: `a`}));
+            outputs.push(xfs.createWriteStream(ppath.resolve(state.cwd, npath.toPortablePath(args[u])), {flags: `a`}));
           } break;
         }
       }
@@ -355,7 +355,7 @@ function makeCommandAction(args: Array<string>, opts: ShellOptions, state: Shell
   const [name, ...rest] = args;
   if (name === `command`) {
     return makeProcess(rest[0], rest.slice(1), opts, {
-      cwd: NodeFS.fromPortablePath(state.cwd),
+      cwd: npath.fromPortablePath(state.cwd),
       env: state.environment,
     });
   }
@@ -591,7 +591,7 @@ function locateArgsVariable(node: ShellLine): boolean {
 
 export async function execute(command: string, args: Array<string> = [], {
   builtins = {},
-  cwd = NodeFS.toPortablePath(process.cwd()),
+  cwd = npath.toPortablePath(process.cwd()),
   env = process.env,
   stdin = process.stdin,
   stdout = process.stdout,

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -1,4 +1,4 @@
-import {NodeFS, xfs} from '@yarnpkg/fslib';
+import {npath, xfs}  from '@yarnpkg/fslib';
 import {execute}     from '@yarnpkg/shell';
 import {PassThrough} from 'stream';
 import {fileSync}    from 'tmp';
@@ -415,7 +415,7 @@ describe(`Simple shell features`, () => {
   });
 
   it(`should support input redirections (file)`, async () => {
-    const file = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
     await xfs.writeFilePromise(file, `hello world\n`);
 
     await expect(bufferResult(
@@ -434,7 +434,7 @@ describe(`Simple shell features`, () => {
   });
 
   it(`should support output redirections (overwrite)`, async () => {
-    const file = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
 
     await expect(bufferResult(
       `echo "hello world" > "${file}"`,
@@ -446,7 +446,7 @@ describe(`Simple shell features`, () => {
   });
 
   it(`should support output redirections (append)`, async () => {
-    const file = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
     await xfs.writeFilePromise(file, `foo bar baz\n`);
 
     await expect(bufferResult(
@@ -459,8 +459,8 @@ describe(`Simple shell features`, () => {
   });
 
   it(`should support multiple outputs`, async () => {
-    const file1 = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
-    const file2 = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file1 = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file2 = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
 
     await expect(bufferResult(
       `echo "hello world" > "${file1}" > "${file2}"`,
@@ -473,10 +473,10 @@ describe(`Simple shell features`, () => {
   });
 
   it(`should support multiple inputs`, async () => {
-    const file1 = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file1 = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
     await xfs.writeFilePromise(file1, `foo bar baz\n`);
 
-    const file2 = NodeFS.toPortablePath(fileSync({discardDescriptor: true}).name);
+    const file2 = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
     await xfs.writeFilePromise(file2, `hello world\n`);
 
     await expect(bufferResult(


### PR DESCRIPTION
**What's the problem this PR addresses?**

- The `toPortablePath` / `fromPortablePath` were exposed from both `NodeFS` and `path.ts`.
- There was no way to implement a partial `FakeFS` without implementing each and every method.
- Checking whether a path is contained in another path is common but annoying to reimplement.

**How did you fix it?**

- The `toPortablePath` and `fromPortablePath` are moved into `npath`. Callsites are updated.
- A new `NoFS` implementation will throw at runtime for each unimplemented method.
- Both `npath` and `ppath` now expose an utility called `contains` which returns `null` if the second parameter isn't contained in the first one, or the subpath otherwise.
