### PR TITLE
Improve documentation's flow

### DIFF
--- a/packages/gatsby/content/advanced/questions-and-answers.md
+++ b/packages/gatsby/content/advanced/questions-and-answers.md
@@ -46,28 +46,14 @@ Lockfiles should **always** be kept within the repository. Continuous integratio
 
 ## Which files should be gitignored?
 
-- `.yarn/plugins` and `.yarn/releases` contain the Yarn releases used in the current repository (as defined by [`yarn set version`](/cli/set/version)). You will want to keep them versioned (this prevents potential issues if, say, two engineers use different Yarn versions with different features).
-
-- `.yarn/unplugged` and `.yarn/build-state.yml` should likely always be ignored since they typically hold machine-specific build artifacts. Ignoring them might however prevent [Zero-Installs](https://next.yarnpkg.com/features/zero-installs) from working (to prevent this, set [`enableScripts`](/configuration/yarnrc#enableScripts) to `false`).
-
-- `.yarn/versions` is used by the [version plugin](/features/release-workflow) to store the package release definitions. You will want to keep it within your repository.
-
-- `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).
-
-- `yarn.lock` should always be stored within your repository ([even if you develop a library](#should-lockfiles-be-committed-to-the-repository)).
-
-- `.yarnrc.yml` (and its older counterpart, `.yarnrc`) are configuration files. They should always be stored in your project.
-
-So to summarize:
-
-**If you're using Zero-Installs:**
+If you're using Zero-Installs:
 
 ```gitignore
 .yarn/unplugged
 .yarn/build-state.yml
 ```
 
-**If you're not using Zero-Installs:**
+If you're not using Zero-Installs:
 
 ```gitignore
 .yarn/cache
@@ -76,3 +62,17 @@ So to summarize:
 .pnp.*
 ```
 
+### Explanations
+
+- `.yarn/unplugged` and `.yarn/build-state.yml` should likely always be ignored since they typically hold machine-specific build artifacts. Ignoring them might however prevent [Zero-Installs](https://next.yarnpkg.com/features/zero-installs) from working (to prevent this, set [`enableScripts`](/configuration/yarnrc#enableScripts) to `false`).
+
+- `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).
+
+- `.yarn/plugins` and `.yarn/releases` contain the Yarn releases used in the current repository (as defined by [`yarn set version`](/cli/set/version)). You will want to keep them versioned (this prevents potential issues if, say, two engineers use different Yarn versions with different features).
+
+
+- `.yarn/versions` is used by the [version plugin](/features/release-workflow) to store the package release definitions. You will want to keep it within your repository.
+
+- `yarn.lock` should always be stored within your repository ([even if you develop a library](#should-lockfiles-be-committed-to-the-repository)).
+
+- `.yarnrc.yml` (and its older counterpart, `.yarnrc`) are configuration files. They should always be stored in your project.

--- a/packages/gatsby/content/advanced/questions-and-answers.md
+++ b/packages/gatsby/content/advanced/questions-and-answers.md
@@ -62,14 +62,13 @@ If you're not using Zero-Installs:
 .pnp.*
 ```
 
-### Explanations
+### Details
 
 - `.yarn/unplugged` and `.yarn/build-state.yml` should likely always be ignored since they typically hold machine-specific build artifacts. Ignoring them might however prevent [Zero-Installs](https://next.yarnpkg.com/features/zero-installs) from working (to prevent this, set [`enableScripts`](/configuration/yarnrc#enableScripts) to `false`).
 
 - `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).
 
 - `.yarn/plugins` and `.yarn/releases` contain the Yarn releases used in the current repository (as defined by [`yarn set version`](/cli/set/version)). You will want to keep them versioned (this prevents potential issues if, say, two engineers use different Yarn versions with different features).
-
 
 - `.yarn/versions` is used by the [version plugin](/features/release-workflow) to store the package release definitions. You will want to keep it within your repository.
 

--- a/packages/gatsby/gatsby-plugin-clipanion-cli/gatsby-node.js
+++ b/packages/gatsby/gatsby-plugin-clipanion-cli/gatsby-node.js
@@ -32,14 +32,6 @@ exports.sourceNodes = ({actions, createNodeId, createContentDigest}, opts) => {
       `\`\`\`\n`,
     ].join(``));
 
-    if (command.details) {
-      sections.push([
-        `## Details\n`,
-        `\n`,
-        `${command.details}\n`,
-      ].join(``));
-    }
-
     if (command.examples && command.examples.length > 0) {
       sections.push([
         `## Examples\n`,
@@ -52,6 +44,15 @@ exports.sourceNodes = ({actions, createNodeId, createContentDigest}, opts) => {
         ].join(``)),
       ].join(``));
     }
+
+    if (command.details) {
+      sections.push([
+        `## Details\n`,
+        `\n`,
+        `${command.details}\n`,
+      ].join(``));
+    }
+
 
     const content = sections.join(`\n`);
     const contentDigest = createContentDigest(content);


### PR DESCRIPTION
## Why • [preview](https://deploy-preview-855--yarn2.netlify.com/)

In general, people are lazy to it's better to have the TL;DR at the beginning and then the full explanations

## Details

Put examples first:

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73488797-9351c400-4377-11ea-85da-27e10cd7a56a.png) | ![image](https://user-images.githubusercontent.com/22725671/73488814-98167800-4377-11ea-95cc-5f9b4da70b46.png)

Reorder (gitignored then as you want then kept files) + put TL;DR first

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73488971-cac07080-4377-11ea-851f-2ca88b631fd2.png) | ![image](https://user-images.githubusercontent.com/22725671/73488977-d01dbb00-4377-11ea-94f1-fd574f62b98b.png)
