### PR TITLE
Fixes TS patch for older TS versions

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -404,7 +404,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-environment-node", "npm:24.5.0"],
             ["jest-junit", "npm:5.2.0"],
             ["micromatch", "npm:4.0.2"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "linkType": "SOFT"
         }]
@@ -5023,7 +5023,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["regexpp", "npm:2.0.1"],
             ["requireindex", "npm:1.2.0"],
             ["tsutils", "virtual:45cefb3a778deece82fc842b2b72f0afc757b6c0484407b9caa29c093b750350155ac2abd0f56e4ac93885a167aa5c99574da658766a7bf001a0aae00168eb82#npm:3.10.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "eslint",
@@ -5057,7 +5057,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["eslint", "npm:5.16.0"],
             ["eslint-scope", "npm:4.0.0"],
             ["eslint-visitor-keys", "npm:1.0.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "eslint",
@@ -5074,7 +5074,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/typescript-estree", "virtual:be22e969588e5b9bb01154245a30a1bfa2fad15f08a9f0d7874afa09a4651ae4fe9cd0600afa10932b5dfe007f9b520145319057e59f92e2d7a8fb54b87c1da9#npm:2.13.0"],
             ["eslint", "npm:5.16.0"],
             ["eslint-visitor-keys", "npm:1.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "eslint",
@@ -5090,7 +5090,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@typescript-eslint/typescript-estree", "virtual:45cefb3a778deece82fc842b2b72f0afc757b6c0484407b9caa29c093b750350155ac2abd0f56e4ac93885a167aa5c99574da658766a7bf001a0aae00168eb82#npm:1.7.0"],
             ["lodash.unescape", "npm:4.0.1"],
             ["semver", "npm:5.5.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "typescript"
@@ -5126,7 +5126,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["lodash.unescape", "npm:4.0.1"],
             ["semver", "npm:6.3.0"],
             ["tsutils", "virtual:faf413bcdf63d4ba216a03af4562f5428e636501de9fdbe6a8290b289fd010181647b2e3f557d4967e3d32c0e2e93d138ad4315d4b6048c665fd19f5d4a4f89d#npm:3.17.1"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "typescript"
@@ -5559,7 +5559,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["semver", "npm:5.6.0"],
             ["terser-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:2.1.3"],
             ["ts-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:6.2.1"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["val-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:1.1.1"],
             ["webpack", "npm:4.41.2"],
             ["webpack-merge", "npm:4.2.1"],
@@ -5621,7 +5621,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["globby", "npm:10.0.1"],
             ["micromatch", "npm:4.0.2"],
             ["p-limit", "npm:2.2.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "linkType": "SOFT"
         }]
@@ -5661,7 +5661,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5703,7 +5703,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5745,7 +5745,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5787,7 +5787,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5829,7 +5829,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5871,7 +5871,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5913,7 +5913,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5955,7 +5955,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -5997,7 +5997,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6039,7 +6039,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6081,7 +6081,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6123,7 +6123,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6165,7 +6165,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6207,7 +6207,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6249,7 +6249,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6291,7 +6291,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6333,7 +6333,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6375,7 +6375,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6417,7 +6417,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6459,7 +6459,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["promise.prototype.finally", "npm:3.1.1"],
             ["semver", "npm:5.6.0"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -6668,7 +6668,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-environment-node", "npm:24.5.0"],
             ["jest-junit", "npm:5.2.0"],
             ["micromatch", "npm:4.0.2"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "linkType": "SOFT"
         }]
@@ -8325,7 +8325,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["tmp", "npm:0.1.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "core"
@@ -8863,7 +8863,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["diff", "npm:4.0.1"],
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10732,7 +10732,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10749,7 +10749,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10766,7 +10766,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10783,7 +10783,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10800,7 +10800,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10817,7 +10817,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10834,7 +10834,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10851,7 +10851,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10868,7 +10868,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10885,7 +10885,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10902,7 +10902,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10919,7 +10919,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10936,7 +10936,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10953,7 +10953,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10970,7 +10970,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -10987,7 +10987,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11004,7 +11004,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11021,7 +11021,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11038,7 +11038,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11055,7 +11055,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11072,7 +11072,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11089,7 +11089,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11106,7 +11106,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11123,7 +11123,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11140,7 +11140,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11157,7 +11157,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11174,7 +11174,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11193,7 +11193,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/plugin-essentials", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/plugin-essentials"],
             ["@yarnpkg/plugin-pack", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/plugin-pack"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "cli",
@@ -11220,7 +11220,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11246,7 +11246,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11272,7 +11272,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11298,7 +11298,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11324,7 +11324,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11350,7 +11350,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11376,7 +11376,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11402,7 +11402,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11428,7 +11428,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11454,7 +11454,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11480,7 +11480,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11506,7 +11506,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11532,7 +11532,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11558,7 +11558,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11584,7 +11584,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11610,7 +11610,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11636,7 +11636,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11662,7 +11662,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11688,7 +11688,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11714,7 +11714,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11740,7 +11740,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ink", "virtual:58c6a160e6d00ccf90867e4b527877bcde337a320c79277ab938543a3cd2ca12d5ecbaf449b71356276a2c24db742e5ae759512bae3689b4ef8ec896c616a6e2#npm:2.3.0"],
             ["react", "npm:16.8.4"],
             ["semver", "npm:5.6.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11763,7 +11763,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.1.5"],
             ["p-limit", "npm:2.2.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["yup", "npm:0.27.0"]
           ],
           "packagePeers": [
@@ -11782,7 +11782,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/builder", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-builder"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/pnpify", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["webpack", "npm:4.41.2"],
             ["webpack-cli", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#npm:3.3.2"],
             ["webpack-sources", "npm:1.3.0"]
@@ -11803,7 +11803,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["comment-json", "npm:2.2.0"],
             ["cross-spawn", "npm:6.0.5"],
             ["eslint", "npm:5.16.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "typescript"
@@ -11822,7 +11822,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["comment-json", "npm:2.2.0"],
             ["cross-spawn", "npm:6.0.5"],
             ["eslint", "npm:5.16.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "eslint",
@@ -32253,7 +32253,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["loader-utils", "npm:1.2.3"],
             ["micromatch", "npm:4.0.2"],
             ["semver", "npm:6.3.0"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "typescript"
@@ -32300,7 +32300,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["tsutils", "virtual:45cefb3a778deece82fc842b2b72f0afc757b6c0484407b9caa29c093b750350155ac2abd0f56e4ac93885a167aa5c99574da658766a7bf001a0aae00168eb82#npm:3.10.0"],
             ["tslib", "npm:1.9.3"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "typescript"
@@ -32324,7 +32324,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["tsutils", "virtual:faf413bcdf63d4ba216a03af4562f5428e636501de9fdbe6a8290b289fd010181647b2e3f557d4967e3d32c0e2e93d138ad4315d4b6048c665fd19f5d4a4f89d#npm:3.17.1"],
             ["tslib", "npm:1.9.3"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "packagePeers": [
             "typescript"
@@ -32443,10 +32443,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["typescript", [
-        ["patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0", {
-          "packageLocation": "./.yarn/cache/typescript-patch-1e9c2c8354-1.zip/node_modules/typescript/",
+        ["patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c", {
+          "packageLocation": "./.yarn/cache/typescript-patch-d665bedbda-1.zip/node_modules/typescript/",
           "packageDependencies": [
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"]
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"]
           ],
           "linkType": "HARD"
         }]
@@ -33384,7 +33384,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnpify", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify"],
             ["pnp-webpack-plugin", "npm:1.4.3"],
             ["ts-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:6.2.1"],
-            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"],
+            ["typescript", "patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"],
             ["vsce", "npm:1.61.0"],
             ["webpack", "npm:4.41.2"],
             ["webpack-cli", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#npm:3.3.2"]

--- a/packages/plugin-compat/gen-typescript-patch.sh
+++ b/packages/plugin-compat/gen-typescript-patch.sh
@@ -30,4 +30,5 @@ reset-git() {
 git diff --no-index "$TMPDIR"/orig "$TMPDIR"/patched \
     | perl -p -e"s#$TMPDIR/orig##" \
     | perl -p -e"s#$TMPDIR/patched##" \
+    | perl -p -e"s#__spreadArrays#[].concat#" \
     > typescript.patch

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/plugin-compat",
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "semver": "2.0.0-rc.2",
+    "nonce": "2540932548576125"
+  },
   "main": "./sources/index.ts",
   "peerDependencies": {
     "@yarnpkg/core": "^2.0.0-rc.15",

--- a/packages/plugin-compat/sources/patches/typescript-1.ts
+++ b/packages/plugin-compat/sources/patches/typescript-1.ts
@@ -48,7 +48,7 @@ index d7f749f..3b98f16 100644
 +        var nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
 +        var pnpTypes = getPnpTypeRoots(currentDirectory);
 +        if (nmTypes.length > 0 || pnpTypes.length > 0) {
-+            return __spreadArrays(nmTypes, pnpTypes);
++            return [].concat(nmTypes, pnpTypes);
 +        }
 +    }
      function resolveTypeReferenceDirective(typeReferenceDirectiveName, containingFile, options, host, redirectedReference) {
@@ -179,7 +179,7 @@ index 4ea67ec..41c335a 100644
 +        var nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
 +        var pnpTypes = getPnpTypeRoots(currentDirectory);
 +        if (nmTypes.length > 0 || pnpTypes.length > 0) {
-+            return __spreadArrays(nmTypes, pnpTypes);
++            return [].concat(nmTypes, pnpTypes);
 +        }
 +    }
      /**
@@ -322,7 +322,7 @@ index 2897a22..da04c70 100644
 +        var nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
 +        var pnpTypes = getPnpTypeRoots(currentDirectory);
 +        if (nmTypes.length > 0 || pnpTypes.length > 0) {
-+            return __spreadArrays(nmTypes, pnpTypes);
++            return [].concat(nmTypes, pnpTypes);
 +        }
 +    }
      /**
@@ -465,7 +465,7 @@ index 548ceea..5e0e897 100644
 +        var nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
 +        var pnpTypes = getPnpTypeRoots(currentDirectory);
 +        if (nmTypes.length > 0 || pnpTypes.length > 0) {
-+            return __spreadArrays(nmTypes, pnpTypes);
++            return [].concat(nmTypes, pnpTypes);
 +        }
 +    }
      /**
@@ -608,7 +608,7 @@ index 9046c6f..7d0d7a9 100644
 +        var nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
 +        var pnpTypes = getPnpTypeRoots(currentDirectory);
 +        if (nmTypes.length > 0 || pnpTypes.length > 0) {
-+            return __spreadArrays(nmTypes, pnpTypes);
++            return [].concat(nmTypes, pnpTypes);
 +        }
 +    }
      /**
@@ -751,7 +751,7 @@ index 776a2e0..26e5510 100644
 +        var nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
 +        var pnpTypes = getPnpTypeRoots(currentDirectory);
 +        if (nmTypes.length > 0 || pnpTypes.length > 0) {
-+            return __spreadArrays(nmTypes, pnpTypes);
++            return [].concat(nmTypes, pnpTypes);
 +        }
 +    }
      /**

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-constraints",
   "version": "2.0.0-rc.8",
+  "nextVersion": {
+    "nonce": "4504081233976721"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git"

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-dlx",
   "version": "2.0.0-rc.9",
+  "nextVersion": {
+    "nonce": "5496545511674191"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-essentials",
   "version": "2.0.0-rc.16",
+  "nextVersion": {
+    "nonce": "5481798449360365"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-init",
   "version": "2.0.0-rc.9",
+  "nextVersion": {
+    "nonce": "8344405561343829"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-interactive-tools",
   "version": "2.0.0-rc.10",
+  "nextVersion": {
+    "nonce": "7452966136840619"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/libui": "workspace:^2.0.0-rc.1",

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-npm-cli",
   "version": "2.0.0-rc.9",
+  "nextVersion": {
+    "nonce": "4349026436917297"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-pack",
   "version": "2.0.0-rc.12",
+  "nextVersion": {
+    "nonce": "1837285398600697"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-patch",
   "version": "2.0.0-rc.1",
+  "nextVersion": {
+    "nonce": "1695990524453109"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-pnp",
   "version": "2.0.0-rc.12",
+  "nextVersion": {
+    "nonce": "3172183830835679"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-stage",
   "version": "2.0.0-rc.12",
+  "nextVersion": {
+    "nonce": "1446116570980833"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-typescript",
   "version": "2.0.0-rc.10",
+  "nextVersion": {
+    "nonce": "938098439424615"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/plugin-pack": "workspace:^2.0.0-rc.11"

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/plugin-version",
   "version": "2.0.0-rc.15",
+  "nextVersion": {
+    "semver": "2.0.0-rc.16",
+    "nonce": "2067310077837823"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/plugin-workspace-tools",
   "version": "2.0.0-rc.11",
+  "nextVersion": {
+    "nonce": "1746282461491163"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/yarnpkg-check/package.json
+++ b/packages/yarnpkg-check/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/check",
   "version": "2.0.0-rc.8",
+  "nextVersion": {
+    "nonce": "3798325493381339"
+  },
   "bin": "./sources/boot-cli-dev.js",
   "dependencies": {
     "@yarnpkg/cli": "workspace:^2.0.0-rc.19",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/cli",
   "version": "2.0.0-rc.20",
+  "nextVersion": {
+    "semver": "2.0.0-rc.21",
+    "nonce": "1744453385370855"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@yarnpkg/core",
   "version": "2.0.0-rc.16",
+  "nextVersion": {
+    "nonce": "1036848147942221"
+  },
   "main": "./sources/index.ts",
   "sideEffects": false,
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24119,11 +24119,11 @@ typescript@^3.7.4:
 
 "typescript@patch:typescript@^3.7.4#builtin<compat/typescript>":
   version: 3.7.4
-  resolution: "typescript@patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=9aabd0"
+  resolution: "typescript@patch:typescript@npm%3A3.7.4#builtin<compat/typescript>::hash=bafb4c"
   bin:
     tsc: ./bin/tsc
     tsserver: ./bin/tsserver
-  checksum: bf2e32168279d11ec3b4d1af5aa6da632d05640142496aacf55f121d3c9f612ade060de99525dc493bd87b4920aa34c8953aa346c08e57e996fbc13f66b212ae
+  checksum: 76801a625f79ee313070bf80459d54457c3f8eefeb78fa1d7d5f394f8092279faf6a637fdb15f691b42e93a7920aff52161b9dd771035fcca6251237bb390e70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

It seems that `__spreadArray` wasn't available on older TS releases, so while the patch can be applied it doesn't actually work.

**How did you fix it?**

I now use `[].concat(A, B)` instead of `[...A, ...B]`.
