### PR TITLE
docs: fix typo in yarnpkg-shell README

### DIFF
--- a/packages/yarnpkg-shell/README.md
+++ b/packages/yarnpkg-shell/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/shell`
 
-A Javascript implementation of a bash-like shell (we use it in Yarn 2 to provide cross-platform scripting). This package exposes an API that abstracts both the parser and the interpreter; should you only need the parser you can check out `@yarnpkg/parsers`, but you probably won't need it.
+A JavaScript implementation of a bash-like shell (we use it in Yarn 2 to provide cross-platform scripting). This package exposes an API that abstracts both the parser and the interpreter; should you only need the parser you can check out `@yarnpkg/parsers`, but you probably won't need it.
 
 ## Usage
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Just a minor typo in the yarnpkg-shell README.

**How did you fix it?**

Javascript → JavaScript