### PR TITLE
fix: normalize INIT_CWD

### DIFF
--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -51,7 +51,7 @@ export async function makeScriptEnv({project, lifecycleScript}: {project?: Proje
   }
 
   if (project)
-    scriptEnv.INIT_CWD = project.configuration.startingCwd;
+    scriptEnv.INIT_CWD = npath.fromPortablePath(project.configuration.startingCwd);
 
   scriptEnv.PATH = scriptEnv.PATH
     ? `${nativeBinFolder}${npath.delimiter}${scriptEnv.PATH}`


### PR DESCRIPTION
**What's the problem this PR addresses?**


The install step of husky `>= 4.0.0-beta.4` fails on windows because `INIT_CWD` starts with `/`.

Since husky doesn't use an exit code, the install step passes, ref https://github.com/typicode/husky/pull/633

**How did you fix it?**

Normalize `INIT_CWD` using `npath.fromPortablePath`.