### PR TITLE
Removes PnPify from the TS SDK

### DIFF
--- a/.yarn/versions/927303f6.yml
+++ b/.yarn/versions/927303f6.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify@2.0.0-rc.14": prerelease
+
+declined:
+  - vscode-zipfs@0.1.1-2
+  - "@yarnpkg/builder@2.0.0-rc.16"
+  - "@yarnpkg/cli@2.0.0-rc.22"
+  - "@yarnpkg/pnp@2.0.0-rc.14"

--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -1,0 +1,53 @@
+---
+category: advanced
+path: /advanced/editor-sdks
+title: "Editor SDKs"
+---
+
+Smart IDEs (such as VSCode or IntelliJ) require special configuration for TypeScript to work. This page intends to be a collection of settings for each editor we've worked with - please contribute to this list!
+
+## Editors
+
+### VSCode
+
+1. Add PnPify to your dependencies:
+
+```bash
+yarn add @yarnpkg/pnpify
+```
+
+2. Run the following command, which will generate a new directory called `.vscode/pnpify`:
+
+```bash
+yarn pnpify --sdk
+```
+
+3. For safety reason VSCode requires you to explicitly activate the custom TS settings:
+
+  1. Press <kbd>ctrl+shift+p</kbd> in a TypeScript file
+  2. Choose "Select TypeScript Version"
+  3. Pick "Use Workspace Version"
+
+Your VSCode project is now configured to use the exact same version of TypeScript as the one you usually use, except that it will now be able to properly resolve the type definitions!
+
+Note that VSCode might ask you to do Step 3 again from time to time, but apart from that your experience should be mostly the same as usual. Happy development!
+
+### VIM / coc.nvim
+
+1. Add PnPify to your dependencies:
+
+```bash
+yarn add @yarnpkg/pnpify
+```
+
+2. Run the following command, which will generate a new directory called `.vscode/pnpify`:
+
+```bash
+yarn pnpify --sdk
+```
+
+3. Set [`tsserver.tsdk`](https://github.com/neoclide/coc-tsserver#configuration-options) to `.vscode/pnpify/typescript/lib`
+
+## Caveat
+
+- Since the Yarn packages are kept within their archives, editors need to understand how to work with such paths should you want to actually open the files (for example when command-clicking on an import path originating from an external package). This can only be implemented by those editors, and we can't do much more than opening issues to ask for this feature to be implemented (for example, here's the VSCode issue: [#75559](https://github.com/microsoft/vscode/issues/75559)).

--- a/packages/gatsby/content/advanced/pnpify.md
+++ b/packages/gatsby/content/advanced/pnpify.md
@@ -6,60 +6,30 @@ title: "PnPify"
 
 ## Motivation
 
-Plug'n'Play is, by design, compatible with all projects that only make use of the `require` API - whether it's `require`, `require.resolve`, or `createRequireFromPath`. However, some projects like to reimplement the resolution themselves and aren't compatible by default with our environment (unless they add some specific lines into their resolution logic). One such project is for example TypeScript, which doesn't natively supports Plug'n'Play in its `tsc` binary at the time of this writing ([#28289](https://github.com/Microsoft/TypeScript/issues/28289)).
+Plug'n'Play is, by design, compatible with all projects that only make use of the `require` API - whether it's `require`, `require.resolve`, or `createRequireFromPath`. However, some rare projects prefer to reimplement the Node resolution themselves and as such aren't compatible by default with our environment (unless they integrate their resolvers with the [PnP API](/advanced/pnpapi)).
 
 ## PnPify
 
-PnPify is a tool designed to workaround these compatibility issues. It's not perfect in that it brings its own set of caveats and doesn't allow you to leverage all the features that PnP has to offer, but it's often good enough to unblock you until better solutions are implemented.
+PnPify is a tool designed to workaround these compatibility issues. It's not perfect - it brings its own set of caveats and doesn't allow you to leverage all the features that PnP has to offer - but it's often good enough to unblock you until better solutions are implemented.
 
-How it works is simple: when a non-PnP-compliant project tries to access the `node_modules` directories (for example through `readdir` or `readFile`), PnPify intercepts those calls and converts them into calls to the PnP API. Then, based on the result, it simulates an actual filesystem for the underlying tool to use.
+How it works is simple: when a non-PnP-compliant project tries to access the `node_modules` directories (for example through `readdir` or `readFile`), PnPify intercepts those calls and converts them into calls to the PnP API. Then, based on the result, it simulates the existence of a virtual `node_modules` folder that the underlying tool will then consume - still unaware that the files are extracted from a virtual filesystem.
 
 ## Usage
 
 1. Add PnPify to your dependencies:
 
-   ```bash
-   yarn add @yarnpkg/pnpify
-   ```
+```bash
+yarn add @yarnpkg/pnpify
+```
 
 2. Use pnpify to run the incompatible tool:
 
-   ```bash
-   yarn pnpify tsc
-   ```
-
-## VSCode Support
-
-PnPify also is compatible with VSCode! Follow those steps to enable it:
-
-1. Add PnPify to your dependencies:
-
-   ```bash
-   yarn add @yarnpkg/pnpify
-   ```
-
-2. Run the following command, which will generate a new directory called `.vscode/pnpify`:
-
-   ```bash
-   yarn pnpify --sdk
-   ```
-
-3. For safety reason VSCode requires you to explicitly activate the custom TS settings:
-
-    1. Press <kbd>ctrl+shift+p</kbd> in a TypeScript file
-    2. Choose "Select TypeScript Version"
-    3. Pick "Use Workspace Version"
-
-Your VSCode project is now configured to use the exact same version of TypeScript as the one you usually use, except that it will now be able to properly resolve the type definitions!
-
-Note that VSCode might ask you to do Step 4 again from time to time, but apart from that your experience should be the same as usual. Happy development!
+```bash
+yarn pnpify tsc
+```
 
 ## Caveat
 
 - Due to how PnPify emulates the `node_modules` directory, some problems are to be expected, especially with tools that watch directories inside `node_modules`.
 
 - PnPify isn't designed to be a long-term solution; its purpose is purely to help projects during their transition to the stricter Plug'n'Play module resolution scheme. Relying on PnPify doesn't allow you to take full advantage of everything Plug'n'Play has to offer, in particular perfect flattening and boundary checks.
-
-## Alternatives
-
-- A non-official VSCode extension called [`TypeScript Plug'n'Play`](https://marketplace.visualstudio.com/items?itemName=ark120202.vscode-typescript-pnp-plugin) is maintained by [@ark120202](https://github.com/ark120202/vscode-typescript-pnp-plugin) and add PnP support to VSCode in a more integrated way.

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -55,7 +55,7 @@ const generateTypescriptWrapper = async (projectRoot: PortablePath, target: Port
 
   await xfs.mkdirpPromise(ppath.dirname(tsserver));
   await xfs.writeFilePromise(manifest, JSON.stringify({name: 'typescript', version: `${dynamicRequire('typescript/package.json').version}-pnpify`}, null, 2));
-  await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath, "typescript/lib/tsserver", {usePnpify: true}));
+  await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath, "typescript/lib/tsserver", {usePnpify: false}));
 
   await addVSCodeWorkspaceSettings(projectRoot, {'typescript.tsdk': npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver)))});
 };

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -54,10 +54,12 @@ const generateTypescriptWrapper = async (projectRoot: PortablePath, target: Port
   const relPnpApiPath = ppath.relative(ppath.dirname(tsserver), ppath.join(projectRoot, `.pnp.js` as Filename));
 
   await xfs.mkdirpPromise(ppath.dirname(tsserver));
-  await xfs.writeFilePromise(manifest, JSON.stringify({name: 'typescript', version: `${dynamicRequire('typescript/package.json').version}-pnpify`}, null, 2));
-  await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath, "typescript/lib/tsserver", {usePnpify: false}));
+  await xfs.writeFilePromise(manifest, JSON.stringify({name: `typescript`, version: `${dynamicRequire(`typescript/package.json`).version}-pnpify`}, null, 2));
+  await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath, `typescript/lib/tsserver`, {usePnpify: false}));
 
-  await addVSCodeWorkspaceSettings(projectRoot, {'typescript.tsdk': npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver)))});
+  await addVSCodeWorkspaceSettings(projectRoot, {
+    [`typescript.tsdk`]: npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver))),
+  });
 };
 
 export const generateEslintWrapper = async (projectRoot: PortablePath, target: PortablePath) => {
@@ -68,10 +70,12 @@ export const generateEslintWrapper = async (projectRoot: PortablePath, target: P
   const relPnpApiPath = ppath.relative(ppath.dirname(api), ppath.join(projectRoot, `.pnp.js` as Filename));
 
   await xfs.mkdirpPromise(ppath.dirname(api));
-  await xfs.writeFilePromise(manifest, JSON.stringify({name: 'eslint', version: `${dynamicRequire('eslint/package.json').version}-pnpify`, main: 'lib/api.js'}, null, 2));
-  await xfs.writeFilePromise(api, TEMPLATE(relPnpApiPath, "eslint", {usePnpify: false}));
+  await xfs.writeFilePromise(manifest, JSON.stringify({name: `eslint`, version: `${dynamicRequire(`eslint/package.json`).version}-pnpify`, main: `lib/api.js`}, null, 2));
+  await xfs.writeFilePromise(api, TEMPLATE(relPnpApiPath, `eslint`, {usePnpify: false}));
 
-  await addVSCodeWorkspaceSettings(projectRoot, {'eslint.nodePath': npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(eslint)))});
+  await addVSCodeWorkspaceSettings(projectRoot, {
+    [`eslint.nodePath`]: npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(eslint))),
+  });
 };
 
 const isPackageInstalled = (name: string): boolean => {
@@ -79,7 +83,7 @@ const isPackageInstalled = (name: string): boolean => {
     dynamicRequire.resolve(name);
     return true;
   } catch (e) {
-    if (e.code && e.code === 'MODULE_NOT_FOUND') {
+    if (e.code && e.code === `MODULE_NOT_FOUND`) {
       return false;
     } else  {
       throw e;
@@ -88,8 +92,8 @@ const isPackageInstalled = (name: string): boolean => {
 };
 
 export const generateSdk = async (projectRoot: PortablePath): Promise<any> => {
-  const hasTypescript = isPackageInstalled('typescript');
-  const hasEslint = isPackageInstalled('eslint');
+  const hasTypescript = isPackageInstalled(`typescript`);
+  const hasEslint = isPackageInstalled(`eslint`);
 
   const targetFolder = ppath.join(projectRoot, `.vscode/pnpify` as PortablePath);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Since TS now has native support for PnP through our patch approach, we don't need PnPify to run it anymore.

**How did you fix it?**

Removed PnPify from the TS SDK.
