### PR TITLE
Fix news container overlap the logo on mobile

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -17,12 +17,15 @@ const HeaderContainer = styled.div`
 const NewsContainer = styled.div`
   position: relative;
 
-  height: 2.5em;
-
   padding: 0 1em;
 
   text-decoration: none;
   line-height: 2.5em;
+
+  ${ifMobile} {
+    white-space: pre-wrap;
+    line-height: 1.5em;
+  }
 
   background: #2188b6;
   color: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
**What's the problem this PR addresses?**

![Screen Shot 2020-01-28 at 7 55 15 PM](https://user-images.githubusercontent.com/558752/73295639-56b38a80-4208-11ea-97df-fc08153a3c9c.png)

...

**How did you fix it?**

Remove the css properly `height` and reduce `line-height` and wrap the white spaces only on mobile (this might depend of future text)

![Screen Shot 2020-01-28 at 8 00 24 PM](https://user-images.githubusercontent.com/558752/73295896-d6d9f000-4208-11ea-8fbe-dcb2b7ccf373.png)

There are other issues in the home page, but this one looks ugly on mobile.