### PR TITLE
Add failing test for node_modules hoisting with workspace conflict

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1,7 +1,7 @@
 import {npath} from '@yarnpkg/fslib';
 import {fs}    from 'pkg-tests-core';
 
-const {writeFile} = fs;
+const {writeFile, writeJson} = fs;
 
 describe('Node_Modules', () => {
   it('should install one dependency',
@@ -21,5 +21,51 @@ describe('Node_Modules', () => {
         );
       },
     )
+  );
+
+  test(
+    `workspace packages shouldn't be hoisted if they conflict with root dependencies`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        workspaces: [`packages/*`],
+        dependencies: {
+          [`no-deps`]: `*`,
+        },
+      },
+      async ({path, run, source}) => {
+        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
+          enableTransparentWorkspaces: false
+          nodeLinker: "node-modules"
+        `);
+
+        await writeFile(
+          npath.toPortablePath(`${path}/index.js`),
+          `
+            module.exports = require('no-deps/package.json');
+          `,
+        );
+
+        await writeJson(npath.toPortablePath(`${path}/packages/workspace/package.json`), {
+          name: `workspace`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: `workspace:*`,
+          },
+        });
+
+        await writeJson(npath.toPortablePath(`${path}/packages/no-deps/package.json`), {
+          name: `no-deps`,
+          version: `1.0.0-local`,
+        });
+
+        await run(`install`);
+
+        await expect(source(`require('.')`)).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `2.0.0`,
+        });
+      },
+    ),
   );
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

I found this problem while testing the `node-modules` plugin in Babel's monorepo.
If a workspace package A depends on another workspace package B, and the root depends on B but from the registry, the workspace B is incorrectly hoisted and replaces the registry B.

**How did you fix it?**

I didn't :upside_down_face: I'd be glad if someone with more experience could take a look at this, but if you don't have time maybe you could give me some directions and I'll try to fix it.