### PR TITLE
fix(details): prevent images from overflowing in readmes

### DIFF
--- a/packages/gatsby/src/components/details/ReadMore.js
+++ b/packages/gatsby/src/components/details/ReadMore.js
@@ -94,6 +94,10 @@ const ReadMoreContainer = styled.div`
     font-size: 1.25rem;
     border-left: .25rem solid #eceeef;
   }
+
+  img {
+    max-width: 100%;
+  }
 `;
 
 const ReadMore = ({text, height, children}) => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

<img width="848" alt="Screenshot 2020-01-08 at 13 27 19" src="https://user-images.githubusercontent.com/6270048/71978034-a8c14b80-321a-11ea-8a04-a86eac3865d6.png">


Images in readme were too big

**How did you fix it?**

images now can not be wider than the size of the container, like in v1
