### PR TITLE
Switch to typescript for compilation to generate .d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build:plugin-commands": "node ./scripts/gen-plugin-commands.js > packages/plugin-essentials/sources/pluginCommands.ts",
-    "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && babel \"$0\"/sources --out-dir \"$0\"/lib --copy-files --extensions .js,.ts,.tsx",
+    "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && rsync -a --exclude '*.ts' --exclude '*.tsx' --include '*.d.ts' \"$0\"/sources/ \"$0\"/lib/ && node scripts/compile \"$0\"",
     "build:compile-inline": "find \"$0\"/sources -name '*.js' && babel \"$0\"/sources --out-dir \"$0\"/sources --extensions .ts,.tsx",
     "gen-tssdk": "pnpify --sdk scripts",
     "release:all": "./scripts/release.sh",

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const {EOL} = require('os');
+const path = require('path');
+const ts = require('typescript');
+
+/**
+ * @param {string} tsConfigPath
+ * @param {string} folder
+ */
+function compile(tsConfigPath, folder) {
+  const parsedConfig = ts.parseJsonConfigFileContent({
+    extends: tsConfigPath,
+    compilerOptions: {
+      rootDir: 'sources',
+      outDir: 'lib',
+    },
+    include: ['sources/**/*.ts', 'sources/**/*.tsx'],
+  }, ts.sys, folder);
+
+  const program = ts.createProgram({
+    options: parsedConfig.options,
+    rootNames: parsedConfig.fileNames,
+    configFileParsingDiagnostics: parsedConfig.errors,
+  });
+
+  const diagnostics = program.emit();
+
+  return reportErrors(diagnostics.diagnostics);
+}
+exports.compile = compile;
+
+/**
+ * @param {readonly import('typescript').Diagnostic[]} allDiagnostics
+ */
+function reportErrors(allDiagnostics) {
+  const errorsAndWarnings = allDiagnostics.filter(function(d) {
+    return d.category !== ts.DiagnosticCategory.Message;
+  });
+
+  if (errorsAndWarnings.length === 0)
+    return 0;
+
+  const formatDiagnosticsHost = {
+    getCurrentDirectory: () => path.dirname(__dirname),
+    getCanonicalFileName: fileName => fileName,
+    getNewLine: () => EOL,
+  };
+
+  for (const errorAndWarning of errorsAndWarnings)
+    console.error(ts.formatDiagnostic(errorAndWarning, formatDiagnosticsHost));
+
+  return 1;
+}
+
+if (process.mainModule === module)
+  process.exitCode = compile(path.resolve(__dirname, '../tsconfig.json'), process.argv[2]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "lib": ["dom", "es2017", "esnext.asynciterable"],
     "module": "commonjs",
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "declaration": true
   },
   "exclude": [
     "packages/*/lib",


### PR DESCRIPTION
Switch to the typescript compiler instead of babel to output `.d.ts` files next to the `.js` files.
Use a custom compile script instead of `tsc` to allow for a single `tsconfig.json` file for the entire berry project.

Fixes #707 

I still need to make some changes to the commands, because typescript is now complaining about the `usage` properties, but I wanted feedback on the setup before starting on that.

```
$ yarn packages/plugin-essentials prepack
sources/commands/add.ts(44,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/bin.ts(14,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/cache/clean.ts(14,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/config.ts(18,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/config/get.ts(10,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/config/set.ts(13,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/install.ts(42,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/link.ts(20,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/node.ts(11,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/plugin/import.ts(15,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/plugin/list.ts(17,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/plugin/runtime.ts(7,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/rebuild.ts(12,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/remove.ts(18,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/run.ts(34,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/set/resolution.ts(17,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/set/version.ts(22,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/set/version/sources.ts(57,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/up.ts(31,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/why.ts(22,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.

sources/commands/workspaces/list.ts(15,10): error TS2742: The inferred type of 'usage' cannot be named without a reference to '../../../../../.yarn/cache/clipanion-npm-2.1.5-aef0ebbd62-1.zip/node_modules/clipanion/lib/advanced'. This is likely not portable. A type annotation is necessary.```