### PR TITLE
Removes the node_modules by default

### DIFF
--- a/.yarn/versions/c60c2dbe.yml
+++ b/.yarn/versions/c60c2dbe.yml
@@ -1,0 +1,19 @@
+releases:
+  "@yarnpkg/cli@2.0.0-rc.22": prerelease
+  "@yarnpkg/plugin-pnp@2.0.0-rc.13": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints@2.0.0-rc.9"
+  - "@yarnpkg/plugin-dlx@2.0.0-rc.10"
+  - "@yarnpkg/plugin-essentials@2.0.0-rc.18"
+  - "@yarnpkg/plugin-init@2.0.0-rc.10"
+  - "@yarnpkg/plugin-interactive-tools@2.0.0-rc.11"
+  - "@yarnpkg/plugin-npm-cli@2.0.0-rc.10"
+  - "@yarnpkg/plugin-pack@2.0.0-rc.13"
+  - "@yarnpkg/plugin-patch@2.0.0-rc.2"
+  - "@yarnpkg/plugin-stage@2.0.0-rc.13"
+  - "@yarnpkg/plugin-typescript@2.0.0-rc.11"
+  - "@yarnpkg/plugin-version@2.0.0-rc.17"
+  - "@yarnpkg/plugin-workspace-tools@2.0.0-rc.12"
+  - "@yarnpkg/check@2.0.0-rc.9"
+  - "@yarnpkg/core@2.0.0-rc.17"


### PR DESCRIPTION
**What's the problem this PR addresses?**

People ignore warnings, so the presence of the `node_modules` makes them thing that something is wrong in Yarn when the resolution goes there.

**How did you fix it?**

The lingering `node_modules` will now be removed when running `yarn install`.
