### PR TITLE
feat: normalize and preserve line endings

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -180,7 +180,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       }
     ],
     "enableTopLevelFallback": true,
-    "ignorePatternData": "(^(?:\\.vscode\\/pnpify(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)|$))$)",
+    "ignorePatternData": "(^(?:\\.vscode[\\\\\\/]pnpify(?:[\\\\\\/](?!\\.)(?:(?:(?!(?:^|[\\\\\\/])\\.).)*?)|$))$)",
     "fallbackExclusionList": [
       ["@yarnpkg/builder", ["virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-builder", "workspace:packages/yarnpkg-builder"]],
       ["@yarnpkg/check", ["workspace:packages/yarnpkg-check"]],
@@ -39854,8 +39854,6 @@ const fs_1 = __importDefault(__webpack_require__(1));
 
 const module_1 = __importDefault(__webpack_require__(7));
 
-const path_1 = __importDefault(__webpack_require__(2));
-
 const string_decoder_1 = __importDefault(__webpack_require__(45));
 
 const applyPatch_1 = __webpack_require__(46);
@@ -39872,7 +39870,7 @@ const makeManager_1 = __webpack_require__(49); // We must copy the fs into a loc
 const localFs = Object.assign({}, fs_1.default);
 const nodeFs = new fslib_1.NodeFS(localFs);
 const defaultRuntimeState = $$SETUP_STATE(hydrateRuntimeState_1.hydrateRuntimeState);
-const defaultPnpapiResolution = path_1.default.resolve(__dirname, __filename); // We create a virtual filesystem that will do three things:
+const defaultPnpapiResolution = __filename; // We create a virtual filesystem that will do three things:
 // 1. all requests inside a folder named "$$virtual" will be remapped according the virtual folder rules
 // 2. all requests going inside a Zip archive will be handled by the Zip fs implementation
 // 3. any remaining request will be forwarded to Node as-is
@@ -44315,9 +44313,10 @@ function makeManager(pnpapi, opts) {
   }]]);
 
   function loadApiInstance(pnpApiPath) {
-    // @ts-ignore
-    const module = new module_1.Module(fslib_1.npath.fromPortablePath(pnpApiPath), null);
-    module.load(pnpApiPath);
+    const nativePath = fslib_1.npath.fromPortablePath(pnpApiPath); // @ts-ignore
+
+    const module = new module_1.Module(nativePath, null);
+    module.load(nativePath);
     return module.exports;
   }
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -822,7 +822,7 @@ describe(`Plug'n'Play`, () => {
 
         const pnpJs = await readFile(`${path}/.pnp.js`, `utf8`);
 
-        expect(pnpJs.replace(/\n.*/s, ``)).toMatch(/^#!foo$/);
+        expect(pnpJs.replace(/(\r\n|\r|\n).*/s, ``)).toMatch(/^#!foo$/);
       },
     ),
   );

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.2",
   "nextVersion": {
     "semver": "2.0.0-rc.3",
-    "nonce": "3835955033853351"
+    "nonce": "7838528448046121"
   },
   "main": "./sources/index.ts",
   "peerDependencies": {

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-constraints",
   "version": "2.0.0-rc.8",
   "nextVersion": {
-    "nonce": "4644723356663205"
+    "semver": "2.0.0-rc.9",
+    "nonce": "1157212325168189"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-dlx",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "nonce": "8633653840320395"
+    "semver": "2.0.0-rc.10",
+    "nonce": "6478393691774883"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-essentials",
   "version": "2.0.0-rc.17",
   "nextVersion": {
-    "nonce": "6980142853211519"
+    "semver": "2.0.0-rc.18",
+    "nonce": "5979268992269523"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -261,7 +261,9 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
   const merged = Object.assign({}, parsedLeft, parsedRight);
   const serialized = stringifySyml(merged);
 
-  await xfs.changeFilePromise(lockfilePath, serialized);
+  await xfs.changeFilePromise(lockfilePath, serialized, {
+    automaticNewlines: true,
+  });
 
   return true;
 }

--- a/packages/plugin-exec/package.json
+++ b/packages/plugin-exec/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-exec",
   "version": "2.0.0-rc.12",
   "nextVersion": {
-    "nonce": "4857827304320955"
+    "semver": "2.0.0-rc.13",
+    "nonce": "7775193041397609"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-file",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "nonce": "7338051564847907"
+    "semver": "2.0.0-rc.10",
+    "nonce": "3626760655061209"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.12",
   "nextVersion": {
     "semver": "2.0.0-rc.13",
-    "nonce": "3446541692419607"
+    "nonce": "4377879255233525"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-github",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "nonce": "5701631085515075"
+    "semver": "2.0.0-rc.10",
+    "nonce": "3847775796677047"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-http",
   "version": "2.0.0-rc.8",
   "nextVersion": {
-    "nonce": "7561198339636525"
+    "semver": "2.0.0-rc.9",
+    "nonce": "3440141502633535"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-init",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "nonce": "7074591094005049"
+    "semver": "2.0.0-rc.10",
+    "nonce": "8157100585986273"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-interactive-tools",
   "version": "2.0.0-rc.10",
   "nextVersion": {
-    "nonce": "6034719165693555"
+    "semver": "2.0.0-rc.11",
+    "nonce": "3575618137238383"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-link",
   "version": "2.0.0-rc.8",
   "nextVersion": {
-    "nonce": "239291317642155"
+    "semver": "2.0.0-rc.9",
+    "nonce": "8931950889443569"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-npm-cli",
   "version": "2.0.0-rc.9",
   "nextVersion": {
-    "nonce": "3484398539889275"
+    "semver": "2.0.0-rc.10",
+    "nonce": "6297198947972263"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.11",
   "nextVersion": {
     "semver": "2.0.0-rc.12",
-    "nonce": "8891440094278893"
+    "nonce": "6978681226996703"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-pack",
   "version": "2.0.0-rc.12",
   "nextVersion": {
-    "nonce": "7618899371255411"
+    "semver": "2.0.0-rc.13",
+    "nonce": "785604694352707"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "nextVersion": {
     "semver": "2.0.0-rc.2",
-    "nonce": "4298963677558397"
+    "nonce": "3657910648713087"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-pnp",
   "version": "2.0.0-rc.12",
   "nextVersion": {
-    "nonce": "257653629921063"
+    "semver": "2.0.0-rc.13",
+    "nonce": "5556963896504851"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -197,7 +197,7 @@ class PnpInstaller implements Installer {
     if (this.opts.project.configuration.get(`pnpEnableInlining`)) {
       const loaderFile = generateInlinedScript(pnpSettings);
 
-      await xfs.changeFilePromise(pnpPath, loaderFile);
+      await xfs.changeFilePromise(pnpPath, loaderFile, {automaticNewlines: true});
       await xfs.chmodPromise(pnpPath, 0o755);
 
       await xfs.removePromise(pnpDataPath);
@@ -205,10 +205,10 @@ class PnpInstaller implements Installer {
       const dataLocation = ppath.relative(ppath.dirname(pnpPath), pnpDataPath);
       const {dataFile, loaderFile} = generateSplitScript({...pnpSettings, dataLocation});
 
-      await xfs.changeFilePromise(pnpPath, loaderFile);
+      await xfs.changeFilePromise(pnpPath, loaderFile, {automaticNewlines: true});
       await xfs.chmodPromise(pnpPath, 0o755);
 
-      await xfs.changeFilePromise(pnpDataPath, dataFile);
+      await xfs.changeFilePromise(pnpDataPath, dataFile, {automaticNewlines: true});
       await xfs.chmodPromise(pnpDataPath, 0o644);
     }
 

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-stage",
   "version": "2.0.0-rc.12",
   "nextVersion": {
-    "nonce": "4345360952629985"
+    "semver": "2.0.0-rc.13",
+    "nonce": "5314199999994855"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-typescript",
   "version": "2.0.0-rc.10",
   "nextVersion": {
-    "nonce": "3413975139447461"
+    "semver": "2.0.0-rc.11",
+    "nonce": "7941544767382369"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-version",
   "version": "2.0.0-rc.16",
   "nextVersion": {
-    "nonce": "3613419340668431"
+    "semver": "2.0.0-rc.17",
+    "nonce": "2738158938311813"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/plugin-workspace-tools",
   "version": "2.0.0-rc.11",
   "nextVersion": {
-    "nonce": "6813198720441243"
+    "semver": "2.0.0-rc.12",
+    "nonce": "1627510756950559"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/builder",
   "version": "2.0.0-rc.15",
   "nextVersion": {
-    "nonce": "7405591410197173"
+    "semver": "2.0.0-rc.16",
+    "nonce": "2972474085615669"
   },
   "bin": "./sources/boot-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-check/package.json
+++ b/packages/yarnpkg-check/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/check",
   "version": "2.0.0-rc.8",
   "nextVersion": {
-    "nonce": "8994600960034007"
+    "semver": "2.0.0-rc.9",
+    "nonce": "5133219199959275"
   },
   "bin": "./sources/boot-cli-dev.js",
   "dependencies": {

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.21",
   "nextVersion": {
     "semver": "2.0.0-rc.22",
-    "nonce": "459172943796967"
+    "nonce": "8193351460332865"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.16",
   "nextVersion": {
     "semver": "2.0.0-rc.17",
-    "nonce": "8897465501539947"
+    "nonce": "2359414758380757"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -769,7 +769,9 @@ export class Configuration {
     if (!patched)
       return;
 
-    await xfs.changeFilePromise(configurationPath, stringifySyml(current));
+    await xfs.changeFilePromise(configurationPath, stringifySyml(current), {
+      automaticNewlines: true,
+    });
   }
 
   static async updateHomeConfiguration(patch: any) {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1193,7 +1193,9 @@ export class Project {
       }
 
       await xfs.mkdirpPromise(ppath.dirname(bstatePath));
-      await xfs.changeFilePromise(bstatePath, bstateFile);
+      await xfs.changeFilePromise(bstatePath, bstateFile, {
+        automaticNewlines: true,
+      });
     } else {
       await xfs.removePromise(bstatePath);
     }
@@ -1363,7 +1365,9 @@ export class Project {
     const lockfilePath = ppath.join(this.cwd, this.configuration.get(`lockfileFilename`));
     const lockfileContent = this.generateLockfile();
 
-    await xfs.changeFilePromise(lockfilePath, lockfileContent);
+    await xfs.changeFilePromise(lockfilePath, lockfileContent, {
+      automaticNewlines: true,
+    });
   }
 
   async persist() {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1,7 +1,7 @@
-import {PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
 import {parseSyml, stringifySyml}                    from '@yarnpkg/parsers';
 import {createHash}                                  from 'crypto';
 import {structuredPatch}                             from 'diff';
+import {PortablePath, npath, ppath, toFilename, xfs, normalizeLineEndings} from '@yarnpkg/fslib';
 // @ts-ignore
 import Logic                                         from 'logic-solver';
 import pLimit                                        from 'p-limit';
@@ -1238,7 +1238,7 @@ export class Project {
       await this.resolveEverything(opts);
 
       if (initialLockfile !== null) {
-        const newLockfile = this.generateLockfile();
+        const newLockfile = normalizeLineEndings(initialLockfile, this.generateLockfile());
 
         if (newLockfile !== initialLockfile) {
           const diff = structuredPatch(lockfilePath, lockfilePath, initialLockfile, newLockfile);

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1,37 +1,37 @@
-import {parseSyml, stringifySyml}                    from '@yarnpkg/parsers';
-import {createHash}                                  from 'crypto';
-import {structuredPatch}                             from 'diff';
 import {PortablePath, npath, ppath, toFilename, xfs, normalizeLineEndings} from '@yarnpkg/fslib';
+import {parseSyml, stringifySyml}                                          from '@yarnpkg/parsers';
+import {createHash}                                                        from 'crypto';
+import {structuredPatch}                                                   from 'diff';
 // @ts-ignore
-import Logic                                         from 'logic-solver';
-import pLimit                                        from 'p-limit';
-import semver                                        from 'semver';
-import {tmpNameSync}                                 from 'tmp';
+import Logic                                                               from 'logic-solver';
+import pLimit                                                              from 'p-limit';
+import semver                                                              from 'semver';
+import {tmpNameSync}                                                       from 'tmp';
 
-import {Cache}                                       from './Cache';
-import {Configuration, FormatType}                   from './Configuration';
-import {Fetcher}                                     from './Fetcher';
-import {Installer, BuildDirective, BuildType}        from './Installer';
-import {LegacyMigrationResolver}                     from './LegacyMigrationResolver';
-import {Linker}                                      from './Linker';
-import {LockfileResolver}                            from './LockfileResolver';
-import {DependencyMeta, Manifest}                    from './Manifest';
-import {MessageName}                                 from './MessageName';
-import {MultiResolver}                               from './MultiResolver';
-import {OverrideResolver}                            from './OverrideResolver';
-import {Report, ReportError}                         from './Report';
-import {ResolveOptions, Resolver}                    from './Resolver';
-import {RunInstallPleaseResolver}                    from './RunInstallPleaseResolver';
-import {ThrowReport}                                 from './ThrowReport';
-import {Workspace}                                   from './Workspace';
-import {isFolderInside}                              from './folderUtils';
-import * as miscUtils                                from './miscUtils';
-import * as scriptUtils                              from './scriptUtils';
-import * as semverUtils                              from './semverUtils';
-import * as structUtils                              from './structUtils';
-import {IdentHash, DescriptorHash, LocatorHash}      from './types';
-import {Descriptor, Ident, Locator, Package}         from './types';
-import {LinkType}                                    from './types';
+import {Cache}                                                             from './Cache';
+import {Configuration, FormatType}                                         from './Configuration';
+import {Fetcher}                                                           from './Fetcher';
+import {Installer, BuildDirective, BuildType}                              from './Installer';
+import {LegacyMigrationResolver}                                           from './LegacyMigrationResolver';
+import {Linker}                                                            from './Linker';
+import {LockfileResolver}                                                  from './LockfileResolver';
+import {DependencyMeta, Manifest}                                          from './Manifest';
+import {MessageName}                                                       from './MessageName';
+import {MultiResolver}                                                     from './MultiResolver';
+import {OverrideResolver}                                                  from './OverrideResolver';
+import {Report, ReportError}                                               from './Report';
+import {ResolveOptions, Resolver}                                          from './Resolver';
+import {RunInstallPleaseResolver}                                          from './RunInstallPleaseResolver';
+import {ThrowReport}                                                       from './ThrowReport';
+import {Workspace}                                                         from './Workspace';
+import {isFolderInside}                                                    from './folderUtils';
+import * as miscUtils                                                      from './miscUtils';
+import * as scriptUtils                                                    from './scriptUtils';
+import * as semverUtils                                                    from './semverUtils';
+import * as structUtils                                                    from './structUtils';
+import {IdentHash, DescriptorHash, LocatorHash}                            from './types';
+import {Descriptor, Ident, Locator, Package}                               from './types';
+import {LinkType}                                                          from './types';
 
 // When upgraded, the lockfile entries have to be resolved again (but the specific
 // versions are still pinned, no worry). Bump it when you change the fields within

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -128,7 +128,11 @@ export class Workspace {
     const data = {};
     this.manifest.exportTo(data);
 
+    const path = ppath.join(this.cwd, Manifest.fileName);
     const content = `${JSON.stringify(data, null, this.manifest.indent)}\n`;
-    await xfs.changeFilePromise(ppath.join(this.cwd, toFilename(`package.json`)), content);
+
+    await xfs.changeFilePromise(path, content, {
+      automaticNewlines: true,
+    });
   }
 }

--- a/packages/yarnpkg-fslib/package.json
+++ b/packages/yarnpkg-fslib/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/fslib",
   "version": "2.0.0-rc.13",
   "nextVersion": {
-    "nonce": "8891659325007283"
+    "semver": "2.0.0-rc.14",
+    "nonce": "7392197390234973"
   },
   "main": "./sources/index.ts",
   "sideEffects": false,

--- a/packages/yarnpkg-fslib/sources/FakeFS.ts
+++ b/packages/yarnpkg-fslib/sources/FakeFS.ts
@@ -524,6 +524,6 @@ function getEndOfLine(content: string) {
   return crlf > lf ? `\r\n` : `\n`;
 }
 
-function normalizeLineEndings(originalContent: string, newContent: string){
+export function normalizeLineEndings(originalContent: string, newContent: string){
   return newContent.replace(/\r?\n/g, getEndOfLine(originalContent));
 }

--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -11,6 +11,7 @@ export {WatchOptions}             from './FakeFS';
 export {WatchCallback}            from './FakeFS';
 export {Watcher}                  from './FakeFS';
 export {WriteFileOptions}         from './FakeFS';
+export {normalizeLineEndings}     from './FakeFS';
 
 export {FSPath, Path, PortablePath, NativePath, Filename} from './path';
 export {ParsedPath, PathUtils, FormatInputPathObject} from './path';

--- a/packages/yarnpkg-json-proxy/package.json
+++ b/packages/yarnpkg-json-proxy/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/json-proxy",
   "version": "2.0.0-rc.5",
+  "nextVersion": {
+    "semver": "2.0.0-rc.6",
+    "nonce": "6611533137052923"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12"

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.13",
   "nextVersion": {
     "semver": "2.0.0-rc.14",
-    "nonce": "3639273132331119"
+    "nonce": "2897679859272021"
   },
   "main": "./sources/index.ts",
   "dependencies": {

--- a/packages/yarnpkg-pnp/sources/loader/_entryPoint.ts
+++ b/packages/yarnpkg-pnp/sources/loader/_entryPoint.ts
@@ -1,7 +1,6 @@
 import {FakeFS, NodeFS, NativePath, PortablePath, VirtualFS, ZipOpenFS} from '@yarnpkg/fslib';
 import fs                                                               from 'fs';
 import Module                                                           from 'module';
-import path                                                             from 'path';
 import StringDecoder                                                    from 'string_decoder';
 
 import {RuntimeState, PnpApi}                                           from '../types';

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -2,7 +2,8 @@
   "name": "@yarnpkg/pnpify",
   "version": "2.0.0-rc.13",
   "nextVersion": {
-    "nonce": "5543185103982103"
+    "semver": "2.0.0-rc.14",
+    "nonce": "1296200516586759"
   },
   "main": "./sources/boot-dev.js",
   "bin": "./sources/boot-cli-dev.js",

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -41,7 +41,9 @@ const addVSCodeWorkspaceSettings = async (projectRoot: PortablePath, settings: a
   const patched = `${CJSON.stringify({...data, ...settings}, null, 2)}\n`;
 
   await xfs.mkdirpPromise(ppath.dirname(settingsPath));
-  await xfs.changeFilePromise(settingsPath, patched);
+  await xfs.changeFilePromise(settingsPath, patched, {
+    automaticNewlines: true,
+  });
 };
 
 const generateTypescriptWrapper = async (projectRoot: PortablePath, target: PortablePath) => {

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@yarnpkg/shell",
   "version": "2.0.0-rc.5",
+  "nextVersion": {
+    "semver": "2.0.0-rc.6",
+    "nonce": "4672248976888983"
+  },
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",


### PR DESCRIPTION
**What's the problem this PR addresses?**

TL;DR; Whenever yarn updates the lockfile or a manifest its line endings are inconsistent on Windows. This results in git showing all `package.json` and `yarn.lock` files as changed.

https://github.com/yarnpkg/berry/pull/666#issuecomment-570806471

**How did you fix it?**

Normalize line endings before writing the manifest and lockfile and preserve the line endings that was used, defaulting to the OS default
