### PR TITLE
Fix symlink handling in ZipFS

### DIFF
--- a/.yarn/versions/1e97f110.yml
+++ b/.yarn/versions/1e97f110.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/fslib": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -533,7 +533,9 @@ export class ZipFS extends BasePortableFakeFS {
 
       const type = this.listings.has(p)
         ? S_IFDIR
-        : S_IFREG;
+        : this.isSymbolicLink(entry)
+          ? S_IFLNK
+          : S_IFREG;
 
       const defaultMode = type === S_IFDIR
         ? 0o755
@@ -627,7 +629,7 @@ export class ZipFS extends BasePortableFakeFS {
       if (!resolveLastComponent)
         break;
 
-      const index = this.libzip.name.locate(this.zip, resolvedP);
+      const index = this.libzip.name.locate(this.zip, resolvedP.slice(1));
       if (index === -1)
         break;
 

--- a/packages/yarnpkg-fslib/tests/ZipFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/ZipFS.test.ts
@@ -1,0 +1,82 @@
+import {getLibzipSync}                   from '@yarnpkg/libzip';
+import {Stats}                           from 'fs';
+
+import {PortablePath, ppath, toFilename} from '../sources/path';
+import {xfs, ZipFS}                      from '../sources';
+
+describe(`ZipFS`, () => {
+  it(`should handle symlink correctly`, () => {
+    const expectSameStats = (a: Stats, b: Stats) => {
+      expect(a.ino).toEqual(b.ino);
+      expect(a.size).toEqual(b.size);
+      expect(a.mode).toEqual(b.mode);
+      expect(a.atimeMs).toEqual(b.atimeMs);
+      expect(a.mtimeMs).toEqual(b.mtimeMs);
+      expect(a.ctimeMs).toEqual(b.ctimeMs);
+      expect(a.birthtimeMs).toEqual(b.birthtimeMs);
+      expect(a.isFile()).toEqual(a.isFile());
+      expect(a.isDirectory()).toEqual(a.isDirectory());
+      expect(a.isSymbolicLink()).toEqual(a.isSymbolicLink());
+    };
+
+    const asserts = (zipFs: ZipFS) => {
+      const dir = zipFs.statSync("/dir" as PortablePath);
+      expect(dir.isFile()).toBeFalsy();
+      expect(dir.isDirectory()).toBeTruthy();
+      expect(dir.isSymbolicLink()).toBeFalsy();
+
+      const file = zipFs.statSync("/dir/file" as PortablePath);
+      expect(file.isFile()).toBeTruthy();
+      expect(file.isDirectory()).toBeFalsy();
+      expect(file.isSymbolicLink()).toBeFalsy();
+
+      expectSameStats(zipFs.lstatSync("/dir/file" as PortablePath), file);
+      expectSameStats(zipFs.lstatSync("/dir" as PortablePath), dir);
+
+      expectSameStats(zipFs.statSync("/linkToFileA" as PortablePath), file);
+      expectSameStats(zipFs.statSync("/linkToFileB" as PortablePath), file);
+      expectSameStats(zipFs.statSync("/linkToDirA/file" as PortablePath), file);
+      expectSameStats(zipFs.statSync("/linkToDirB/file" as PortablePath), file);
+
+      expectSameStats(zipFs.statSync("/linkToCwd/linkToCwd/linkToCwd/linkToCwd/dir/file" as PortablePath), file);
+
+      expectSameStats(zipFs.statSync("/linkToDirA" as PortablePath), dir);
+      expectSameStats(zipFs.statSync("/linkToDirB" as PortablePath), dir);
+      expectSameStats(zipFs.statSync("/linkToCwd/linkToCwd/linkToCwd/linkToCwd/linkToDirA" as PortablePath), dir);
+
+      expectSameStats(zipFs.lstatSync("/linkToDirA/file" as PortablePath), file);
+      expectSameStats(zipFs.lstatSync("/linkToDirB/file" as PortablePath), file);
+      expectSameStats(zipFs.lstatSync("/linkToCwd/linkToCwd/linkToCwd/linkToCwd/dir/file" as PortablePath), file);
+
+      const linkToDirA = zipFs.lstatSync("/linkToDirA" as PortablePath);
+      expect(linkToDirA.isFile()).toBeFalsy();
+      expect(linkToDirA.isDirectory()).toBeFalsy();
+      expect(linkToDirA.isSymbolicLink()).toBeTruthy();
+
+      const linkToDirB = zipFs.lstatSync("/linkToDirB" as PortablePath);
+      expect(linkToDirB.isFile()).toBeFalsy();
+      expect(linkToDirB.isDirectory()).toBeFalsy();
+      expect(linkToDirB.isSymbolicLink()).toBeTruthy();
+    };
+
+    const libzip = getLibzipSync();
+    const tmpfile = ppath.resolve(xfs.mktempSync(), toFilename("test.zip"));
+    const zipFs = new ZipFS(tmpfile, {libzip, create: true});
+
+    zipFs.mkdirPromise("/dir" as PortablePath);
+    zipFs.writeFileSync("/dir/file" as PortablePath, "file content");
+
+    zipFs.symlinkSync("dir/file" as PortablePath, "linkToFileA" as PortablePath);
+    zipFs.symlinkSync("./dir/file" as PortablePath, "linkToFileB" as PortablePath);
+    zipFs.symlinkSync("dir" as PortablePath, "linkToDirA" as PortablePath);
+    zipFs.symlinkSync("./dir" as PortablePath, "linkToDirB" as PortablePath);
+    zipFs.symlinkSync("." as PortablePath, "linkToCwd" as PortablePath);
+
+    // asserts(zipFs);
+    zipFs.saveAndClose();
+
+    const zipFs2 = new ZipFS(tmpfile, {libzip});
+    asserts(zipFs2);
+    zipFs2.discardAndClose();
+  });
+});

--- a/packages/yarnpkg-fslib/tests/ZipFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/ZipFS.test.ts
@@ -37,7 +37,6 @@ describe(`ZipFS`, () => {
       expectSameStats(zipFs.statSync("/linkToFileB" as PortablePath), file);
       expectSameStats(zipFs.statSync("/linkToDirA/file" as PortablePath), file);
       expectSameStats(zipFs.statSync("/linkToDirB/file" as PortablePath), file);
-
       expectSameStats(zipFs.statSync("/linkToCwd/linkToCwd/linkToCwd/linkToCwd/dir/file" as PortablePath), file);
 
       expectSameStats(zipFs.statSync("/linkToDirA" as PortablePath), dir);
@@ -57,6 +56,27 @@ describe(`ZipFS`, () => {
       expect(linkToDirB.isFile()).toBeFalsy();
       expect(linkToDirB.isDirectory()).toBeFalsy();
       expect(linkToDirB.isSymbolicLink()).toBeTruthy();
+
+      for (const path of [
+        "/linkToFileA",
+        "/linkToFileB",
+        "/linkToDirA/file",
+        "/linkToDirB/file",
+        "/dir/file",
+        "/linkToCwd/linkToCwd/linkToCwd/linkToCwd/dir/file",
+      ])
+        expect(zipFs.readFileSync(path as PortablePath, "utf8")).toEqual("file content");
+
+
+      for (const path of [
+        "/linkToDirA",
+        "/linkToDirB",
+        "/linkToCwd/linkToCwd/linkToCwd/linkToCwd/dir",
+        "/linkToCwd/linkToCwd/linkToCwd/linkToCwd/linkToDirA",
+        "/linkToCwd/linkToCwd/linkToCwd/linkToCwd/linkToDirB",
+      ]) {
+        expect(zipFs.readdirSync(path as PortablePath)).toContain("file");
+      }
     };
 
     const libzip = getLibzipSync();


### PR DESCRIPTION
**What's the problem this PR addresses?**

`zipFs.readFileSync("/a symlink")` returns the symlink target instead of the file content targeted by the symlink.

**How did you fix it?**

`zip_name_locate` uses paths without leading slash. Remote the slash. Also, fix the `statImpl` to return `S_IFLNK`.