### PR TITLE
feat(plugin-essentials): yarn add --optional

### DIFF
--- a/.yarn/versions/8d1e5cf5.yml
+++ b/.yarn/versions/8d1e5cf5.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/plugin-interactive-tools": prerelease
+  "@yarnpkg/plugin-typescript": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/8d1e5cf5.yml
+++ b/.yarn/versions/8d1e5cf5.yml
@@ -1,19 +1,19 @@
 releases:
   "@yarnpkg/plugin-essentials": prerelease
-  "@yarnpkg/plugin-interactive-tools": prerelease
-  "@yarnpkg/plugin-typescript": prerelease
   "@yarnpkg/cli": prerelease
 
 declined:
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
   - "@yarnpkg/plugin-node-modules"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
   - "@yarnpkg/plugin-pnp"
   - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/core"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -200,16 +200,16 @@ export default class AddCommand extends BaseCommand {
         );
 
         if (this.optional) {
-          if (target === 'dependencies') {
+          if (target === `dependencies`) {
             workspace.manifest.ensureDependencyMeta({
               ...selected,
-              range: 'unknown',
+              range: `unknown`,
             }).optional = true;
           }
-          else if (target === 'peerDependencies') {
+          else if (target === `peerDependencies`) {
             workspace.manifest.ensurePeerDependencyMeta({
               ...selected,
-              range: 'unknown',
+              range: `unknown`,
             }).optional = true;
           }
         }

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -32,6 +32,9 @@ export default class AddCommand extends BaseCommand {
   @Command.Boolean(`-P,--peer`)
   peer: boolean = false;
 
+  @Command.Boolean(`-O,--optional`)
+  optional: boolean = false;
+
   @Command.Boolean(`--prefer-dev`)
   preferDev: boolean = false;
 
@@ -51,6 +54,16 @@ export default class AddCommand extends BaseCommand {
       - If the package was already listed in your dependencies, it will by default be upgraded whether it's part of your \`dependencies\` or \`devDependencies\` (it won't ever update \`peerDependencies\`, though).
 
       - If set, the \`--prefer-dev\` flag will operate as a more flexible \`-D,--dev\` in that it will add the package to your \`devDependencies\` if it isn't already listed in either \`dependencies\` or \`devDependencies\`, but it will also happily upgrade your \`dependencies\` if that's what you already use (whereas \`-D,--dev\` would throw an exception).
+
+      - If set, the \`-O,--optional\` flag will add the package to the \`optionalDependencies\` field and, in combination with the \`-P,--peer\ flag, it will add the package as an optional peer dependency (
+        \`\`\`json
+        "peerDependenciesMeta": {
+          "<package>": {
+            "optional": true
+          }
+        }
+        \`\`\`. If the package was already listed in your dependencies, it will be upgraded to \`optionalDependencies\`.
+      )
 
       - If the added package doesn't specify a range at all its \`latest\` tag will be resolved and the returned version will be used to generate a new semver range (using the \`^\` modifier by default unless otherwise configured via the \`savePrefix\` configuration, or the \`~\` modifier if \`-T,--tilde\` is specified, or no modifier at all if \`-E,--exact\` is specified). Two exceptions to this rule: the first one is that if the package is a workspace then its local version will be used, and the second one is that if you use \`-P,--peer\` the default range will be \`*\` and won't be resolved at all.
 
@@ -114,6 +127,7 @@ export default class AddCommand extends BaseCommand {
         dev: this.dev,
         peer: this.peer,
         preferDev: this.preferDev,
+        optional: this.optional,
       });
 
       const suggestions = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, target, modifier, strategies, maxResults});
@@ -160,7 +174,7 @@ export default class AddCommand extends BaseCommand {
     ]> = [];
 
     for (const [/*request*/, suggestions, target] of allSuggestions) {
-      let selected;
+      let selected: Descriptor;
 
       const nonNullSuggestions = suggestions.filter(suggestion => {
         return suggestion.descriptor !== null;
@@ -192,6 +206,21 @@ export default class AddCommand extends BaseCommand {
           selected.identHash,
           selected,
         );
+
+        if (this.optional) {
+          if (target === 'dependencies') {
+            workspace.manifest.ensureDependencyMeta({
+              ...selected,
+              range: 'unknown',
+            }).optional = true;
+          }
+          else if (target === 'peerDependencies') {
+            workspace.manifest.ensurePeerDependencyMeta({
+              ...selected,
+              range: 'unknown',
+            }).optional = true;
+          }
+        }
 
         if (typeof current === `undefined`) {
           afterWorkspaceDependencyAdditionList.push([
@@ -236,7 +265,7 @@ export default class AddCommand extends BaseCommand {
   }
 }
 
-function suggestTarget(workspace: Workspace, ident: Ident, {dev, peer, preferDev}: {dev: boolean, peer: boolean, preferDev: boolean}) {
+function suggestTarget(workspace: Workspace, ident: Ident, {dev, peer, preferDev, optional}: {dev: boolean, peer: boolean, preferDev: boolean, optional: boolean}) {
   const hasRegular = workspace.manifest[suggestUtils.Target.REGULAR].has(ident.identHash);
   const hasDev = workspace.manifest[suggestUtils.Target.DEVELOPMENT].has(ident.identHash);
   const hasPeer = workspace.manifest[suggestUtils.Target.PEER].has(ident.identHash);
@@ -245,6 +274,15 @@ function suggestTarget(workspace: Workspace, ident: Ident, {dev, peer, preferDev
     throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a regular dependency - remove the -D,-P flags or remove it from your dependencies first`);
   if (!dev && !peer && hasPeer)
     throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a peer dependency - use either of -D or -P, or remove it from your peer dependencies first`);
+
+  if (optional && hasDev)
+    throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a dev dependency - remove the -O flag or remove it from your dev dependencies first`);
+
+  if (optional && hasPeer)
+    throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a peer dependency - remove the -O flag or remove it from your peer dependencies first`);
+
+  if ((dev || preferDev) && optional)
+    throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" cannot simultaneously be a dev dependency and an optional dependency`);
 
   if (peer)
     return suggestUtils.Target.PEER;

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -205,8 +205,7 @@ export default class AddCommand extends BaseCommand {
               ...selected,
               range: `unknown`,
             }).optional = true;
-          }
-          else if (target === `peerDependencies`) {
+          } else if (target === `peerDependencies`) {
             workspace.manifest.ensurePeerDependencyMeta({
               ...selected,
               range: `unknown`,

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -55,15 +55,14 @@ export default class AddCommand extends BaseCommand {
 
       - If set, the \`--prefer-dev\` flag will operate as a more flexible \`-D,--dev\` in that it will add the package to your \`devDependencies\` if it isn't already listed in either \`dependencies\` or \`devDependencies\`, but it will also happily upgrade your \`dependencies\` if that's what you already use (whereas \`-D,--dev\` would throw an exception).
 
-      - If set, the \`-O,--optional\` flag will add the package to the \`optionalDependencies\` field and, in combination with the \`-P,--peer\ flag, it will add the package as an optional peer dependency (
-        \`\`\`json
-        "peerDependenciesMeta": {
-          "<package>": {
-            "optional": true
-          }
+      - If set, the \`-O,--optional\` flag will add the package to the \`optionalDependencies\` field and, in combination with the \`-P,--peer\` flag, it will add the package as an optional peer dependency. If the package was already listed in your \`dependencies\`, it will be upgraded to \`optionalDependencies\`. If the package was already listed in your \`peerDependencies\`, in combination with the \`-P,--peer\` flag, it will be upgraded to an optional peer dependency:
+      \`\`\`json
+      "peerDependenciesMeta": {
+        "<package>": {
+          "optional": true
         }
-        \`\`\`. If the package was already listed in your dependencies, it will be upgraded to \`optionalDependencies\`.
-      )
+      }
+      \`\`\`
 
       - If the added package doesn't specify a range at all its \`latest\` tag will be resolved and the returned version will be used to generate a new semver range (using the \`^\` modifier by default unless otherwise configured via the \`savePrefix\` configuration, or the \`~\` modifier if \`-T,--tilde\` is specified, or no modifier at all if \`-E,--exact\` is specified). Two exceptions to this rule: the first one is that if the package is a workspace then its local version will be used, and the second one is that if you use \`-P,--peer\` the default range will be \`*\` and won't be resolved at all.
 

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -278,11 +278,12 @@ function suggestTarget(workspace: Workspace, ident: Ident, {dev, peer, preferDev
   if (optional && hasDev)
     throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a dev dependency - remove the -O flag or remove it from your dev dependencies first`);
 
-  if (optional && hasPeer)
-    throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a peer dependency - remove the -O flag or remove it from your peer dependencies first`);
+  if (optional && !peer && hasPeer)
+    throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" is already listed as a peer dependency - remove the -O flag or add the -P flag or remove it from your peer dependencies first`);
 
   if ((dev || preferDev) && optional)
     throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" cannot simultaneously be a dev dependency and an optional dependency`);
+
 
   if (peer)
     return suggestUtils.Target.PEER;

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -55,14 +55,7 @@ export default class AddCommand extends BaseCommand {
 
       - If set, the \`--prefer-dev\` flag will operate as a more flexible \`-D,--dev\` in that it will add the package to your \`devDependencies\` if it isn't already listed in either \`dependencies\` or \`devDependencies\`, but it will also happily upgrade your \`dependencies\` if that's what you already use (whereas \`-D,--dev\` would throw an exception).
 
-      - If set, the \`-O,--optional\` flag will add the package to the \`optionalDependencies\` field and, in combination with the \`-P,--peer\` flag, it will add the package as an optional peer dependency. If the package was already listed in your \`dependencies\`, it will be upgraded to \`optionalDependencies\`. If the package was already listed in your \`peerDependencies\`, in combination with the \`-P,--peer\` flag, it will be upgraded to an optional peer dependency:
-      \`\`\`json
-      "peerDependenciesMeta": {
-        "<package>": {
-          "optional": true
-        }
-      }
-      \`\`\`
+      - If set, the \`-O,--optional\` flag will add the package to the \`optionalDependencies\` field and, in combination with the \`-P,--peer\` flag, it will add the package as an optional peer dependency. If the package was already listed in your \`dependencies\`, it will be upgraded to \`optionalDependencies\`. If the package was already listed in your \`peerDependencies\`, in combination with the \`-P,--peer\` flag, it will be upgraded to an optional peer dependency: \`"peerDependenciesMeta": { "<package>": { "optional": true } }\`
 
       - If the added package doesn't specify a range at all its \`latest\` tag will be resolved and the returned version will be used to generate a new semver range (using the \`^\` modifier by default unless otherwise configured via the \`savePrefix\` configuration, or the \`~\` modifier if \`-T,--tilde\` is specified, or no modifier at all if \`-E,--exact\` is specified). Two exceptions to this rule: the first one is that if the package is a workspace then its local version will be used, and the second one is that if you use \`-P,--peer\` the default range will be \`*\` and won't be resolved at all.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR adds `yarn add --optional` to Berry and closes #837.

**How did you fix it?**

I added the `-O,--optional` flag to Berry.

It currenly has 4 uses:
* `yarn add --optional <package>` adds `<package>` to the `optionalDependencies` field, if it isn't already present in `package.json`
* `yarn add --optional <package>` moves `<package>` from the `dependencies` field to the `optionalDependencies` field, if it is already present in `package.json`
* `yarn add --optional --peer <package>` adds `<package>` as an optional peer dependency (
```json
"peerDependencies": {
  "<package>": "<version>"
},
"peerDependenciesMeta": {
  "<package>": {
    "optional": true
  }
}
```
) if it isn't already present in `package.json`
* `yarn add --optional --peer <package>` upgrades `<package>` to an optional peer dependency (
```json
"peerDependenciesMeta": {
  "<package>": {
    "optional": true
  }
}
```
) if it is already in the `peerDependencies` field in `package.json`

Anything else results in an error:

|                         | unexistent    | existsAsRegular | existsAsDev | existsAsPeer  |
| ----------------------- | ------------- | --------------- | ----------- | ------------- |
| --optional              | optional      | optional        | error       | error         |
| --optional --dev        | error         | error           | error       | error         |
| --optional --prefer-dev | error         | error           | error       | error         |
| --optional --peer       | optional peer | error           | error       | optional peer |
