### PR TITLE
Add development server e2e for gatsby

### DIFF
--- a/.github/workflows/e2e-gatsby-workflow.yml
+++ b/.github/workflows/e2e-gatsby-workflow.yml
@@ -6,7 +6,7 @@ on:
     - master
   pull_request:
     paths:
-    - .github/workflows/e2e-eslint-workflow.yml
+    - .github/workflows/e2e-gatsby-workflow.yml
     - scripts/e2e-setup-ci.sh
 
 name: 'E2E Gatsby'
@@ -30,5 +30,11 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
+
         yarn dlx gatsby new my-gatsby && cd my-gatsby
+
+        # Test production build
         yarn build
+
+        # Test development server (which includes development only loaders like eslint-loader)
+        yarn dlx start-server-and-test "yarn start" :8000 "curl -s localhost:8000 | grep \"<h1>Hi people</h1>\""

--- a/.github/workflows/e2e-gatsby-workflow.yml
+++ b/.github/workflows/e2e-gatsby-workflow.yml
@@ -31,10 +31,12 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
 
-        yarn dlx gatsby new my-gatsby && cd my-gatsby
+        yarn dlx gatsby new my-gatsby
+        cd my-gatsby
 
         # Test production build
         yarn build
 
         # Test development server (which includes development only loaders like eslint-loader)
-        yarn dlx start-server-and-test "yarn start" :8000 "curl -s localhost:8000 | grep \"<h1>Hi people</h1>\""
+        # Redirect the output to log.txt and check if it contains "ERROR #"
+        yarn dlx start-server-and-test "yarn start > log.txt 2>&1" :8000 "! cat log.txt | grep \"ERROR #\""

--- a/.github/workflows/e2e-rollup-workflow.yml
+++ b/.github/workflows/e2e-rollup-workflow.yml
@@ -43,7 +43,7 @@ jobs:
 
         yarn rollup -c
         [[ "$(node dist/bundle.js)" = "125" ]]
-        cat dist/bundle.js | grep -v "square"
+        ! cat dist/bundle.js | grep "square"
 
         rm -rf dist src
 
@@ -87,7 +87,7 @@ jobs:
         echo "import answer from 'the-answer'; import _ from 'lodash';" | tee src/main.js
 
         yarn rollup -c
-        cat dist/bundle.js | grep -v "lodash"
+        ! cat dist/bundle.js | grep "lodash"
 
         rm -rf src dist
 
@@ -102,7 +102,7 @@ jobs:
 
         yarn rollup -c
         [[ "$(node dist/bundle.js)" = "the answer is 42" ]]
-        cat dist/bundle.js | grep -v "console.log(\`"
+        ! cat dist/bundle.js | grep "console.log(\`"
 
         rm -rf src dist
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Related to #368 and #689. Test against development build (yarn start) for `gatsby` app. Which includes some development only loaders like `eslint-loader`.

**How did you fix it?**

Since https://github.com/gatsbyjs/gatsby/pull/20629 has landed and released, it should fix the test now.

There are still some plugins that are not supported yet, one would be https://github.com/gatsbyjs/gatsby/pull/20638. We'll make another PR to make the test more comprehensive after upstream fixes the issue.

I also fix a bug in rollup e2e test where I accidentally use the wrong command 😞.