### PR TITLE
Add URL for packageExtensions link

### DIFF
--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -152,7 +152,7 @@ This error appears when Node is executed without the proper environment variable
 
 Some packages don't properly list their actual dependencies for a reason or another. Now that we've fully switched to Plug'n'Play and enforce boundaries between the various branches of the dependency tree, this kind of issue will start to become more apparent than it previously was.
 
-The long term fix is to submit a pull request upstream to add the missing dependency to the package listing. Given that it sometimes might take sometime before they get merged, we also have a more short-term fix available: create `.yarnrc.yml` in your project, then use the [`packageExtensions` setting]() to add the missing dependency to the relevant packages. Once you're done, run `yarn install` to apply your changes and voilà!
+The long term fix is to submit a pull request upstream to add the missing dependency to the package listing. Given that it sometimes might take sometime before they get merged, we also have a more short-term fix available: create `.yarnrc.yml` in your project, then use the [`packageExtensions` setting](/configuration/yarnrc#packageExtensions) to add the missing dependency to the relevant packages. Once you're done, run `yarn install` to apply your changes and voilà!
 
 ```yaml
 packageExtensions:

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -161,3 +161,5 @@ packageExtensions:
       "supports-color":
         optional: true
 ```
+
+If you also open a PR on the upstream repository you will also be able to contribute your package extension to our [compat plugin](https://github.com/yarnpkg/berry/blob/master/packages/plugin-compat/sources/extensions.ts), helping the whole ecosystem move forward.


### PR DESCRIPTION
**What's the problem this PR addresses?**

The link to "packageExtensions" does not go anywhere.


**How did you fix it?**

I added the correct path.
