### PR TITLE
Tweaks the plugin pipeline

### DIFF
--- a/.yarn/versions/042aef38.yml
+++ b/.yarn/versions/042aef38.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/check@2.0.0-rc.9": prerelease
+  "@yarnpkg/cli@2.0.0-rc.22": prerelease
+  "@yarnpkg/core@2.0.0-rc.17": prerelease
+  "@yarnpkg/parsers@2.0.0-rc.7": prerelease
+  "@yarnpkg/plugin-essentials@2.0.0-rc.18": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat@2.0.0-rc.3"
+  - "@yarnpkg/plugin-constraints@2.0.0-rc.9"
+  - "@yarnpkg/plugin-dlx@2.0.0-rc.10"
+  - "@yarnpkg/plugin-exec@2.0.0-rc.13"
+  - "@yarnpkg/plugin-file@2.0.0-rc.10"
+  - "@yarnpkg/plugin-git@2.0.0-rc.13"
+  - "@yarnpkg/plugin-github@2.0.0-rc.10"
+  - "@yarnpkg/plugin-http@2.0.0-rc.9"
+  - "@yarnpkg/plugin-init@2.0.0-rc.10"
+  - "@yarnpkg/plugin-interactive-tools@2.0.0-rc.11"
+  - "@yarnpkg/plugin-link@2.0.0-rc.9"
+  - "@yarnpkg/plugin-npm@2.0.0-rc.12"
+  - "@yarnpkg/plugin-npm-cli@2.0.0-rc.10"
+  - "@yarnpkg/plugin-pack@2.0.0-rc.13"
+  - "@yarnpkg/plugin-patch@2.0.0-rc.2"
+  - "@yarnpkg/plugin-pnp@2.0.0-rc.13"
+  - "@yarnpkg/plugin-stage@2.0.0-rc.13"
+  - "@yarnpkg/plugin-typescript@2.0.0-rc.11"
+  - "@yarnpkg/plugin-version@2.0.0-rc.17"
+  - "@yarnpkg/plugin-workspace-tools@2.0.0-rc.12"
+  - "@yarnpkg/builder@2.0.0-rc.16"
+  - "@yarnpkg/shell@2.0.0-rc.6"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.js
@@ -1,0 +1,11 @@
+describe(`Commands`, () => {
+  describe(`plugin import`, () => {
+    test(
+      `it should support adding a plugin via its path`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`plugin`, `import`, require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`));
+        await run(`hello`, `--email`, `postmaster@example.org`);
+      }),
+    );
+  });
+});

--- a/packages/gatsby/content/advanced/plugin-tutorial.md
+++ b/packages/gatsby/content/advanced/plugin-tutorial.md
@@ -4,7 +4,7 @@ path: /advanced/plugin-tutorial
 title: "Plugin Tutorial"
 ---
 
-Starting from the v2, Yarn now supports plugins. For more information about what they are and in which case you'd want to use them, consult the [dedicated page](/features/plugins). We'll talk here about the exact steps needed to write one. It's quite simple, really!
+Starting from the Yarn 2, Yarn now supports plugins. For more information about what they are and in which case you'd want to use them, consult the [dedicated page](/features/plugins). We'll talk here about the exact steps needed to write one. It's quite simple, really!
 
 ## What does a plugin look like?
 
@@ -20,6 +20,17 @@ Open in a text editor a new file called `plugin-hello-world.js`, and type the fo
 module.exports = {
   name: `plugin-hello-world`,
   factory: require => ({
+    // What is this `require` function, you ask? It's a `require`
+    // implementation provided by Yarn core that allows you to
+    // access various packages (such as @yarnpkg/core) without
+    // having to list them in your own dependencies - hence
+    // lowering your plugin bundle size, and making sure that
+    // you'll use the exact same core modules as the rest of the
+    // application.
+    //
+    // Of course, the regular `require` implementation remains
+    // available, so feel free to use the `require` you need for
+    // your use case!
   })
 };
 ```
@@ -70,7 +81,7 @@ module.exports = {
       }
     }
     
-    Command.Path(`hello`)(HelloWorldCommand.prototype);
+    HelloWorldCommand.addPath(`hello`);
 
     return {
       commands: [
@@ -99,7 +110,11 @@ module.exports = {
     // Note: This curious syntax is because @Command.String is actually
     // a decorator! But since they aren't supported in native JS at the
     // moment, we need to call them manually.
-    Command.String(`--email`)(HelloWorldCommand.prototype, `email`);
+    HelloWorldCommand.addOption(`email`, Command.String(`--email`));
+
+    // Similarly we would be able to use a decorator here too, but since
+    // we're writing our code in JS-only we need to go through "addPath".
+    HelloWorldCommand.addPath(`hello`);
 
     // Similarly, native JS doesn't support member variable as of today,
     // hence the awkward writing.
@@ -124,6 +139,6 @@ module.exports = {
         HelloWorldCommand,
       ],
     };
-  }
+  },
 };
 ```

--- a/packages/gatsby/content/advanced/questions-and-answers.md
+++ b/packages/gatsby/content/advanced/questions-and-answers.md
@@ -50,6 +50,8 @@ Lockfiles should **always** be kept within the repository. Continuous integratio
 
 - `.yarn/unplugged` and `.yarn/build-state.yml` should likely always be ignored since they typically hold machine-specific build artifacts. Ignoring them might however prevent [Zero-Installs](https://next.yarnpkg.com/features/zero-installs) from working (to prevent this, set [`enableScripts`](/configuration/yarnrc#enableScripts) to `false`).
 
+- `.yarn/versions` is used by the [version plugin](/features/release-workflow) to store the package release definitions. You will want to keep it within your repository.
+
 - `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).
 
 - `yarn.lock` should always be stored within your repository ([even if you develop a library](#should-lockfiles-be-committed-to-the-repository)).
@@ -68,9 +70,9 @@ So to summarize:
 **If you're not using Zero-Installs:**
 
 ```gitignore
-.yarn/*
-!.yarn/releases
-!.yarn/plugins
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
 .pnp.*
 ```
 

--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -8,6 +8,16 @@ Ever since Yarn was created, our very essence has been about experimenting, evol
 
 As you can guess, this philosophy (coupled with the high number of external contribution we receive) requires us to iterate fast in order to accomodate with the various experiments that we brew. In a major step forward, Yarn got redesigned in the v2 in order to leverage a new modular API that can be extended through plugins. Nowadays, most of our features are implemented through those plugins - even `yarn add` and `yarn install` are preinstalled plugins!
 
+## Where to find plugins?
+
+Just type [`yarn plugin list`](/cli/plugin/list), or consult the repository: [plugins.yml](https://github.com/yarnpkg/berry/blob/master/plugins.yml).
+
+Note that the plugins exposed through `yarn plugin list` are only the official ones. Since plugins are single-file JS scripts, anyone can author them. By using [`yarn plugin import`](/cli/plugin/import) with an URL or a filesystem path, you'll be able to download (and execute, be careful!) code provided by anyone.
+
+## How to write plugins?
+
+We have a tutorial for this! Head over to [Plugin Tutorial](/advanced/plugin-tutorial).
+
 ## What can plugins do?
 
   - **Plugins can add new resolvers.** Resolvers are the components tasked from converting dependency ranges (for example `^1.2.0`) into fully-qualified package references (for example `npm:1.2.0`). By implementing a resolver, you can tell Yarn which versions are valid candidates to a specific range.
@@ -18,31 +28,6 @@ As you can guess, this philosophy (coupled with the high number of external cont
 
   - **Plugins can add new commands.** Each plugin can ship as many commands as they see fit, which will be injected into our CLI (also making them available through `yarn --help`). Because the Yarn plugins are dynamically linked with the running Yarn process, they can be very small and guaranteed to share the exact same behavior as your package manager (which wouldn't be the case if you were to reimplement the workspace detection, for example).
 
+  - **Plugins can register to some events.** Yarn has a concept known as "hooks", where events are periodically triggered during the lifecycle of the package manager. Plugins can register to those hooks in order to add their own logic depending on what the core allows. For example, the `afterAllInstalled` hook will be called each time the `Project#install` method ends - typically after each `yarn install`.
+
   - **Plugins can be integrated with each other.** Each plugin has the ability to trigger special actions called hooks, and to register themselves to any defined hook. So for example, you could make a plugin that would execute an action each time a package is added as dependency of one of your workspaces!
-
-## How to use plugins?
-
-The Yarn plugins are single-file JS scripts. They are easy to use:
-
-### Automatic setup
-
-The official plugins (the ones whose development happen on the Yarn repository) can be installed using the following commands:
-
-  - `yarn plugin list` will print the name of all available [official plugins](https://github.com/yarnpkg/berry/tree/plugins.yml).
-
-  - `yarn plugin import <plugin-name>` will download one of the plugins from the list, store it within the `.yarn/plugins` directory, and modify your local `.yarnrc.yml` file to reference it.
-
-  - `yarn plugin import <url>` will do the same thing, but because it uses an URL it will also work with any plugin regardless of where the plugin is actually hosted.
-
-### Manual setup
-
-The `yarn plugin import` command is useful, but in case you prefer to setup your project yourself:
-
-  - Download the plugin you want to use and put it somewhere
-
-  - Update your project-level `.yarnrc.yml` file by adding the following property:
-
-    ```yaml
-    plugins:
-      - "./my-plugin.js"
-    ```

--- a/plugins.yml
+++ b/plugins.yml
@@ -1,5 +1,10 @@
 # This file contains the list of officially endorsed plugins.
 
+"@yarnpkg/plugin-hello-world":
+  url: "https://github.com/yarnpkg/berry/raw/master/scripts/plugin-hello-world.js"
+  experimental: true
+  description: "Adds a `yarn hello` command that says 'hello'."
+
 "@yarnpkg/plugin-exec":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-exec/bin/%40yarnpkg/plugin-exec.js"
   experimental: true

--- a/scripts/plugin-hello-world.js
+++ b/scripts/plugin-hello-world.js
@@ -1,5 +1,5 @@
 module.exports = {
-  name: `plugin-hello-world`,
+  name: `@yarnpkg/plugin-hello-world`,
   factory: require => {
     const {Command} = require(`clipanion`);
     const yup = require(`yup`);

--- a/scripts/plugin-hello-world.js
+++ b/scripts/plugin-hello-world.js
@@ -1,0 +1,46 @@
+module.exports = {
+  name: `plugin-hello-world`,
+  factory: require => {
+    const {Command} = require(`clipanion`);
+    const yup = require(`yup`);
+
+    class HelloWorldCommand extends Command {
+      async execute() {
+        this.context.stdout.write(`Hello ${this.email} 💌\n`);
+      }
+    }
+
+    // Note: This curious syntax is because @Command.String is actually
+    // a decorator! But since they aren't supported in native JS at the
+    // moment, we need to call them manually.
+    HelloWorldCommand.addOption(`email`, Command.String(`--email`));
+
+    // Similarly we would be able to use a decorator here too, but since
+    // we're writing our code in JS-only we need to go through "addPath".
+    HelloWorldCommand.addPath(`hello`);
+
+    // Similarly, native JS doesn't support member variable as of today,
+    // hence the awkward writing.
+    HelloWorldCommand.schema = yup.object().shape({
+      email: yup.string().required().email(),
+    });
+
+    // Show descriptive usage for a --help argument passed to this command
+    HelloWorldCommand.usage = Command.Usage({
+      description: `hello world!`,
+      details: `
+        This command will print a nice message.
+      `,
+      examples: [[
+        `Say hello to an email user`,
+        `yarn hello --email acidburn@example.com`,
+      ]],
+    });
+
+    return {
+      commands: [
+        HelloWorldCommand,
+      ],
+    };
+  },
+};


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn plugin import` required to know the full name of the plugin, which wasn't very easy (especially considering that all of our plugins have the same prefix anyway).

Plugins had to expose a `default` key, which wasn't obvious either.

**How did you fix it?**

The `yarn plugin import` command now automatically expands the plugin name if required, so running something like `yarn plugin import version` will now work.

The plugin loader now uses the `default` key if present, but also fallback to the whole object if the key isn't there (kind of like what the interop Babel helper does).
