### PR TITLE
Prevents workspaces from listing duplicates

### DIFF
--- a/.yarn/versions/03fb926a.yml
+++ b/.yarn/versions/03fb926a.yml
@@ -1,0 +1,28 @@
+releases:
+  "@yarnpkg/check": prerelease
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-constraints": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/plugin-interactive-tools": prerelease
+  "@yarnpkg/plugin-pack": prerelease
+  "@yarnpkg/plugin-version": prerelease
+  "@yarnpkg/plugin-workspace-tools": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/builder"

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -43,10 +43,10 @@ const tauModule = new pl.type.Module(`constraints`, {
     const descriptor = structUtils.makeDescriptor(ident, descriptorRange.id);
 
     const project = getProject(thread);
-    const workspaces = project.findWorkspacesByDescriptor(descriptor);
+    const workspace = project.tryWorkspaceByDescriptor(descriptor);
 
     if (isVariable(workspaceCwd)) {
-      for (const workspace of workspaces) {
+      if (workspace !== null) {
         prependGoals(thread, point, [new pl.type.Term(`=`, [
           workspaceCwd,
           new pl.type.Term(String(workspace.relativeCwd)),
@@ -55,7 +55,7 @@ const tauModule = new pl.type.Module(`constraints`, {
     }
 
     if (isAtom(workspaceCwd)) {
-      if (workspaces.find(workspace => workspace.relativeCwd === workspaceCwd.id)) {
+      if (workspace !== null && workspace.relativeCwd === workspaceCwd.id) {
         thread.success(point);
       }
     }

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -40,16 +40,14 @@ export default class WorkspacesListCommand extends BaseCommand {
 
           for (const dependencyType of DEPENDENCY_TYPES) {
             for (const [identHash, descriptor]  of manifest.getForScope(dependencyType)) {
-              const matchingWorkspaces = project.findWorkspacesByDescriptor(descriptor);
+              const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
 
-              if (matchingWorkspaces.length === 0) {
+              if (matchingWorkspace === null) {
                 if (project.workspacesByIdent.has(identHash)) {
                   mismatchedWorkspaceDependencies.add(descriptor);
                 }
               } else {
-                for (const workspaceDependency of matchingWorkspaces) {
-                  workspaceDependencies.add(workspaceDependency);
-                }
+                workspaceDependencies.add(matchingWorkspace);
               }
             }
           }

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -209,11 +209,15 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
       } break;
 
       case Strategy.PROJECT: {
+        const workspace = project.tryWorkspaceByIdent(request);
+        if (workspace === null)
+          continue;
+
         // Don't suggest a workspace to depend on itself
         if (workspace.manifest.name !== null && request.identHash === workspace.manifest.name.identHash)
           continue;
 
-        for (const workspace of project.workspacesByIdent.get(request.identHash) || []) {
+        if (workspace !== null) {
           const reason = `Attach ${structUtils.prettyWorkspace(project.configuration, workspace)} (local workspace at ${workspace.cwd})`;
           suggested.push({descriptor: workspace.anchoredDescriptor, reason});
         }

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -209,18 +209,16 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
       } break;
 
       case Strategy.PROJECT: {
-        const workspace = project.tryWorkspaceByIdent(request);
-        if (workspace === null)
-          continue;
-
         // Don't suggest a workspace to depend on itself
         if (workspace.manifest.name !== null && request.identHash === workspace.manifest.name.identHash)
           continue;
 
-        if (workspace !== null) {
-          const reason = `Attach ${structUtils.prettyWorkspace(project.configuration, workspace)} (local workspace at ${workspace.cwd})`;
-          suggested.push({descriptor: workspace.anchoredDescriptor, reason});
-        }
+        const candidateWorkspace = project.tryWorkspaceByIdent(request);
+        if (candidateWorkspace === null)
+          continue;
+
+        const reason = `Attach ${structUtils.prettyWorkspace(project.configuration, candidateWorkspace)} (local workspace at ${candidateWorkspace.cwd})`;
+        suggested.push({descriptor: candidateWorkspace.anchoredDescriptor, reason});
       } break;
 
       case Strategy.LATEST: {

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -159,7 +159,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       for (const workspace of project.workspaces)
         for (const dependencyType of [`dependencies`, `devDependencies`] as Array<HardDependencies>)
           for (const descriptor of workspace.manifest[dependencyType].values())
-            if (project.findWorkspacesByDescriptor(descriptor).length === 0)
+            if (project.tryWorkspaceByDescriptor(descriptor) === null)
               allDependencies.set(descriptor.descriptorHash, descriptor);
 
       const sortedDependencies = miscUtils.sortMap(allDependencies.values(), descriptor => {

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -222,9 +222,9 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
   const versionData = parseSyml(versionContent);
   const releaseStore: Releases = new Map();
 
-  for (const locatorStr of versionData.declined || []) {
-    const locator = structUtils.parseLocator(locatorStr);
-    const workspace = project.getWorkspaceByLocator(locator);
+  for (const identStr of versionData.declined || []) {
+    const ident = structUtils.parseIdent(identStr);
+    const workspace = project.getWorkspaceByIdent(ident);
 
     releaseStore.set(workspace, Decision.DECLINE);
   }

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -3,7 +3,6 @@ import {Filename, PortablePath, npath, ppath, xfs}                              
 import {parseSyml, stringifySyml}                                                                                                                       from '@yarnpkg/parsers';
 import {UsageError}                                                                                                                                     from 'clipanion';
 import semver                                                                                                                                           from 'semver';
-import {version}                                                                                                                                        from 'punycode';
 
 // Basically we only support auto-upgrading the ranges that are very simple (^x.y.z, ~x.y.z, >=x.y.z, and of course x.y.z)
 const SUPPORTED_UPGRADE_REGEXP = /^(>=|[~^]|)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/;
@@ -115,12 +114,12 @@ export async function resolveVersionFiles(project: Project) {
     const versionContent = await xfs.readFilePromise(versionPath, `utf8`);
     const versionData = parseSyml(versionContent);
 
-    for (const [locatorStr, decision] of Object.entries(versionData.releases || {})) {
-      const locator = structUtils.parseLocator(locatorStr);
+    for (const [identStr, decision] of Object.entries(versionData.releases || {})) {
+      const ident = structUtils.parseIdent(identStr);
 
-      const workspace = project.tryWorkspaceByLocator(locator);
+      const workspace = project.tryWorkspaceByIdent(ident);
       if (workspace === null)
-        throw new Error(`Assertion failed: Expected a release definition file to only reference existing workspaces (${ppath.basename(versionPath)} references ${locatorStr})`);
+        throw new Error(`Assertion failed: Expected a release definition file to only reference existing workspaces (${ppath.basename(versionPath)} references ${identStr})`);
 
       if (workspace.manifest.version === null)
         throw new Error(`Assertion failed: Expected the workspace to have a version (${structUtils.prettyLocator(project.configuration, workspace.anchoredLocator)})`);
@@ -266,15 +265,15 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
         if (workspace.manifest.version === null)
           continue;
 
-        const locatorStr = structUtils.stringifyLocator(workspace.locator);
+        const identStr = structUtils.stringifyIdent(workspace.locator);
 
         const decision = releaseStore.get(workspace);
         if (decision === Decision.DECLINE) {
-          declined.push(locatorStr);
+          declined.push(identStr);
         } else if (typeof decision !== `undefined`) {
-          releases[locatorStr] = decision;
+          releases[identStr] = decision;
         } else if (changedWorkspaces.has(workspace)) {
-          undecided.push(locatorStr);
+          undecided.push(identStr);
         }
       }
 
@@ -353,20 +352,20 @@ export function getUndecidedDependentWorkspaces(versionFile: Pick<VersionFile, '
 
     for (const dependencyType of Manifest.hardDependencies) {
       for (const descriptor  of workspace.manifest.getForScope(dependencyType).values()) {
-        const matchingWorkspaces = versionFile.project.findWorkspacesByDescriptor(descriptor);
+        const matchingWorkspace = versionFile.project.tryWorkspaceByDescriptor(descriptor);
+        if (matchingWorkspace === null)
+          continue;
 
-        for (const workspaceDependency of matchingWorkspaces) {
-          // We only care about workspaces, and we only care about workspaces that will be bumped
-          if (bumpedWorkspaces.has(workspaceDependency.anchoredLocator.locatorHash)) {
-            // Quick note: we don't want to check whether the workspace pointer
-            // by `resolution` is private, because while it doesn't makes sense
-            // to bump a private package because its dependencies changed, the
-            // opposite isn't true: a (public) package might need to be bumped
-            // because one of its dev dependencies is a (private) package whose
-            // behavior sensibly changed.
+        // We only care about workspaces, and we only care about workspaces that will be bumped
+        if (bumpedWorkspaces.has(matchingWorkspace.anchoredLocator.locatorHash)) {
+          // Quick note: we don't want to check whether the workspace pointer
+          // by `resolution` is private, because while it doesn't makes sense
+          // to bump a private package because its dependencies changed, the
+          // opposite isn't true: a (public) package might need to be bumped
+          // because one of its dev dependencies is a (private) package whose
+          // behavior sensibly changed.
 
-            undecided.push([workspace, workspaceDependency]);
-          }
+          undecided.push([workspace, matchingWorkspace]);
         }
       }
     }
@@ -420,17 +419,16 @@ export function applyReleases(project: Project, newVersions: Map<Workspace, stri
   for (const dependent of project.workspaces) {
     for (const set of Manifest.allDependencies) {
       for (const descriptor of dependent.manifest[set].values()) {
-        const workspaces = project.findWorkspacesByDescriptor(descriptor);
-        if (workspaces.length !== 1)
+        const workspace = project.tryWorkspaceByDescriptor(descriptor);
+        if (workspace === null)
           continue;
 
         // We only care about workspaces that depend on a workspace that will
         // receive a fresh update
-        const dependency = workspaces[0];
-        if (!newVersions.has(dependency))
+        if (!newVersions.has(workspace))
           continue;
 
-        const dependents = miscUtils.getArrayWithDefault(allDependents, dependency);
+        const dependents = miscUtils.getArrayWithDefault(allDependents, workspace);
         dependents.push([dependent, set, descriptor.identHash]);
       }
     }

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -229,9 +229,9 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
     releaseStore.set(workspace, Decision.DECLINE);
   }
 
-  for (const [locatorStr, decision] of Object.entries(versionData.releases || {})) {
-    const locator = structUtils.parseLocator(locatorStr);
-    const workspace = project.getWorkspaceByLocator(locator);
+  for (const [identStr, decision] of Object.entries(versionData.releases || {})) {
+    const ident = structUtils.parseIdent(identStr);
+    const workspace = project.getWorkspaceByIdent(ident);
 
     releaseStore.set(workspace, decision as any);
   }

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -225,15 +225,12 @@ export default class WorkspacesForeachCommand extends BaseCommand {
 
           if (this.topological || this.topologicalDev) {
             const resolvedSet = this.topologicalDev
-              ? [...workspace.manifest.dependencies, ...workspace.manifest.devDependencies]
+              ? new Map([...workspace.manifest.dependencies, ...workspace.manifest.devDependencies])
               : workspace.manifest.dependencies;
 
-            for (const [/*identHash*/, descriptor] of resolvedSet) {
-              const workspaces = project.findWorkspacesByDescriptor(descriptor);
-
-              isRunnable = !workspaces.some(workspace => {
-                return needsProcessing.has(workspace.anchoredLocator.locatorHash);
-              });
+            for (const descriptor of resolvedSet.values()) {
+              const workspace = project.tryWorkspaceByDescriptor(descriptor);
+              isRunnable = workspace === null || !needsProcessing.has(workspace.anchoredLocator.locatorHash);
 
               if (!isRunnable) {
                 break;

--- a/packages/yarnpkg-core/sources/WorkspaceResolver.ts
+++ b/packages/yarnpkg-core/sources/WorkspaceResolver.ts
@@ -13,8 +13,8 @@ export class WorkspaceResolver implements Resolver {
     if (descriptor.range.startsWith(WorkspaceResolver.protocol))
       return true;
 
-    const matchingWorkspaces = opts.project.findWorkspacesByDescriptor(descriptor);
-    if (matchingWorkspaces.length > 0)
+    const workspace = opts.project.tryWorkspaceByDescriptor(descriptor);
+    if (workspace !== null)
       return true;
 
     return false;
@@ -40,20 +40,9 @@ export class WorkspaceResolver implements Resolver {
   }
 
   async getCandidates(descriptor: Descriptor, dependencies: unknown, opts: ResolveOptions) {
-    const candidateWorkspaces = opts.project.findWorkspacesByDescriptor(descriptor);
+    const workspace = opts.project.getWorkspaceByDescriptor(descriptor);
 
-    if (candidateWorkspaces.length < 1) {
-      if (!opts.project.workspacesByIdent.has(descriptor.identHash)) {
-        throw new ReportError(MessageName.WORKSPACE_NOT_FOUND, `No local workspace found for this name`);
-      } else {
-        throw new ReportError(MessageName.WORKSPACE_NOT_FOUND, `No local workspace found for this range`);
-      }
-    }
-
-    if (candidateWorkspaces.length > 1)
-      throw new ReportError(MessageName.TOO_MANY_MATCHING_WORKSPACES, `Too many workspaces match this range, please disambiguate`);
-
-    return [candidateWorkspaces[0].anchoredLocator];
+    return [workspace.anchoredLocator];
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -482,13 +482,7 @@ export function sortDescriptors(descriptors: Iterable<Descriptor>) {
 }
 
 export function prettyWorkspace(configuration: Configuration, workspace: Workspace) {
-  const byIdent = workspace.project.workspacesByIdent.get(workspace.locator.identHash);
-
-  if (!byIdent || byIdent.length <= 1) {
-    return prettyIdent(configuration, workspace.locator);
-  } else {
-    return prettyLocator(configuration, workspace.anchoredLocator);
-  }
+  return prettyIdent(configuration, workspace.locator);
 }
 
 /**


### PR DESCRIPTION
**What's the problem this PR addresses?**

Back when I started Yarn 2 I felt like maybe it could be interesting to have multiple workspaces with different versions. In retrospect it felt a very bad idea, and I always planned to remove this before tagging the stable release.

**How did you fix it?**

Removed `findWorkspacesByDescriptor` since it can only have one result at most.
