### PR TITLE
Improves an error message

### DIFF
--- a/.yarn/versions/d9fa2c10.yml
+++ b/.yarn/versions/d9fa2c10.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/check@2.0.0-rc.9": prerelease
+  "@yarnpkg/cli@2.0.0-rc.22": prerelease
+  "@yarnpkg/plugin-dlx@2.0.0-rc.10": prerelease
+  "@yarnpkg/plugin-essentials@2.0.0-rc.18": prerelease
+  "@yarnpkg/plugin-interactive-tools@2.0.0-rc.11": prerelease
+  "@yarnpkg/plugin-npm-cli@2.0.0-rc.10": prerelease
+  "@yarnpkg/plugin-pack@2.0.0-rc.13": prerelease
+  "@yarnpkg/plugin-patch@2.0.0-rc.2": prerelease
+  "@yarnpkg/plugin-pnp@2.0.0-rc.13": prerelease
+  "@yarnpkg/plugin-version@2.0.0-rc.17": prerelease
+  "@yarnpkg/plugin-workspace-tools@2.0.0-rc.12": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat@2.0.0-rc.3"
+  - "@yarnpkg/plugin-constraints@2.0.0-rc.9"
+  - "@yarnpkg/plugin-init@2.0.0-rc.10"
+  - "@yarnpkg/plugin-stage@2.0.0-rc.13"
+  - "@yarnpkg/plugin-typescript@2.0.0-rc.11"
+  - "@yarnpkg/core@2.0.0-rc.17"

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -62,7 +62,7 @@ export default class DlxCommand extends BaseCommand {
       const {project, workspace} = await Project.find(configuration, tmpDir);
 
       if (workspace === null)
-        throw new WorkspaceRequiredError(tmpDir);
+        throw new WorkspaceRequiredError(project.cwd, tmpDir);
 
       await project.resolveEverything({
         lockfileOnly: true,

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -80,7 +80,7 @@ export default class AddCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     // @ts-ignore
     const prompt = inquirer.createPromptModule({

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -203,7 +203,7 @@ export default class YarnCommand extends BaseCommand {
     const cache = await Cache.find(configuration, {immutable: this.immutableCache, check: this.checkCache});
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     // Important: Because other commands also need to run installs, if you
     // get in a situation where you need to change this file in order to

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -42,7 +42,7 @@ export default class LinkCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
 
@@ -50,7 +50,7 @@ export default class LinkCommand extends BaseCommand {
     const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
 
     if (!workspace2)
-      throw new WorkspaceRequiredError(absoluteDestination);
+      throw new WorkspaceRequiredError(project2.cwd, absoluteDestination);
 
     const topLevelWorkspace = project.topLevelWorkspace;
     const linkedWorkspaces = [];

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -38,7 +38,7 @@ export default class RemoveCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const affectedWorkspaces = this.all
       ? project.workspaces

--- a/packages/plugin-essentials/sources/commands/runIndex.ts
+++ b/packages/plugin-essentials/sources/commands/runIndex.ts
@@ -9,10 +9,10 @@ export default class RunCommand extends BaseCommand {
   @Command.Path(`run`)
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {workspace} = await Project.find(configuration, this.context.cwd);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const report = await StreamReport.start({
       configuration,

--- a/packages/plugin-essentials/sources/commands/set/resolution.ts
+++ b/packages/plugin-essentials/sources/commands/set/resolution.ts
@@ -36,7 +36,7 @@ export default class SetResolutionCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const fromDescriptor = structUtils.parseDescriptor(this.descriptor, true);
     const toDescriptor = structUtils.makeDescriptor(fromDescriptor, this.resolution);

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -71,7 +71,7 @@ export default class SetVersionCommand extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const target = typeof this.installPath !== `undefined`
       ? ppath.resolve(this.context.cwd, npath.toPortablePath(this.installPath))

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -56,7 +56,7 @@ export default class UpCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     // @ts-ignore
     const prompt = inquirer.createPromptModule({

--- a/packages/plugin-essentials/sources/commands/why.ts
+++ b/packages/plugin-essentials/sources/commands/why.ts
@@ -40,7 +40,7 @@ export default class WhyCommand extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.resolveEverything({
       lockfileOnly: true,

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -35,7 +35,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const colorizeRawDiff = (from: string, to: string) => {
       const diff = diffWords(from, to);

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -40,7 +40,7 @@ export default class NpmPublishCommand extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     if (workspace.manifest.private)
       throw new UsageError(`Private workspaces cannot be published`);

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -51,7 +51,7 @@ export default class PackCommand extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     if (await packUtils.hasPackScripts(workspace)) {
       if (this.installIfNeeded) {

--- a/packages/plugin-patch/sources/commands/patch.ts
+++ b/packages/plugin-patch/sources/commands/patch.ts
@@ -23,7 +23,7 @@ export default class PatchCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.resolveEverything({
       lockfileOnly: true,

--- a/packages/plugin-patch/sources/commands/patchCommit.ts
+++ b/packages/plugin-patch/sources/commands/patchCommit.ts
@@ -25,7 +25,7 @@ export default class PatchCommitCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.resolveEverything({
       lockfileOnly: true,

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -35,7 +35,7 @@ export default class UnplugCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const topLevelWorkspace = project.topLevelWorkspace;
 

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -67,7 +67,7 @@ export default class VersionCommand extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     let deferred = configuration.get(`preferDeferredVersions`);
     if (this.deferred)

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -39,7 +39,7 @@ export default class VersionApplyCommand extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const applyReport = await StreamReport.start({
       configuration,

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -51,7 +51,7 @@ export default class VersionApplyCommand extends Command<CommandContext> {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.resolveEverything({
       lockfileOnly: true,
@@ -271,7 +271,7 @@ export default class VersionApplyCommand extends Command<CommandContext> {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.resolveEverything({
       lockfileOnly: true,

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -114,7 +114,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     const {project, workspace: cwdWorkspace} = await Project.find(configuration, this.context.cwd);
 
     if (!this.all && !cwdWorkspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const command = this.cli.process([this.commandName, ...this.args]) as {path: string[], scriptName?: string};
     const scriptName = command.path.length === 1 && command.path[0] === `run` && typeof command.scriptName !== `undefined`

--- a/packages/plugin-workspace-tools/sources/commands/workspace.ts
+++ b/packages/plugin-workspace-tools/sources/commands/workspace.ts
@@ -37,7 +37,7 @@ export default class WorkspaceCommand extends Command<CommandContext> {
     const {project, workspace: cwdWorkspace} = await Project.find(configuration, this.context.cwd);
 
     if (!cwdWorkspace)
-      throw new WorkspaceRequiredError(this.context.cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const candidates = project.workspaces;
     const candidatesByName = new Map(

--- a/packages/yarnpkg-cli/sources/tools/WorkspaceRequiredError.ts
+++ b/packages/yarnpkg-cli/sources/tools/WorkspaceRequiredError.ts
@@ -1,7 +1,12 @@
-import {UsageError} from 'clipanion';
+import {Manifest}            from '@yarnpkg/core';
+import {PortablePath, ppath} from '@yarnpkg/fslib';
+import {UsageError}          from 'clipanion';
 
 export class WorkspaceRequiredError extends UsageError {
-  constructor(cwd: string) {
-    super(`This command can only be run from within a workspace of your project.`);
+  constructor(projectCwd: PortablePath, cwd: PortablePath) {
+    const relativePath = ppath.relative(projectCwd, cwd);
+    const manifestPath = ppath.join(projectCwd, Manifest.fileName);
+
+    super(`This command can only be run from within a workspace of your project (${relativePath} isn't a workspace of ${manifestPath}).`);
   }
 }

--- a/packages/yarnpkg-cli/sources/tools/openWorkspace.ts
+++ b/packages/yarnpkg-cli/sources/tools/openWorkspace.ts
@@ -4,9 +4,10 @@ import {PortablePath}           from '@yarnpkg/fslib';
 import {WorkspaceRequiredError} from './WorkspaceRequiredError';
 
 export async function openWorkspace(configuration: Configuration, cwd: PortablePath) {
-  const {workspace} = await Project.find(configuration, cwd);
+  const {project, workspace} = await Project.find(configuration, cwd);
+
   if (!workspace)
-    throw new WorkspaceRequiredError(cwd);
+    throw new WorkspaceRequiredError(project.cwd, cwd);
 
   return workspace;
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

```
This command can only be run from within a workspace of your project
```

The error meant that there was a lockfile somewhere within the ancestors that prevented Yarn from correctly detecting the project root, but that was fairly difficult to understand.

**How did you fix it?**

The error now includes detailed information:

```
This command can only be run from within a workspace of your project (foo is not a workspace of /home/arcanis/package.json)
```
