### PR TITLE
remove Baumans font

### DIFF
--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -44,9 +44,6 @@ module.exports = {
           family: `Abel`,
           variants: [`300`, `400`],
         }, {
-          family: `Baumans`,
-          variants: [`400`],
-        }, {
           family: `PT Mono`,
         }],
       },


### PR DESCRIPTION


**What's the problem this PR addresses?**

it isn't used by the site, so its preloading isn't necessary as far as I can tell.

**How did you fix it?**

Removed Baumans from the font configuration
