### PR TITLE
Improve homepage on mobile

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -25,6 +25,8 @@ const NewsContainer = styled.div`
   ${ifMobile} {
     white-space: pre-wrap;
     line-height: 1.5em;
+    text-align: center;
+    padding-top: 5px;
   }
 
   background: #2188b6;

--- a/packages/gatsby/src/components/search/SearchBox.js
+++ b/packages/gatsby/src/components/search/SearchBox.js
@@ -38,6 +38,7 @@ const SearchInput = styled.input`
   font: inherit;
   color: #2c8ebb;
   margin-left: 0.5em;
+  text-overflow: ellipsis;
 `;
 
 const IconButton = styled.button`
@@ -64,6 +65,7 @@ const IconButton = styled.button`
 
 const SubmitButton = styled(IconButton)`
   order: 1;
+  top: -2px;
   svg {
     top: 0.2em;
     left: 0.2em;

--- a/packages/gatsby/src/pages/index.js
+++ b/packages/gatsby/src/pages/index.js
@@ -50,6 +50,11 @@ const Hero = styled.div`
 
 const HeroTitle = styled.div`
   font-size: 4em;
+  ${ifMobile} {
+    font-size: 2.2em;
+    text-align: center;
+  }
+
   font-weight: bold;
 
   color: #ffffff;
@@ -58,12 +63,16 @@ const HeroTitle = styled.div`
 
 const HeroSubtitle = styled.div`
   max-width: 800px;
-
+  color: #ffffff;
   margin-top: 40px;
-
   font-size: 1.5em;
 
-  color: #ffffff;
+  ${ifMobile} {
+    margin-top: 20px;
+    font-size: 1.2em;
+    text-align: center;
+    margin-bottom: 10px;
+  }
 `;
 
 const SellingPoints = styled.div`

--- a/packages/gatsby/src/pages/index.js
+++ b/packages/gatsby/src/pages/index.js
@@ -23,6 +23,10 @@ const sectionStyle = css`
 
 const Section = styled.div`
   ${sectionStyle}
+
+  ${ifMobile} {
+    padding: 0 1em;
+  }
 `;
 
 const sectionContentStyle = css`
@@ -89,6 +93,9 @@ const SellingPointContainer = styled.div`
   ${ifDesktop} {
     width: calc(50% - 20px);
   }
+  ${ifMobile} {
+    align-items: center;
+  }
 
   margin-top: 40px;
 
@@ -100,6 +107,10 @@ const SellingPointContainer = styled.div`
 const SellingPointIcon = styled.img`
   width: 100px;
   height: 100px;
+  ${ifMobile} {
+    width: 75px;
+    height: 75px;
+  }
 `;
 
 const SellingPointContent = styled.div`
@@ -107,6 +118,9 @@ const SellingPointContent = styled.div`
 
   h3 {
     margin-top: 0;
+    ${ifMobile} {
+      margin-bottom: .5em;
+    }
   }
 `;
 


### PR DESCRIPTION
## TL;DR

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73599011-f3c63a00-450c-11ea-9c3d-66e8903fe924.png) | ![image](https://user-images.githubusercontent.com/22725671/73599009-ee68ef80-450c-11ea-992e-acc05cb1ce4b.png) 

Continuation of this PR: https://github.com/yarnpkg/berry/pull/842

## Details

### Banner

- Text center
- Increase padding top

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73599030-148e8f80-450d-11ea-887a-995b1fd74539.png) | ![image](https://user-images.githubusercontent.com/22725671/73599034-18baad00-450d-11ea-81d7-bc0372d487cd.png)

### Title

- Reduce font size (avoid making the page scrollable because the text is too big)
- Text center
- Increase margin bottom

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73599052-3556e500-450d-11ea-985f-6b26a61c7f7e.png) | ![image](https://user-images.githubusercontent.com/22725671/73599055-3b4cc600-450d-11ea-9cb4-bc93f5b07242.png)

### Selling points

- reduce icon size
- reduce padding on section
- reduce margin bottom on h3
- flex center

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73599068-5d464880-450d-11ea-9a64-a2160bbeff27.png) | ![image](https://user-images.githubusercontent.com/22725671/73599072-646d5680-450d-11ea-8d7c-8de8cd657abf.png)

