### PR TITLE
Fixes a bug in how peer dependencies are propagated to workspaces

### DIFF
--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,7 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.10",
   "nextVersion": {
-    "nonce": "5191992078608543"
+    "nonce": "4106707045091205"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.12",
   "nextVersion": {
     "semver": "2.0.0-rc.13",
-    "nonce": "4110222124485203"
+    "nonce": "5495764503173505"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.12",
   "nextVersion": {
     "semver": "2.0.0-rc.13",
-    "nonce": "2879303891365455"
+    "nonce": "3497361319583277"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -40,9 +40,14 @@ export function convertPackageToLocator(pkg: Package): Locator {
   return {identHash: pkg.identHash, scope: pkg.scope, name: pkg.name, locatorHash: pkg.locatorHash, reference: pkg.reference};
 }
 
-export function renamePackage(pkg: Package, locator: Locator) {
+export function renamePackage(pkg: Package, locator: Locator): Package {
   return {
-    ...locator,
+    identHash: locator.identHash,
+    scope: locator.scope,
+    name: locator.name,
+
+    locatorHash: locator.locatorHash,
+    reference: locator.reference,
 
     version: pkg.version,
 
@@ -57,6 +62,10 @@ export function renamePackage(pkg: Package, locator: Locator) {
 
     bin: new Map(pkg.bin),
   };
+}
+
+export function copyPackage(pkg: Package) {
+  return renamePackage(pkg, pkg);
 }
 
 export function virtualizeDescriptor(descriptor: Descriptor, entropy: string): Descriptor {


### PR DESCRIPTION
**What's the problem this PR addresses?**

We create copies of packages when they have peer dependencies, and update their immediate parents to instead reference the copy.

Since parents have been copied themselves if there's a possibility they would resolve to different versions (because it only happens when they have peer dependencies themselves) the patch operation is safe. There's one catch though: workspaces aren't traversed this way in our implementation, so they aren't copied, and the dependency replacements may end up being mirrored in the other unrelated instances of the same package.

**How did you fix it?**

We now clone the original workspace dependencies before starting the traversal. This way, even if they are overwritten, further accesses will still be able to retrieve the base information.
