### PR TITLE
Fixes authentication when redirected

### DIFF
--- a/.yarn/versions/f7939de5.yml
+++ b/.yarn/versions/f7939de5.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -82,12 +82,12 @@ export async function request(target: string, body: Body, {configuration, header
   const makeHooks = () => ({
     beforeRequest: [
       (options: NormalizedOptions) => {
-        hostname = options.hostname;
+        hostname = options.url.hostname;
       },
     ],
     beforeRedirect: [
       (options: NormalizedOptions) => {
-        if (options.headers && options.headers.authorization && options.hostname !== hostname) {
+        if (options.headers && options.headers.authorization && options.url.hostname !== hostname) {
           delete options.headers.authorization;
         }
       },


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `got@10` upgrade changed how the `hostname` property worked, and that caused one of our checks to be disabled. As a result, the authentication information were forwarded even when switching from an hostname to another. This caused problems on the GitHub Package Registry, which throws 400 when receiving multiple authentication tokens.

Fixes #846 

**How did you fix it?**

Fixed the condition to check the new name for the `hostname` property.
