### PR TITLE
Fix Next.js E2E Workflow

### DIFF
--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -33,7 +33,7 @@ jobs:
         yarn init
 
         # Required
-        yarn add next@^9.0.8 react react-dom
+        yarn add next@^9.1.5-canary.0 react react-dom
 
         # Test itself
         yarn add raw-loader


### PR DESCRIPTION
**What's the problem this PR addresses?**

This upgrades the workflow's Next.js version to the latest canary, which should stop it from failing.

**How did you fix it?**

This canary includes the fix landed in https://github.com/zeit/next.js/pull/9453.
