### PR TITLE
docs: fix typo in migration.md

### DIFF
--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -91,7 +91,7 @@ Yarn 2 uses a different style of configuration files than Yarn 1. While mostly i
 
   - Custom registries are now configured via [`npmRegistryServer`](/configuration/yarnrc#npmRegistryServer).
 
-  - Registry authentication tokens are now configuration via [`npmAuthToken`](/configuration/yarnrc#npmAuthToken).
+  - Registry authentication tokens are now configured via [`npmAuthToken`](/configuration/yarnrc#npmAuthToken).
 
   - The `yarn-offline-mirror` has been removed, since the offline mirror has been merged with the cache as part of the [Zero-Install effort](/features/zero-installs). Just commit the Yarn cache and you're ready to go.
 


### PR DESCRIPTION
Maybe this line
```
yarn policies set-version berry
```
could be added to the migration guide? 🤔 
I mean it's in getting started, yet could make things even easier 😁

**What's the problem this PR addresses?**

...

**How did you fix it?**

...
