### PR TITLE
fix(www): avoid autocorrect etc.

### DIFF
--- a/packages/gatsby/src/components/search/SearchBox.js
+++ b/packages/gatsby/src/components/search/SearchBox.js
@@ -91,6 +91,12 @@ const SearchBox = ({currentRefinement, refine, autoFocus}) => {
         autoFocus={autoFocus}
         active={active}
         type="search"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck="false"
+        required="required"
+        maxLength="512"
         onFocus={() => setActive(true)}
         onBlur={() => setActive(false)}
         value={currentRefinement}


### PR DESCRIPTION



**What's the problem this PR addresses?**

Package names often are slight misspellings from real words, and thus the behaviour of the spelling getting changed is very frustrating!

**How did you fix it?**

avoid autocomplete, -correct, -capitalize & spell check. Also avoids a length of > 512 characters from being submitted (will throw an Algolia error)


This is the default behaviour of React InstantSearch (and thus Yarn v1)  too
