### PR TITLE
Update compatibility status on Typescript-Eslint

### DIFF
--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -55,12 +55,12 @@ The following compatibility table gives you an idea of the integration status wi
 | Husky             | Native     | Starting from 4.0.0-1+ |
 | Jest              | Native     | Starting from 24.1+ |
 | Prettier          | Native     | Starting from 1.17+ |
-| Rollup            | Plugin     | Via [`rollup-plugin-pnp-resolve`](https://github.com/arcanis/rollup-plugin-pnp-resolve) |
-| TypeScript        | Workaround | Patched with [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (native with Webpack's [`ts-loader`](https://github.com/arcanis/pnp-webpack-plugin#ts-loader-integration)) |
+| Rollup            | Native     | Starting from `resolve` 1.9+ |
 | TypeScript-ESLint | Native     | Starting from 2.12+ |
-| VSCode-ESLint     | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
-| VSCode            | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
+| WebStorm          | Native     | Starting from 2019.3+; See [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
+| TypeScript        | Transparent | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by default) |
+| VSCode-ESLint     | Plugin     | Follow [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
+| VSCode            | Plugin     | Follow [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
 | Webpack           | Plugin     | Via [`pnp-webpack-plugin`](https://github.com/arcanis/pnp-webpack-plugin), will be native starting from 5+ |
-| WebStorm          | Native     | Starting from 2019.3+; limited TypeScript support (see [issue](https://youtrack.jetbrains.com/issue/WEB-42637)) |
 
 This list is kept up-to-date based on the latest release we've published starting from the v2. In case you notice something off in your own project please try to upgrade Yarn and the problematic package first, then feel free to an issue. And maybe a PR? 😊

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -56,7 +56,7 @@ The following compatibility table gives you an idea of the integration status wi
 | Jest              | Native     | Starting from 24.1+ |
 | Prettier          | Native     | Starting from 1.17+ |
 | Rollup            | Plugin     | Via [`rollup-plugin-pnp-resolve`](https://github.com/arcanis/rollup-plugin-pnp-resolve) |
-| TypeScript        | Plugin     | Via [PnPify](/advanced/pnpify), or Webpack and [`ts-loader`](https://github.com/arcanis/pnp-webpack-plugin#ts-loader-integration) |
+| TypeScript        | Workaround | Patched with [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (native with Webpack's [`ts-loader`](https://github.com/arcanis/pnp-webpack-plugin#ts-loader-integration)) |
 | TypeScript-ESLint | Native     | Starting from 2.12+ |
 | VSCode-ESLint     | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | VSCode            | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -57,10 +57,10 @@ The following compatibility table gives you an idea of the integration status wi
 | Prettier          | Native     | Starting from 1.17+ |
 | Rollup            | Plugin     | Via [`rollup-plugin-pnp-resolve`](https://github.com/arcanis/rollup-plugin-pnp-resolve) |
 | TypeScript        | Plugin     | Via [PnPify](/advanced/pnpify), or Webpack and [`ts-loader`](https://github.com/arcanis/pnp-webpack-plugin#ts-loader-integration) |
+| TypeScript-ESLint | Native     | Starting from 2.12+ |
 | VSCode-ESLint     | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | VSCode            | Plugin     | Via [PnPify](/advanced/pnpify#vscode-support) |
 | Webpack           | Plugin     | Via [`pnp-webpack-plugin`](https://github.com/arcanis/pnp-webpack-plugin), will be native starting from 5+ |
 | WebStorm          | Native     | Starting from 2019.3+; limited TypeScript support (see [issue](https://youtrack.jetbrains.com/issue/WEB-42637)) |
-| Typescript-Eslint | Workaround | Update the lockfile to add `typescript: "*"` into its `peerDependencies`. [`Relevant Issue`](https://github.com/typescript-eslint/typescript-eslint/issues/770) |
 
 This list is kept up-to-date based on the latest release we've published starting from the v2. In case you notice something off in your own project please try to upgrade Yarn and the problematic package first, then feel free to an issue. And maybe a PR? 😊


### PR DESCRIPTION
According to @merceyz, the table was out of the date. From the Discord conversation:

![image](https://user-images.githubusercontent.com/6893840/73123218-f1546500-3f8d-11ea-864a-895f391e877a.png)

Apparently @typescript-eslint has been fully compatible since 2.12.
The last commit that sets the peer dependencies is the following: https://github.com/typescript-eslint/typescript-eslint/commit/348d2f6b207acb9e18721cba53f0aa85908fa777
The tag 2.12 is the first one whose diff with master doesn't display the commit: https://github.com/typescript-eslint/typescript-eslint/compare/v2.12.0...master

**UPDATE:** More good info from @merceyz:
![image](https://user-images.githubusercontent.com/6893840/73124946-86148e00-3fa1-11ea-989a-541248850d23.png)
I've added a commit to also update TypeScript's status.