### PR TITLE
Strip byte order mark characters before parsing JSON

### DIFF
--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -635,6 +635,7 @@ function getIndent(content: string) {
 function stripBOM(content: string) {
   if (content.charCodeAt(0) === 0xFEFF) {
 		return content.slice(1);
-	}
-	return content;
+	} else {
+  	return content;
+  }
 }

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -96,7 +96,7 @@ export class Manifest {
   loadFromText(text: string) {
     let data;
     try {
-      data = JSON.parse(text || `{}`);
+      data = JSON.parse(stripBOM(text) || `{}`);
     } catch (error) {
       error.message += ` (when parsing ${text})`;
       throw error;
@@ -111,7 +111,7 @@ export class Manifest {
 
     let data;
     try {
-      data = JSON.parse(content || `{}`);
+      data = JSON.parse(stripBOM(content) || `{}`);
     } catch (error) {
       error.message += ` (when parsing ${path})`;
       throw error;
@@ -630,4 +630,11 @@ function getIndent(content: string) {
   } else {
     return `  `;
   }
+}
+
+function stripBOM(content: string) {
+  if (content.charCodeAt(0) === 0xFEFF) {
+		return content.slice(1);
+	}
+	return content;
 }

--- a/packages/yarnpkg-core/tests/Manifest.test.ts
+++ b/packages/yarnpkg-core/tests/Manifest.test.ts
@@ -1,0 +1,8 @@
+import {Manifest} from '../sources/Manifest';
+
+describe(`Manifest`, () => {
+  it(`should handle byte order mark character`, async () => {
+    const manifest = Manifest.fromText('\uFEFF{"name":"foo"}');
+    expect(manifest.name.name).toEqual("foo");
+  });
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes https://github.com/yarnpkg/berry/issues/619

**How did you fix it?**

Remove BOM character prior to `JSON.parse`
