### PR TITLE
Forces bash on GitHub Actions

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -21,6 +21,7 @@ jobs:
     - name: 'Check that the Yarn files don''t change on new installs (fix w/ "yarn install")'
       run: |
         node ./scripts/run-yarn.js --immutable --immutable-cache
+      shell: bash
       env:
         YARN_ENABLE_NETWORK: 0
 
@@ -29,6 +30,7 @@ jobs:
         if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- .yarn/{cache,virtual} | wc -l) -gt 0 ]]; then
           node ./scripts/run-yarn.js --immutable --immutable-cache --check-cache
         fi
+      shell: bash
       if: |
         github.event.pull_request != ''
       env:
@@ -37,16 +39,19 @@ jobs:
     - name: 'Check that the PR describes which packages should be bumped (fix w/ "yarn version check -i")'
       run: |
         node ./scripts/run-yarn.js version check
+      shell: bash
       if: |
         github.event.pull_request != ''
 
     - name: 'Check for linting errors (fix w/ "yarn test:lint --fix")'
       run: |
         node ./scripts/run-yarn.js test:lint
+      shell: bash
 
     - name: 'Check for unmet constraints (fix w/ "yarn constraints --fix")'
       run: |
         node ./scripts/run-yarn.js constraints
+      shell: bash
 
   acceptance:
     strategy:
@@ -77,7 +82,6 @@ jobs:
 
     - name: 'Build the standard bundle & plugins'
       run: |
-        set -e
         node --version
         node ./scripts/run-yarn.js build:cli
         node ./scripts/run-yarn.js build:plugin-exec
@@ -85,11 +89,14 @@ jobs:
         node ./scripts/run-yarn.js build:plugin-typescript
         node ./scripts/run-yarn.js build:plugin-version
         node ./scripts/run-yarn.js build:plugin-workspace-tools
+      shell: bash
 
     - name: 'Run the integration tests'
       run: |
         node ./scripts/run-yarn.js test:integration --runInBand
+      shell: bash
 
     - name: 'Run the unit tests'
       run: |
         node ./scripts/run-yarn.js test:unit
+      shell: bash


### PR DESCRIPTION
**What's the problem this PR addresses?**

It seems that the default shell changed and Windows is now using Powershell out of the box. It's problematic for our integration tests, since they are meant to run on both Windows and Posix.

**How did you fix it?**

I've explicitly set `bash` as the shell to use everywhere (cf [documentation](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell)).
