### PR TITLE
Fixes error handling when publishing

### DIFF
--- a/.yarn/versions/e251a5e7.yml
+++ b/.yarn/versions/e251a5e7.yml
@@ -1,0 +1,19 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-npm-cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/check"
+  - "@yarnpkg/core"

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -112,7 +112,7 @@ export default class NpmPublishCommand extends BaseCommand {
           if (error.name !== `HTTPError`) {
             throw error;
           } else {
-            const message = error.response.body && error.body.response.error
+            const message = error.response.body && error.response.body.error
               ? error.response.body.error
               : `The remote server answered with HTTP ${error.response.statusCode} ${error.response.statusMessage}`;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The code was referencing `body.response` instead of `response.body`, which caused `yarn npm publish` to fail to print the error messages.

**How did you fix it?**

Fixed the typo.
