### PR TITLE
Reuse seo keywords in all pages

### DIFF
--- a/packages/gatsby/src/components/seo.js
+++ b/packages/gatsby/src/components/seo.js
@@ -10,6 +10,8 @@ import PropTypes                 from 'prop-types';
 import Helmet                    from 'react-helmet';
 import React                     from 'react';
 
+export const defaultKeywords = [`package manager`, `yarn`, `yarnpkg`, `configuration`, `yarnrc`];
+
 export function SEO({description, lang, meta, keywords, title}) {
   const {site} = useStaticQuery(
     graphql`

--- a/packages/gatsby/src/pages/configuration/manifest.js
+++ b/packages/gatsby/src/pages/configuration/manifest.js
@@ -4,14 +4,14 @@ import {JsonContainer, JsonMain, JsonScalar}   from '../../components/json';
 import {JsonArrayProperty, JsonObjectProperty} from '../../components/json';
 import {JsonScalarProperty}                    from '../../components/json';
 import {ConfigurationLayout}                   from '../../components/layout-configuration';
-import {SEO}                                   from '../../components/seo';
+import {SEO, defaultKeywords}                  from '../../components/seo';
 
 const PackageJsonDoc = () => <>
   <ConfigurationLayout>
     <SEO
       title={`Manifest fields`}
       description={`List of all the supported fields for a Yarn project manifest (package.json files)`}
-      keywords={[`package manager`, `yarn`, `yarnpkg`, `configuration`, `package.json`]}
+      keywords={defaultKeywords}
     />
     <JsonContainer>
       <JsonMain>

--- a/packages/gatsby/src/pages/configuration/yarnrc.js
+++ b/packages/gatsby/src/pages/configuration/yarnrc.js
@@ -10,7 +10,7 @@ const YarnrcDoc = () => <>
     <SEO
       title={`Configuration options`}
       description={`List of all the configuration option for Yarn (yarnrc files)`}
-      keywords={[defaultKeywords]}
+      keywords={defaultKeywords}
     />
     <SymlContainer>
       <SymlMain>

--- a/packages/gatsby/src/pages/configuration/yarnrc.js
+++ b/packages/gatsby/src/pages/configuration/yarnrc.js
@@ -1,7 +1,7 @@
 import React                                                    from 'react';
 
 import {ConfigurationLayout}                                    from '../../components/layout-configuration';
-import {SEO}                                                    from '../../components/seo';
+import {SEO, defaultKeywords}                                   from '../../components/seo';
 import {SymlObjectProperty, SymlScalarProperty}                 from '../../components/syml';
 import {SymlContainer, SymlMain, SymlArrayProperty, SymlScalar} from '../../components/syml';
 
@@ -10,7 +10,7 @@ const YarnrcDoc = () => <>
     <SEO
       title={`Configuration options`}
       description={`List of all the configuration option for Yarn (yarnrc files)`}
-      keywords={[`package manager`, `yarn`, `yarnpkg`, `configuration`, `yarnrc`]}
+      keywords={[defaultKeywords]}
     />
     <SymlContainer>
       <SymlMain>

--- a/packages/gatsby/src/pages/index.js
+++ b/packages/gatsby/src/pages/index.js
@@ -7,7 +7,7 @@ import {Layout}                                from '../components/layout';
 import {ifDesktop, ifMobile}                   from '../components/responsive';
 import {SearchProvider}                        from '../components/search';
 import {SearchBar, SearchResults, withUrlSync} from '../components/search';
-import {SEO}                                   from '../components/seo';
+import {SEO, defaultKeywords}                  from '../components/seo';
 import agendaIcon                              from '../images/homeicons/agenda.svg';
 import laptopIcon                              from '../images/homeicons/laptop.svg';
 import noteIcon                                from '../images/homeicons/note.svg';
@@ -146,7 +146,7 @@ const IndexPage = ({data, searchState, onSearchStateChange}) => {
           </Header>
         }
       >
-        <SEO title="Home" keywords={[`gatsby`, `application`, `react`]} />
+        <SEO title="Home" keywords={[defaultKeywords]} />
 
         <SearchResults
           onTagClick={tag => setTags([...tags, tag])}

--- a/packages/gatsby/src/pages/index.js
+++ b/packages/gatsby/src/pages/index.js
@@ -146,7 +146,7 @@ const IndexPage = ({data, searchState, onSearchStateChange}) => {
           </Header>
         }
       >
-        <SEO title="Home" keywords={[defaultKeywords]} />
+        <SEO title="Home" keywords={defaultKeywords} />
 
         <SearchResults
           onTagClick={tag => setTags([...tags, tag])}

--- a/packages/gatsby/src/pages/package.js
+++ b/packages/gatsby/src/pages/package.js
@@ -5,7 +5,7 @@ import {Details}                                               from '../componen
 import {Header}                                                from '../components/header';
 import {Layout}                                                from '../components/layout';
 import {SearchProvider, SearchBar, SearchResults, withUrlSync} from '../components/search';
-import {SEO}                                                   from '../components/seo';
+import {SEO, defaultKeywords}                                  from '../components/seo';
 
 const Hero = styled.div`
   position: relative;
@@ -66,7 +66,7 @@ const PackagePage = ({searchState, onSearchStateChange}) => {
           </Header>
         }
       >
-        <SEO title="Home" keywords={[`gatsby`, `application`, `react`]} />
+        <SEO title="Home" keywords={[defaultKeywords]} />
 
         <SearchResults
           onTagClick={tag => setTags([...tags, tag])}

--- a/packages/gatsby/src/pages/package.js
+++ b/packages/gatsby/src/pages/package.js
@@ -66,7 +66,7 @@ const PackagePage = ({searchState, onSearchStateChange}) => {
           </Header>
         }
       >
-        <SEO title="Home" keywords={[defaultKeywords]} />
+        <SEO title="Home" keywords={defaultKeywords} />
 
         <SearchResults
           onTagClick={tag => setTags([...tags, tag])}


### PR DESCRIPTION
**What's the problem this PR addresses?**

The SEO for the website is inconsistent and contains default values from Gatsby.

![Screen Shot 2020-01-27 at 10 39 55 PM](https://user-images.githubusercontent.com/558752/73217030-6f179c80-4157-11ea-9619-67c124f9e04d.png)

**How did you fix it?**

Define a constant to be reused in all pages. 