### PR TITLE
Use CRA's new --template parameter in E2E test

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -36,5 +36,5 @@ jobs:
     - name: 'Running the TypeScript integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        yarn dlx create-react-app my-cra-ts --typescript && cd my-cra-ts
+        yarn dlx create-react-app my-cra-ts --template typescript && cd my-cra-ts
         yarn build


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current E2E CRA test uses the `--typescript` flag, which is deprecated in favor of `--template typescript`.

**How did you fix it?**

Use the new `--template typescript` invocation
