### PR TITLE
Keep the cache (n_m/.cache) between runs

### DIFF
--- a/.yarn/versions/51b29e0f.yml
+++ b/.yarn/versions/51b29e0f.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1313,6 +1313,46 @@ describe(`Plug'n'Play`, () => {
   );
 
   test(
+    `it should remove the lingering node_modules folders`,
+    makeTemporaryEnv({}, async ({path, run, source}) => {
+      await xfs.mkdirpPromise(`${path}/node_modules/foo`);
+
+      await run(`install`);
+
+      await expect(xfs.readdirPromise(path)).resolves.not.toContain(`node_modules`);
+    }),
+  );
+
+  test(
+    `it shouldn't remove the lingering node_modules folders when they contain dot-folders`,
+    makeTemporaryEnv({}, async ({path, run, source}) => {
+      await xfs.mkdirpPromise(`${path}/node_modules/.cache`);
+
+      await run(`install`);
+
+      await expect(xfs.readdirPromise(path)).resolves.toContain(`node_modules`);
+      await expect(xfs.readdirPromise(ppath.join(path, `node_modules`))).resolves.toEqual([
+        `.cache`,
+      ]);
+    }),
+  );
+
+  test(
+    `it should remove lingering folders from the node_modules even when they contain dot-folders`,
+    makeTemporaryEnv({}, async ({path, run, source}) => {
+      await xfs.mkdirpPromise(`${path}/node_modules/.cache`);
+      await xfs.mkdirpPromise(`${path}/node_modules/foo`);
+
+      await run(`install`);
+
+      await expect(xfs.readdirPromise(path)).resolves.toContain(`node_modules`);
+      await expect(xfs.readdirPromise(ppath.join(path, `node_modules`))).resolves.toEqual([
+        `.cache`,
+      ]);
+    }),
+  );
+
+  test(
     `it should transparently support the "resolve" package`,
     makeTemporaryEnv(
       {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Similar to 1.x which was removing this directory until recently, 2.x was removing the whole node_modules regardless of what was stored inside. Since that's usually the place where caches are stored (for example in `babel-loader`), it was causing cold cache more often than needed.

**How did you fix it?**

Only non-dot-folders will be removed (or the whole folder if there is no dot folder). Added tests to prevent regressions.
