### PR TITLE
add fallback font families

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -13,7 +13,7 @@
     height: 100%;
     margin: 0;
     padding: 0;
-    font-family: Open Sans;
+    font-family: "Open Sans", sans-serif;
     line-height: 1.5
   }
 
@@ -37,7 +37,7 @@
 <script>window.location = "https://next.yarnpkg.com" + window.location.pathname.replace("/berry", "") + window.location.search + window.location.hash</script>
 <style data-emotion-css=1rgujud>
   body {
-    font-family: sans-serif;
+    font-family: "Open Sans", sans-serif;
   }
 
   @media (min-width:761px) {
@@ -163,7 +163,7 @@
     height: 4em;
     border: 3px solid transparent;
     padding: 0 1em;
-    font-family: sans-serif;
+    font-family: "Open Sans", sans-serif;
     -webkit-text-decoration: none;
     text-decoration: none;
     text-transform: uppercase;

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
     height: 100%;
     margin: 0;
     padding: 0;
-    font-family: Open Sans;
+    font-family: "Open Sans", sans-serif;
     line-height: 1.5
   }
 
@@ -37,7 +37,7 @@
 <script>window.location = "https://next.yarnpkg.com" + window.location.pathname.replace("/berry", "") + window.location.search + window.location.hash</script>
 <style data-emotion-css=1rgujud>
   body {
-    font-family: sans-serif;
+    font-family: "Open Sans", sans-serif;
   }
 
   @media (min-width:761px) {
@@ -163,7 +163,7 @@
     height: 4em;
     border: 3px solid transparent;
     padding: 0 1em;
-    font-family: sans-serif;
+    font-family: "Open Sans", sans-serif;
     -webkit-text-decoration: none;
     text-decoration: none;
     text-transform: uppercase;

--- a/packages/gatsby/src/components/layout.css
+++ b/packages/gatsby/src/components/layout.css
@@ -9,12 +9,12 @@ body {
   margin: 0;
   padding: 0;
 
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   line-height: 1.5;
 }
 
 code {
-  font-family: "PT Mono";
+  font-family: "PT Mono", monospace;
 }
 
 /* unset styling from primsjs theme (set in gatsby-browser.js) */

--- a/packages/gatsby/src/components/syntax.js
+++ b/packages/gatsby/src/components/syntax.js
@@ -14,14 +14,14 @@ const getColorForScalar = (theme, scalar) => {
 export const Container = styled.div`
   padding: 1.5em;
 
-  font-family: "PT Mono";
+  font-family: "PT Mono", monospace;
   line-height: 1.6em;
 
   background: ${props => props.theme.colors.background};
   color: ${props => props.theme.colors.documentation};
 
   code {
-    font-family: "PT Mono";
+    font-family: "PT Mono", monospace;
 
     color: ${props => props.theme.colors.code};
   }
@@ -36,7 +36,7 @@ export const Main = styled.div`
 
   padding: 1em;
 
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   white-space: normal;
 
   & + * {
@@ -108,7 +108,7 @@ const AnchorContainer = styled.a`
 const Description = styled.div`
   margin-bottom: 0.5em;
 
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   white-space: normal;
 `;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

If the custom fonts would fail for some reason, or if someone blocks them, right now there are no fallbacks, meaning that a serif font would be displayed

**How did you fix it?**

Adding sans-serif to all instances of Open Sans, monospace to PT Mono
