### PR TITLE
docs: update editor-sdks

### DIFF
--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -12,7 +12,7 @@ Smart IDEs (such as VSCode or IntelliJ) require special configuration for TypeSc
 
 | Extension | Required package.json dependency |
 |---|---|
-| VSCode Typescript Server | [typescript](https://yarnpkg.com/package/typescript) |
+| VS Code TypeScript Server | [typescript](https://yarnpkg.com/package/typescript) |
 | [vscode-eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
 | [prettier-vscode extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
 

--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -6,7 +6,20 @@ title: "Editor SDKs"
 
 Smart IDEs (such as VSCode or IntelliJ) require special configuration for TypeScript to work. This page intends to be a collection of settings for each editor we've worked with - please contribute to this list!
 
-## Editors
+## Tools currently supported
+
+> **Note:** When using the `--sdk` flag, be aware that only the SDKs for the tools present in your package.json will be installed. Don't forget to run the command again after installing new ones in your project.
+
+| Extension | Required package.json dependency |
+|---|---|
+| VSCode Typescript Server | [typescript](https://yarnpkg.com/package/typescript) |
+| [vscode-eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
+| [prettier-vscode extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
+
+If you'd like to contribute more, [take a look here!](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-pnpify/sources/generateSdk.ts)
+
+
+## Editor setup
 
 ### VSCode
 
@@ -51,3 +64,5 @@ yarn pnpify --sdk
 ## Caveat
 
 - Since the Yarn packages are kept within their archives, editors need to understand how to work with such paths should you want to actually open the files (for example when command-clicking on an import path originating from an external package). This can only be implemented by those editors, and we can't do much more than opening issues to ask for this feature to be implemented (for example, here's the VSCode issue: [#75559](https://github.com/microsoft/vscode/issues/75559)).
+
+  As a workaround, you can run `yarn unplug pkg-name` to instruct yarn to unzip the package, which will re-enable `Go to definition` functionality for the specific package.


### PR DESCRIPTION
**What's the problem this PR addresses?**

Updates the documentation of editor-sdks. Adds some additional information about what tools are currently supported, a note about needing to rerun the command after instaling certain dependencies, and a workaround for the go to definition issue.

**How did you fix it?**

Updated the documentation text.

Feel free to request changes if something should be reworded.
