### PR TITLE
Improve location of migration

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -6,7 +6,7 @@ title: "2 - Installation"
 
 > **Migrating from Yarn 1**
 >
-> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/getting-started/migration). Give it a look and contribute to it if you see things that aren't covered yet!
+> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/getting-started/migration-from-classic). Give it a look and contribute to it if you see things that aren't covered yet!
 
 ## Global Install
 

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -6,7 +6,7 @@ title: "2 - Installation"
 
 > **Migrating from Yarn 1**
 >
-> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/advanced/migration). Give it a look and contribute to it if you see things that aren't covered yet!
+> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/getting-started/migration). Give it a look and contribute to it if you see things that aren't covered yet!
 
 ## Global Install
 

--- a/packages/gatsby/content/getting-started/migration.md
+++ b/packages/gatsby/content/getting-started/migration.md
@@ -1,7 +1,7 @@
 ---
 category: getting-started
-path: /getting-started/migration
-title: "Migration from v1"
+path: /getting-started/migration-from-classic
+title: "Migration from 1.x (Classic)"
 ---
 
 Yarn v2 is a very different software from the v1. While one of our aim is to make the transition as easy as possible, some behaviors needed to be tweaked. To make things easier we've documented the most common problems that may arise when porting from one project to the other, along with suggestions to keep moving forward.

--- a/packages/gatsby/content/getting-started/migration.md
+++ b/packages/gatsby/content/getting-started/migration.md
@@ -1,7 +1,7 @@
 ---
-category: advanced
-path: /advanced/migration
-title: "Migration"
+category: getting-started
+path: /getting-started/migration
+title: "Migration from v1"
 ---
 
 Yarn v2 is a very different software from the v1. While one of our aim is to make the transition as easy as possible, some behaviors needed to be tweaked. To make things easier we've documented the most common problems that may arise when porting from one project to the other, along with suggestions to keep moving forward.

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -8,7 +8,7 @@ Now that you have Yarn [installed](/getting-started/install), you can start usin
 
 > **Migrating from Yarn 1**
 >
-> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/getting-started/migration). Give it a look and contribute to it if you see things that aren't covered yet!
+> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/getting-started/migration-from-classic). Give it a look and contribute to it if you see things that aren't covered yet!
 
 ### Accessing the list of commands
 

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -8,7 +8,7 @@ Now that you have Yarn [installed](/getting-started/install), you can start usin
 
 > **Migrating from Yarn 1**
 >
-> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/advanced/migration). Give it a look and contribute to it if you see things that aren't covered yet!
+> We've been compiling helpful advices when porting over from Yarn 1 on the following [Migration Guide](/getting-started/migration). Give it a look and contribute to it if you see things that aren't covered yet!
 
 ### Accessing the list of commands
 

--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -52,6 +52,19 @@ module.exports = {
     });
 
     createRedirect({
+      fromPath: `/advanced/migration`,
+      toPath: `/getting-started/migration-from-classic`,
+      redirectInBrowser: true,
+      isPermanent: false,
+    });
+    createRedirect({
+      fromPath: `/getting-started/migration`,
+      toPath: `/getting-started/migration-from-classic`,
+      redirectInBrowser: true,
+      isPermanent: false,
+    });
+
+    createRedirect({
       fromPath: `/cli`,
       toPath: `/cli/install`,
       redirectInBrowser: true,


### PR DESCRIPTION
## TL;DR

moved `migration` to the `getting-started` section (related to https://github.com/yarnpkg/berry/issues/785)
<!-- - added link on home page selling points -->

## Details

### Migration

I'd like to move the migration guide in the getting started section for now because as `yarn 2` was just released, this is one of the most searched page. So I think it's better to have more visible link to this page

Also I renamed it `migration-from-classic` because it will leave us some room for `migration-from-npm` for instance (with a redirect from `migration` to `migration-from-classic`)

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73602195-d5c4fd80-453d-11ea-8f5b-042d8fbf9928.png) | ![image](https://user-images.githubusercontent.com/22725671/73602198-deb5cf00-453d-11ea-9ebd-a264426b2bd2.png)

<!--

### Links on home page

When I'm on the home page and I see the selling points, I want to click on them to see more details about this point and I found it a bit frustrating that I had to search into every links to get the related article

Before | After
-|-
![image](https://user-images.githubusercontent.com/22725671/73602220-48ce7400-453e-11ea-921b-93ec328bb9f7.png) | ![image](https://user-images.githubusercontent.com/22725671/73602224-5257dc00-453e-11ea-968f-3bf11399f2fd.png)

-->
