### PR TITLE
feat(plugin-essentials): make `yarn remove` remove package(s) from peerDependenciesMeta 

### DIFF
--- a/.yarn/versions/f0f68ba3.yml
+++ b/.yarn/versions/f0f68ba3.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -64,6 +64,13 @@ export default class RemoveCommand extends BaseCommand {
       let isReferenced = false;
 
       for (const workspace of affectedWorkspaces) {
+        if (workspace.manifest.peerDependenciesMeta.get(ident.name)) {
+          workspace.manifest.peerDependenciesMeta.delete(ident.name);
+
+          hasChanged = true;
+          isReferenced = true;
+        }
+
         for (const target of targets) {
           const current = workspace.manifest[target].get(ident.identHash);
 

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -64,7 +64,7 @@ export default class RemoveCommand extends BaseCommand {
       let isReferenced = false;
 
       for (const workspace of affectedWorkspaces) {
-        if (workspace.manifest.peerDependenciesMeta.get(ident.name)) {
+        if (workspace.manifest.peerDependenciesMeta.has(ident.name)) {
           workspace.manifest.peerDependenciesMeta.delete(ident.name);
 
           hasChanged = true;


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn remove <package>` leaves behind:
```json
"peerDependenciesMeta": {
  "<package>": {
    "optional": true
  }
}
```

**How did you fix it?**

I made `yarn remove <package>` also delete `<package>` from `peerDependenciesMeta`. 