### PR TITLE
 feat(compat): add vue-cli-plugin-vuetify and @vuetify/cli-plugin-utils to extensions

### DIFF
--- a/.yarn/versions/1f774814.yml
+++ b/.yarn/versions/1f774814.yml
@@ -1,3 +1,21 @@
 releases:
   "@yarnpkg/cli": prerelease
   "@yarnpkg/plugin-compat": prerelease
+
+declined:
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"

--- a/.yarn/versions/1f774814.yml
+++ b/.yarn/versions/1f774814.yml
@@ -1,0 +1,3 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-compat": prerelease

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -23,4 +23,16 @@ export const packageExtensions: Array<[string, any]> = [
       [`debug`]: `*`,
     },
   }],
+  // https://github.com/vuetifyjs/vue-cli-plugins/pull/155
+  [`vue-cli-plugin-vuetify@*`, {
+    dependencies: {
+      [`semver`]: `*`,
+    },
+  }],
+  // https://github.com/vuetifyjs/vue-cli-plugins/pull/155
+  [`@vuetify/cli-plugin-utils@*`, {
+    dependencies: {
+      [`semver`]: `*`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
`vue-cli-plugin-vuetify` [depends](https://github.com/vuetifyjs/vue-cli-plugins/blob/5ad63c05fa03b9696546c3a0abe608e5c7ccb485/packages/vue-cli-plugin-vuetify/util/helpers.js#L2) on `semver`, but doesn't declare it as a dependency, which causes Yarn 2 PnP to throw `Error: A package is trying to access another package without the second one being listed as a dependency of the first one` when used inside a project.
`@vuetify/cli-plugin-utils` has [the same issue](https://github.com/vuetifyjs/vue-cli-plugins/blob/5ad63c05fa03b9696546c3a0abe608e5c7ccb485/packages/cli-plugin-utils/index.js#L2).

***

**How did you fix it?**
This PR adds `semver` as a dependency to `vue-cli-plugin-vuetify`, as well as to `@vuetify/cli-plugin-utils` in `plugin-compat`'s `extensions`.
I've also created a PR at https://github.com/vuetifyjs/vue-cli-plugins/pull/155.