### PR TITLE
Exposes --yes for yarn init

### DIFF
--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -11,7 +11,8 @@
   },
   "version": "2.0.0-rc.1",
   "nextVersion": {
-    "nonce": "6399265391920169"
+    "semver": "2.0.0-rc.2",
+    "nonce": "5918874990081661"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -7,6 +7,9 @@ import {Command, UsageError}     from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class InitCommand extends BaseCommand {
+  @Command.Boolean(`-y,--yes`, {hidden: true})
+  yes: boolean = false;
+
   @Command.Boolean(`-p,--private`)
   private: boolean = false;
 

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.10",
   "nextVersion": {
     "semver": "2.0.0-rc.11",
-    "nonce": "7091287192486305"
+    "nonce": "291773640700655"
   },
   "main": "./sources/index.ts",
   "dependencies": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some bash scripts use the `-y,--yes` option from Yarn v1. Even though we're streamlining the syntax with the `--interactive` flag we can support `--yes` for now (and formally deprecate it later).

**How did you fix it?**

The `--yes` option won't generate an error (but won't have any effect since we don't ask questions by default).
