### PR TITLE
Remove unused imports

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
@@ -1,4 +1,4 @@
-import {xfs, ppath} from '@yarnpkg/fslib';
+import {xfs} from '@yarnpkg/fslib';
 
 const {
   fs: {createTemporaryFolder, writeJson},

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -1,9 +1,9 @@
-import {InstallStatus, Installer, LinkOptions, LinkType, MessageName, DependencyMeta, FinalizeInstallStatus} from '@yarnpkg/core';
-import {FetchResult, Descriptor, Locator, Package, BuildDirective}                                           from '@yarnpkg/core';
-import {miscUtils, structUtils}                                                                              from '@yarnpkg/core';
-import {FakeFS, PortablePath, ppath}                                                                         from '@yarnpkg/fslib';
-import {PackageRegistry, PnpSettings}                                                                        from '@yarnpkg/pnp';
-import mm                                                                                                    from 'micromatch';
+import {Installer, LinkOptions, LinkType, MessageName, DependencyMeta, FinalizeInstallStatus} from '@yarnpkg/core';
+import {FetchResult, Descriptor, Locator, Package, BuildDirective}                            from '@yarnpkg/core';
+import {miscUtils, structUtils}                                                               from '@yarnpkg/core';
+import {FakeFS, PortablePath, ppath}                                                          from '@yarnpkg/fslib';
+import {PackageRegistry, PnpSettings}                                                         from '@yarnpkg/pnp';
+import mm                                                                                     from 'micromatch';
 
 export abstract class AbstractPnpInstaller implements Installer {
   private readonly packageRegistry: PackageRegistry = new Map();

--- a/packages/yarnpkg-core/sources/WorkspaceResolver.ts
+++ b/packages/yarnpkg-core/sources/WorkspaceResolver.ts
@@ -1,7 +1,5 @@
 import {PortablePath}                                    from '@yarnpkg/fslib';
 
-import {MessageName}                                     from './MessageName';
-import {ReportError}                                     from './Report';
 import {Resolver, ResolveOptions, MinimalResolveOptions} from './Resolver';
 import {Descriptor, Locator}                             from './types';
 import {LinkType}                                        from './types';


### PR DESCRIPTION


**What's the problem this PR addresses?**

Remove unused imports, which were reported by GitHub actions

**How did you fix it?**

Looked at the GitHub output, and remove unused imports. I confirmed that they were actually unused by my editor colouring them lighter too 
