### PR TITLE
Fix yarn init printing undefined values

### DIFF
--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -114,6 +114,7 @@ export default class InitCommand extends BaseCommand {
 
     this.context.stdout.write(`${inspect(inspectable, {
       depth: Infinity,
+      compact: false,
     })}\n`);
   }
 }

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -112,8 +112,11 @@ export default class InitCommand extends BaseCommand {
     const inspectable: any = {};
     manifest.exportTo(inspectable);
 
+    inspect.styles.name = `cyan`;
+
     this.context.stdout.write(`${inspect(inspectable, {
       depth: Infinity,
+      colors: true,
       compact: false,
     })}\n`);
   }

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -533,14 +533,14 @@ export class Manifest {
     else
       delete data.languageName;
 
-    if (this.bin.size === 0) {
-      data.bin = undefined;
-    } else if (this.bin.size === 1 && this.name !== null && this.bin.has(this.name.name)) {
+    if (this.bin.size === 1 && this.name !== null && this.bin.has(this.name.name)) {
       data.bin = this.bin.get(this.name.name)!;
-    } else {
+    } else if (this.bin.size > 0) {
       data.bin = Object.assign({}, ...Array.from(this.bin.keys()).sort().map(name => {
         return {[name]: this.bin.get(name)};
       }));
+    } else {
+      delete data.bin;
     }
 
     const regularDependencies = [];
@@ -566,21 +566,37 @@ export class Manifest {
       }
     }
 
-    data.dependencies = regularDependencies.length === 0 ? undefined : Object.assign({}, ...structUtils.sortDescriptors(regularDependencies).map(dependency => {
-      return {[structUtils.stringifyIdent(dependency)]: dependency.range};
-    }));
+    if (regularDependencies.length > 0) {
+      data.dependencies = Object.assign({}, ...structUtils.sortDescriptors(regularDependencies).map(dependency => {
+        return {[structUtils.stringifyIdent(dependency)]: dependency.range};
+      }));
+    } else {
+      delete data.dependencies;
+    }
 
-    data.optionalDependencies = optionalDependencies.length === 0 ? undefined : Object.assign({}, ...structUtils.sortDescriptors(optionalDependencies).map(dependency => {
-      return {[structUtils.stringifyIdent(dependency)]: dependency.range};
-    }));
+    if (optionalDependencies.length > 0) {
+      data.optionalDependencies = Object.assign({}, ...structUtils.sortDescriptors(optionalDependencies).map(dependency => {
+        return {[structUtils.stringifyIdent(dependency)]: dependency.range};
+      }));
+    } else {
+      delete data.optionalDependencies;
+    }
 
-    data.devDependencies = this.devDependencies.size === 0 ? undefined : Object.assign({}, ...structUtils.sortDescriptors(this.devDependencies.values()).map(dependency => {
-      return {[structUtils.stringifyIdent(dependency)]: dependency.range};
-    }));
+    if (this.devDependencies.size > 0) {
+      data.devDependencies = Object.assign({}, ...structUtils.sortDescriptors(this.devDependencies.values()).map(dependency => {
+        return {[structUtils.stringifyIdent(dependency)]: dependency.range};
+      }));
+    } else {
+      delete data.devDependencies;
+    }
 
-    data.peerDependencies = this.peerDependencies.size === 0 ? undefined : Object.assign({}, ...structUtils.sortDescriptors(this.peerDependencies.values()).map(dependency => {
-      return {[structUtils.stringifyIdent(dependency)]: dependency.range};
-    }));
+    if (this.peerDependencies.size > 0) {
+      data.peerDependencies = Object.assign({}, ...structUtils.sortDescriptors(this.peerDependencies.values()).map(dependency => {
+        return {[structUtils.stringifyIdent(dependency)]: dependency.range};
+      }));
+    } else {
+      delete data.peerDependencies;
+    }
 
     data.dependenciesMeta = {};
 
@@ -603,20 +619,28 @@ export class Manifest {
     }
 
     if (Object.keys(data.dependenciesMeta).length === 0)
-      data.dependenciesMeta = undefined;
+      delete data.dependenciesMeta;
 
-    data.peerDependenciesMeta = this.peerDependenciesMeta.size === 0 ? undefined : Object.assign({}, ...miscUtils.sortMap(this.peerDependenciesMeta.entries(), ([identString, meta]) => identString).map(([identString, meta]) => {
-      return {[identString]: meta};
-    }));
+    if (this.peerDependenciesMeta.size > 0) {
+      data.peerDependenciesMeta = Object.assign({}, ...miscUtils.sortMap(this.peerDependenciesMeta.entries(), ([identString, meta]) => identString).map(([identString, meta]) => {
+        return {[identString]: meta};
+      }));
+    } else {
+      delete data.peerDependenciesMeta;
+    }
 
-    data.resolutions = this.resolutions.length === 0 ? undefined : Object.assign({}, ...this.resolutions.map(({pattern, reference}) => {
-      return {[stringifyResolution(pattern)]: reference};
-    }));
+    if (this.resolutions.length > 0) {
+      data.resolutions = Object.assign({}, ...this.resolutions.map(({pattern, reference}) => {
+        return {[stringifyResolution(pattern)]: reference};
+      }));
+    } else {
+      delete data.resolutions;
+    }
 
-    if (this.files === null)
-      data.files = undefined;
-    else
+    if (this.files !== null)
       data.files = Array.from(this.files);
+    else
+      delete data.files;
 
     return data;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**
This PR fixes #624 

To summarize the issue, when running `yarn init` in a new project, the unused fields are all listed with the value `undefined`. This is because in `Manifest.ts` `exportTo` method, fields in the `data` object are being set as `undefined` if not used.

Here is an example:

```bash
> yarn init
{
  name: 'example-project',
  bin: undefined,
  dependencies: undefined,
  optionalDependencies: undefined,
  devDependencies: undefined,
  peerDependencies: undefined,
  dependenciesMeta: undefined,
  peerDependenciesMeta: undefined,
  resolutions: undefined,
  files: undefined
}
```

**How did you fix it?**

Now in the `Manifest.ts` `exportTo` function, instead of setting unused fields as `undefined` they get deleted from the `data` object. The new output looks like this:
```bash
> yarn init
{ name: 'example-project' }
```

In order to get proper formatting, the `compact` option is now set to `false` in `init.ts` `executeRegular`. The final output looks like this:
```bash
> yarn init
{
  name: 'example-project'
}
```

**Other solutions**

This solution touches a lot of code. An easier fix could be adding something like this to the bottom of the `exportTo` function:
```typescript
// Remove all keys with 'undefined' value
for (const key in data)
  if (data[key] === undefined)
    delete data[key];
```
I opted to go the other route because it seemed more explicit and I think it's better to handle the individual cases closer to the actual logic.