### PR TITLE
[fix][doc] Fix doc for interactive plugin

### DIFF
--- a/packages/plugin-interactive-tools/bin/@yarnpkg/plugin-interactive-tools.js
+++ b/packages/plugin-interactive-tools/bin/@yarnpkg/plugin-interactive-tools.js
@@ -341,7 +341,7 @@ module.exports = {
     category: `Interactive commands`,
     description: `open the upgrade interace`,
     details: `
-        > In order to use this command you will need to add \`@yarnpkg/plugin-interactive\` to your plugins. Check the documentation for \`yarn plugin import\` for more details.
+        > In order to use this command you will need to add \`@yarnpkg/plugin-interactive-tools\` to your plugins. Check the documentation for \`yarn plugin import\` for more details.
 
         This command opens a fullscreen terminal interace where you can see the packages used by your application, their status compared to the latest versions available on the remote registry, and let you upgrade.
       `,

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -18,7 +18,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     category: `Interactive commands`,
     description: `open the upgrade interace`,
     details: `
-      > In order to use this command you will need to add \`@yarnpkg/plugin-interactive\` to your plugins. Check the documentation for \`yarn plugin import\` for more details.
+      > In order to use this command you will need to add \`@yarnpkg/plugin-interactive-tools\` to your plugins. Check the documentation for \`yarn plugin import\` for more details.
 
       This command opens a fullscreen terminal interace where you can see the packages used by your application, their status compared to the latest versions available on the remote registry, and let you upgrade.
     `,


### PR DESCRIPTION
The plugin is @yarnpkg/plugin-interactive-tools instead of @yarnpkg/plugin-interactive

**What's the problem this PR addresses?**
Documentation problem to use upgrade-interactive command
...