### PR TITLE
Improve navigation of website (specially on mobile)

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -85,6 +85,12 @@ const MenuLogo = styled(Link)`
 
   padding: 0 1em;
 
+  ${ifDesktop} {
+    &:hover {
+      background: hsl(204, 33%, 96%);
+    }
+  }
+
   ${ifMobile} {
     margin-right: auto;
 
@@ -135,6 +141,11 @@ const MenuNavigation = styled.div`
 `;
 
 const MenuEntry = styled.div`
+  ${ifDesktop} {
+    &:hover {
+      background: hsl(204, 33%, 96%);
+    }
+  }
   a {
     display: flex;
     align-items: center;

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -72,7 +72,7 @@ const MenuContainer = styled.header`
 
   ${ifDesktop} {
     display: flex;
-    border-bottom: 4px solid #d1dee8;
+    border-bottom: 2px solid #d1dee8;
   }
 `;
 
@@ -127,7 +127,7 @@ const MenuNavigation = styled.div`
 
   ${ifMobile} {
     position: absolute;
-    z-index: 1;
+    z-index: 2;
 
     width: 100%;
 
@@ -153,7 +153,7 @@ const MenuEntry = styled.div`
 
     height: 4rem;
 
-    border: 3px solid transparent;
+    border: 4px solid transparent;
 
     padding: 0 1em;
 

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -100,9 +100,14 @@ const MenuLogo = styled(Link)`
 `;
 
 const MenuToggle = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   margin: 1em;
   margin-left: 0;
 
+  color: grey;
   border: 1px solid lightgrey;
   border-radius: 10px;
 
@@ -137,6 +142,7 @@ const MenuNavigation = styled.div`
 
     &.expanded {
       transform: scaleY(1);
+      box-shadow: 0px 6px 6px 0px rgba(0, 0, 0, 0.1);
     }
   }
 `;
@@ -223,7 +229,7 @@ export const Header = ({children}) => {
             <Logo height={`3em`} align={`middle`} />
           </MenuLogo>
           <MenuToggle onClick={() => setExpanded(!expanded)}>
-            {`≡`}
+            {expanded ? `×` : `≡`}
           </MenuToggle>
         </MenuTools>
 

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -72,6 +72,7 @@ const MenuContainer = styled.header`
 
   ${ifDesktop} {
     display: flex;
+    border-bottom: 4px solid #d1dee8;
   }
 `;
 

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -72,7 +72,6 @@ const MenuContainer = styled.header`
 
   ${ifDesktop} {
     display: flex;
-    border-bottom: 2px solid #d1dee8;
   }
 `;
 

--- a/packages/gatsby/src/components/layout-content-nav.js
+++ b/packages/gatsby/src/components/layout-content-nav.js
@@ -3,16 +3,9 @@ import React        from 'react';
 
 import {Layout}     from './layout';
 import {Navigation} from './navigation';
-import {ifDesktop}  from './responsive';
 
 const Container = styled.div`
   padding: 2em;
-
-  ${ifDesktop} {
-    border-top: 1px solid #cfdee9;
-
-    text-align: justify;
-  }
 `;
 
 export const LayoutContentNav = ({items, children}) => {

--- a/packages/gatsby/src/components/layout-content-nav.js
+++ b/packages/gatsby/src/components/layout-content-nav.js
@@ -1,14 +1,17 @@
-import styled       from '@emotion/styled';
-import React        from 'react';
+import styled                from '@emotion/styled';
+import React                 from 'react';
 
-import {Layout}     from './layout';
-import {Navigation} from './navigation';
-import {ifMobile}   from './responsive';
+import {Layout}              from './layout';
+import {Navigation}          from './navigation';
+import {ifMobile, ifDesktop} from './responsive';
 
 const Container = styled.div`
   padding: 2em;
   ${ifMobile} {
     padding: 1em;
+  }
+  ${ifDesktop} {
+    border-top: 1px solid #cfdee9;
   }
 `;
 

--- a/packages/gatsby/src/components/layout-content-nav.js
+++ b/packages/gatsby/src/components/layout-content-nav.js
@@ -3,9 +3,13 @@ import React        from 'react';
 
 import {Layout}     from './layout';
 import {Navigation} from './navigation';
+import {ifMobile}   from './responsive';
 
 const Container = styled.div`
   padding: 2em;
+  ${ifMobile} {
+    padding: 1em;
+  }
 `;
 
 export const LayoutContentNav = ({items, children}) => {

--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -14,8 +14,6 @@ const Title = styled.h1`
 
   margin: 0;
 
-  height: 4rem;
-
   border-bottom: 1px solid;
 
   font-weight: 300;

--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -77,8 +77,6 @@ const Content = styled.div`
   }
 
   h2, h3, h4 {
-    border-bottom: 1px solid #d1dee8;
-
     padding-bottom: 0.2em;
 
     font-weight: 300;

--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -53,7 +53,7 @@ const Content = styled.div`
   }
 
   p, table {
-    margin-bottom: 1em;
+    margin-bottom: 1.2em;
   }
 
   table {

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -42,8 +42,13 @@ const MenuEntry = styled(Link)`
 
   text-decoration: none;
 
-  background: #ffffff;
   color: #333333;
+  background: #ffffff;
+  ${ifDesktop} {
+    &:hover {
+      background: hsl(204, 33%, 96%);
+    }
+  }
 
   &::before {
     content: "";

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -23,7 +23,7 @@ const Menu = styled.div`
     height: calc(100vh - 6.5em);
     overflow-y: auto;
 
-    padding-right: 3px;
+    padding-right: 4px;
     background: #d1dee8;
   }
   ${ifMobile} {

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -23,15 +23,14 @@ const Menu = styled.div`
     height: calc(100vh - 6.5em);
     overflow-y: auto;
 
+    padding-right: 3px;
     background: #d1dee8;
   }
 `;
 
 const MenuEntry = styled(Link)`
   display: flex;
-  position: relative;
   align-items: center;
-
 
   padding: 1em;
 
@@ -39,28 +38,16 @@ const MenuEntry = styled(Link)`
 
   color: #333333;
   background: #ffffff;
+
   ${ifDesktop} {
     &:hover {
       background: hsl(204, 33%, 96%);
     }
   }
 
-  &::before {
-    content: "";
-
-    position: absolute;
-    z-index: 1;
-    top: -1px;
-    bottom: -1px;
-    right: 0;
-
-    width: 5px;
-
-    background: #cfdee9;
-  }
-
-  &.active::before {
-    background: #2188b6;
+  border: 4px solid transparent;
+  &.active {
+    border-right-color #2188b6;
   }
 `;
 

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -19,7 +19,7 @@ const Menu = styled.div`
     position: fixed;
     left: 0;
 
-    width: 300px;
+    width: 260px;
     height: calc(100vh - 6.5em);
     overflow-y: auto;
 
@@ -32,13 +32,8 @@ const MenuEntry = styled(Link)`
   position: relative;
   align-items: center;
 
-  border-bottom: 1px solid #cfdee9;
 
-  &:first-of-type {
-    border-top: 1px solid #cfdee9;
-  }
-
-  padding: 1.5em;
+  padding: 1em;
 
   text-decoration: none;
 

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -1,10 +1,10 @@
-import styled      from '@emotion/styled';
-import {Link}      from 'gatsby';
-import React       from 'react';
+import styled                from '@emotion/styled';
+import {Link}                from 'gatsby';
+import React                 from 'react';
 
-import useScroll   from '../utils/useScroll';
+import useScroll             from '../utils/useScroll';
 
-import {ifDesktop} from './responsive';
+import {ifDesktop, ifMobile} from './responsive';
 
 const Container = styled.div`
   position: relative;
@@ -26,13 +26,17 @@ const Menu = styled.div`
     padding-right: 3px;
     background: #d1dee8;
   }
+  ${ifMobile} {
+    display: flex;
+    overflow-x: auto;
+    padding-left: 1em;
+    padding-right: 1em;
+  }
 `;
 
 const MenuEntry = styled(Link)`
   display: flex;
   align-items: center;
-
-  padding: 1em;
 
   text-decoration: none;
 
@@ -40,14 +44,25 @@ const MenuEntry = styled(Link)`
   background: #ffffff;
 
   ${ifDesktop} {
+    padding: 1em;
     &:hover {
       background: hsl(204, 33%, 96%);
     }
   }
 
+  ${ifMobile} {
+    padding: .5em;
+    white-space: pre;
+  }
+
   border: 4px solid transparent;
   &.active {
-    border-right-color #2188b6;
+    ${ifDesktop} {
+      border-right-color #2188b6;
+    }
+    ${ifMobile} {
+      border-bottom-color #2188b6;
+    }
   }
 `;
 

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -10,7 +10,7 @@ const Container = styled.div`
   position: relative;
 
   ${ifDesktop} {
-    padding-left: 300px;
+    padding-left: 260px;
   }
 `;
 
@@ -45,23 +45,39 @@ const MenuEntry = styled(Link)`
 
   ${ifDesktop} {
     padding: 1em;
+    position: relative;
+
+    &:first-of-type {
+      border-top: 1px solid #cfdee9;
+    }
     &:hover {
       background: hsl(204, 33%, 96%);
     }
-  }
 
+    &::before {
+      content: "";
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      bottom: 0;
+      left: 100%;
+      width: 4px;
+      background: transparent;
+    }
+    &:first-of-type::before {
+      top: -1px;
+    }
+    &.active::before {
+      background: #2188b6;
+    }
+  }
   ${ifMobile} {
     padding: .5em;
     white-space: pre;
-  }
-
-  border: 4px solid transparent;
-  &.active {
-    ${ifDesktop} {
-      border-right-color #2188b6;
-    }
-    ${ifMobile} {
-      border-bottom-color #2188b6;
+    border-bottom: 4px solid transparent;
+    &.active {
+        border-bottom-color #2188b6;
+      }
     }
   }
 `;

--- a/packages/gatsby/src/components/syml.js
+++ b/packages/gatsby/src/components/syml.js
@@ -13,7 +13,7 @@ import {
 
 const theme = {
   colors: {
-    background: `#242424`,
+    background: `#3f3f3f`,
     documentation: `#ddddcc`,
     highlight: `#716f6f`,
     code: `#639db1`,

--- a/packages/gatsby/src/components/syml.js
+++ b/packages/gatsby/src/components/syml.js
@@ -13,7 +13,7 @@ import {
 
 const theme = {
   colors: {
-    background: `#3f3f3f`,
+    background: `#242424`,
     documentation: `#ddddcc`,
     highlight: `#716f6f`,
     code: `#639db1`,


### PR DESCRIPTION
## Various visual improvements • [preview](https://deploy-preview-842--yarn2.netlify.com/)

### Main structure

- reduce the size of menu item
  - takes less space
    - width: 300px -> 260px
    - padding: 1.5em -> 1em
  - more readable
- [use fewer borders](https://twitter.com/steveschoger/status/897849211110273024)
- unify marker of top nav and of side menu
- add hover behavior
- [avoid using text justify](https://designforhackers.com/blog/justify-text-html-css/)

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73415379-aca73180-42df-11ea-84c0-fd1ab7ddb836.png) | ![image](https://user-images.githubusercontent.com/22725671/73415386-b2047c00-42df-11ea-83de-aa38a0da311a.png)
![image](https://user-images.githubusercontent.com/22725671/73415556-41aa2a80-42e0-11ea-8a79-f70b2a4f3219.png) | ![image](https://user-images.githubusercontent.com/22725671/73415475-03ad0680-42e0-11ea-9e65-c82d947c4acf.png)
![image](https://user-images.githubusercontent.com/22725671/73415564-4969cf00-42e0-11ea-9cdd-ab53aeb940d2.png) | ![image](https://user-images.githubusercontent.com/22725671/73415492-0c054180-42e0-11ea-9012-adaa074beeca.png)
![image](https://user-images.githubusercontent.com/22725671/73415640-7ae29a80-42e0-11ea-8317-f5db1e5e6f66.png) | ![image](https://user-images.githubusercontent.com/22725671/73415654-8209a880-42e0-11ea-9855-c66fb25ef625.png)

### Improve mobile website

- reduce padding of document: 2em -> 1em (only on mobile)
- fix z-index issue with main navigation
- make sub navigation scrollable instead of taking a lot of place on the page
(the padding are set to cut the text and so to highlight that this div is scrollable)
- add shadow on main nav
- use `x` in menu toggle when is open
- center and use a gray color for the content on the menu toggle
- avoid cutting title in their middle

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73415770-ceed7f00-42e0-11ea-8d5e-9d9518f85ac2.png) | ![image](https://user-images.githubusercontent.com/22725671/73416915-512b7280-42e4-11ea-9b87-c68a2e59c24f.png)
![image](https://user-images.githubusercontent.com/22725671/73415790-e0368b80-42e0-11ea-9f42-684a95219080.png) | ![image](https://user-images.githubusercontent.com/22725671/73416920-5983ad80-42e4-11ea-8e2f-69e76b066381.png)
![image](https://user-images.githubusercontent.com/22725671/73417701-0a8b4780-42e7-11ea-834b-62a9bcaf6843.png) | ![image](https://user-images.githubusercontent.com/22725671/73417711-11b25580-42e7-11ea-8aea-f8ec6ac55ecf.png)

<!--

### yarnrc files background

Use same darker background as in `manifests` to increase readability (better contrast)

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73416997-8f289680-42e4-11ea-86df-1bc198881fc2.png) | ![image](https://user-images.githubusercontent.com/22725671/73417002-93ed4a80-42e4-11ea-916d-a913972192aa.png)

-->