### PR TITLE
Update release-workflow.md

### DIFF
--- a/packages/gatsby/content/features/release-workflow.md
+++ b/packages/gatsby/content/features/release-workflow.md
@@ -4,7 +4,7 @@ path: /features/release-workflow
 title: "Release Workflow"
 ---
 
-A hard task when working in a monorepo, and in particular when managing multiple packages, is to figure out which packages should be bumped when doing a new release. Yarn offers a few tools that aim to make this workflow easier without need for third-party softwares, althought it's possible to leverage those tools and build more integrated workflows.
+A hard task when working in a monorepo, and in particular when managing multiple packages, is to figure out which packages should be bumped when doing a new release. Yarn offers a few tools that aim to make this workflow easier without need for third-party software, althought it's possible to leverage those tools and build more integrated workflows.
 
 ## Auto-updated dependencies
 
@@ -24,7 +24,7 @@ In pre-2.0, upgrading `common` would have required you to run the command there,
 /packages/client (depends on common@^1.1.1)
 ```
 
-Of course it's not that important when the packages from the monorepo are always meant to be used as part of the monorepo, but it becomes much more interesting when you work with multiple packages meant to be published. Had you forget to bump the referenced range of either of your dependent packages, your users would have potentially downloaded an old version of `common` which wouldn't have been compatible with the newer one.
+Of course it's not that important when the packages from the monorepo are always meant to be used as part of the monorepo, but it becomes much more interesting when you work with multiple packages meant to be published. Had you forgotten to bump the referenced range of either of your dependent packages, your users would have potentially downloaded an old version of `common` which wouldn't have been compatible with the newer one.
 
 ## Deferred versioning
 

--- a/packages/gatsby/content/features/release-workflow.md
+++ b/packages/gatsby/content/features/release-workflow.md
@@ -4,7 +4,7 @@ path: /features/release-workflow
 title: "Release Workflow"
 ---
 
-An hard task when working in a monorepo, and in particular when managing multiple packages, is to figure out which packages should be bumped when doing a new release. Yarn offers a few tools that aim to make this workflow easier without need for third-party softwares, althought it's possible to leverage those tools and build more integrated workflows.
+A hard task when working in a monorepo, and in particular when managing multiple packages, is to figure out which packages should be bumped when doing a new release. Yarn offers a few tools that aim to make this workflow easier without need for third-party softwares, althought it's possible to leverage those tools and build more integrated workflows.
 
 ## Auto-updated dependencies
 


### PR DESCRIPTION
Typo in file...

**What's the problem this PR addresses?**
> An hard task when working in a monorepo,

Should be: "A hard task..."

> softwares

Should be: "Software"

> forget

Should be conjugated to: "forgotten"

**How did you fix it?**
Fixed the Typo
...
