### PR TITLE
Rebuild packages when switching between Node versions

### DIFF
--- a/.yarn/versions/12db9b67.yml
+++ b/.yarn/versions/12db9b67.yml
@@ -1,0 +1,27 @@
+releases:
+  "@yarnpkg/cli@2.0.0-rc.22": prerelease
+  "@yarnpkg/core@2.0.0-rc.17": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat@2.0.0-rc.3"
+  - "@yarnpkg/plugin-constraints@2.0.0-rc.9"
+  - "@yarnpkg/plugin-dlx@2.0.0-rc.10"
+  - "@yarnpkg/plugin-essentials@2.0.0-rc.18"
+  - "@yarnpkg/plugin-exec@2.0.0-rc.13"
+  - "@yarnpkg/plugin-file@2.0.0-rc.10"
+  - "@yarnpkg/plugin-git@2.0.0-rc.13"
+  - "@yarnpkg/plugin-github@2.0.0-rc.10"
+  - "@yarnpkg/plugin-http@2.0.0-rc.9"
+  - "@yarnpkg/plugin-init@2.0.0-rc.10"
+  - "@yarnpkg/plugin-interactive-tools@2.0.0-rc.11"
+  - "@yarnpkg/plugin-link@2.0.0-rc.9"
+  - "@yarnpkg/plugin-npm@2.0.0-rc.12"
+  - "@yarnpkg/plugin-npm-cli@2.0.0-rc.10"
+  - "@yarnpkg/plugin-patch@2.0.0-rc.2"
+  - "@yarnpkg/plugin-pnp@2.0.0-rc.13"
+  - "@yarnpkg/plugin-stage@2.0.0-rc.13"
+  - "@yarnpkg/plugin-typescript@2.0.0-rc.11"
+  - "@yarnpkg/plugin-version@2.0.0-rc.17"
+  - "@yarnpkg/plugin-workspace-tools@2.0.0-rc.12"
+  - "@yarnpkg/builder@2.0.0-rc.16"
+  - "@yarnpkg/check@2.0.0-rc.9"

--- a/.yarn/versions/12db9b67.yml
+++ b/.yarn/versions/12db9b67.yml
@@ -17,6 +17,7 @@ declined:
   - "@yarnpkg/plugin-link@2.0.0-rc.9"
   - "@yarnpkg/plugin-npm@2.0.0-rc.12"
   - "@yarnpkg/plugin-npm-cli@2.0.0-rc.10"
+  - "@yarnpkg/plugin-pack@2.0.0-rc.13"
   - "@yarnpkg/plugin-patch@2.0.0-rc.2"
   - "@yarnpkg/plugin-pnp@2.0.0-rc.13"
   - "@yarnpkg/plugin-stage@2.0.0-rc.13"

--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -57,6 +57,14 @@ export type Hooks = {
     extra: {script: string, args: Array<string>, cwd: PortablePath, env: ProcessEnvironment, stdin: Readable | null, stdout: Writable, stderr: Writable},
   ) => Promise<() => Promise<number>>,
 
+  // Called before the build, to compute a global hash key that we will use
+  // to detect whether packages must be rebuilt (typically when the Node
+  // version changes)
+  globalHashGeneration?: (
+    project: Project,
+    contributeHash: (data: string | Buffer) => void,
+  ) => Promise<void>,
+
   // Before the resolution runs; should be use to setup new aliases that won't
   // persist on the project instance itself.
   reduceDependency?: (


### PR DESCRIPTION
**What's the problem this PR addresses?**

Changing Node version wasn't causing the dependencies to be rebuilt.

**How did you fix it?**

A global cache key is now determined and may be used to trigger a fresh rebuild. By default this cache key includes the Node version, plugins can add others as needed (this should be fairly rare as I would prefer people to use regular dependencies to mark their ... dependencies).
