### PR TITLE
Update readme of @yarnpkg/plugin-exec

### DIFF
--- a/packages/plugin-exec/README.md
+++ b/packages/plugin-exec/README.md
@@ -27,7 +27,7 @@ yarn plugin import @yarnpkg/plugin-exec
 **gen-pkg.js**
 
 ```js
-const {mkdirSync, writeFileSync} = require(`child_process`);
+const {mkdirSync, writeFileSync} = require(`fs`);
 const generatorPath = process.argv[2];
 
 mkdirSync(`${generatorPath}/build`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

`mkdirSync` and `writeFileSync` are functions exported by `fs` node package not `child_process`.

**How did you fix it?**

Just change `child_process` to `fs` in readme.
