### PR TITLE
Skips setting node_option when useless

### DIFF
--- a/.vscode/pnpify/eslint/bin/eslint.js
+++ b/.vscode/pnpify/eslint/bin/eslint.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {createRequire, createRequireFromPath} = require(`module`);
-const {dirname, resolve} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
@@ -10,10 +10,6 @@ const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require eslint/bin/eslint.js
 require(absPnpApiPath).setup();
-
-// Prepare the environment (to be ready in case of child_process.spawn etc)
-process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
-process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real eslint/bin/eslint.js your application uses
 module.exports = absRequire(`eslint/bin/eslint.js`);

--- a/.vscode/pnpify/eslint/lib/api.js
+++ b/.vscode/pnpify/eslint/lib/api.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {createRequire, createRequireFromPath} = require(`module`);
-const {dirname, resolve} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
@@ -10,10 +10,6 @@ const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require eslint/lib/api.js
 require(absPnpApiPath).setup();
-
-// Prepare the environment (to be ready in case of child_process.spawn etc)
-process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
-process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real eslint/lib/api.js your application uses
 module.exports = absRequire(`eslint/lib/api.js`);

--- a/.vscode/pnpify/typescript/bin/tsc
+++ b/.vscode/pnpify/typescript/bin/tsc
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {createRequire, createRequireFromPath} = require(`module`);
-const {dirname, resolve} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
@@ -10,10 +10,6 @@ const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require typescript/bin/tsc
 require(absPnpApiPath).setup();
-
-// Prepare the environment (to be ready in case of child_process.spawn etc)
-process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
-process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real typescript/bin/tsc your application uses
 module.exports = absRequire(`typescript/bin/tsc`);

--- a/.vscode/pnpify/typescript/bin/tsserver
+++ b/.vscode/pnpify/typescript/bin/tsserver
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {createRequire, createRequireFromPath} = require(`module`);
-const {dirname, resolve} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
@@ -10,10 +10,6 @@ const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require typescript/bin/tsserver
 require(absPnpApiPath).setup();
-
-// Prepare the environment (to be ready in case of child_process.spawn etc)
-process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
-process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real typescript/bin/tsserver your application uses
 module.exports = absRequire(`typescript/bin/tsserver`);

--- a/.vscode/pnpify/typescript/lib/tsc.js
+++ b/.vscode/pnpify/typescript/lib/tsc.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {createRequire, createRequireFromPath} = require(`module`);
-const {dirname, resolve} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
@@ -10,10 +10,6 @@ const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require typescript/lib/tsc.js
 require(absPnpApiPath).setup();
-
-// Prepare the environment (to be ready in case of child_process.spawn etc)
-process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
-process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real typescript/lib/tsc.js your application uses
 module.exports = absRequire(`typescript/lib/tsc.js`);

--- a/.vscode/pnpify/typescript/lib/tsserver.js
+++ b/.vscode/pnpify/typescript/lib/tsserver.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const {createRequire, createRequireFromPath} = require(`module`);
-const {dirname, resolve} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../../.pnp.js";
 
@@ -10,10 +10,6 @@ const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 // Setup the environment to be able to require typescript/lib/tsserver.js
 require(absPnpApiPath).setup();
-
-// Prepare the environment (to be ready in case of child_process.spawn etc)
-process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
-process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
 
 // Defer to the real typescript/lib/tsserver.js your application uses
 module.exports = absRequire(`typescript/lib/tsserver.js`);

--- a/.yarn/versions/a8210a0e.yml
+++ b/.yarn/versions/a8210a0e.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Setting the `NODE_OPTIONS` environment value has adverse effects on ... npm, which VSCode is using when putting the mouse over a dependency name in a `package.json`. I haven't investigated why although I'd be curious to know what might cause a problem.

**How did you fix it?**

Since we don't actually seem to need `NODE_OPTIONS` (tested without it locally) it's now disabled by default in the SDK.
