### PR TITLE
docs: corrected policy script

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -39,7 +39,7 @@ cd ~/path/to/project
 3. Run the following command:
 
 ```bash
-yarn policies set-version berry
+yarn set version berry
 ```
 
 4. Commit the `.yarn` and `.yarnrc.yml` changes


### PR DESCRIPTION
The provided script is incorrect as there is no `policies` command

**What's the problem this PR addresses?**

Docs provide an incorrect command for setting policies

**How did you fix it?**

I refactored the command to be the one that worked for me on my local
