### PR TITLE
docs(sherlock): await expect statements if they aren't returned

### DIFF
--- a/packages/gatsby/content/advanced/sherlock.md
+++ b/packages/gatsby/content/advanced/sherlock.md
@@ -105,7 +105,7 @@ This means that your code is throwing an exception on our systems which doesn't 
 If you wish to test that something is failing (for example to test that `yarn install --immutable` doesn't work when the lockfile isn't up-to-date, or something like this) you can use the following pattern:
 
 ```js
-expect(async () => {
+await expect(async () => {
   // ...
 }()).rejects.toThrow();
 ```


### PR DESCRIPTION
**What's the problem this PR addresses?**

Let's pretend I read this statement and got confused how to expect on promises in #754 :laughing: 

**How did you fix it?**

`await` the `expect` statement
