### PR TITLE
chore(www): hide bullet points on contributor list

### DIFF
--- a/packages/gatsby/src/components/details/Contributors.js
+++ b/packages/gatsby/src/components/details/Contributors.js
@@ -1,16 +1,23 @@
+import styled  from '@emotion/styled';
 import React   from 'react';
 
 import {Owner} from '../hit';
 
+const List = styled`
+  list-style-type: none;
+  padding-inline-start: 0;
+  padding-left: 0;
+`;
+
 export const Contributors = ({contributors}) => (
   <article>
     <h1>Contributors</h1>
-    <ul>
+    <List>
       {contributors.map(contributor => (
         <li key={contributor.name}>
           <Owner {...contributor} />
         </li>
       ))}
-    </ul>
+    </List>
   </article>
 );

--- a/packages/gatsby/src/components/details/Contributors.js
+++ b/packages/gatsby/src/components/details/Contributors.js
@@ -3,7 +3,7 @@ import React   from 'react';
 
 import {Owner} from '../hit';
 
-const List = styled`
+const List = styled.ul`
   list-style-type: none;
   padding-inline-start: 0;
   padding-left: 0;


### PR DESCRIPTION
**What's the problem this PR addresses?**

before|after
---|---
<img width="207" alt="Screenshot 2020-01-27 at 10 21 37" src="https://user-images.githubusercontent.com/6270048/73162767-d4837300-40ee-11ea-808a-af519b1a1fd3.png"> | <img width="278" alt="Screenshot 2020-01-27 at 10 21 30" src="https://user-images.githubusercontent.com/6270048/73162768-d51c0980-40ee-11ea-9edb-41a6a2480ecc.png">


**How did you fix it?**

Added left padding: 0, and list-style-type: none
