### PR TITLE
Reload PnP runtime on PnP file change in pnpify

### DIFF
--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/pnpify",
   "version": "2.0.0-rc.12",
+  "nextVersion": {
+    "semver": "2.0.0-rc.13",
+    "nonce": "4737881063391685"
+  },
   "main": "./sources/boot-dev.js",
   "bin": "./sources/boot-cli-dev.js",
   "types": "./sources/index.ts",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some n_m packages rely on the fact that when they run `yarn add foo`, then foo will be available inside currently running Node process without need for process restart.

**How did you fix it?**

When we detect pnp file change in pnpify, we not only update pnp api instance, we instead do full pnp runtime reload:
  1. First we restore original fs
  2. Then we clear cache, require pnp file and call `setup()` to update runtime
  3. And then we patch back fs with nodeModulesFs 