### PR TITLE
Fixes assertion

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -207,7 +207,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@yarnpkg/plugin-version", ["virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-version", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-version", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-version", "virtual:381a246dcb7de41565b7f807dad363d33e7845cbeaab8718b2310c7db922bb0991e2c4951bf72a53b696dc68432c0d43145b1b29571d06347e4c3c45a9b02a68#workspace:packages/plugin-version", "virtual:44985de498d4b861cee4edc36947f6418031153f0f666cbe8c46ae330f08365a0ff18b960c45973ea58deec073e79edbf2d221d94371c60da3f55e150ac10efe#workspace:packages/plugin-version", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-version", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-version", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-version", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-version", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-version", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-version", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-version", "virtual:c44c4b6360dc34d25da6d32e39622e7e40f36f37b99dc66b6ebbd615fdd49465f496bf10f81b6fa5f71b95443fda61174ad51d2799fc7ca433af9a9666cd0f37#workspace:packages/plugin-version", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-version", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-version", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-version", "virtual:e23070551897c977d5b8085c4d1e9a894a68fa8203db624358fb50a574c8e05714fb57031cb1acbef3b066e56b561ac5b876c49fef2e6b9466f45869bf78103f#workspace:packages/plugin-version", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-version", "workspace:packages/plugin-version"]],
       ["@yarnpkg/plugin-workspace-tools", ["workspace:packages/plugin-workspace-tools"]],
       ["@yarnpkg/pnp", ["workspace:packages/yarnpkg-pnp"]],
-      ["@yarnpkg/pnpify", ["virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify", "virtual:5d170a96e3bd35439131aba7820e7b850e9381656d638624d34e228d96fc2f134ebf73b7eb6235db8cb822a7bcd252e04750d4dfcaeb49408c4e561390950138#workspace:packages/yarnpkg-pnpify", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-pnpify", "workspace:packages/yarnpkg-pnpify"]],
+      ["@yarnpkg/pnpify", ["virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify", "workspace:packages/yarnpkg-pnpify"]],
       ["@yarnpkg/shell", ["workspace:packages/yarnpkg-shell"]],
       ["acceptance-tests-229a13", ["workspace:packages/acceptance-tests"]],
       ["pkg-tests-core", ["workspace:packages/acceptance-tests/pkg-tests-core"]],
@@ -432,7 +432,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/parser", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#npm:1.6.0"],
             ["@yarnpkg/cli", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@yarnpkg/pnpify", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-pnpify"],
+            ["@yarnpkg/pnpify", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify"],
             ["babel-jest", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#npm:24.5.0"],
             ["eslint", "npm:5.16.0"],
             ["eslint-plugin-arca", "npm:0.9.0"],
@@ -531,27 +531,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "linkType": "HARD"
         }],
-        ["npm:7.3.3", {
-          "packageLocation": "./.yarn/cache/@babel-core-npm-7.3.3-72ff1d630e-1.zip/node_modules/@babel/core/",
-          "packageDependencies": [
-            ["@babel/core", "npm:7.3.3"],
-            ["@babel/code-frame", "npm:7.0.0"],
-            ["@babel/generator", "npm:7.3.3"],
-            ["@babel/helpers", "npm:7.2.0"],
-            ["@babel/parser", "npm:7.7.4"],
-            ["@babel/template", "npm:7.2.2"],
-            ["@babel/traverse", "npm:7.2.3"],
-            ["@babel/types", "npm:7.3.3"],
-            ["convert-source-map", "npm:1.6.0"],
-            ["debug", "npm:4.1.1"],
-            ["json5", "npm:2.1.0"],
-            ["lodash", "npm:4.17.11"],
-            ["resolve", "npm:1.9.0"],
-            ["semver", "npm:5.6.0"],
-            ["source-map", "npm:0.5.7"]
-          ],
-          "linkType": "HARD"
-        }],
         ["npm:7.7.4", {
           "packageLocation": "./.yarn/cache/@babel-core-npm-7.7.4-960c104f6a-1.zip/node_modules/@babel/core/",
           "packageDependencies": [
@@ -580,18 +559,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@babel/generator", "npm:7.2.2"],
             ["@babel/types", "npm:7.2.2"],
-            ["jsesc", "npm:2.5.2"],
-            ["lodash", "npm:4.17.11"],
-            ["source-map", "npm:0.5.7"],
-            ["trim-right", "npm:1.0.1"]
-          ],
-          "linkType": "HARD"
-        }],
-        ["npm:7.3.3", {
-          "packageLocation": "./.yarn/cache/@babel-generator-npm-7.3.3-1b10c0ab61-1.zip/node_modules/@babel/generator/",
-          "packageDependencies": [
-            ["@babel/generator", "npm:7.3.3"],
-            ["@babel/types", "npm:7.3.3"],
             ["jsesc", "npm:2.5.2"],
             ["lodash", "npm:4.17.11"],
             ["source-map", "npm:0.5.7"],
@@ -5785,7 +5752,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/monorepo", "workspace:."],
-            ["@yarnpkg/pnpify", "virtual:5d170a96e3bd35439131aba7820e7b850e9381656d638624d34e228d96fc2f134ebf73b7eb6235db8cb822a7bcd252e04750d4dfcaeb49408c4e561390950138#workspace:packages/yarnpkg-pnpify"],
+            ["@yarnpkg/pnpify", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify"],
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.0.6"],
             ["babel-plugin-lazy-import", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#https://github.com/arcanis/babel-plugin-lazy-import.git#commit:ff060e230afb4f2f36a1c495be65271c14ae2e4b"],
             ["chalk", "npm:2.4.2"],
@@ -6809,7 +6776,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/parser", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#npm:1.6.0"],
             ["@yarnpkg/cli", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@yarnpkg/pnpify", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-pnpify"],
+            ["@yarnpkg/pnpify", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify"],
             ["babel-jest", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#npm:24.5.0"],
             ["eslint", "npm:5.16.0"],
             ["eslint-plugin-arca", "npm:0.9.0"],
@@ -11104,53 +11071,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["comment-json", "npm:2.2.0"],
             ["cross-spawn", "npm:6.0.5"],
-            ["eslint", null],
-            ["typescript", "npm:3.7.0-dev.20191002"]
-          ],
-          "packagePeers": [
-            "eslint",
-            "typescript"
-          ],
-          "linkType": "SOFT"
-        }],
-        ["virtual:5d170a96e3bd35439131aba7820e7b850e9381656d638624d34e228d96fc2f134ebf73b7eb6235db8cb822a7bcd252e04750d4dfcaeb49408c4e561390950138#workspace:packages/yarnpkg-pnpify", {
-          "packageLocation": "./.yarn/virtual/@yarnpkg-pnpify-virtual-62e070a2e2/1/packages/yarnpkg-pnpify/",
-          "packageDependencies": [
-            ["@yarnpkg/pnpify", "virtual:5d170a96e3bd35439131aba7820e7b850e9381656d638624d34e228d96fc2f134ebf73b7eb6235db8cb822a7bcd252e04750d4dfcaeb49408c4e561390950138#workspace:packages/yarnpkg-pnpify"],
-            ["@types/comment-json", "npm:1.1.1"],
-            ["@types/cross-spawn", "npm:6.0.0"],
-            ["@types/node", "npm:12.12.8"],
-            ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/monorepo", "workspace:."],
-            ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
-            ["comment-json", "npm:2.2.0"],
-            ["cross-spawn", "npm:6.0.5"],
-            ["eslint", null],
-            ["typescript", null]
-          ],
-          "packagePeers": [
-            "eslint",
-            "typescript"
-          ],
-          "linkType": "SOFT"
-        }],
-        ["virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-pnpify", {
-          "packageLocation": "./.yarn/virtual/@yarnpkg-pnpify-virtual-ccefe75d97/1/packages/yarnpkg-pnpify/",
-          "packageDependencies": [
-            ["@yarnpkg/pnpify", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-pnpify"],
-            ["@types/comment-json", "npm:1.1.1"],
-            ["@types/cross-spawn", "npm:6.0.0"],
-            ["@types/node", "npm:12.12.8"],
-            ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/monorepo", "workspace:."],
-            ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
-            ["comment-json", "npm:2.2.0"],
-            ["cross-spawn", "npm:6.0.5"],
             ["eslint", "npm:5.16.0"],
             ["typescript", "npm:3.7.0-dev.20191002"]
           ],
           "packagePeers": [
-            "eslint",
             "typescript"
           ],
           "linkType": "SOFT"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/fallback-peer-deps-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/fallback-peer-deps-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/fallback-peer-deps-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/fallback-peer-deps-1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fallback-peer-deps",
+  "version": "1.0.0",
+  "dependencies": {
+    "no-deps": "2.0.0"
+  },
+  "peerDependencies": {
+    "no-deps": "*"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
@@ -322,4 +322,55 @@ describe(`Basic tests`, () => {
       },
     ),
   );
+
+  test(
+    `it should prefer peer dependencies when a package also has the same regular dependency`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`fallback-peer-deps`]: `1.0.0`,
+          [`no-deps`]: `1.0.0`,
+        },
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(source(`require('fallback-peer-deps')`)).resolves.toMatchObject({
+          name: `fallback-peer-deps`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `1.0.0`,
+            },
+          },
+        });
+      },
+    ),
+  );
+
+  test(
+    `it should fallback to the regular dependency if the peer dependency isn't met`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`fallback-peer-deps`]: `1.0.0`,
+        },
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(source(`require('fallback-peer-deps')`)).resolves.toMatchObject({
+          name: `fallback-peer-deps`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `2.0.0`,
+            },
+          },
+        });
+      },
+    ),
+  );
 });

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1504,6 +1504,11 @@ function applyVirtualResolutionMutations({
             volatileDescriptors.delete(peerDescriptor.descriptorHash);
           }
 
+          if (!peerDescriptor && virtualizedPackage.dependencies.has(peerRequest.identHash)) {
+            virtualizedPackage.peerDependencies.delete(peerRequest.identHash);
+            continue;
+          }
+
           if (!peerDescriptor) {
             if (!parentPackage.peerDependencies.has(peerRequest.identHash)) {
               const peerDependencyMeta = virtualizedPackage.peerDependenciesMeta.get(structUtils.stringifyIdent(peerRequest));
@@ -1654,6 +1659,8 @@ function applyVirtualResolutionMutations({
 
           allVirtualizedDescriptorsDependents.delete(duplicateDescriptor.descriptorHash);
           virtualDescriptors.delete(duplicateDescriptor);
+
+          accessibleLocators.delete(duplicateVirtualPackage.locatorHash);
         }
       }
     }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -74,8 +74,8 @@ export class Project {
   public storedPackages: Map<LocatorHash, Package> = new Map();
   public storedChecksums: Map<LocatorHash, string> = new Map();
 
+  public accessibleLocators: Set<LocatorHash> = new Set();
   public originalPackages: Map<LocatorHash, Package> = new Map();
-
   public optionalBuilds: Set<LocatorHash> = new Set();
 
   static async find(configuration: Configuration, startingCwd: PortablePath): Promise<{project: Project, workspace: Workspace | null, locator: Locator}> {
@@ -698,11 +698,13 @@ export class Project {
 
     const volatileDescriptors = new Set(this.resolutionAliases.values());
     const optionalBuilds = new Set(allPackages.keys());
+    const accessibleLocators = new Set<LocatorHash>();
 
     applyVirtualResolutionMutations({
       project: this,
       report: opts.report,
 
+      accessibleLocators,
       volatileDescriptors,
       optionalBuilds,
 
@@ -737,8 +739,8 @@ export class Project {
     this.storedDescriptors = allDescriptors;
     this.storedPackages = allPackages;
 
+    this.accessibleLocators = accessibleLocators;
     this.originalPackages = originalPackages;
-
     this.optionalBuilds = optionalBuilds;
   }
 
@@ -810,19 +812,12 @@ export class Project {
     const packageLocations: Map<LocatorHash, PortablePath> = new Map();
     const packageBuildDirectives: Map<LocatorHash, BuildDirective[]> = new Map();
 
-    // We can skip installing packages that have been split into virtual
-    // packages, except for our workspaces (because they also exist by
-    // themselves, outside of the typical dependency considerations)
-    const skipPackageLink = (pkg: Package) =>
-      pkg.peerDependencies.size > 0 &&
-      !structUtils.isVirtualLocator(pkg) &&
-      !this.tryWorkspaceByLocator(pkg);
-
     // Step 1: Installing the packages on the disk
 
-    for (const pkg of this.storedPackages.values()) {
-      if (skipPackageLink(pkg))
-        continue;
+    for (const locatorHash of this.accessibleLocators) {
+      const pkg = this.storedPackages.get(locatorHash);
+      if (!pkg)
+        throw new Error(`Assertion failed: The locator should have been registered`);
 
       const linker = linkers.find(linker => linker.supportsPackage(pkg, linkerOptions));
       if (!linker)
@@ -855,9 +850,10 @@ export class Project {
 
     const externalDependents: Map<LocatorHash, Array<PortablePath>> = new Map();
 
-    for (const pkg of this.storedPackages.values()) {
-      if (skipPackageLink(pkg))
-        continue;
+    for (const locatorHash of this.accessibleLocators) {
+      const pkg = this.storedPackages.get(locatorHash);
+      if (!pkg)
+        throw new Error(`Assertion failed: The locator should have been registered`);
 
       const packageLinker = packageLinkers.get(pkg.locatorHash);
       if (!packageLinker)
@@ -1307,6 +1303,7 @@ function applyVirtualResolutionMutations({
   allResolutions,
   allPackages,
 
+  accessibleLocators = new Set(),
   optionalBuilds = new Set(),
   volatileDescriptors = new Set(),
 
@@ -1320,6 +1317,7 @@ function applyVirtualResolutionMutations({
   allResolutions: Map<DescriptorHash, LocatorHash>,
   allPackages: Map<LocatorHash, Package>,
 
+  accessibleLocators?: Set<LocatorHash>,
   optionalBuilds?: Set<LocatorHash>,
   volatileDescriptors?: Set<DescriptorHash>,
 
@@ -1327,7 +1325,6 @@ function applyVirtualResolutionMutations({
 
   tolerateMissingPackages?: boolean,
 }) {
-  const hasBeenTraversed = new Set();
   const resolutionStack: Array<Locator> = [];
 
   // We'll be keeping track of all virtual descriptors; once they have all
@@ -1392,10 +1389,10 @@ function applyVirtualResolutionMutations({
   };
 
   const resolvePeerDependenciesImpl = (parentLocator: Locator, first: boolean, optional: boolean) => {
-    if (hasBeenTraversed.has(parentLocator.locatorHash))
+    if (accessibleLocators.has(parentLocator.locatorHash))
       return;
 
-    hasBeenTraversed.add(parentLocator.locatorHash);
+    accessibleLocators.add(parentLocator.locatorHash);
 
     if (!optional)
       optionalBuilds.delete(parentLocator.locatorHash);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes #626 

> I found the issue - we're currently iterating over each package to find out their linkers, then we iterate a second time to inject the packages into the linkers. When I say "each package" it's not entirely true: we don't actually do this for packages that are "virtual package templates", since they usually don't need to be linked.
>
> The problem occurs when such a regular package template somehow depends on a virtual package template: since the virtual package template didn't get traversed in step 1, we haven't assigned it a linker, hence the failed assertion.
> 
> Package templates should never be valid package dependencies, but they currently are in one particular case: when a package lists the same name as both a dependency and a peer dependency. In this case the regular dependency is still resolved as part of the regular resolution pass, but then we simply ignore the regular resolution to prefer the peer resolution instead. This makes the package orphan, so it never goes into the virtual hydratation, and its virtual package template dependencies never get changed into virtual instances.

**How did you fix it?**

> - First I will add proper support for listing the same name as both dependency and peer dependency. The semantic will be that Yarn will prefer the peer dependency if possible, but will fallback to the regular dependency otherwise. It'll be an optional dependency with steroids.
>
> - Second I will make the package hydratation process keep track of which packages have been traversed, and use that when linking the project (rather than all the packages currently stored). I won't prune them altogether because we will still want the resolutions to be persisted into the lockfile.
