### PR TITLE
Fix release compilation

### DIFF
--- a/.yarn/versions/c7654edc.yml
+++ b/.yarn/versions/c7654edc.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/builder": prerelease
+  "@yarnpkg/check": prerelease
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+  "@yarnpkg/plugin-constraints": prerelease
+  "@yarnpkg/plugin-dlx": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/plugin-exec": prerelease
+  "@yarnpkg/plugin-file": prerelease
+  "@yarnpkg/plugin-git": prerelease
+  "@yarnpkg/plugin-github": prerelease
+  "@yarnpkg/plugin-http": prerelease
+  "@yarnpkg/plugin-init": prerelease
+  "@yarnpkg/plugin-interactive-tools": prerelease
+  "@yarnpkg/plugin-link": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+  "@yarnpkg/plugin-npm": prerelease
+  "@yarnpkg/plugin-npm-cli": prerelease
+  "@yarnpkg/plugin-pack": prerelease
+  "@yarnpkg/plugin-patch": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+  "@yarnpkg/plugin-stage": prerelease
+  "@yarnpkg/plugin-typescript": prerelease
+  "@yarnpkg/plugin-version": prerelease
+  "@yarnpkg/plugin-workspace-tools": prerelease
+  "@yarnpkg/pnp": prerelease
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - vscode-zipfs

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build:plugin-commands": "node ./scripts/gen-plugin-commands.js > packages/plugin-essentials/sources/pluginCommands.ts",
-    "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && rsync -a --exclude '*.ts' --exclude '*.tsx' --include '*.d.ts' \"$0\"/sources/ \"$0\"/lib/ && node scripts/compile \"$0\"",
+    "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && rsync -a --exclude '*.ts' --exclude '*.tsx' --include '*.d.ts' \"$0\"/sources/ \"$0\"/lib/ && node scripts/compile \"$@\"",
     "build:compile-inline": "find \"$0\"/sources -name '*.js' && babel \"$0\"/sources --out-dir \"$0\"/sources --extensions .ts,.tsx",
     "gen-tssdk": "pnpify --sdk scripts",
     "release:all": "./scripts/release.sh",

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -2,7 +2,7 @@ import {BaseCommand}                                                    from '@y
 import {Configuration, IdentHash, Ident, Project, Workspace, miscUtils} from '@yarnpkg/core';
 import {MessageName, StreamReport, AllDependencies, Report}             from '@yarnpkg/core';
 import {structUtils}                                                    from '@yarnpkg/core';
-import {Command}                                                        from 'clipanion';
+import {Command, Usage}                                                 from 'clipanion';
 import getPath                                                          from 'lodash/get';
 import setPath                                                          from 'lodash/set';
 import unsetPath                                                        from 'lodash/unset';
@@ -14,7 +14,7 @@ export default class ConstraintsCheckCommand extends BaseCommand {
   @Command.Boolean(`--fix`)
   fix: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Constraints-related commands`,
     description: `check that the project constraints are met`,
     details: `

--- a/packages/plugin-constraints/sources/commands/constraints/query.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/query.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}            from '@yarnpkg/cli';
 import {Configuration, Project} from '@yarnpkg/core';
 import {StreamReport}           from '@yarnpkg/core';
-import {Command}                from 'clipanion';
+import {Command, Usage}         from 'clipanion';
 
 import {Constraints}            from '../../Constraints';
 
@@ -13,7 +13,7 @@ export default class ConstraintsQueryCommand extends BaseCommand {
   @Command.String()
   query!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Constraints-related commands`,
     description: `query the constraints fact database`,
     details: `

--- a/packages/plugin-constraints/sources/commands/constraints/source.ts
+++ b/packages/plugin-constraints/sources/commands/constraints/source.ts
@@ -1,6 +1,6 @@
 import {BaseCommand}            from '@yarnpkg/cli';
 import {Configuration, Project} from '@yarnpkg/core';
-import {Command}                from 'clipanion';
+import {Command, Usage}         from 'clipanion';
 
 import {Constraints}            from '../../Constraints';
 
@@ -9,7 +9,7 @@ export default class ConstraintsSourceCommand extends BaseCommand {
   @Command.Boolean(`-v,--verbose`)
   verbose: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Constraints-related commands`,
     description: `print the source code for the constraints`,
     details: `

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -2,7 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}                   from '@yarnpkg/cl
 import {Configuration, Project, ThrowReport}                   from '@yarnpkg/core';
 import {scriptUtils, structUtils}                              from '@yarnpkg/core';
 import {Filename, PortablePath, npath, ppath, toFilename, xfs} from '@yarnpkg/fslib';
-import {Command}                                               from 'clipanion';
+import {Command, Usage}                                        from 'clipanion';
 import tmp                                                     from 'tmp';
 
 // eslint-disable-next-line arca/no-default-export
@@ -19,7 +19,7 @@ export default class DlxCommand extends BaseCommand {
   @Command.Proxy()
   args: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `run a package in a temporary environment`,
     details: `
       This command will install a package within a temporary environment, and run its binary script if it contains any. The binary will run within the current cwd.

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -3,7 +3,7 @@ import {Cache, Configuration, Descriptor, LightReport, MessageName} from '@yarnp
 import {Project, StreamReport, Workspace, Ident}                    from '@yarnpkg/core';
 import {structUtils}                                                from '@yarnpkg/core';
 import {PortablePath}                                               from '@yarnpkg/fslib';
-import {Command, UsageError}                                        from 'clipanion';
+import {Command, Usage, UsageError}                                 from 'clipanion';
 import inquirer                                                     from 'inquirer';
 
 import * as suggestUtils                                            from '../suggestUtils';
@@ -41,7 +41,7 @@ export default class AddCommand extends BaseCommand {
   @Command.Boolean(`--cached`)
   cached: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `add dependencies to the project`,
     details: `
       This command adds a package to the package.json for the nearest workspace.

--- a/packages/plugin-essentials/sources/commands/bin.ts
+++ b/packages/plugin-essentials/sources/commands/bin.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                                       from '@yarnpkg/cli';
 import {Configuration, Project, ThrowReport, StreamReport} from '@yarnpkg/core';
 import {scriptUtils, structUtils}                          from '@yarnpkg/core';
-import {Command, UsageError}                               from 'clipanion';
+import {Command, Usage, UsageError}                        from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class BinCommand extends BaseCommand {
@@ -14,7 +14,7 @@ export default class BinCommand extends BaseCommand {
   @Command.Boolean(`--json`)
   json: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `get the path to a binary script`,
     details: `
       When used without arguments, this command will print the list of all the binaries available in the current workspace. Adding the \`-v,--verbose\` flag will cause the output to contain both the binary name and the locator of the package that provides the binary.

--- a/packages/plugin-essentials/sources/commands/cache/clean.ts
+++ b/packages/plugin-essentials/sources/commands/cache/clean.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                        from '@yarnpkg/cli';
 import {Configuration, Cache, StreamReport} from '@yarnpkg/core';
 import {xfs}                                from '@yarnpkg/fslib';
-import {Command}                            from 'clipanion';
+import {Command, Usage}                     from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class CacheCleanCommand extends BaseCommand {
@@ -11,7 +11,7 @@ export default class CacheCleanCommand extends BaseCommand {
   @Command.Boolean(`--all`)
   all: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `remove the shared cache files`,
     details: `
       This command will remove all the files in the shared cache.

--- a/packages/plugin-essentials/sources/commands/config.ts
+++ b/packages/plugin-essentials/sources/commands/config.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                                            from '@yarnpkg/cli';
 import {Configuration, MessageName, SettingsType, StreamReport} from '@yarnpkg/core';
 import {miscUtils}                                              from '@yarnpkg/core';
-import {Command}                                                from 'clipanion';
+import {Command, Usage}                                         from 'clipanion';
 import {inspect}                                                from 'util';
 
 // eslint-disable-next-line arca/no-default-export
@@ -15,7 +15,7 @@ export default class ConfigCommand extends BaseCommand {
   @Command.Boolean(`--json`)
   json: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `display the current configuration`,
     details: `
       This command prints the current active configuration settings.

--- a/packages/plugin-essentials/sources/commands/config/get.ts
+++ b/packages/plugin-essentials/sources/commands/config/get.ts
@@ -1,13 +1,13 @@
-import {BaseCommand}         from '@yarnpkg/cli';
-import {Configuration}       from '@yarnpkg/core';
-import {Command, UsageError} from 'clipanion';
+import {BaseCommand}                from '@yarnpkg/cli';
+import {Configuration}              from '@yarnpkg/core';
+import {Command, Usage, UsageError} from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ConfigSetCommand extends BaseCommand {
   @Command.String()
   name!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `read a configuration settings`,
   });
 

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -1,6 +1,6 @@
-import {BaseCommand}         from '@yarnpkg/cli';
-import {Configuration}       from '@yarnpkg/core';
-import {Command, UsageError} from 'clipanion';
+import {BaseCommand}                from '@yarnpkg/cli';
+import {Configuration}              from '@yarnpkg/core';
+import {Command, Usage, UsageError} from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ConfigSetCommand extends BaseCommand {
@@ -10,7 +10,7 @@ export default class ConfigSetCommand extends BaseCommand {
   @Command.String()
   value!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `change a configuration settings`,
   });
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -2,7 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}                                   f
 import {Configuration, Cache, MessageName, Project, ReportError, StreamReport} from '@yarnpkg/core';
 import {xfs, ppath}                                                            from '@yarnpkg/fslib';
 import {parseSyml, stringifySyml}                                              from '@yarnpkg/parsers';
-import {Command}                                                               from 'clipanion';
+import {Command, Usage}                                                        from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class YarnCommand extends BaseCommand {
@@ -39,7 +39,7 @@ export default class YarnCommand extends BaseCommand {
   @Command.Boolean(`--silent`, {hidden: true})
   silent?: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `install the project dependencies`,
     details: `
       This command setup your project if needed. The installation is splitted in four different steps that each have their own characteristics:

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}                      from '@yarnpkg/cli';
 import {Cache, Configuration, Project, StreamReport, structUtils} from '@yarnpkg/core';
 import {npath, ppath}                                             from '@yarnpkg/fslib';
-import {Command, UsageError}                                      from 'clipanion';
+import {Command, Usage, UsageError}                               from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class LinkCommand extends BaseCommand {
@@ -17,7 +17,7 @@ export default class LinkCommand extends BaseCommand {
   @Command.Boolean(`-r,--relative`)
   relative: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `connect the local project to another one`,
     details: `
       This command will set a new \`resolutions\` field in the project-level manifest and point it to the workspace at the specified location (even if part of another project).

--- a/packages/plugin-essentials/sources/commands/node.ts
+++ b/packages/plugin-essentials/sources/commands/node.ts
@@ -1,14 +1,14 @@
 import {BaseCommand}            from '@yarnpkg/cli';
 import {Configuration, Project} from '@yarnpkg/core';
 import {execUtils, scriptUtils} from '@yarnpkg/core';
-import {Command}                from 'clipanion';
+import {Command, Usage}         from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NodeCommand extends BaseCommand {
   @Command.Proxy()
   args: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `run node with the hook already setup`,
     details: `
       This command simply runs Node. It also makes sure to call it in a way that's compatible with the current project (for example, on PnP projects the environment will be setup in such a way that PnP will be correctly injected into the environment).

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -2,7 +2,7 @@ import {BaseCommand}                                                            
 import {Configuration, MessageName, Project, ReportError, StreamReport, miscUtils} from '@yarnpkg/core';
 import {httpUtils, structUtils}                                                    from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs}                                           from '@yarnpkg/fslib';
-import {Command}                                                                   from 'clipanion';
+import {Command, Usage}                                                            from 'clipanion';
 import {runInNewContext}                                                           from 'vm';
 
 import {getAvailablePlugins}                                                       from './list';
@@ -12,7 +12,7 @@ export default class PluginDlCommand extends BaseCommand {
   @Command.String()
   name!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Plugin-related commands`,
     description: `download a plugin`,
     details: `

--- a/packages/plugin-essentials/sources/commands/plugin/list.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/list.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                            from '@yarnpkg/cli';
 import {Configuration, StreamReport, httpUtils} from '@yarnpkg/core';
 import {parseSyml}                              from '@yarnpkg/parsers';
-import {Command}                                from 'clipanion';
+import {Command, Usage}                         from 'clipanion';
 
 const REMOTE_REGISTRY = `https://raw.githubusercontent.com/yarnpkg/berry/master/plugins.yml`;
 
@@ -17,7 +17,7 @@ export default class PluginDlCommand extends BaseCommand {
   @Command.Boolean(`--json`)
   json: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Plugin-related commands`,
     description: `list the available official plugins`,
     details: `

--- a/packages/plugin-essentials/sources/commands/plugin/runtime.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/runtime.ts
@@ -1,10 +1,10 @@
 import {BaseCommand}                 from '@yarnpkg/cli';
 import {Configuration, StreamReport} from '@yarnpkg/core';
-import {Command}                     from 'clipanion';
+import {Command, Usage}              from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class PluginListCommand extends BaseCommand {
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Plugin-related commands`,
     description: `list the active plugins`,
     details: `

--- a/packages/plugin-essentials/sources/commands/rebuild.ts
+++ b/packages/plugin-essentials/sources/commands/rebuild.ts
@@ -2,14 +2,14 @@ import {BaseCommand, WorkspaceRequiredError}                                    
 import {Cache, Configuration, Project, StreamReport, ThrowReport, structUtils, IdentHash, LocatorHash} from '@yarnpkg/core';
 import {PortablePath, xfs, ppath}                                                                      from '@yarnpkg/fslib';
 import {parseSyml}                                                                                     from '@yarnpkg/parsers';
-import {Command}                                                                                       from 'clipanion';
+import {Command, Usage}                                                                                from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class RunCommand extends BaseCommand {
   @Command.Rest()
   idents: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `rebuild the project's native packages`,
     details: `
       This command will automatically cause Yarn to forget about previous compilations of the given packages and to run them again.

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -2,7 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}       from '@yarnpkg/cli';
 import {Configuration, Cache, Descriptor, Project} from '@yarnpkg/core';
 import {StreamReport, Workspace}                   from '@yarnpkg/core';
 import {structUtils}                               from '@yarnpkg/core';
-import {Command, UsageError}                       from 'clipanion';
+import {Command, Usage, UsageError}                from 'clipanion';
 
 import * as suggestUtils                           from '../suggestUtils';
 import {Hooks}                                     from '..';
@@ -15,7 +15,7 @@ export default class RemoveCommand extends BaseCommand {
   @Command.Rest()
   names: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `remove dependencies from the project`,
     details: `
       This command will remove the specified packages from the current workspace.

--- a/packages/plugin-essentials/sources/commands/run.ts
+++ b/packages/plugin-essentials/sources/commands/run.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                                    from '@yarnpkg/cli';
 import {Configuration, Project, Workspace, ThrowReport} from '@yarnpkg/core';
 import {scriptUtils, structUtils}                       from '@yarnpkg/core';
-import {Command, UsageError}                            from 'clipanion';
+import {Command, Usage, UsageError}                     from 'clipanion';
 
 import {pluginCommands}                                 from '../pluginCommands';
 
@@ -31,7 +31,7 @@ export default class RunCommand extends BaseCommand {
   @Command.Proxy()
   args: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `run a script defined in the package.json`,
     details: `
       This command will run a tool. The exact tool that will be executed will depend on the current state of your workspace:

--- a/packages/plugin-essentials/sources/commands/set/resolution.ts
+++ b/packages/plugin-essentials/sources/commands/set/resolution.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}         from '@yarnpkg/cli';
 import {Configuration, Cache, Project, StreamReport} from '@yarnpkg/core';
 import {structUtils}                                 from '@yarnpkg/core';
-import {Command}                                     from 'clipanion';
+import {Command, Usage}                              from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class SetResolutionCommand extends BaseCommand {
@@ -14,7 +14,7 @@ export default class SetResolutionCommand extends BaseCommand {
   @Command.Boolean(`-s,--save`)
   save: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `enforce a package resolution`,
     details: `
       This command updates the resolution table so that \`descriptor\` is resolved by \`resolution\`.

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -2,7 +2,7 @@ import {BaseCommand}                                               from '@yarnpk
 import {Configuration, Project, StreamReport, MessageName, Report} from '@yarnpkg/core';
 import {httpUtils}                                                 from '@yarnpkg/core';
 import {Filename, PortablePath, ppath, xfs}                        from '@yarnpkg/fslib';
-import {Command, UsageError}                                       from 'clipanion';
+import {Command, Usage, UsageError}                                from 'clipanion';
 import semver, {SemVer}                                            from 'semver';
 
 const BUNDLE_REGEXP = /^yarn-[0-9]+\.[0-9]+\.[0-9]+\.js$/;
@@ -19,7 +19,7 @@ export default class SetVersionCommand extends BaseCommand {
   @Command.Boolean(`--dry-run`)
   dryRun: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `lock the Yarn version used by the project`,
     details: `
       This command will download a specific release of Yarn directly from the Yarn Github repository, will store it inside your project, and will change the \`yarnPath\` settings from your project \`.yarnrc.yml\` file to point to the new file.

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -2,7 +2,7 @@ import {BaseCommand}                                                  from '@yar
 import {WorkspaceRequiredError}                                       from '@yarnpkg/cli';
 import {Configuration, MessageName, Project, StreamReport, execUtils} from '@yarnpkg/core';
 import {Filename, PortablePath, npath, ppath, xfs}                    from '@yarnpkg/fslib';
-import {Command}                                                      from 'clipanion';
+import {Command, Usage}                                               from 'clipanion';
 import {tmpdir}                                                       from 'os';
 
 import {setVersion}                                                   from '../version';
@@ -54,7 +54,7 @@ export default class SetVersionCommand extends BaseCommand {
   @Command.Boolean(`-f,--force`)
   force: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `build Yarn from master`,
     details: `
       This command will clone the Yarn repository into a temporary folder, then build it. The resulting bundle will then be copied into the local project.

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -2,7 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}                        from '@yarnp
 import {Cache, Configuration, Descriptor, LightReport, MessageName} from '@yarnpkg/core';
 import {Project, StreamReport, Workspace}                           from '@yarnpkg/core';
 import {structUtils}                                                from '@yarnpkg/core';
-import {Command, UsageError}                                        from 'clipanion';
+import {Command, Usage, UsageError}                                 from 'clipanion';
 import inquirer                                                     from 'inquirer';
 
 import * as suggestUtils                                            from '../suggestUtils';
@@ -28,7 +28,7 @@ export default class UpCommand extends BaseCommand {
   @Command.Boolean(`-C,--caret`)
   caret: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `upgrade dependencies across the project`,
     details: `
       This command upgrades a list of packages to their latest available version across the whole project (regardless of whether they're part of \`dependencies\` or \`devDependencies\` - \`peerDependencies\` won't be affected). This is a project-wide command: all workspaces will be upgraded in the process.

--- a/packages/plugin-essentials/sources/commands/why.ts
+++ b/packages/plugin-essentials/sources/commands/why.ts
@@ -2,7 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}              from '@yarnpkg/cli';
 import {Configuration, LocatorHash, Package, ThrowReport} from '@yarnpkg/core';
 import {IdentHash, Project}                               from '@yarnpkg/core';
 import {miscUtils, structUtils}                           from '@yarnpkg/core';
-import {Command}                                          from 'clipanion';
+import {Command, Usage}                                   from 'clipanion';
 import {Writable}                                         from 'stream';
 import {asTree}                                           from 'treeify';
 
@@ -19,7 +19,7 @@ export default class WhyCommand extends BaseCommand {
   @Command.Boolean(`--peers`)
   peers: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `display the reason why a package is needed`,
     details: `
       This command prints the exact reasons why a package appears in the dependency tree.

--- a/packages/plugin-essentials/sources/commands/workspace.ts
+++ b/packages/plugin-essentials/sources/commands/workspace.ts
@@ -1,7 +1,7 @@
 import {WorkspaceRequiredError}                            from "@yarnpkg/cli";
 import {CommandContext, Configuration, Project, Workspace} from "@yarnpkg/core";
 import {structUtils}                                       from "@yarnpkg/core";
-import {Command, UsageError}                               from "clipanion";
+import {Command, Usage, UsageError}                        from "clipanion";
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspaceCommand extends Command<CommandContext> {
@@ -14,7 +14,7 @@ export default class WorkspaceCommand extends Command<CommandContext> {
   @Command.Proxy()
   args: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Workspace-related commands`,
     description: `run a command within the specified workspace`,
     details: `

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -1,6 +1,6 @@
 import {BaseCommand}                                                              from '@yarnpkg/cli';
 import {Configuration, Project, StreamReport, structUtils, Descriptor, Workspace} from '@yarnpkg/core';
-import {Command}                                                                  from 'clipanion';
+import {Command, Usage}                                                           from 'clipanion';
 
 const DEPENDENCY_TYPES = ['devDependencies', 'dependencies'];
 
@@ -12,7 +12,7 @@ export default class WorkspacesListCommand extends BaseCommand {
   @Command.Boolean(`--json`)
   json: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Workspace-related commands`,
     description: `list all available workspaces`,
     details: `

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -2,7 +2,7 @@ import {BaseCommand}                         from '@yarnpkg/cli';
 import {Configuration, Manifest}             from '@yarnpkg/core';
 import {execUtils, scriptUtils, structUtils} from '@yarnpkg/core';
 import {xfs, ppath, Filename}                from '@yarnpkg/fslib';
-import {Command, UsageError}                 from 'clipanion';
+import {Command, Usage, UsageError}          from 'clipanion';
 import {inspect}                             from 'util';
 
 // eslint-disable-next-line arca/no-default-export
@@ -16,7 +16,7 @@ export default class InitCommand extends BaseCommand {
   @Command.String(`-i,--install`)
   install?: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `create a new package`,
     details: `
       This command will setup a new package in your local directory.

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -5,7 +5,7 @@ import {ScrollableItems}                                                        
 import {useMinistore}                                                                                                      from '@yarnpkg/libui/sources/hooks/useMinistore';
 import {renderForm}                                                                                                        from '@yarnpkg/libui/sources/misc/renderForm';
 import {suggestUtils}                                                                                                      from '@yarnpkg/plugin-essentials';
-import {Command}                                                                                                           from 'clipanion';
+import {Command, Usage}                                                                                                    from 'clipanion';
 import {diffWords}                                                                                                         from 'diff';
 import {Box, Color}                                                                                                        from 'ink';
 import React, {useEffect, useState}                                                                                        from 'react';
@@ -14,7 +14,7 @@ const SIMPLE_SEMVER = /^([\^~]?)([0-9+])(\.[0-9]+)(\.[0-9]+)((?:-\S+)?)$/;
 
 // eslint-disable-next-line arca/no-default-export
 export default class UpgradeInteractiveCommand extends BaseCommand {
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Interactive commands`,
     description: `open the upgrade interface`,
     details: `

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -2,7 +2,7 @@ import {BaseCommand, openWorkspace}   from '@yarnpkg/cli';
 import {Configuration, MessageName}   from '@yarnpkg/core';
 import {StreamReport}                 from '@yarnpkg/core';
 import {npmConfigUtils, npmHttpUtils} from '@yarnpkg/plugin-npm';
-import {Command}                      from 'clipanion';
+import {Command, Usage}               from 'clipanion';
 import inquirer                       from 'inquirer';
 
 // eslint-disable-next-line arca/no-default-export
@@ -13,7 +13,7 @@ export default class NpmLoginCommand extends BaseCommand {
   @Command.Boolean(`--publish`)
   publish: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Npm-related commands`,
     description: `store new login info to access the npm registry`,
     details: `

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -3,7 +3,7 @@ import {Configuration, MessageName, Project, ReportError, StreamReport, Workspac
 import {miscUtils, structUtils}                                                                 from '@yarnpkg/core';
 import {npmConfigUtils, npmHttpUtils}                                                           from '@yarnpkg/plugin-npm';
 import {packUtils}                                                                              from '@yarnpkg/plugin-pack';
-import {Command, UsageError}                                                                    from 'clipanion';
+import {Command, Usage, UsageError}                                                             from 'clipanion';
 import {createHash}                                                                             from 'crypto';
 import ssri                                                                                     from 'ssri';
 
@@ -18,7 +18,7 @@ export default class NpmPublishCommand extends BaseCommand {
   @Command.Boolean(`--tolerate-republish`)
   tolerateRepublish: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Npm-related commands`,
     description: `publish the active workspace to the npm registry`,
     details: `

--- a/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
@@ -2,7 +2,7 @@ import {BaseCommand, openWorkspace}   from '@yarnpkg/cli';
 import {Configuration, MessageName}   from '@yarnpkg/core';
 import {StreamReport}                 from '@yarnpkg/core';
 import {npmConfigUtils, npmHttpUtils} from '@yarnpkg/plugin-npm';
-import {Command}                      from 'clipanion';
+import {Command, Usage}               from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NpmWhoamiCommand extends BaseCommand {
@@ -12,7 +12,7 @@ export default class NpmWhoamiCommand extends BaseCommand {
   @Command.Boolean(`--publish`)
   publish: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Npm-related commands`,
     description: `display the name of the authenticated user`,
     details: `

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}                                                           from '@yarnpkg/cli';
 import {Cache, Configuration, MessageName, Project, StreamReport, Workspace, structUtils, ThrowReport} from '@yarnpkg/core';
 import {Filename, npath, ppath, xfs}                                                                   from '@yarnpkg/fslib';
-import {Command}                                                                                       from 'clipanion';
+import {Command, Usage}                                                                                from 'clipanion';
 
 import * as packUtils                                                                                  from '../packUtils';
 
@@ -20,7 +20,7 @@ export default class PackCommand extends BaseCommand {
   @Command.String(`-o,--out`)
   out?: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `generate a tarball from the active workspace`,
     details: `
       This command will turn the active workspace into a compressed archive suitable for publishing. The archive will by default be stored at the root of the workspace (\`package.tgz\`).

--- a/packages/plugin-patch/sources/commands/patch.ts
+++ b/packages/plugin-patch/sources/commands/patch.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}                                                from '@yarnpkg/cli';
 import {Cache, Configuration, Project, ThrowReport, structUtils, StreamReport, MessageName} from '@yarnpkg/core';
 import {npath}                                                                              from '@yarnpkg/fslib';
-import {Command, UsageError}                                                                from 'clipanion';
+import {Command, Usage, UsageError}                                                         from 'clipanion';
 
 import * as patchUtils                                                                      from '../patchUtils';
 
@@ -10,7 +10,7 @@ export default class PatchCommand extends BaseCommand {
   @Command.String()
   package!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `
       This command will cause a package to be extracted in a temporary directory (under a folder named "patch-workdir"). This folder will be editable at will; running \`yarn patch\` inside it will then cause Yarn to generate a patchfile and register it into your top-level manifest (cf the \`patch:\` protocol).
     `,

--- a/packages/plugin-patch/sources/commands/patchCommit.ts
+++ b/packages/plugin-patch/sources/commands/patchCommit.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}                                           from '@yarnpkg/cli';
 import {Cache, Configuration, Project, ThrowReport, structUtils, execUtils, miscUtils} from '@yarnpkg/core';
 import {npath, xfs, Filename, ppath}                                                   from '@yarnpkg/fslib';
-import {Command, UsageError}                                                           from 'clipanion';
+import {Command, Usage, UsageError}                                                    from 'clipanion';
 
 import * as patchUtils                                                                 from '../patchUtils';
 
@@ -10,7 +10,7 @@ export default class PatchCommitCommand extends BaseCommand {
   @Command.String()
   patchFolder!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `
       This will turn the folder passed in parameter into a patchfile suitable for consumption with the \`patch:\` protocol.
 

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -1,14 +1,14 @@
 import {BaseCommand, WorkspaceRequiredError}         from '@yarnpkg/cli';
 import {Cache, Configuration, Project, StreamReport} from '@yarnpkg/core';
 import {structUtils}                                 from '@yarnpkg/core';
-import {Command}                                     from 'clipanion';
+import {Command, Usage}                              from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UnplugCommand extends BaseCommand {
   @Command.Rest()
   patterns: Array<string> = [];
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `force the unpacking of a list of packages`,
     details: `
       This command will add the specified selectors to the list of packages that must be unplugged when installed.

--- a/packages/plugin-stage/sources/commands/stage.ts
+++ b/packages/plugin-stage/sources/commands/stage.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                     from '@yarnpkg/cli';
 import {Configuration, Project}          from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
-import {Command, UsageError}             from 'clipanion';
+import {Command, Usage, UsageError}      from 'clipanion';
 
 import {Driver as GitDriver}             from '../drivers/GitDriver';
 import {Driver as MercurialDriver}       from '../drivers/MercurialDriver';
@@ -26,7 +26,7 @@ export default class StageCommand extends BaseCommand {
   @Command.Boolean(`-n,--dry-run`)
   dryRun: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `add all yarn files to your vcs`,
     details: `
       This command will add to your staging area the files belonging to Yarn (typically any modified \`package.json\` and \`.yarnrc.yml\` files, but also linker-generated files, cache data, etc). It will take your ignore list into account, so the cache files won't be added if the cache is ignored in a \`.gitignore\` file (assuming you use Git).

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -1,6 +1,6 @@
 import {BaseCommand, WorkspaceRequiredError} from '@yarnpkg/cli';
 import {Configuration, Project}              from '@yarnpkg/core';
-import {Command, UsageError}                 from 'clipanion';
+import {Command, Usage, UsageError}          from 'clipanion';
 import semver                                from 'semver';
 import * as yup                              from 'yup';
 
@@ -35,7 +35,7 @@ export default class VersionCommand extends BaseCommand {
     }),
   });
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Release-related commands`,
     description: `apply a new version to the current package`,
     details: `

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError} from '@yarnpkg/cli';
 import {Cache, Configuration}                from '@yarnpkg/core';
 import {Project, StreamReport}               from '@yarnpkg/core';
-import {Command}                             from 'clipanion';
+import {Command, Usage}                      from 'clipanion';
 
 import * as versionUtils                     from '../../versionUtils';
 
@@ -13,7 +13,7 @@ export default class VersionApplyCommand extends BaseCommand {
   @Command.Boolean(`--json`)
   json: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Release-related commands`,
     description: `apply all the deferred version bumps at once`,
     details: `

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -5,7 +5,7 @@ import {ScrollableItems}                                                        
 import {FocusRequest}                                                                                           from '@yarnpkg/libui/sources/hooks/useFocusRequest';
 import {useListInput}                                                                                           from '@yarnpkg/libui/sources/hooks/useListInput';
 import {renderForm}                                                                                             from '@yarnpkg/libui/sources/misc/renderForm';
-import {Command, UsageError}                                                                                    from 'clipanion';
+import {Command, Usage, UsageError}                                                                             from 'clipanion';
 import {Box, Color}                                                                                             from 'ink';
 import React, {useCallback, useState}                                                                           from 'react';
 import semver                                                                                                   from 'semver';
@@ -19,7 +19,7 @@ export default class VersionApplyCommand extends Command<CommandContext> {
   @Command.Boolean(`-i,--interactive`)
   interactive?: boolean;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Release-related commands`,
     description: `check that all the relevant packages have been bumped`,
     details: `

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -2,7 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}               from '@yarnpkg/cli';
 import {Configuration, LocatorHash, Project, Workspace}    from '@yarnpkg/core';
 import {DescriptorHash, MessageName, Report, StreamReport} from '@yarnpkg/core';
 import {miscUtils, structUtils}                            from '@yarnpkg/core';
-import {Command, UsageError}                               from 'clipanion';
+import {Command, Usage, UsageError}                        from 'clipanion';
 import {cpus}                                              from 'os';
 import pLimit                                              from 'p-limit';
 import {Writable}                                          from 'stream';
@@ -74,7 +74,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     }),
   });
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     category: `Workspace-related commands`,
     description: `run a command on all workspaces`,
     details: `

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -1,14 +1,14 @@
-import chalk         from 'chalk';
-import {Command}     from 'clipanion';
-import filesize      from 'filesize';
-import fs            from 'fs';
-import path          from 'path';
-import TerserPlugin  from 'terser-webpack-plugin';
-import webpack       from 'webpack';
+import chalk            from 'chalk';
+import {Command, Usage} from 'clipanion';
+import filesize         from 'filesize';
+import fs               from 'fs';
+import path             from 'path';
+import TerserPlugin     from 'terser-webpack-plugin';
+import webpack          from 'webpack';
 
-import {dynamicLibs} from '../../data/dynamicLibs';
-import {findPlugins} from '../../tools/findPlugins';
-import {makeConfig}  from '../../tools/makeConfig';
+import {dynamicLibs}    from '../../data/dynamicLibs';
+import {findPlugins}    from '../../tools/findPlugins';
+import {makeConfig}     from '../../tools/makeConfig';
 
 const pkgJsonVersion = (basedir: string) => {
   const pkgJson = require(`${basedir}/package.json`);
@@ -26,7 +26,7 @@ export default class BuildBundleCommand extends Command {
   @Command.Boolean(`--no-minify`)
   noMinify: boolean = false;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `build the local bundle`,
   });
 

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -1,14 +1,14 @@
-import chalk                 from 'chalk';
-import {Command, UsageError} from 'clipanion';
-import filesize              from 'filesize';
-import fs                    from 'fs';
-import path                  from 'path';
-import {RawSource}           from 'webpack-sources';
-import webpack               from 'webpack';
+import chalk                        from 'chalk';
+import {Command, Usage, UsageError} from 'clipanion';
+import filesize                     from 'filesize';
+import fs                           from 'fs';
+import path                         from 'path';
+import {RawSource}                  from 'webpack-sources';
+import webpack                      from 'webpack';
 
-import {isDynamicLib}        from '../../data/dynamicLibs';
-import {makeConfig}          from '../../tools/makeConfig';
-import {reindent}            from '../../tools/reindent';
+import {isDynamicLib}               from '../../data/dynamicLibs';
+import {makeConfig}                 from '../../tools/makeConfig';
+import {reindent}                   from '../../tools/reindent';
 
 // The name gets normalized so that everyone can override some plugins by
 // their own (@arcanis/yarn-plugin-foo would override @yarnpkg/plugin-foo
@@ -23,7 +23,7 @@ const getNormalizedName = (name: string) => {
 
 // eslint-disable-next-line arca/no-default-export
 export default class BuildPluginCommand extends Command {
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `build the local plugin`,
   });
 

--- a/packages/yarnpkg-builder/sources/commands/new/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/new/plugin.ts
@@ -1,6 +1,6 @@
 import {Filename, npath, ppath, xfs} from '@yarnpkg/fslib';
 import chalk                         from 'chalk';
-import {Command, UsageError}         from 'clipanion';
+import {Command, Usage, UsageError}  from 'clipanion';
 import path                          from 'path';
 
 // eslint-disable-next-line arca/no-default-export
@@ -8,7 +8,7 @@ export default class NewPluginCommand extends Command {
   @Command.String()
   target!: string;
 
-  static usage = Command.Usage({
+  static usage: Usage = Command.Usage({
     description: `generate the template for a new plugin`,
   });
 

--- a/packages/yarnpkg-builder/sources/tools/makeConfig.ts
+++ b/packages/yarnpkg-builder/sources/tools/makeConfig.ts
@@ -43,6 +43,9 @@ export const makeConfig = (config: webpack.Configuration) => merge({
         },
       }, {
         loader: require.resolve(`ts-loader`),
+        options: {
+          compilerOptions: {declaration: false},
+        },
       }],
     }],
   },

--- a/packages/yarnpkg-parsers/sources/syml.ts
+++ b/packages/yarnpkg-parsers/sources/syml.ts
@@ -9,10 +9,10 @@ const simpleStringPattern = /^(?![-?:,\][{}#&*!|>'"%@` \t\r\n]).([ \t]*(?![,\][{
 // specified order. It's not fair but life isn't fair either.
 const specialObjectKeys = [`__metadata`, `version`, `resolution`, `dependencies`, `peerDependencies`, `dependenciesMeta`, `peerDependenciesMeta`, `binaries`];
 
-class PreserveOrdering {
+export class PreserveOrdering {
   constructor(public readonly data: any) {
   }
-};
+}
 
 function stringifyString(value: string): string {
   if (value.match(simpleStringPattern)) {

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -19,7 +19,7 @@
     "build:pnp:hook": "run pnpify webpack-cli --config webpack.config.hook.js",
     "build:pnp": "run pnpify webpack-cli --config webpack.config.pkg.js",
     "postpack": "rm -rf lib",
-    "prepack": "run build:pnp && run build:compile packages/yarnpkg-pnp --emitDeclarationOnly --declaration",
+    "prepack": "run build:compile packages/yarnpkg-pnp --emitDeclarationOnly && run build:pnp",
     "release": "yarn npm publish",
     "update-local": "run build:pnp:hook"
   },

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -8,14 +8,17 @@ const ts = require('typescript');
  * @param {string} tsConfigPath
  * @param {string} folder
  */
-function compile(tsConfigPath, folder) {
+function compile(tsConfigPath, folder, ...opts) {
+  const emitDeclarationOnly = opts.includes(`--emitDeclarationOnly`);
+
   const parsedConfig = ts.parseJsonConfigFileContent({
     extends: tsConfigPath,
     compilerOptions: {
-      rootDir: 'sources',
-      outDir: 'lib',
+      rootDir: `sources`,
+      outDir: `lib`,
+      emitDeclarationOnly,
     },
-    include: ['sources/**/*.ts', 'sources/**/*.tsx'],
+    include: [`sources/**/*.ts`, `sources/**/*.tsx`],
   }, ts.sys, folder);
 
   const program = ts.createProgram({
@@ -54,4 +57,4 @@ function reportErrors(allDiagnostics) {
 }
 
 if (process.mainModule === module)
-  process.exitCode = compile(path.resolve(__dirname, '../tsconfig.json'), process.argv[2]);
+  process.exitCode = compile(path.resolve(__dirname, `../tsconfig.json`), ...process.argv.slice(2));


### PR DESCRIPTION
- Make necessary changes to allow declaration generation to succeed
- Stop emitting declarations in webpack builds, because those land in the sources folders
- Change the build command of pnp to make it work (running `build:compile` used to delete the output of `build:pnp`)