### PR TITLE
feat(compat): add @pm2/agent to extensions

### DIFF
--- a/.yarn/versions/b851b003.yml
+++ b/.yarn/versions/b851b003.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/doctor": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+  "@yarnpkg/plugin-dlx": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"

--- a/.yarn/versions/b851b003.yml
+++ b/.yarn/versions/b851b003.yml
@@ -1,11 +1,11 @@
 releases:
   "@yarnpkg/cli": prerelease
-  "@yarnpkg/doctor": prerelease
   "@yarnpkg/plugin-compat": prerelease
-  "@yarnpkg/plugin-dlx": prerelease
 
 declined:
+  - "@yarnpkg/doctor"
   - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -17,4 +17,10 @@ export const packageExtensions: Array<[string, any]> = [
       [`zenObservable`]: `*`,
     },
   }],
+  // https://github.com/keymetrics/pm2-io-agent/pull/125
+  [`@pm2/agent@*`, {
+    dependencies: {
+      [`debug`]: `*`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Can't use `@pm2/agent` because it doesn't declare `debug` as a dependency
Closes https://github.com/yarnpkg/berry/issues/795

**How did you fix it?**

Added `debug` as a dependency of `@pm2/agent` in `plugin-compat`'s extensions
