### PR TITLE
limit parallel requests to registry during resolution

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,7 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "semver": "2.0.0-rc.10",
+    "semver": "2.0.0-rc.9",
     "nonce": "2397602753556307"
   },
   "bin": "./sources/boot-dev.js",

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.9",
+  "nextVersion": {
+    "semver": "2.0.0-rc.10",
+    "nonce": "2397602753556307"
+  },
   "bin": "./sources/boot-dev.js",
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,6 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "semver": "2.0.0-rc.9",
     "nonce": "2397602753556307"
   },
   "bin": "./sources/boot-dev.js",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.11",
   "nextVersion": {
     "semver": "2.0.0-rc.12",
-    "nonce": "99525153414315"
+    "nonce": "6623953652684197"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/core",
   "version": "2.0.0-rc.11",
   "nextVersion": {
-    "nonce": "2905733943814283"
+    "semver": "2.0.0-rc.12",
+    "nonce": "3714013031290855"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -439,6 +439,8 @@ export class Project {
       mustBeResolved.add(workspaceDescriptor.descriptorHash);
     }
 
+    const limit = pLimit(10);
+
     while (mustBeResolved.size !== 0) {
       // We remove from the "mustBeResolved" list all packages that have
       // already been resolved previously.
@@ -451,7 +453,7 @@ export class Project {
       // match the given ranges. That will give us a set of candidate references
       // for each descriptor.
 
-      const passCandidates = new Map(await Promise.all(Array.from(mustBeResolved).map(async descriptorHash => {
+      const passCandidates = new Map(await Promise.all(Array.from(mustBeResolved).map(descriptorHash => limit(async () => {
         const descriptor = allDescriptors.get(descriptorHash);
         if (!descriptor)
           throw new Error(`Assertion failed: The descriptor should have been registered`);
@@ -469,7 +471,7 @@ export class Project {
           throw new Error(`No candidate found for ${structUtils.prettyDescriptor(this.configuration, descriptor)}`);
 
         return [descriptor.descriptorHash, candidateLocators] as [DescriptorHash, Array<Locator>];
-      })));
+      }))));
 
       // That's where we'll store our resolutions until everything has been
       // resolved and can be injected into the various stores.


### PR DESCRIPTION

**What's the problem this PR addresses?**
During resolution there is no throttling of requests for metadata. A medium size
project (react native v61 boilerplate) can have more than 385 simultaneous
open connections to the npm registry. While registry.npmjs.org
and registry.yarnpkg.com can handle this load, a private registry such as
Nexus may not. 
...

**How did you fix it?**
This limits the concurrent requests to something manageable
for private registries. It leverages the same tool to limit parallel fetches
of tarballs in the fetchEverything method
...
