### PR TITLE
handle yarn add without defining a range or tag when using a registry…

### DIFF
--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -17,7 +17,7 @@
   "version": "2.0.0-rc.9",
   "nextVersion": {
     "semver": "2.0.0-rc.10",
-    "nonce": "85603850990873"
+    "nonce": "720973866478737"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -266,7 +266,7 @@ export async function fetchDescriptorFrom(ident: Ident, range: string, {project,
   // Per the requirements exposed in Resolver.ts, the best is the first one
   const bestLocator = candidateLocators[0];
 
-  let {protocol, source, selector} = structUtils.parseRange(bestLocator.reference);
+  let {protocol, source, selector} = structUtils.parseRange(structUtils.convertToManifestRange(bestLocator.reference));
   if (protocol === project.configuration.get(`defaultProtocol`))
     protocol = null;
 

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -9,6 +9,9 @@
     "semver": "^5.6.0"
   },
   "version": "2.0.0-rc.5",
+  "nextVersion": {
+    "nonce": "7830167139549229"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -15,7 +15,7 @@ export class NpmHttpFetcher implements Fetcher {
 
     if (!semver.valid(url.pathname))
       return false;
-    if (!url.searchParams.has(`archiveUrl`))
+    if (!url.searchParams.has(`__archiveUrl`))
       return false;
 
     return true;
@@ -46,7 +46,7 @@ export class NpmHttpFetcher implements Fetcher {
   }
 
   async fetchFromNetwork(locator: Locator, opts: FetchOptions) {
-    const archiveUrl = new URL(locator.reference).searchParams.get(`archiveUrl`);
+    const archiveUrl = new URL(locator.reference).searchParams.get(`__archiveUrl`);
     if (archiveUrl === null)
       throw new Error(`Assertion failed: The archiveUrl querystring parameter should have been available`);
 

--- a/packages/plugin-npm/sources/NpmSemverFetcher.ts
+++ b/packages/plugin-npm/sources/NpmSemverFetcher.ts
@@ -17,7 +17,7 @@ export class NpmSemverFetcher implements Fetcher {
 
     if (!semver.valid(url.pathname))
       return false;
-    if (url.searchParams.has(`archiveUrl`))
+    if (url.searchParams.has(`__archiveUrl`))
       return false;
 
     return true;

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -2,7 +2,6 @@ import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOption
 import {Descriptor, Locator}                                                                 from '@yarnpkg/core';
 import {LinkType}                                                                            from '@yarnpkg/core';
 import {structUtils}                                                                         from '@yarnpkg/core';
-import querystring                                                                           from 'querystring';
 import semver                                                                                from 'semver';
 import {URL}                                                                                 from 'url';
 
@@ -67,7 +66,7 @@ export class NpmSemverResolver implements Resolver {
       if (NpmSemverFetcher.isConventionalTarballUrl(versionLocator, archiveUrl, {configuration: opts.project.configuration})) {
         return versionLocator;
       } else {
-        return structUtils.makeLocator(versionLocator, `${versionLocator.reference}?${querystring.stringify({archiveUrl})}`);
+        return structUtils.bindLocator(versionLocator, {__archiveUrl: archiveUrl});
       }
     });
   }

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -1,7 +1,6 @@
 import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {structUtils}                                                               from '@yarnpkg/core';
 import {Descriptor, Locator, Package}                                              from '@yarnpkg/core';
-import querystring                                                                 from 'querystring';
 
 import {NpmSemverFetcher}                                                          from './NpmSemverFetcher';
 import {PROTOCOL}                                                                  from './constants';
@@ -59,7 +58,7 @@ export class NpmTagResolver implements Resolver {
     if (NpmSemverFetcher.isConventionalTarballUrl(versionLocator, archiveUrl, {configuration: opts.project.configuration})) {
       return [versionLocator];
     } else {
-      return [structUtils.makeLocator(versionLocator, `${versionLocator.reference}?${querystring.stringify({archiveUrl})}`)];
+      return [structUtils.bindLocator(versionLocator, {__archiveUrl: archiveUrl})];
     }
   }
 

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.9",
   "nextVersion": {
     "semver": "2.0.0-rc.10",
-    "nonce": "247034447775533"
+    "nonce": "6034501781774081"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.11",
   "nextVersion": {
     "semver": "2.0.0-rc.12",
-    "nonce": "7270117957209325"
+    "nonce": "5560501795975389"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.11",
   "nextVersion": {
     "semver": "2.0.0-rc.12",
-    "nonce": "8728707341249083"
+    "nonce": "3707983391710503"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,


### PR DESCRIPTION
… with custom tarball path

**What's the problem this PR addresses?**
When using a private registry with custom tarball paths the command `yarn add {packagename}` fails with the error 
```
➤ YN0010: │ semver@6.3.0?[...] isn't supported by any available resolver
```
This is not an an issue if you provide an explicit version, range, or tag in the command. 
...

**How did you fix it?**
I traced the error down to the NpmTagResolver and NpmSemverResolver both [modifying the reference for the locator](https://github.com/yarnpkg/berry/blob/master/packages/plugin-npm/sources/NpmTagResolver.ts#L59) to include the custom tarball query params. However, during add the [protocol is stripped](https://github.com/yarnpkg/berry/blob/master/packages/plugin-essentials/sources/suggestUtils.ts#L273) when creating the final descriptor and the assumption is that removing the 'npm:' will leave a valid semver range. However, the query params get in the way so the [supportsDescriptor](https://github.com/yarnpkg/berry/blob/master/packages/plugin-npm/sources/NpmTagResolver.ts#L17) checks in the resolvers fail. This PR removes the query param section when creating the final descriptor inserted into the package manifest.

I did attempt to update the supportsDescriptors in the respective resolvers to handle the tarball query params. However, this lead to the query params being included in the updated package.json which is not desirable. I'm not too happy with the code fix as it hard codes a specialization for the npm protocol but could not find another way. 

I did try to think through a solution where a new method in resolver interface named convertRefernceToExternalRange could take a reference and convert it to a range that would be usable in the package.json. I chose not to go with this because i was not too confident in the approach and would have touched every resolver (most would would just be identity functions)
...
