### PR TITLE
fix(www): position links correctly in search

### DIFF
--- a/packages/gatsby/src/components/hit/index.js
+++ b/packages/gatsby/src/components/hit/index.js
@@ -136,7 +136,7 @@ export const Downloads = ({ downloads = 0, humanDownloads }) => (
 );
 
 const HitLinkList = styled.div`
-  position: inherit;
+  position: absolute;
   top: calc(50% - 12px);
   right: 1rem;
 `;


### PR DESCRIPTION
**What's the problem this PR addresses?**

v1 | v2
---|---
<img width="1161" alt="Screenshot 2020-01-24 at 14 25 28" src="https://user-images.githubusercontent.com/6270048/73072479-6f910880-3eb5-11ea-9aa2-7611989bff88.png"> | <img width="1134" alt="Screenshot 2020-01-24 at 14 25 32" src="https://user-images.githubusercontent.com/6270048/73072481-6f910880-3eb5-11ea-9d07-8ed43f74dfc0.png">


**How did you fix it?**

Make position absolute, like in v1 site
