### PR TITLE
Adds prettier to the PnPify SDK

### DIFF
--- a/.vscode/pnpify/eslint/lib/api.js
+++ b/.vscode/pnpify/eslint/lib/api.js
@@ -1,18 +1,17 @@
+const {createRequire, createRequireFromPath} = require(`module`);
 const {dirname, resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
-const absRootPath = dirname(absPnpApiPath);
+const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require eslint
 require(absPnpApiPath).setup();
-
-const moduleResolution = require.resolve(`eslint`, {paths: [absRootPath]});
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real eslint your application uses
-module.exports = require(moduleResolution);
+module.exports = absRequire(`eslint`);

--- a/.vscode/pnpify/typescript/lib/tsserver.js
+++ b/.vscode/pnpify/typescript/lib/tsserver.js
@@ -1,18 +1,17 @@
+const {createRequire, createRequireFromPath} = require(`module`);
 const {dirname, resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
-const absRootPath = dirname(absPnpApiPath);
+const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require typescript/lib/tsserver
 require(absPnpApiPath).setup();
-
-const moduleResolution = require.resolve(`typescript/lib/tsserver`, {paths: [absRootPath]});
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real typescript/lib/tsserver your application uses
-module.exports = require(moduleResolution);
+module.exports = absRequire(`typescript/lib/tsserver`);

--- a/.vscode/pnpify/typescript/package.json
+++ b/.vscode/pnpify/typescript/package.json
@@ -1,4 +1,4 @@
 {
   "name": "typescript",
-  "version": "3.7.0-dev.20191002-pnpify"
+  "version": "3.7.4-pnpify"
 }

--- a/.yarn/versions/f79ad2fd.yml
+++ b/.yarn/versions/f79ad2fd.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify@2.0.0-rc.14": prerelease
+
+declined:
+  - vscode-zipfs@0.1.1-2
+  - "@yarnpkg/builder@2.0.0-rc.16"
+  - "@yarnpkg/cli@2.0.0-rc.22"
+  - "@yarnpkg/pnp@2.0.0-rc.14"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Prettier is a common extension that wasn't covered by the SDK.

**How did you fix it?**

- Added a shim for `prettier` (plus the relevant configuration)
- Updated the shim template to use `createRequire` instead of the `paths` option, which seems more fickle (I'm not entirely sure why, but it didn't work with Prettier despite working for TS and ESLint).
