### PR TITLE
normalize npm registries with trailing slash

### DIFF
--- a/.yarn/versions/b434333c.yml
+++ b/.yarn/versions/b434333c.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-npm": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
@@ -149,9 +149,9 @@ describe(`Auth tests`, () => {
         await writeFile(`${path}/.yarnrc.yml`, [
           `npmScopes:`,
           `  private:`,
-          `    npmRegistryServer: "${url}/"`, // Testing the trailing `/`
+          `    npmRegistryServer: "${url}"`,
           `npmRegistries:`,
-          `  "${url}":`,
+          `  "${url}/":`,  // Testing the trailing `/`
           `    npmAuthToken: ${AUTH_TOKEN}`,
         ].join(`\n`));
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
@@ -1,5 +1,6 @@
 const {
   fs: {writeFile},
+  tests: {startPackageServer},
 } = require('pkg-tests-core');
 
 const AUTH_TOKEN = `686159dc-64b3-413e-a244-2de2b8d1c36f`;
@@ -125,6 +126,34 @@ describe(`Auth tests`, () => {
       },
       async ({path, run, source}) => {
         await writeFile(`${path}/.yarnrc.yml`, `npmAuthIdent: "${AUTH_IDENT}"\n`);
+
+        await run(`install`);
+
+        await expect(source(`require('@private/package')`)).resolves.toMatchObject({
+          name: `@private/package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  test(
+    `it should normalize registries url keys`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmScopes:`,
+          `  private:`,
+          `    npmRegistryServer: "${url}/"`, // Testing the trailing `/`
+          `npmRegistries:`,
+          `  "${url}":`,
+          `    npmAuthToken: ${AUTH_TOKEN}`,
+        ].join(`\n`));
 
         await run(`install`);
 

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -63,6 +63,7 @@ const plugin: Plugin = {
     npmRegistries: {
       description: `Settings per registry`,
       type: SettingsType.MAP,
+      normalizeKeys: key => key.replace(/\/$/, ``),
       valueDefinition: {
         description: ``,
         type: SettingsType.SHAPE,

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -63,7 +63,7 @@ const plugin: Plugin = {
     npmRegistries: {
       description: `Settings per registry`,
       type: SettingsType.MAP,
-      normalizeKeys: key => key.replace(/\/$/, ``),
+      normalizeKeys: npmConfigUtils.normalizeRegistry,
       valueDefinition: {
         description: ``,
         type: SettingsType.SHAPE,

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -9,7 +9,7 @@ export interface MapLike {
   get(key: string): any;
 }
 
-function normalizeRegistry(registry: string) {
+export function normalizeRegistry(registry: string) {
   return registry.replace(/\/$/, ``);
 }
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -107,6 +107,7 @@ export type ShapeSettingsDefinition = BaseSettingsDefinition<SettingsType.SHAPE>
 
 export type MapSettingsDefinition = BaseSettingsDefinition<SettingsType.MAP> & {
   valueDefinition: SettingsDefinitionNoDefault,
+  normalizeKeys?: (key: string) => string,
 };
 
 export type SimpleSettingsDefinition = BaseSettingsDefinition<Exclude<SettingsType, SettingsType.SHAPE | SettingsType.MAP>> & {
@@ -421,13 +422,14 @@ function parseMap(configuration: Configuration, path: string, value: unknown, de
     return result;
 
   for (const [propKey, propValue] of Object.entries(value)) {
-    const subPath = `${path}['${propKey}']`;
+    const normalizedKey = definition.normalizeKeys? definition.normalizeKeys(propKey) : propKey;
+    const subPath = `${path}['${normalizedKey}']`;
 
     // @ts-ignore: SettingsDefinitionNoDefault has ... no default ... but
     // that's fine because we're guaranteed it's not undefined.
     const valueDefinition: SettingsDefinition = definition.valueDefinition;
 
-    result.set(propKey, parseValue(configuration, subPath, propValue, valueDefinition, folder));
+    result.set(normalizedKey, parseValue(configuration, subPath, propValue, valueDefinition, folder));
   }
 
   return result;


### PR DESCRIPTION
**What's the problem this PR addresses?**
We were normalizing `npmRegistryServer` when reading from config, which caused mismatch for `npmRegistries` keys ending with trailing `/`

**How did you fix it?**
Added a `normalizeKeys` fn and normalize `npmRegistries` keys.

Related: https://github.com/yarnpkg/berry/issues/760