### PR TITLE
Moves `yarn workspace` to the essentials

### DIFF
--- a/.yarn/versions/f2edabde.yml
+++ b/.yarn/versions/f2edabde.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/plugin-workspace-tools": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/check"
+  - "@yarnpkg/core"

--- a/packages/plugin-essentials/sources/commands/workspace.ts
+++ b/packages/plugin-essentials/sources/commands/workspace.ts
@@ -18,8 +18,6 @@ export default class WorkspaceCommand extends Command<CommandContext> {
     category: `Workspace-related commands`,
     description: `run a command within the specified workspace`,
     details: `
-      > In order to use this command you need to add \`@yarnpkg/plugin-workspace-tools\` to your plugins.
-
       This command will run a given sub-command on a single workspace.
     `,
     examples: [[
@@ -53,13 +51,7 @@ export default class WorkspaceCommand extends Command<CommandContext> {
 
     if (workspace === undefined) {
       const otherNames = Array.from(candidatesByName.keys()).sort();
-      throw new UsageError(
-        `Workspace '${
-          this.workspaceName
-        }' not found. Did you mean any of the following:\n  - ${otherNames.join(
-          "\n  - "
-        )}?`
-      );
+      throw new UsageError(`Workspace '${this.workspaceName}' not found. Did you mean any of the following:\n  - ${otherNames.join(`\n  - `)}?`);
     }
 
     return this.cli.run([this.commandName, ...this.args], {cwd: workspace.cwd});

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -1,5 +1,5 @@
-import {Descriptor, Plugin, SettingsType} from '@yarnpkg/core';
 import {Workspace}                        from '@yarnpkg/core';
+import {Descriptor, Plugin, SettingsType} from '@yarnpkg/core';
 
 import add                                from './commands/add';
 import bin                                from './commands/bin';
@@ -27,6 +27,7 @@ import setVersionPolicy                   from './commands/set/version';
 import up                                 from './commands/up';
 import why                                from './commands/why';
 import listWorkspaces                     from './commands/workspaces/list';
+import workspace                          from './commands/workspace';
 import * as suggestUtils                  from './suggestUtils';
 
 export {suggestUtils};
@@ -93,6 +94,7 @@ const plugin: Plugin = {
     run,
     up,
     why,
+    workspace,
   ],
 };
 

--- a/packages/plugin-workspace-tools/sources/index.ts
+++ b/packages/plugin-workspace-tools/sources/index.ts
@@ -1,12 +1,10 @@
-import {Plugin}  from '@yarnpkg/core';
+import {Plugin} from '@yarnpkg/core';
 
-import foreach   from './commands/foreach';
-import workspace from './commands/workspace';
+import foreach  from './commands/foreach';
 
 const plugin: Plugin = {
   commands: [
     foreach,
-    workspace,
   ],
 };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using `yarn workspace` is very handy to work in another project than the current one. At the moment it requires installing the `workspace-tools` plugin which, although technically correct, is a bit annoying. From what I've seen, it'll most likely be the main command from our plugins that people will miss.

**How did you fix it?**

Given how small and useful it is we can just move it to the essentials plugin.
