### PR TITLE
Bag of fixes

### DIFF
--- a/.vscode/pnpify/eslint/bin/eslint.js
+++ b/.vscode/pnpify/eslint/bin/eslint.js
@@ -8,12 +8,12 @@ const relPnpApiPath = "../../../../.pnp.js";
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
-// Setup the environment to be able to require eslint/lib/api.js
+// Setup the environment to be able to require eslint/bin/eslint.js
 require(absPnpApiPath).setup();
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
-// Defer to the real eslint/lib/api.js your application uses
-module.exports = absRequire(`eslint/lib/api.js`);
+// Defer to the real eslint/bin/eslint.js your application uses
+module.exports = absRequire(`eslint/bin/eslint.js`);

--- a/.vscode/pnpify/eslint/package.json
+++ b/.vscode/pnpify/eslint/package.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint",
   "version": "5.16.0-pnpify",
-  "main": "lib/api.js"
+  "main": "./lib/api.js"
 }

--- a/.vscode/pnpify/typescript/bin/tsc
+++ b/.vscode/pnpify/typescript/bin/tsc
@@ -8,12 +8,12 @@ const relPnpApiPath = "../../../../.pnp.js";
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
-// Setup the environment to be able to require eslint/lib/api.js
+// Setup the environment to be able to require typescript/bin/tsc
 require(absPnpApiPath).setup();
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
-// Defer to the real eslint/lib/api.js your application uses
-module.exports = absRequire(`eslint/lib/api.js`);
+// Defer to the real typescript/bin/tsc your application uses
+module.exports = absRequire(`typescript/bin/tsc`);

--- a/.vscode/pnpify/typescript/bin/tsserver
+++ b/.vscode/pnpify/typescript/bin/tsserver
@@ -8,12 +8,12 @@ const relPnpApiPath = "../../../../.pnp.js";
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
-// Setup the environment to be able to require eslint/lib/api.js
+// Setup the environment to be able to require typescript/bin/tsserver
 require(absPnpApiPath).setup();
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
-// Defer to the real eslint/lib/api.js your application uses
-module.exports = absRequire(`eslint/lib/api.js`);
+// Defer to the real typescript/bin/tsserver your application uses
+module.exports = absRequire(`typescript/bin/tsserver`);

--- a/.vscode/pnpify/typescript/lib/tsc.js
+++ b/.vscode/pnpify/typescript/lib/tsc.js
@@ -8,12 +8,12 @@ const relPnpApiPath = "../../../../.pnp.js";
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
-// Setup the environment to be able to require eslint/lib/api.js
+// Setup the environment to be able to require typescript/lib/tsc.js
 require(absPnpApiPath).setup();
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
-// Defer to the real eslint/lib/api.js your application uses
-module.exports = absRequire(`eslint/lib/api.js`);
+// Defer to the real typescript/lib/tsc.js your application uses
+module.exports = absRequire(`typescript/lib/tsc.js`);

--- a/.vscode/pnpify/typescript/lib/tsserver.js
+++ b/.vscode/pnpify/typescript/lib/tsserver.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const {createRequire, createRequireFromPath} = require(`module`);
 const {dirname, resolve} = require(`path`);
 
@@ -6,12 +8,12 @@ const relPnpApiPath = "../../../../.pnp.js";
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
-// Setup the environment to be able to require typescript/lib/tsserver
+// Setup the environment to be able to require typescript/lib/tsserver.js
 require(absPnpApiPath).setup();
 
 // Prepare the environment (to be ready in case of child_process.spawn etc)
 process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
 process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
-// Defer to the real typescript/lib/tsserver your application uses
-module.exports = absRequire(`typescript/lib/tsserver`);
+// Defer to the real typescript/lib/tsserver.js your application uses
+module.exports = absRequire(`typescript/lib/tsserver.js`);

--- a/.vscode/pnpify/typescript/package.json
+++ b/.vscode/pnpify/typescript/package.json
@@ -1,4 +1,5 @@
 {
   "name": "typescript",
-  "version": "3.7.4-pnpify"
+  "version": "3.7.4-pnpify",
+  "main": "./lib/typescript.js"
 }

--- a/.yarn/versions/09310360.yml
+++ b/.yarn/versions/09310360.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/plugin-git": prerelease
+  "@yarnpkg/plugin-github": prerelease
+  "@yarnpkg/plugin-npm": prerelease
+  "@yarnpkg/plugin-npm-cli": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+  "@yarnpkg/pnpify": prerelease
+  "@yarnpkg/shell": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/package.json
+++ b/package.json
@@ -61,19 +61,15 @@
     "build:plugin-commands": "node ./scripts/gen-plugin-commands.js > packages/plugin-essentials/sources/pluginCommands.ts",
     "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && rsync -a --exclude '*.ts' --exclude '*.tsx' --include '*.d.ts' \"$0\"/sources/ \"$0\"/lib/ && node scripts/compile \"$@\"",
     "build:compile-inline": "find \"$0\"/sources -name '*.js' && babel \"$0\"/sources --out-dir \"$0\"/sources --extensions .ts,.tsx",
-    "gen-tssdk": "pnpify --sdk scripts",
-    "release:all": "./scripts/release.sh",
     "test:lint": "eslint \"packages/**/@(sources|tests)/**/!(libzip).@(tsx|ts|js)\"",
     "test:unit": "jest",
+    "sleep": "sleep 10",
     "typecheck:all": "tsc --noEmit"
   },
   "sherlock": {
     "requireList": [
       "scripts/actions/sherlock-prepare.js"
     ]
-  },
-  "nextVersion": {
-    "nonce": "6668117343518271"
   },
   "repository": {
     "type": "git",

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/login.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/login.test.js
@@ -88,7 +88,7 @@ describe(`Commands`, () => {
               TEST_NPM_PASSWORD: `incorrect password`,
             },
           })
-        ).rejects.toThrowError(/Invalid Authentication/);
+        ).rejects.toThrowError(/Invalid authentication \(attempted as anotherTestUser\)/);
       })
     );
 
@@ -103,7 +103,7 @@ describe(`Commands`, () => {
               TEST_NPM_2FA_TOKEN: `incorrect OTP`,
             },
           })
-        ).rejects.toThrowError(/Invalid Authentication/);
+        ).rejects.toThrowError(/Invalid authentication \(attempted as testUser\)/);
       })
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
@@ -88,7 +88,7 @@ describe(`Commands`, () => {
       `it should throw an error when config has an invalid npmAuthToken`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await writeFile(`${path}/.yarnrc.yml`, `npmAuthToken: "${INVALID_AUTH_TOKEN}"\n`);
-        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
+        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Invalid authentication \(as an unknown user\)/);
       })
     );
 
@@ -96,7 +96,7 @@ describe(`Commands`, () => {
       `it should throw an error when config has an invalid npmAuthIdent`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await writeFile(`${path}/.yarnrc.yml`, `npmAuthIdent: "${INVALID_AUTH_IDENT}"\n`);
-        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
+        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Invalid authentication \(as an unknown user\)/);
       })
     );
 
@@ -114,8 +114,8 @@ describe(`Commands`, () => {
           `    npmAuthToken: ${INVALID_AUTH_TOKEN}`,
         ].join(``));
 
-        await expect(run(`npm`, `whoami`, `--scope`, `testScope`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
-        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
+        await expect(run(`npm`, `whoami`, `--scope`, `testScope`)).rejects.toThrowError(/Invalid authentication \(as an unknown user\)/);
+        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Invalid authentication \(as an unknown user\)/);
       })
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
@@ -88,7 +88,7 @@ describe(`Commands`, () => {
       `it should throw an error when config has an invalid npmAuthToken`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await writeFile(`${path}/.yarnrc.yml`, `npmAuthToken: "${INVALID_AUTH_TOKEN}"\n`);
-        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed/);
+        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
       })
     );
 
@@ -96,7 +96,7 @@ describe(`Commands`, () => {
       `it should throw an error when config has an invalid npmAuthIdent`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await writeFile(`${path}/.yarnrc.yml`, `npmAuthIdent: "${INVALID_AUTH_IDENT}"\n`);
-        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed/);
+        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
       })
     );
 
@@ -114,8 +114,8 @@ describe(`Commands`, () => {
           `    npmAuthToken: ${INVALID_AUTH_TOKEN}`,
         ].join(``));
 
-        await expect(run(`npm`, `whoami`, `--scope`, `testScope`)).rejects.toThrowError(/Authentication failed/);
-        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed/);
+        await expect(run(`npm`, `whoami`, `--scope`, `testScope`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
+        await expect(run(`npm`, `whoami`)).rejects.toThrowError(/Authentication failed \(as an unknown user\)/);
       })
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
@@ -1,4 +1,4 @@
-import {xfs, ppath} from '@yarnpkg/fslib';
+import {xfs} from '@yarnpkg/fslib';
 
 const {
   fs: {createTemporaryFolder, writeJson},

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -61,7 +61,7 @@ export default class PluginDlCommand extends BaseCommand {
         pluginSpec = ppath.relative(project.cwd, candidatePath);
         pluginBuffer = await xfs.readFilePromise(candidatePath);
       } else {
-        let pluginUrl;
+        let pluginUrl: string;
         if (this.name.match(/^https?:/)) {
           try {
             // @ts-ignore We don't want to add the dom to the TS env just for this line

--- a/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
+++ b/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
+
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#hash 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
+
+exports[`gitUtils should properly normalize git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize git://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
+
+exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js#hash 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#master 1`] = `"https://github.com/TooTallNate/util-deprecate.git#master"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#v1.0.0 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.0"`;

--- a/packages/plugin-git/sources/gitUtils.test.js
+++ b/packages/plugin-git/sources/gitUtils.test.js
@@ -30,7 +30,7 @@ describe(`gitUtils`, () => {
     });
   }
 
-  for (const pattern of VALID_PATTERN) {
+  for (const pattern of VALID_PATTERNS) {
     it(`should properly normalize ${pattern}`, () => {
       expect(gitUtils.normalizeRepoUrl(pattern)).toMatchSnapshot();
     });

--- a/packages/plugin-git/sources/gitUtils.test.js
+++ b/packages/plugin-git/sources/gitUtils.test.js
@@ -1,0 +1,38 @@
+import * as gitUtils from './gitUtils';
+
+const VALID_PATTERNS = [
+  `GitHubOrg/foo-bar.js`,
+  `GitHubOrg/foo-bar.js#hash`,
+  `github:GitHubOrg/foo-bar.js`,
+  `github:GitHubOrg/foo-bar.js#hash`,
+  `https://github.com/TooTallNate/util-deprecate.git#v1.0.0`,
+  `https://github.com/TooTallNate/util-deprecate.git#master`,
+  `https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d`,
+  `git://github.com/TooTallNate/util-deprecate.git#v1.0.1`,
+  `git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,
+];
+
+const INVALID_PATTERNS = [
+  `./.`,
+  `../..`,
+];
+
+describe(`gitUtils`, () => {
+  for (const pattern of VALID_PATTERNS) {
+    it(`should detect ${pattern} as a valid Git url`, () => {
+      expect(gitUtils.isGitUrl(pattern)).toEqual(true);
+    });
+  }
+
+  for (const pattern of INVALID_PATTERNS) {
+    it(`shouldn't detect ${pattern} as a valid Git url`, () => {
+      expect(gitUtils.isGitUrl(pattern)).toEqual(false);
+    });
+  }
+
+  for (const pattern of VALID_PATTERN) {
+    it(`should properly normalize ${pattern}`, () => {
+      expect(gitUtils.normalizeRepoUrl(pattern)).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -14,7 +14,7 @@ const gitPatterns = [
   /^git(?:\+ssh)?:/,
   /^(?:git\+)?https?:[^#]+\/[^#]+\.git(?:#.*)?$/,
   /^git@[^#]+\/[^#]+\.git(?:#.*)?$/,
-  /^(?:github:|https:\/\/github\.com\/)?([a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d]))+)\/([a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d]))+)(?:#.*)?$/,
+  /^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z._-]+?)(?:\.git)?(?:#.*)?$/,
 ];
 
 /**
@@ -59,7 +59,7 @@ export function normalizeRepoUrl(url: string) {
   url = url.replace(/^git\+https:/, `https:`);
 
   // We support this as an alias to Github repositories
-  url = url.replace(/^(?:github:|https:\/\/github\.com\/)?([a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d]))+)\/([a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d]))+)(#.*)?$/, `https://github.com/$1/$2.git$3`);
+  url = url.replace(/^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
 
   return url;
 }

--- a/packages/plugin-git/sources/index.ts
+++ b/packages/plugin-git/sources/index.ts
@@ -2,6 +2,7 @@ import {FetchOptions, FetchResult, Locator, Plugin} from '@yarnpkg/core';
 
 import {GitFetcher}                                 from './GitFetcher';
 import {GitResolver}                                from './GitResolver';
+import * as gitUtils                                from './gitUtils';
 
 export interface Hooks {
   fetchHostedRepository?: (
@@ -19,6 +20,8 @@ const plugin: Plugin = {
     GitResolver,
   ],
 };
+
+export {gitUtils};
 
 // eslint-disable-next-line arca/no-default-export
 export default plugin;

--- a/packages/plugin-github/sources/githubUtils.test.js
+++ b/packages/plugin-github/sources/githubUtils.test.js
@@ -1,0 +1,18 @@
+import {gitUtils}       from '@yarnpkg/plugin-git';
+
+import * as githubUtils from './githubUtils';
+
+const VALID_PATTERNS = [
+  `GitHubOrg/foo-bar.js`,
+  `GitHubOrg/foo-bar.js#hash`,
+  `github:GitHubOrg/foo-bar.js`,
+  `github:GitHubOrg/foo-bar.js#hash`,
+];
+
+describe(`gitUtils`, () => {
+  for (const pattern of VALID_PATTERNS) {
+    it(`should detect ${pattern} as a valid Git url`, () => {
+      expect(githubUtils.isGithubUrl(gitUtils.normalizeRepoUrl(pattern))).toEqual(true);
+    });
+  }
+});

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -62,21 +62,13 @@ export default class NpmLoginCommand extends BaseCommand {
       const credentials = await getCredentials(prompt, {registry, report});
       const url = `/-/user/org.couchdb.user:${encodeURIComponent(credentials.name)}`;
 
-      let response;
-      try {
-        response = await npmHttpUtils.put(url, credentials, {
-          configuration,
-          registry,
-          json: true,
-          authType: npmHttpUtils.AuthType.NO_AUTH,
-        }) as any;
-      } catch (error) {
-        if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-          return report.reportError(MessageName.AUTHENTICATION_INVALID, `Invalid Authentication`);
-        } else {
-          throw error;
-        }
-      }
+      const response = await npmHttpUtils.put(url, credentials, {
+        attemptedAs: credentials.name,
+        configuration,
+        registry,
+        json: true,
+        authType: npmHttpUtils.AuthType.NO_AUTH,
+      }) as any;
 
       await setAuthToken(registry, response.token, {configuration});
       return report.reportInfo(MessageName.UNNAMED, `Successfully logged in`);

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -1,9 +1,9 @@
-import {BaseCommand, openWorkspace}   from '@yarnpkg/cli';
-import {Configuration, MessageName}   from '@yarnpkg/core';
-import {StreamReport}                 from '@yarnpkg/core';
-import {npmConfigUtils, npmHttpUtils} from '@yarnpkg/plugin-npm';
-import {Command, Usage}               from 'clipanion';
-import inquirer                       from 'inquirer';
+import {BaseCommand, openWorkspace}         from '@yarnpkg/cli';
+import {Configuration, MessageName, Report} from '@yarnpkg/core';
+import {StreamReport}                       from '@yarnpkg/core';
+import {npmConfigUtils, npmHttpUtils}       from '@yarnpkg/plugin-npm';
+import {Command, Usage}                     from 'clipanion';
+import inquirer                             from 'inquirer';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NpmLoginCommand extends BaseCommand {
@@ -59,24 +59,27 @@ export default class NpmLoginCommand extends BaseCommand {
       configuration,
       stdout: this.context.stdout,
     }, async report => {
-      const credentials = await getCredentials(prompt);
+      const credentials = await getCredentials(prompt, {registry, report});
       const url = `/-/user/org.couchdb.user:${encodeURIComponent(credentials.name)}`;
 
+      let response;
       try {
-        const response = await npmHttpUtils.put(url, credentials, {
+        response = await npmHttpUtils.put(url, credentials, {
           configuration,
           registry,
           json: true,
           authType: npmHttpUtils.AuthType.NO_AUTH,
-        });
-
-        // @ts-ignore
-        await setAuthToken(registry, response.token, {configuration});
-
-        return report.reportInfo(MessageName.UNNAMED, `Successfully logged in`);
+        }) as any;
       } catch (error) {
-        return report.reportError(MessageName.AUTHENTICATION_INVALID, `Invalid Authentication`);
+        if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
+          return report.reportError(MessageName.AUTHENTICATION_INVALID, `Invalid Authentication`);
+        } else {
+          throw error;
+        }
       }
+
+      await setAuthToken(registry, response.token, {configuration});
+      return report.reportInfo(MessageName.UNNAMED, `Successfully logged in`);
     });
 
     return report.exitCode();
@@ -95,13 +98,24 @@ async function setAuthToken(registry: string, npmAuthToken: string, {configurati
   });
 }
 
-async function getCredentials(prompt: any) {
+async function getCredentials(prompt: any, {registry, report}: {registry: string, report: Report}) {
   if (process.env.TEST_ENV) {
     return {
       name: process.env.TEST_NPM_USER || '',
       password: process.env.TEST_NPM_PASSWORD || '',
     };
   }
+
+  report.reportInfo(MessageName.UNNAMED, `Logging in to ${registry}`);
+
+  let isToken = false;
+
+  if (registry.match(/^https:\/\/npm\.pkg\.github\.com(\/|$)/)) {
+    report.reportInfo(MessageName.UNNAMED, `You seem to be using the GitHub Package Registry. Tokens must be generated with the 'repo', 'write:packages', and 'read:packages' permissions.`);
+    isToken = true;
+  }
+
+  report.reportSeparator();
 
   const {username, password} = await prompt([{
     type: `input`,
@@ -111,9 +125,11 @@ async function getCredentials(prompt: any) {
   }, {
     type: `password`,
     name: `password`,
-    message: `Password:`,
+    message: isToken ? `Token:` : `Password:`,
     validate: (input: string) => validateRequiredInput(input, `Password`),
   }]);
+
+  report.reportSeparator();
 
   return {
     name: username,

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -1,9 +1,9 @@
-import {InstallStatus, Installer, LinkOptions, LinkType, MessageName, DependencyMeta, FinalizeInstallStatus} from '@yarnpkg/core';
-import {FetchResult, Descriptor, Locator, Package, BuildDirective}                                           from '@yarnpkg/core';
-import {miscUtils, structUtils}                                                                              from '@yarnpkg/core';
-import {FakeFS, PortablePath, ppath}                                                                         from '@yarnpkg/fslib';
-import {PackageRegistry, PnpSettings}                                                                        from '@yarnpkg/pnp';
-import mm                                                                                                    from 'micromatch';
+import {Installer, LinkOptions, LinkType, MessageName, DependencyMeta, FinalizeInstallStatus} from '@yarnpkg/core';
+import {FetchResult, Descriptor, Locator, Package, BuildDirective}                            from '@yarnpkg/core';
+import {miscUtils, structUtils}                                                               from '@yarnpkg/core';
+import {FakeFS, PortablePath, ppath}                                                          from '@yarnpkg/fslib';
+import {PackageRegistry, PnpSettings}                                                         from '@yarnpkg/pnp';
+import mm                                                                                     from 'micromatch';
 
 export abstract class AbstractPnpInstaller implements Installer {
   private readonly packageRegistry: PackageRegistry = new Map();

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -13,7 +13,7 @@
     "camelcase": "^5.3.1",
     "chalk": "^3.0.0",
     "clipanion": "^2.1.5",
-    "cross-spawn": "^6.0.5",
+    "cross-spawn": "6.0.5",
     "diff": "^4.0.1",
     "globby": "^10.0.1",
     "got": "^10.2.0",

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -518,7 +518,7 @@ export class Manifest {
     else
       delete data.name;
 
-      if (this.version !== null)
+    if (this.version !== null)
       data.version = this.version;
     else
       delete data.version;

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -38,6 +38,8 @@ export class Manifest {
   public name: Ident | null = null;
   public version: string | null = null;
 
+  public type: string | null = null;
+
   public ["private"]: boolean = false;
   public license: string | null = null;
 
@@ -138,6 +140,9 @@ export class Manifest {
 
     if (typeof data.version === `string`)
       this.version = data.version;
+
+    if (typeof data.type === `string`)
+      this.type = data.type;
 
     if (typeof data.private === `boolean`)
       this.private = data.private;
@@ -513,10 +518,15 @@ export class Manifest {
     else
       delete data.name;
 
-    if (this.version !== null)
+      if (this.version !== null)
       data.version = this.version;
     else
       delete data.version;
+
+    if (this.type !== null)
+      data.type = this.type;
+    else
+      delete data.type;
 
     if (this.private)
       data.private = true;

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -115,7 +115,7 @@ export class Project {
     if (locator)
       return {project, locator, workspace: null};
 
-    throw new Error(`Assertion failed: The package should have been detected as part of the project`);
+    throw new UsageError(`The nearest package directory (${packageCwd}) doesn't seem to be part of the project declared at ${project.cwd}. If the project directory is right, it might be that you forgot to list a workspace. If it isn't, it's likely because you have a yarn.lock file at the detected location, confusing the project detection.`);
   }
 
   static generateBuildStateFile(buildState: Map<LocatorHash, string>, locatorStore: Map<LocatorHash, Locator>) {
@@ -1561,6 +1561,7 @@ function applyVirtualResolutionMutations({
 
   tolerateMissingPackages?: boolean,
 }) {
+  const virtualStack = new Map<LocatorHash, number>();
   const resolutionStack: Array<Locator> = [];
 
   // We'll be keeping track of all virtual descriptors; once they have all
@@ -1617,6 +1618,9 @@ function applyVirtualResolutionMutations({
   };
 
   const resolvePeerDependencies = (parentLocator: Locator, first: boolean, optional: boolean) => {
+    if (resolutionStack.length > 1000)
+      reportStackOverflow();
+
     resolutionStack.push(parentLocator);
     const result = resolvePeerDependenciesImpl(parentLocator, first, optional);
     resolutionStack.pop();
@@ -1702,6 +1706,14 @@ function applyVirtualResolutionMutations({
         continue;
       }
 
+      // The stack overflow is checked against two level because a workspace
+      // may have a dev dependency on another workspace that lists the first
+      // one as a regular dependency. In this case the loop will break so we
+      // don't need to throw an exception.
+      const stackDepth = virtualStack.get(pkg.locatorHash);
+      if (typeof stackDepth === `number` && stackDepth >= 2)
+        reportStackOverflow();
+
       let virtualizedDescriptor: Descriptor;
       let virtualizedPackage: Package;
 
@@ -1785,7 +1797,12 @@ function applyVirtualResolutionMutations({
       });
 
       thirdPass.push(() => {
+        const current = virtualStack.get(pkg.locatorHash);
+        const next = typeof current !== `undefined` ? current + 1 : 1;
+
+        virtualStack.set(pkg.locatorHash, next);
         resolvePeerDependencies(virtualizedPackage, false, isOptional);
+        virtualStack.set(pkg.locatorHash, next - 1);
       });
 
       fourthPass.push(() => {
@@ -1807,17 +1824,9 @@ function applyVirtualResolutionMutations({
     }
   };
 
-  try {
-    for (const workspace of project.workspaces) {
-      volatileDescriptors.delete(workspace.anchoredDescriptor.descriptorHash);
-      resolvePeerDependencies(workspace.anchoredLocator, true, false);
-    }
-  } catch (error) {
-    if (error.name === `RangeError` && error.message === `Maximum call stack size exceeded`) {
-      reportStackOverflow();
-    } else {
-      throw error;
-    }
+  for (const workspace of project.workspaces) {
+    volatileDescriptors.delete(workspace.anchoredDescriptor.descriptorHash);
+    resolvePeerDependencies(workspace.anchoredLocator, true, false);
   }
 
   // A package may have a peer dependency while being included as a standard dependency

--- a/packages/yarnpkg-core/sources/WorkspaceResolver.ts
+++ b/packages/yarnpkg-core/sources/WorkspaceResolver.ts
@@ -1,7 +1,5 @@
 import {PortablePath}                                    from '@yarnpkg/fslib';
 
-import {MessageName}                                     from './MessageName';
-import {ReportError}                                     from './Report';
 import {Resolver, ResolveOptions, MinimalResolveOptions} from './Resolver';
 import {Descriptor, Locator}                             from './types';
 import {LinkType}                                        from './types';

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.15",
     "comment-json": "^2.2.0",
-    "cross-spawn": "^6.0.5"
+    "cross-spawn": "6.0.5"
   },
   "devDependencies": {
     "@types/comment-json": "^1.1.1",

--- a/packages/yarnpkg-pnpify/sources/cli.ts
+++ b/packages/yarnpkg-pnpify/sources/cli.ts
@@ -17,7 +17,6 @@ else if (typeof name !== `undefined` && name[0] !== `-`)
 else
   help(true);
 
-
 function help(error: boolean) {
   const logFn = error ? console.error : console.log;
   process.exitCode = error ? 1 : 0;

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -7,7 +7,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {usePnpify}: {use
   `#!/usr/bin/env node\n`,
   `\n`,
   `const {createRequire, createRequireFromPath} = require(\`module\`);\n`,
-  `const {dirname, resolve} = require(\`path\`);\n`,
+  `const {resolve} = require(\`path\`);\n`,
   `\n`,
   `const relPnpApiPath = ${JSON.stringify(npath.fromPortablePath(relPnpApiPath))};\n`,
   `\n`,

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -4,6 +4,8 @@ import CJSON                                       from 'comment-json';
 import {dynamicRequire}                            from './dynamicRequire';
 
 const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {usePnpify}: {usePnpify: boolean}) => [
+  `#!/usr/bin/env node\n`,
+  `\n`,
   `const {createRequire, createRequireFromPath} = require(\`module\`);\n`,
   `const {dirname, resolve} = require(\`path\`);\n`,
   `\n`,
@@ -42,51 +44,116 @@ const addVSCodeWorkspaceSettings = async (projectRoot: PortablePath, settings: a
   });
 };
 
+class Wrapper {
+  private name: PortablePath;
+
+  private projectRoot: PortablePath;
+  private target: PortablePath;
+
+  private paths: Map<PortablePath, PortablePath> = new Map();
+
+  constructor(name: PortablePath, {projectRoot, target}: {projectRoot: PortablePath, target: PortablePath}) {
+    this.name = name;
+
+    this.projectRoot = projectRoot;
+    this.target = target;
+  }
+
+  async writeManifest() {
+    const absWrapperPath = ppath.join(this.target, this.name, `package.json` as Filename);
+    const manifest = dynamicRequire(`${this.name}/package.json`);
+
+    await xfs.mkdirpPromise(ppath.dirname(absWrapperPath));
+    await xfs.writeFilePromise(absWrapperPath, JSON.stringify({
+      name: this.name,
+      version: `${manifest.version}-pnpify`,
+      main: manifest.main,
+    }, null, 2));
+  }
+
+  async writeBinary(relPackagePath: PortablePath) {
+    const absPackagePath = await this.writeFile(relPackagePath);
+
+    await xfs.chmodPromise(absPackagePath, 0o755);
+  }
+
+  async writeFile(relPackagePath: PortablePath) {
+    const absWrapperPath = ppath.join(this.target, this.name, relPackagePath);
+    const relPnpApiPath = ppath.relative(ppath.dirname(absWrapperPath), ppath.join(this.projectRoot, `.pnp.js` as Filename));
+    const relProjectPath = ppath.relative(this.projectRoot, absWrapperPath);
+
+    await xfs.mkdirpPromise(ppath.dirname(absWrapperPath));
+    await xfs.writeFilePromise(absWrapperPath, TEMPLATE(relPnpApiPath, ppath.join(this.name, relPackagePath), {usePnpify: false}));
+
+    this.paths.set(relPackagePath, relProjectPath);
+
+    return absWrapperPath;
+  }
+
+  getProjectPathTo(relPackagePath: PortablePath) {
+    const relProjectPath = this.paths.get(relPackagePath);
+
+    if (typeof relProjectPath === `undefined`)
+      throw new Error(`Assertion failed: Expected path to have been registered`);
+
+    return relProjectPath;
+  }
+}
+
 const generateTypescriptWrapper = async (projectRoot: PortablePath, target: PortablePath) => {
-  const typescript = ppath.join(target, `typescript` as PortablePath);
-  const manifest = ppath.join(typescript, `package.json` as PortablePath);
-  const tsserver = ppath.join(typescript, `lib/tsserver.js` as PortablePath);
+  const wrapper = new Wrapper(`typescript` as PortablePath, {projectRoot, target});
 
-  const relPnpApiPath = ppath.relative(ppath.dirname(tsserver), ppath.join(projectRoot, `.pnp.js` as Filename));
+  await wrapper.writeManifest();
 
-  await xfs.mkdirpPromise(ppath.dirname(tsserver));
-  await xfs.writeFilePromise(manifest, JSON.stringify({name: `typescript`, version: `${dynamicRequire(`typescript/package.json`).version}-pnpify`}, null, 2));
-  await xfs.writeFilePromise(tsserver, TEMPLATE(relPnpApiPath, `typescript/lib/tsserver`, {usePnpify: false}));
+  await wrapper.writeBinary(`bin/tsc` as PortablePath);
+  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
+
+  await wrapper.writeFile(`lib/tsc.js` as PortablePath);
+  await wrapper.writeFile(`lib/tsserver.js` as PortablePath);
 
   await addVSCodeWorkspaceSettings(projectRoot, {
-    [`typescript.tsdk`]: npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(tsserver))),
+    [`typescript.tsdk`]: npath.fromPortablePath(
+      ppath.dirname(
+        wrapper.getProjectPathTo(
+          `lib/tsserver.js` as PortablePath,
+        ),
+      ),
+    ),
   });
 };
 
 export const generateEslintWrapper = async (projectRoot: PortablePath, target: PortablePath) => {
-  const eslint = ppath.join(target, `eslint` as PortablePath);
-  const manifest = ppath.join(eslint, `package.json` as PortablePath);
-  const api = ppath.join(eslint, `lib/api.js` as PortablePath);
+  const wrapper = new Wrapper(`eslint` as PortablePath, {projectRoot, target});
 
-  const relPnpApiPath = ppath.relative(ppath.dirname(api), ppath.join(projectRoot, `.pnp.js` as Filename));
+  await wrapper.writeManifest();
 
-  await xfs.mkdirpPromise(ppath.dirname(api));
-  await xfs.writeFilePromise(manifest, JSON.stringify({name: `eslint`, version: `${dynamicRequire(`eslint/package.json`).version}-pnpify`, main: `lib/api.js`}, null, 2));
-  await xfs.writeFilePromise(api, TEMPLATE(relPnpApiPath, `eslint`, {usePnpify: false}));
+  await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
+  await wrapper.writeFile(`lib/api.js` as PortablePath);
 
   await addVSCodeWorkspaceSettings(projectRoot, {
-    [`eslint.nodePath`]: npath.fromPortablePath(ppath.relative(projectRoot, ppath.dirname(eslint))),
+    [`eslint.nodePath`]: npath.fromPortablePath(
+      ppath.dirname(ppath.dirname(ppath.dirname(
+        wrapper.getProjectPathTo(
+          `lib/api.js` as PortablePath,
+        ),
+      ))),
+    ),
   });
 };
 
 export const generatePrettierWrapper = async (projectRoot: PortablePath, target: PortablePath) => {
-  const prettier = ppath.join(target, `prettier` as PortablePath);
-  const manifest = ppath.join(prettier, `package.json` as PortablePath);
-  const api = ppath.join(prettier, `index.js` as PortablePath);
+  const wrapper = new Wrapper(`prettier` as PortablePath, {projectRoot, target});
 
-  const relPnpApiPath = ppath.relative(ppath.dirname(api), ppath.join(projectRoot, `.pnp.js` as Filename));
+  await wrapper.writeManifest();
 
-  await xfs.mkdirpPromise(ppath.dirname(api));
-  await xfs.writeFilePromise(manifest, JSON.stringify({name: `prettier`, version: `${dynamicRequire(`prettier/package.json`).version}-pnpify`, main: `index.js`}, null, 2));
-  await xfs.writeFilePromise(api, TEMPLATE(relPnpApiPath, `prettier`, {usePnpify: false}));
+  await wrapper.writeBinary(`index.js` as PortablePath);
 
   await addVSCodeWorkspaceSettings(projectRoot, {
-    [`prettier.prettierPath`]: npath.fromPortablePath(ppath.relative(projectRoot, prettier)),
+    [`prettier.prettierPath`]: npath.fromPortablePath(
+      wrapper.getProjectPathTo(
+        `index.js` as PortablePath,
+      ),
+    ),
   });
 };
 

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.15",
     "@yarnpkg/parsers": "workspace:^2.0.0-rc.9",
-    "cross-spawn": "^6.0.5",
+    "cross-spawn": "6.0.5",
     "stream-buffers": "^3.0.2"
   },
   "devDependencies": {

--- a/plugins.yml
+++ b/plugins.yml
@@ -1,5 +1,10 @@
 # This file contains the list of officially endorsed plugins.
 
+"@yarnpkg/plugin-constraints":
+  url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-constraints/bin/%40yarnpkg/plugin-constraints.js"
+  experimental: true
+  description: "Adds a new command to Yarn (`yarn constraints`) to enforce lint rules across workspaces."
+
 "@yarnpkg/plugin-hello-world":
   url: "https://github.com/yarnpkg/berry/raw/master/scripts/plugin-hello-world.js"
   experimental: true
@@ -25,7 +30,12 @@
   experimental: true
   description: "Adds various utilities for a seamless TypeScript experience. Consult the plugin page for more details."
 
+"@yarnpkg/plugin-version":
+  url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-version/bin/%40yarnpkg/plugin-version.js"
+  experimental: true
+  description: "Adds a new workflow to Yarn (`yarn version`) to efficiently manage releases in a monorepository."
+
 "@yarnpkg/plugin-workspace-tools":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-workspace-tools/bin/%40yarnpkg/plugin-workspace-tools.js"
   experimental: true
-  description: "Adds various commands that make working with workspaces a more pleasing experience. Consult the plugin page for more details."
+  description: "Adds various commands that make working with workspaces a more pleasing experience."

--- a/scripts/actions/local-yarn-command/Dockerfile
+++ b/scripts/actions/local-yarn-command/Dockerfile
@@ -5,7 +5,7 @@ LABEL "com.github.actions.description"="Run a Yarn command using the checked-in 
 LABEL "com.github.actions.icon"="package"
 LABEL "com.github.actions.color"="blue"
 
-RUN apk add --no-cache bash nodejs rsync
+RUN apk add --no-cache bash nodejs rsync git
 
 # For building Sharp
 RUN apk add fftw-dev build-base autoconf python2 imagemagick --update-cache \

--- a/scripts/actions/sherlock-prepare.js
+++ b/scripts/actions/sherlock-prepare.js
@@ -51,7 +51,7 @@ global.yarn = async (...args) => {
   let stdout;
   try {
     ({stdout} = await execFileP(process.execPath, [`${__dirname}/../run-yarn.js`, ...args], {
-      env: {...process.env, YARN_IGNORE_PATH: 1, YARN_ENABLE_INLINE_BUILDS: 1},
+      env: {...process.env, YARN_ENABLE_COLORS: 0, YARN_IGNORE_PATH: 1, YARN_ENABLE_INLINE_BUILDS: 1},
       ...opts,
     }));
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4840,7 +4840,7 @@ __metadata:
     camelcase: ^5.3.1
     chalk: ^3.0.0
     clipanion: ^2.1.5
-    cross-spawn: ^6.0.5
+    cross-spawn: 6.0.5
     diff: ^4.0.1
     globby: ^10.0.1
     got: ^10.2.0
@@ -5441,7 +5441,7 @@ __metadata:
     "@yarnpkg/monorepo": "workspace:0.0.0"
     "@yarnpkg/pnp": "workspace:^2.0.0-rc.16"
     comment-json: ^2.2.0
-    cross-spawn: ^6.0.5
+    cross-spawn: 6.0.5
     eslint: ^5.16.0
     typescript: ^3.7.4
   peerDependencies:
@@ -5465,7 +5465,7 @@ __metadata:
     "@types/tmp": ^0.0.33
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.15"
     "@yarnpkg/parsers": "workspace:^2.0.0-rc.9"
-    cross-spawn: ^6.0.5
+    cross-spawn: 6.0.5
     stream-buffers: ^3.0.2
     tmp: ^0.1.0
   languageName: unknown
@@ -8914,7 +8914,7 @@ babel-plugin-lazy-import@arcanis/babel-plugin-lazy-import:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
+"cross-spawn@npm:6.0.5, cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
   dependencies:


### PR DESCRIPTION
**What are the problems this PR addresses?**

- Fixes the Git and GitHub regexes to add support for dots in repository names. Also adds a set of tests for both to prevent regressions - closes #777 and #778

- Prints an error message when a risky dependency cycle is detected (for example `react-sortable-tree` has a dependency on itself, and to make things worse lists peer dependencies) - closes #776

- Removes the terminal sequence from the output of `yarn sherlock` for a less confusing output

- Refactors the `--sdk` flag to use a common logic and avoid potential bugs. Also adds support for `bin/eslint.js` to ESLint, which I believe is used by some Vim plugins cc @themouette

- Adds the missing plugins in the plugin manifest

- Adds `git` to the image used by Sherlock

- **Experimental** - the `.pnp.js` file will be named `.pnp.cjs` if the project is a module. Experimental because it might not work with tools that expect a `.pnp.js` file (maybe WebStorm? cc @segrey) - fixes #757 and #758
