### PR TITLE
Fix duplicated plugin name

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -5,7 +5,7 @@
   experimental: true
   description: "Adds a new protocol to Yarn (`exec:`) that dynamically generate packages instead of downloading them."
 
-"@yarnpkg/plugin-workspace-tools":
+"@yarnpkg/plugin-interactive-tools":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-interactive-tools/bin/%40yarnpkg/plugin-interactive-tools.js"
   experimental: true
   description: "Adds various commands providing a more high-level control on your project through terminal interfaces."


### PR DESCRIPTION
**What's the problem this PR addresses?**

```
➤ YN0001: YAMLException: duplicated mapping key at line 23, column -324:
    "@yarnpkg/plugin-workspace-tools":
    ^
```

**How did you fix it?**

Fix the typo.
