### PR TITLE
Stops using json proxy

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -8587,7 +8587,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8603,7 +8602,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8619,7 +8617,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8635,7 +8632,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:65b0a3c18b908df18dc5bd8d9a02bf3b64d57b3b4cd45187dca6c1ee574962b917737e89c164c644419160acf275596e0ab62d889c7575234206a0c7ccb06610#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8651,7 +8647,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:d24d64a3622a891ba35a0b4d2c88122e94d918bd1445b9d5766a80190c6593e57b46ae02112d12c69bc0f22df28288ee555b8c0922cada014d06d92749ab6d95#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8667,7 +8662,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8683,7 +8677,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:35104c47575f2fe378d8d20383ae667f19d4dd801df8cc4c76848603aa6b4a2234a00142ff12fd557f6f48bd2810880e31c40c767010ea61a31fca302c2cc5e0#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8699,7 +8692,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8715,7 +8707,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8731,7 +8722,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8747,7 +8737,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8763,7 +8752,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:b67eefea63d6ce2a2493f462bbe6718e1da81a92c1be9fc6d94cbd4f855be65d84717b1951eaa1c805d1369f118fed6e9edfb78044a500657ffc7f84e691dfbb#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8779,7 +8767,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8795,7 +8782,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8811,7 +8797,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:7bf4ad1016291a7e1c04756f55760890095421dd1b945930b62d8d0464c365d1cdce28ed812277b54dc54443922ac82afd5e98ed7f1d218ae7753d16e21541bb#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8827,7 +8812,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:e3ce0ce4b7f0796ca44011528cb9cdc133fc62a76363fea6de68497bae04bdbe5a6dd47e6b9f23c282eb8e4533d75e96cf378c943d07a4e78aae0b715f06a450#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8843,7 +8827,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:86c95fabbcd56c56f5f2d2e080e64a1095e3fe233877aa9f7958f317f88a95627e0be2765e89c0cff02c9f08f27b64b7cbc9d5c3960c1df509d5e6ea98cca4f4#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8859,7 +8842,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8875,7 +8857,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8891,7 +8872,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
@@ -8907,7 +8887,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [

--- a/.yarn/versions/8e9fccb2.yml
+++ b/.yarn/versions/8e9fccb2.yml
@@ -1,0 +1,19 @@
+releases:
+  "@yarnpkg/cli@2.0.0-rc.22": prerelease
+  "@yarnpkg/plugin-init@2.0.0-rc.10": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints@2.0.0-rc.9"
+  - "@yarnpkg/plugin-dlx@2.0.0-rc.10"
+  - "@yarnpkg/plugin-essentials@2.0.0-rc.18"
+  - "@yarnpkg/plugin-interactive-tools@2.0.0-rc.11"
+  - "@yarnpkg/plugin-npm-cli@2.0.0-rc.10"
+  - "@yarnpkg/plugin-pack@2.0.0-rc.13"
+  - "@yarnpkg/plugin-patch@2.0.0-rc.2"
+  - "@yarnpkg/plugin-pnp@2.0.0-rc.13"
+  - "@yarnpkg/plugin-stage@2.0.0-rc.13"
+  - "@yarnpkg/plugin-typescript@2.0.0-rc.11"
+  - "@yarnpkg/plugin-version@2.0.0-rc.17"
+  - "@yarnpkg/plugin-workspace-tools@2.0.0-rc.12"
+  - "@yarnpkg/check@2.0.0-rc.9"
+  - "@yarnpkg/core@2.0.0-rc.17"

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -4,7 +4,6 @@
   "main": "./sources/index.ts",
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12",
-    "@yarnpkg/json-proxy": "workspace:^2.0.0-rc.4",
     "clipanion": "^2.1.5"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5049,7 +5049,6 @@ __metadata:
     "@yarnpkg/cli": "workspace:^2.0.0-rc.19"
     "@yarnpkg/core": "workspace:^2.0.0-rc.15"
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.12"
-    "@yarnpkg/json-proxy": "workspace:^2.0.0-rc.4"
     clipanion: ^2.1.5
   peerDependencies:
     "@yarnpkg/cli": ^2.0.0-rc.19


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn init` used to leave a weird empty `dependenciesMeta` field because the proxy wasn't forwarding the `delete`.

**How did you fix it?**

Removed the proxy altogether. It doesn't matter since there can be no original manifest anyway.