### PR TITLE
Fixes the `yarn plugin import` regex

### DIFF
--- a/.yarn/versions/07dba47d.yml
+++ b/.yarn/versions/07dba47d.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/check"
+  - "@yarnpkg/core"

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -73,7 +73,7 @@ export default class PluginDlCommand extends BaseCommand {
           pluginSpec = this.name;
           pluginUrl = name;
         } else {
-          const ident = structUtils.parseIdent(this.name.replace(/^((@yarnpkg\/)?|(plugin-)?)/, `@yarnpkg/plugin-`));
+          const ident = structUtils.parseIdent(this.name.replace(/^((@yarnpkg\/)?plugin-)?/, `@yarnpkg/plugin-`));
           const identStr = structUtils.stringifyIdent(ident);
           const data = await getAvailablePlugins(configuration);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

I intended to make the following possible:

```
yarn plugin import workspace-tools
yarn plugin import plugin-workspace-tools
yarn plugin import @yarnpkg/plugin-workspace-tools
```

But the regex was boggus, causing #722.

Fixes #722

**How did you fix it?**

Fixed the regex.