### PR TITLE
Add WebStorm as compatible tool

### DIFF
--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -60,6 +60,7 @@ The following compatibility table gives you an idea of the integration status wi
 | VSCode-ESLint     | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | VSCode            | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | Webpack           | Plugin     | Via [`pnp-webpack-plugin`](https://github.com/arcanis/pnp-webpack-plugin), will be native starting from 5+ |
+| WebStorm          | Native     | Starting from 2019.3+ |
 | Typescript-Eslint | Workaround | Update the lockfile to add `typescript: "*"` into its `peerDependencies`. [`Relevant Issue`](https://github.com/typescript-eslint/typescript-eslint/issues/770) |
 
 This list is kept up-to-date based on the latest release we've published starting from the v2. In case you notice something off in your own project please try to upgrade Yarn and the problematic package first, then feel free to an issue. And maybe a PR? 😊

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -60,7 +60,7 @@ The following compatibility table gives you an idea of the integration status wi
 | VSCode-ESLint     | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | VSCode            | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | Webpack           | Plugin     | Via [`pnp-webpack-plugin`](https://github.com/arcanis/pnp-webpack-plugin), will be native starting from 5+ |
-| WebStorm          | Native     | Starting from 2019.3+ |
+| WebStorm          | Native     | Starting from 2019.3+; limited TypeScript support (see [issue](https://youtrack.jetbrains.com/issue/WEB-42637)) |
 | Typescript-Eslint | Workaround | Update the lockfile to add `typescript: "*"` into its `peerDependencies`. [`Relevant Issue`](https://github.com/typescript-eslint/typescript-eslint/issues/770) |
 
 This list is kept up-to-date based on the latest release we've published starting from the v2. In case you notice something off in your own project please try to upgrade Yarn and the problematic package first, then feel free to an issue. And maybe a PR? 😊


### PR DESCRIPTION
WebStorm 2019.3 (and other JetBrains IDEs) adds native [support for Yarn PnP](https://blog.jetbrains.com/webstorm/2019/11/webstorm-2019-3/#tools).
