### PR TITLE
feat: unplug packages with native files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
     "comma-dangle": ["error", "always-multiline"],
     "computed-property-spacing": 2,
     "generator-star-spacing": ["error", {"before": true, "after": true}],
+    "space-before-blocks": 2,
     "keyword-spacing": 2,
     "no-multiple-empty-lines": 2,
     "no-tabs": 2,

--- a/.pnp.js
+++ b/.pnp.js
@@ -15839,7 +15839,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["clipboardy", [
         ["npm:1.2.3", {
-          "packageLocation": "./.yarn/cache/clipboardy-npm-1.2.3-d3a44efb48-1.zip/node_modules/clipboardy/",
+          "packageLocation": "./.yarn/unplugged/clipboardy-npm-1.2.3-d3a44efb48/node_modules/clipboardy/",
           "packageDependencies": [
             ["clipboardy", "npm:1.2.3"],
             ["arch", "npm:2.1.1"],
@@ -26623,7 +26623,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["node-notifier", [
         ["npm:5.4.3", {
-          "packageLocation": "./.yarn/cache/node-notifier-npm-5.4.3-068ef79075-1.zip/node_modules/node-notifier/",
+          "packageLocation": "./.yarn/unplugged/node-notifier-npm-5.4.3-068ef79075/node_modules/node-notifier/",
           "packageDependencies": [
             ["node-notifier", "npm:5.4.3"],
             ["growly", "npm:1.3.0"],
@@ -32644,7 +32644,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["term-size", [
         ["npm:1.2.0", {
-          "packageLocation": "./.yarn/cache/term-size-npm-1.2.0-7629e52ca8-1.zip/node_modules/term-size/",
+          "packageLocation": "./.yarn/unplugged/term-size-npm-1.2.0-7629e52ca8/node_modules/term-size/",
           "packageDependencies": [
             ["term-size", "npm:1.2.0"],
             ["execa", "npm:0.7.0"]

--- a/.yarn/versions/325ffac3.yml
+++ b/.yarn/versions/325ffac3.yml
@@ -1,6 +1,7 @@
 releases:
   "@yarnpkg/fslib": prerelease
   "@yarnpkg/plugin-pnp": prerelease
+  "@yarnpkg/pnpify": prerelease
 
 declined:
   - "@yarnpkg/plugin-constraints"
@@ -28,5 +29,4 @@ declined:
   - "@yarnpkg/doctor"
   - "@yarnpkg/json-proxy"
   - "@yarnpkg/pnp"
-  - "@yarnpkg/pnpify"
   - "@yarnpkg/shell"

--- a/.yarn/versions/325ffac3.yml
+++ b/.yarn/versions/325ffac3.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/fslib": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/FakeFS.ts
+++ b/packages/yarnpkg-fslib/sources/FakeFS.ts
@@ -51,6 +51,10 @@ export type Watcher = {
   close: () => void;
 };
 
+export type ExtractHintOptions = {
+  relevantExtensions: Set<string>;
+}
+
 export abstract class FakeFS<P extends Path> {
   static DEFAULT_TIME = 315532800;
 
@@ -59,6 +63,8 @@ export abstract class FakeFS<P extends Path> {
   protected constructor(pathUtils: PathUtils<P>) {
     this.pathUtils =  pathUtils;
   }
+
+  abstract getExtractHint(hints: ExtractHintOptions): boolean;
 
   abstract getRealPath(): P;
 

--- a/packages/yarnpkg-fslib/sources/FakeFS.ts
+++ b/packages/yarnpkg-fslib/sources/FakeFS.ts
@@ -534,6 +534,6 @@ function getEndOfLine(content: string) {
   return crlf > lf ? `\r\n` : `\n`;
 }
 
-export function normalizeLineEndings(originalContent: string, newContent: string){
+export function normalizeLineEndings(originalContent: string, newContent: string) {
   return newContent.replace(/\r?\n/g, getEndOfLine(originalContent));
 }

--- a/packages/yarnpkg-fslib/sources/NoFS.ts
+++ b/packages/yarnpkg-fslib/sources/NoFS.ts
@@ -10,6 +10,10 @@ export class NoFS extends FakeFS<PortablePath> {
     super(ppath);
   }
 
+  getExtractHint(): never{
+    throw makeError();
+  }
+
   getRealPath(): never {
     throw makeError();
   }

--- a/packages/yarnpkg-fslib/sources/NoFS.ts
+++ b/packages/yarnpkg-fslib/sources/NoFS.ts
@@ -10,7 +10,7 @@ export class NoFS extends FakeFS<PortablePath> {
     super(ppath);
   }
 
-  getExtractHint(): never{
+  getExtractHint(): never {
     throw makeError();
   }
 

--- a/packages/yarnpkg-fslib/sources/NodeFS.ts
+++ b/packages/yarnpkg-fslib/sources/NodeFS.ts
@@ -15,6 +15,10 @@ export class NodeFS extends BasePortableFakeFS {
     this.realFs = realFs;
   }
 
+  getExtractHint() {
+    return false;
+  }
+
   getRealPath() {
     return PortablePath.root;
   }

--- a/packages/yarnpkg-fslib/sources/ProxiedFS.ts
+++ b/packages/yarnpkg-fslib/sources/ProxiedFS.ts
@@ -1,7 +1,7 @@
-import {CreateReadStreamOptions, CreateWriteStreamOptions, FakeFS}            from './FakeFS';
-import {Dirent}                                                               from './FakeFS';
-import {MkdirOptions, WriteFileOptions, WatchCallback, WatchOptions, Watcher} from './FakeFS';
-import {FSPath, Filename, Path}                                               from './path';
+import {CreateReadStreamOptions, CreateWriteStreamOptions, FakeFS, ExtractHintOptions} from './FakeFS';
+import {Dirent}                                                                        from './FakeFS';
+import {MkdirOptions, WriteFileOptions, WatchCallback, WatchOptions, Watcher}          from './FakeFS';
+import {FSPath, Filename, Path}                                                        from './path';
 
 export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<P> {
   protected abstract readonly baseFs: FakeFS<IP>;
@@ -15,6 +15,10 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
    * Convert a path from the format supported by the base FS into the user one.
    */
   protected abstract mapFromBase(path: IP): P;
+
+  getExtractHint(hints: ExtractHintOptions){
+    return this.baseFs.getExtractHint(hints);
+  }
 
   resolve(path: P)  {
     return this.mapFromBase(this.baseFs.resolve(this.mapToBase(path)));

--- a/packages/yarnpkg-fslib/sources/ProxiedFS.ts
+++ b/packages/yarnpkg-fslib/sources/ProxiedFS.ts
@@ -16,7 +16,7 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
    */
   protected abstract mapFromBase(path: IP): P;
 
-  getExtractHint(hints: ExtractHintOptions){
+  getExtractHint(hints: ExtractHintOptions) {
     return this.baseFs.getExtractHint(hints);
   }
 

--- a/packages/yarnpkg-fslib/sources/VirtualFS.ts
+++ b/packages/yarnpkg-fslib/sources/VirtualFS.ts
@@ -1,4 +1,4 @@
-import {FakeFS}                        from './FakeFS';
+import {FakeFS, ExtractHintOptions}    from './FakeFS';
 import {NodeFS}                        from './NodeFS';
 import {ProxiedFS}                     from './ProxiedFS';
 import {Filename, PortablePath, ppath} from './path';
@@ -64,6 +64,10 @@ export class VirtualFS extends ProxiedFS<PortablePath, PortablePath> {
     super(ppath);
 
     this.baseFs = baseFs;
+  }
+
+  getExtractHint(hints: ExtractHintOptions) {
+    return this.baseFs.getExtractHint(hints);
   }
 
   getRealPath() {

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -255,7 +255,6 @@ export class ZipFS extends BasePortableFakeFS {
     for (const fileName of this.entries.keys()) {
       const ext = this.pathUtils.extname(fileName);
       if (hints.relevantExtensions.has(ext)){
-        console.log('Unplugging', fileName);
         return true;
       }
     }

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -251,10 +251,10 @@ export class ZipFS extends BasePortableFakeFS {
     this.ready = true;
   }
 
-  getExtractHint(hints: ExtractHintOptions){
+  getExtractHint(hints: ExtractHintOptions) {
     for (const fileName of this.entries.keys()) {
       const ext = this.pathUtils.extname(fileName);
-      if (hints.relevantExtensions.has(ext)){
+      if (hints.relevantExtensions.has(ext)) {
         return true;
       }
     }

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -1,14 +1,14 @@
-import {Libzip}                                                                from '@yarnpkg/libzip';
-import {ReadStream, Stats, WriteStream, constants}                             from 'fs';
-import {PassThrough}                                                           from 'stream';
-import {isDate}                                                                from 'util';
+import {Libzip}                                                                                    from '@yarnpkg/libzip';
+import {ReadStream, Stats, WriteStream, constants}                                                 from 'fs';
+import {PassThrough}                                                                               from 'stream';
+import {isDate}                                                                                    from 'util';
 
-import {CreateReadStreamOptions, CreateWriteStreamOptions, BasePortableFakeFS} from './FakeFS';
-import {FakeFS, MkdirOptions, WriteFileOptions}                                from './FakeFS';
-import {WatchOptions, WatchCallback, Watcher}                                  from './FakeFS';
-import {NodeFS}                                                                from './NodeFS';
-import * as errors                                                             from './errors';
-import {FSPath, PortablePath, npath, ppath, Filename}                          from './path';
+import {CreateReadStreamOptions, CreateWriteStreamOptions, BasePortableFakeFS, ExtractHintOptions} from './FakeFS';
+import {FakeFS, MkdirOptions, WriteFileOptions}                                                    from './FakeFS';
+import {WatchOptions, WatchCallback, Watcher}                                                      from './FakeFS';
+import {NodeFS}                                                                                    from './NodeFS';
+import * as errors                                                                                 from './errors';
+import {FSPath, PortablePath, npath, ppath, Filename}                                              from './path';
 
 const S_IFMT = 0o170000;
 
@@ -249,6 +249,18 @@ export class ZipFS extends BasePortableFakeFS {
     }
 
     this.ready = true;
+  }
+
+  getExtractHint(hints: ExtractHintOptions){
+    for (const fileName of this.entries.keys()) {
+      const ext = this.pathUtils.extname(fileName);
+      if (hints.relevantExtensions.has(ext)){
+        console.log('Unplugging', fileName);
+        return true;
+      }
+    }
+
+    return false;
   }
 
   getAllFiles() {

--- a/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
@@ -64,7 +64,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
     this.notZip = new Set();
   }
 
-  getExtractHint(hints: ExtractHintOptions){
+  getExtractHint(hints: ExtractHintOptions) {
     return this.baseFs.getExtractHint(hints);
   }
 

--- a/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
@@ -1,13 +1,13 @@
-import {Libzip}                                                                from '@yarnpkg/libzip';
-import {constants}                                                             from 'fs';
+import {Libzip}                                                                                    from '@yarnpkg/libzip';
+import {constants}                                                                                 from 'fs';
 
-import {CreateReadStreamOptions, CreateWriteStreamOptions, BasePortableFakeFS} from './FakeFS';
-import {Dirent}                                                                from './FakeFS';
-import {FakeFS, MkdirOptions, WriteFileOptions}                                from './FakeFS';
-import {WatchOptions, WatchCallback, Watcher}                                  from './FakeFS';
-import {NodeFS}                                                                from './NodeFS';
-import {ZipFS}                                                                 from './ZipFS';
-import {Filename, FSPath, PortablePath}                                        from './path';
+import {CreateReadStreamOptions, CreateWriteStreamOptions, BasePortableFakeFS, ExtractHintOptions} from './FakeFS';
+import {Dirent}                                                                                    from './FakeFS';
+import {FakeFS, MkdirOptions, WriteFileOptions}                                                    from './FakeFS';
+import {WatchOptions, WatchCallback, Watcher}                                                      from './FakeFS';
+import {NodeFS}                                                                                    from './NodeFS';
+import {ZipFS}                                                                                     from './ZipFS';
+import {Filename, FSPath, PortablePath}                                                            from './path';
 
 const ZIP_FD = 0x80000000;
 
@@ -62,6 +62,10 @@ export class ZipOpenFS extends BasePortableFakeFS {
 
     this.isZip = new Set();
     this.notZip = new Set();
+  }
+
+  getExtractHint(hints: ExtractHintOptions){
+    return this.baseFs.getExtractHint(hints);
   }
 
   getRealPath() {

--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -13,6 +13,7 @@ export {WatchCallback}            from './FakeFS';
 export {Watcher}                  from './FakeFS';
 export {WriteFileOptions}         from './FakeFS';
 export {normalizeLineEndings}     from './FakeFS';
+export {ExtractHintOptions}       from './FakeFS';
 
 export {FSPath, Path, PortablePath, NativePath, Filename} from './path';
 export {ParsedPath, PathUtils, FormatInputPathObject} from './path';

--- a/packages/yarnpkg-pnp/sources/generateSerializedState.ts
+++ b/packages/yarnpkg-pnp/sources/generateSerializedState.ts
@@ -1,5 +1,5 @@
-import {LocationBlacklistData, LocationLengthData, PackageRegistryData} from './types';
-import {PackageStoreData, PnpSettings, SerializedState}                 from './types';
+import {LocationBlacklistData, PackageRegistryData}     from './types';
+import {PackageStoreData, PnpSettings, SerializedState} from './types';
 
 // Keep this function is sync with its implementation in:
 // @yarnpkg/core/sources/miscUtils.ts

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -1,4 +1,4 @@
-import {Dirent, Filename, MkdirOptions}                    from '@yarnpkg/fslib';
+import {Dirent, Filename, MkdirOptions,ExtractHintOptions} from '@yarnpkg/fslib';
 import {FSPath, NativePath, PortablePath, npath, ppath}    from '@yarnpkg/fslib';
 import {WatchOptions, WatchCallback, Watcher, toFilename}  from '@yarnpkg/fslib';
 import {NodeFS, FakeFS, WriteFileOptions, ProxiedFS}       from '@yarnpkg/fslib';
@@ -84,6 +84,10 @@ export class PortableNodeModulesFS extends FakeFS<PortablePath> {
     for (const fullPath of pathStack.reverse()) {
       this.baseFs.mkdirSync(fullPath);
     }
+  }
+
+  getExtractHint(hints: ExtractHintOptions){
+    return this.baseFs.getExtractHint(hints);
   }
 
   resolve(path: PortablePath) {

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -86,7 +86,7 @@ export class PortableNodeModulesFS extends FakeFS<PortablePath> {
     }
   }
 
-  getExtractHint(hints: ExtractHintOptions){
+  getExtractHint(hints: ExtractHintOptions) {
     return this.baseFs.getExtractHint(hints);
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When using packages with native files (files that wont be used by node directly) they have to be manually unplugged. This is an annoyance for one project but more of a hurdle if package authors have to provide a "and remember to unplug [...]" step. Then there are packages [silently ignoring access failure ](https://github.com/sindresorhus/term-size/blob/9ee61b4972e3f23047ddaca2aa569e7c91f6396f/index.js#L29-L36) causing issues to go unnoticed.

Fixes https://github.com/yarnpkg/berry/issues/663

**How did you fix it?**

Automatically unplug packages if they contain files with an extension matching a predefined set. This set might not match all use-cases but should take care of most of them.

Running on the yarn repo it unplugs three packages because of these files
```
/node_modules/node-notifier/vendor/notifu/notifu.exe
/node_modules/clipboardy/fallbacks/windows/clipboard_i686.exe
/node_modules/term-size/vendor/windows/term-size.exe
```

Running `yarn add electron-builder` now unplugs these packages which had to be manually unplugged to get `electron-builder` to work
```
/node_modules/7zip-bin/win/ia32/7za.exe
/node_modules/app-builder-bin/win/ia32/app-builder.exe
```

---

@SimenB This handles the case you ran into when [testing berry on the Jest repo](https://github.com/facebook/jest/pull/9476). Where `weak-napi` depends on packages with C/C++ files that the compiler tries to read but fails. If this gets merged you can remove the `dependenciesMeta` field