### PR TITLE
Update site domains

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -17,7 +17,7 @@ A clear and concise description of what the bug is.
 
 The _minimal_ information needed to reproduce your issue (ideally a package.json with a single dep). Note that bugs without minimal reproductions might be closed.
 
-IMPORTANT: We strongly prefer reproductions that use Sherlock. Please check our documentation for more information: https://next.yarnpkg.com/advanced/sherlock
+IMPORTANT: We strongly prefer reproductions that use Sherlock. Please check our documentation for more information: https://yarnpkg.com/advanced/sherlock
 
 **Screenshots**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Remember that a [migration guide](https://yarnpkg.com/advanced/migration) is ava
 
   - The Yarn configuration has been revamped and *will not read the `.npmrc` files anymore.* This used to cause a lot of confusion as to where the configuration was coming from, so the logic is now very simple: Yarn will look in the current directory and all its ancestors for `.yarnrc.yml` files.
 
-      - Note that the configuration files are now called `.yarnrc.yml` and thus are expected to be valid YAML. The available settings are listed [here](https://next.yarnpkg.com/configuration/yarnrc).
+      - Note that the configuration files are now called `.yarnrc.yml` and thus are expected to be valid YAML. The available settings are listed [here](https://yarnpkg.com/configuration/yarnrc).
 
   - The lockfiles now generated should be compatible with Yaml, while staying compatible with old-style lockfiles. Old-style lockfiles will be automatically migrated, but that will require some round-trips to the registry to obtain more information that wasn't stored previously, so the first install will be slightly slower.
 
@@ -38,7 +38,7 @@ Remember that a [migration guide](https://yarnpkg.com/advanced/migration) is ava
 
 ### Package manifests (`package.json`)
 
-To see a comprehensive documentation about each possible field, please check our [documentation](https://next.yarnpkg.com/configuration/manifest).
+To see a comprehensive documentation about each possible field, please check our [documentation](https://yarnpkg.com/configuration/manifest).
 
   - Two new fields are now supported in the `publishConfig` key of your manifests: the `main`, `bin`, and `module` fields will be used to replace the value of their respective top-level counterparts in the manifest shipped along with the generated file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Thanks for being here! Our contribution docs are hosted on [our website](https://next.yarnpkg.com/advanced/contributing). See you there! 😃
+Thanks for being here! Our contribution docs are hosted on [our website](https://yarnpkg.com/advanced/contributing). See you there! 😃

--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ Yarn is a modern package manager split into various packages. Its novel architec
 
 - Yarn supports plugins; adding a plugin is as simple as adding it into your repository
 - Yarn supports Node by default but isn't limited to it - plugins can add support for other languages
-- Yarn supports [workspaces](https://next.yarnpkg.com/features/workspaces) natively, and its CLI takes advantage of that
+- Yarn supports [workspaces](https://yarnpkg.com/features/workspaces) natively, and its CLI takes advantage of that
 - Yarn uses a portable shell to execute package scripts, guaranteeing they work the same way on Windows and Linux
 - Yarn is first and foremost a Node API that can be used programmatically (via [@yarnpkg/core](packages/yarnpkg-core))
 - Yarn is written in TypeScript, and is fully type checked
 
 ## Install
 
-Consult the [dedicated page](https://next.yarnpkg.com/getting-started/install) for more details.
+Consult the [dedicated page](https://yarnpkg.com/getting-started/install) for more details.
 
 ## Documentation
 
-The documentation is being reworked to contain an updated content and a refreshed design, and the most up-to-date version can be found on the repository GitHub pages: [next.yarnpkg.com](https://next.yarnpkg.com/)
+The documentation is being reworked to contain an updated content and a refreshed design, and the most up-to-date version can be found on the repository GitHub pages: [yarnpkg.com](https://yarnpkg.com/)
 
 ## Current status
 
@@ -85,34 +85,34 @@ Note that no other command is needed! Given that our dependencies are checked-in
 Those plugins typically come bundled with Yarn. You don't need to do anything special to use them.
 
 - [★ plugin-constraints](packages/plugin-constraints) adds support for `yarn constraints [--fix]`.
-- [★ plugin-dlx](packages/plugin-dlx) adds support for the [`yarn dlx`](https://next.yarnpkg.com/cli/dlx) command.
+- [★ plugin-dlx](packages/plugin-dlx) adds support for the [`yarn dlx`](https://yarnpkg.com/cli/dlx) command.
 - [★ plugin-essentials](packages/plugin-essentials) adds various commands deemed necessary for a package manager (add, remove, ...).
 - [★ plugin-file](packages/plugin-file) adds support for using the `file:` protocol within your dependencies.
 - [★ plugin-github](packages/plugin-github) adds support for using Github references as dependencies. [This plugin doesn't use git.](https://stackoverflow.com/a/13636954/880703)
 - [★ plugin-http](packages/plugin-http) adds support for using straight URL references as dependencies (tgz archives only).
-- [★ plugin-init](packages/plugin-init) adds support for the [`yarn init`](https://next.yarnpkg.com/cli/init) command.
+- [★ plugin-init](packages/plugin-init) adds support for the [`yarn init`](https://yarnpkg.com/cli/init) command.
 - [★ plugin-link](packages/plugin-link) adds support for using `link:` and `portal:` references as dependencies.
 - [★ plugin-npm](packages/plugin-npm) adds support for using [semver ranges](https://semver.org) as dependencies, resolving them to an NPM-like registry.
-- [★ plugin-npm-cli](packages/plugin-npm-cli) adds support for the NPM-specific commands ([`yarn npm login`](https://next.yarnpkg.com/cli/npm/login), [`yarn npm publish`](https://next.yarnpkg.com/cli/npm/publish), ...).
-- [★ plugin-pack](packages/plugin-pack) adds support for the [`yarn pack`](https://next.yarnpkg.com/cli/pack) command.
-- [★ plugin-pnp](packages/plugin-pnp) adds support for installing Javascript dependencies through the [Plug'n'Play](https://next.yarnpkg.com/features/pnp) specification.
+- [★ plugin-npm-cli](packages/plugin-npm-cli) adds support for the NPM-specific commands ([`yarn npm login`](https://yarnpkg.com/cli/npm/login), [`yarn npm publish`](https://yarnpkg.com/cli/npm/publish), ...).
+- [★ plugin-pack](packages/plugin-pack) adds support for the [`yarn pack`](https://yarnpkg.com/cli/pack) command.
+- [★ plugin-pnp](packages/plugin-pnp) adds support for installing Javascript dependencies through the [Plug'n'Play](https://yarnpkg.com/features/pnp) specification.
 
 ### Contrib plugins
 
 Although developed on the same repository as Yarn itself, those plugins are optional and need to be explicitly installed through `yarn plugin import @yarnpkg/<plugin-name>`.
 
 - [☆ plugin-exec](packages/plugin-exec) adds support for using the `exec:` protocol within your dependencies.
-- [☆ plugin-stage](packages/plugin-stage) adds support for the [`yarn stage`](https://next.yarnpkg.com/cli/stage) command.
+- [☆ plugin-stage](packages/plugin-stage) adds support for the [`yarn stage`](https://yarnpkg.com/cli/stage) command.
 - [☆ plugin-typescript](packages/plugin-typescript) improves the user experience when working with TypeScript.
-- [☆ plugin-workspace-tools](packages/plugin-workspace-tools) adds support for the [`yarn workspaces foreach`](https://next.yarnpkg.com/cli/workspaces/foreach) command.
+- [☆ plugin-workspace-tools](packages/plugin-workspace-tools) adds support for the [`yarn workspaces foreach`](https://yarnpkg.com/cli/workspaces/foreach) command.
 
 ### Third-party plugins
 
-Plugins can be developed by third-party entities. To use them within your applications, just specify the full plugin URL when calling [`yarn plugin import`](https://next.yarnpkg.com/cli/plugin/import). Note that plugins aren't fetched from the npm registry at this time - they must be distributed as a single JavaScript file.
+Plugins can be developed by third-party entities. To use them within your applications, just specify the full plugin URL when calling [`yarn plugin import`](https://yarnpkg.com/cli/plugin/import). Note that plugins aren't fetched from the npm registry at this time - they must be distributed as a single JavaScript file.
 
 ### Creating a new plugin
 
-To create your own plugin, please refer to the [documentation](https://next.yarnpkg.com/features/plugins).
+To create your own plugin, please refer to the [documentation](https://yarnpkg.com/features/plugins).
 
 ## Generic packages
 
@@ -123,7 +123,7 @@ The following packages are generic and can be used in a variety of purposes (inc
 - [@yarnpkg/json-proxy](packages/yarnpkg-json-proxy) allows to temporarily convert any POD object to an immutable object.
 - [@yarnpkg/libzip](packages/yarnpkg-libzip) contains zlib+libzip bindings compiled to WebAssembly.
 - [@yarnpkg/parsers](packages/yarnpkg-parsers) can be used to parse the language used by [@yarnpkg/shell](packages/yarnpkg-shell).
-- [@yarnpkg/pnp](packages/yarnpkg-pnp) can be used to generate [Plug'n'Play](https://next.yarnpkg.com/features/pnp)-compatible hooks.
+- [@yarnpkg/pnp](packages/yarnpkg-pnp) can be used to generate [Plug'n'Play](https://yarnpkg.com/features/pnp)-compatible hooks.
 - [@yarnpkg/pnpify](packages/yarnpkg-pnpify) is a CLI tool to transparently add PnP support to various tools.
 - [@yarnpkg/shell](packages/yarnpkg-shell) is a portable bash-like shell interpreter.
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -34,7 +34,7 @@
 <meta name=twitter:title content="Redirecting to new documentation site...">
 <meta name=twitter:description content="Fast, reliable, and secure dependency management.">
 <meta name=theme-color content=#2188b6>
-<script>window.location = "https://next.yarnpkg.com" + window.location.pathname.replace("/berry", "") + window.location.search + window.location.hash</script>
+<script>window.location = "https://yarnpkg.com" + window.location.pathname.replace("/berry", "") + window.location.search + window.location.hash</script>
 <style data-emotion-css=1rgujud>
   body {
     font-family: "Open Sans", sans-serif;
@@ -184,30 +184,30 @@
 <body><noscript>This app works best with JavaScript enabled.</noscript>
   <div>
     <div style=outline:none tabindex=-1 role=group>
-      <div class="css-1iw4wyv e11px6xy0"><a href=https://next.yarnpkg.com
+      <div class="css-1iw4wyv e11px6xy0"><a href=https://yarnpkg.com
           class="css-17lg5tj e11px6xy1"><span class="css-ol3iif e11px6xy2">Important:</span> This
           documentation covers the v2 onwards and is actively being worked on. Come help us!</a>
         <header class="css-1tbqck0 e11px6xy3">
           <div class="css-k008qs e11px6xy4"><a class="css-114nkxc e11px6xy5"
-              href=https://next.yarnpkg.com/> <img alt=Yarn
+              href=https://yarnpkg.com/> <img alt=Yarn
               src=data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTE1NC44IDUxOCI+PHN0eWxlPi5zdDB7ZmlsbDojMmM4ZWJifS5zdDF7ZmlsbDojZmZmfTwvc3R5bGU+PHBhdGggY2xhc3M9InN0MCIgZD0iTTcxOC42IDI1Ny44Yy04IDI3LjYtMjAuOCA0Ny42LTM1LjIgNjMuNlYxODFjMC05LjYtOC40LTE3LjYtMjEuNi0xNy42LTUuNiAwLTEwLjQgMi44LTEwLjQgNi44IDAgMi44IDEuNiA1LjIgMS42IDEyLjh2NjQuNGMtNC44IDI4LTE2LjggNTQtMzIuOCA1NC0xMS42IDAtMTguNC0xMS42LTE4LjQtMzMuMiAwLTMzLjYgNC40LTUxLjIgMTEuNi04MC44IDEuNi02IDEzLjItMjItNi40LTIyLTIxLjIgMC0xOC40IDgtMjEuMiAxNC44IDAgMC0xMy40IDQ3LjYtMTMuNCA5MCAwIDM0LjggMTQuNiA1Ny42IDQxLjQgNTcuNiAxNy4yIDAgMjkuNi0xMS42IDM5LjItMjcuNlYzNTFjLTI2LjQgMjMuMi00OS42IDQzLjYtNDkuNiA4NCAwIDI1LjYgMTYgNDYgMzguNCA0NiAyMC40IDAgNDEuNi0xNC44IDQxLjYtNTYuOFYzNTVjMjEuNi0xOC44IDQ0LjgtNDIuNCA1OC40LTg4LjguNC0xLjYuNC0zLjYuNC00IDAtNy42LTcuNi0xNi40LTE0LTE2LjQtNCAwLTcuMiAzLjYtOS42IDEyem0tNzYuOCAxOThjLTYuNCAwLTEwLjQtOS42LTEwLjQtMjIgMC0yNCA4LjgtMzkuMiAyMS42LTUyLjR2NDIuOGMwIDcuNiAxLjYgMzEuNi0xMS4yIDMxLjZ6Ii8+PHBhdGggY2xhc3M9InN0MCIgZD0iTTgzMy40IDMwMWMtOS42IDAtMTMuNi05LjYtMTMuNi0xOC40di02NmMwLTkuNi04LjQtMTcuNi0yMS42LTE3LjYtNS42IDAtMTAuNCAyLjgtMTAuNCA2LjggMCAyLjggMS42IDUuMiAxLjYgMTIuOHY2MS42Qzc4NSAyOTEuNCA3NzcuOCAzMDEgNzY3IDMwMWMtMTQgMC0yMi44LTEyLTIyLjgtMzIuOCAwLTU3LjYgMzUuNi04My42IDY2LTgzLjYgNCAwIDggLjggMTEuNi44IDQgMCA1LjItMi40IDUuMi05LjIgMC0xMC40LTcuNi0xNi44LTE4LjQtMTYuOC00OC44IDAtOTUuMiA0MC44LTk1LjIgMTA3LjYgMCAzNCAxNi40IDYwLjQgNDcuNiA2MC40IDE1LjIgMCAyNi40LTcuMiAzNC40LTE2LjQgNiA5LjYgMTYuOCAxNi40IDMwLjggMTYuNCAzNC40IDAgNTAuNC0zNiA1Ny4yLTYyLjQuNC0xLjYuNC0yLjQuNC0yLjggMC03LjYtNy42LTE2LjQtMTQtMTYuNC00IDAtOCAzLjYtOS42IDEyLTMuNiAxNy42LTEwLjggNDMuMi0yNi44IDQzLjJ6Ii8+PHBhdGggY2xhc3M9InN0MCIgZD0iTTk0OSAzMjcuNGMzNC40IDAgNTAtMzYgNTcuMi02Mi40IDAtLjguNC0xLjYuNC0yLjggMC03LjYtNy42LTE2LjQtMTQtMTYuNC00IDAtOCAzLjYtOS42IDEyLTMuNiAxNy42LTEwLjQgNDMuMi0yOC44IDQzLjItMTAuOCAwLTE2LTEwLjQtMTYtMjEuNiAwLTQwIDE4LTg3LjIgMTgtOTIgMS42LTkuMi0xNC40LTIyLjQtMTkuMi0yMi40aC0yMC44Yy00IDAtOCAwLTIxLjItMS42LTQuNC0xNi40LTE1LjYtMjEuMi0yNS4yLTIxLjItMTAuNCAwLTIwIDcuMi0yMCAxOC40IDAgMTEuNiA3LjIgMjAgMTcuMiAyNS42LS40IDIwLjQtMiA1My42LTYuNCA2OS42LTMuNiAxMy42IDE3LjIgMjggMjIuNCAxMS4yIDcuMi0yMy4yIDkuNi01OCAxMC03My42aDM0LjhjLTEyLjggMzQuNC0yMCA2Mi44LTIwIDg4LjQgMCAzNS4yIDIyLjQgNDUuNiA0MS4yIDQ1LjZ6Ii8+PHBhdGggY2xhc3M9InN0MCIgZD0iTTk4NC42IDMwOS44YzAgMTQuOCAxMS4yIDE3LjYgMTkuMiAxNy42IDExLjYgMCAxMS4yLTkuNiAxMS4yLTE3LjJ2LTU4LjRjMi44LTMxLjYgMjcuNi02NiAzOS4yLTY2IDcuNiAwIDguNCAxMC40IDguNCAyMi44djgxLjJjMCAyMC40IDEyLjQgMzcuNiAzMy42IDM3LjYgMzQuNCAwIDUxLjQtMzYgNTguMi02Mi40LjQtMS42LjQtMi40LjQtMi44IDAtNy42LTcuNi0xNi40LTE0LTE2LjQtNCAwLTggMy42LTkuNiAxMi0zLjYgMTcuNi0xMS44IDQzLjItMjcuOCA0My4yLTEwLjQgMC0xMC40LTE0LjgtMTAuNC0xOC40di04Mi44YzAtMTguNC02LjQtNDAuNC0zMy4yLTQwLjQtMTkuNiAwLTM0IDE3LjItNDQuOCAzOS42di0xOGMwLTkuNi04LjQtMTcuNi0yMS42LTE3LjYtNS42IDAtMTAuNCAyLjgtMTAuNCA2LjggMCAyLjggMS42IDUuMiAxLjYgMTIuOHYxMjYuOHpNMjU5IDBjMTQzIDAgMjU5IDExNiAyNTkgMjU5UzQwMiA1MTggMjU5IDUxOCAwIDQwMiAwIDI1OSAxMTYgMCAyNTkgMHoiLz48cGF0aCBjbGFzcz0ic3QxIiBkPSJNNDM1LjIgMzM3LjVjLTEuOC0xNC4yLTEzLjgtMjQtMjkuMi0yMy44LTIzIC4zLTQyLjMgMTIuMi01NS4xIDIwLjEtNSAzLjEtOS4zIDUuNC0xMyA3LjEuOC0xMS42LjEtMjYuOC01LjktNDMuNS03LjMtMjAtMTcuMS0zMi4zLTI0LjEtMzkuNCA4LjEtMTEuOCAxOS4yLTI5IDI0LjQtNTUuNiA0LjUtMjIuNyAzLjEtNTgtNy4yLTc3LjgtMi4xLTQtNS42LTYuOS0xMC04LjEtMS44LS41LTUuMi0xLjUtMTEuOS40QzI5My4xIDk2IDI4OS42IDkzLjggMjg2LjkgOTJjLTUuNi0zLjYtMTIuMi00LjQtMTguNC0yLjEtOC4zIDMtMTUuNCAxMS0yMi4xIDI1LjItMSAyLjEtMS45IDQuMS0yLjcgNi4xLTEyLjcuOS0zMi43IDUuNS00OS42IDIzLjgtMi4xIDIuMy02LjIgNC0xMC41IDUuNmguMWMtOC44IDMuMS0xMi44IDEwLjMtMTcuNyAyMy4zLTYuOCAxOC4yLjIgMzYuMSA3LjEgNDcuNy05LjQgOC40LTIxLjkgMjEuOC0yOC41IDM3LjUtOC4yIDE5LjQtOS4xIDM4LjQtOC44IDQ4LjctNyA3LjQtMTcuOCAyMS4zLTE5IDM2LjktMS42IDIxLjggNi4zIDM2LjYgOS44IDQyIDEgMS42IDIuMSAyLjkgMy4zIDQuMi0uNCAyLjctLjUgNS42LjEgOC42IDEuMyA3IDUuNyAxMi43IDEyLjQgMTYuMyAxMy4yIDcgMzEuNiAxMCA0NS44IDIuOSA1LjEgNS40IDE0LjQgMTAuNiAzMS4zIDEwLjZoMWM0LjMgMCA1OC45LTIuOSA3NC44LTYuOCA3LjEtMS43IDEyLTQuNyAxNS4yLTcuNCAxMC4yLTMuMiAzOC40LTEyLjggNjUtMzAgMTguOC0xMi4yIDI1LjMtMTQuOCAzOS4zLTE4LjIgMTMuNi0zLjMgMjIuMS0xNS43IDIwLjQtMjkuNHptLTIzLjggMTQuN2MtMTYgMy44LTI0LjEgNy4zLTQzLjkgMjAuMi0zMC45IDIwLTY0LjcgMjkuMy02NC43IDI5LjNzLTIuOCA0LjItMTAuOSA2LjFjLTE0IDMuNC02Ni43IDYuMy03MS41IDYuNC0xMi45LjEtMjAuOC0zLjMtMjMtOC42LTYuNy0xNiA5LjYtMjMgOS42LTIzcy0zLjYtMi4yLTUuNy00LjJjLTEuOS0xLjktMy45LTUuNy00LjUtNC4zLTIuNSA2LjEtMy44IDIxLTEwLjUgMjcuNy05LjIgOS4zLTI2LjYgNi4yLTM2LjkuOC0xMS4zLTYgLjgtMjAuMS44LTIwLjFzLTYuMSAzLjYtMTEtMy44Yy00LjQtNi44LTguNS0xOC40LTcuNC0zMi43IDEuMi0xNi4zIDE5LjQtMzIuMSAxOS40LTMyLjFzLTMuMi0yNC4xIDcuMy00OC44YzkuNS0yMi41IDM1LjEtNDAuNiAzNS4xLTQwLjZzLTIxLjUtMjMuOC0xMy41LTQ1LjJjNS4yLTE0IDcuMy0xMy45IDktMTQuNSA2LTIuMyAxMS44LTQuOCAxNi4xLTkuNSAyMS41LTIzLjIgNDguOS0xOC44IDQ4LjktMTguOHMxMy0zOS41IDI1LTMxLjhjMy43IDIuNCAxNyAzMiAxNyAzMnMxNC4yLTguMyAxNS44LTUuMmM4LjYgMTYuNyA5LjYgNDguNiA1LjggNjgtNi40IDMyLTIyLjQgNDkuMi0yOC44IDYwLTEuNSAyLjUgMTcuMiAxMC40IDI5IDQzLjEgMTAuOSAyOS45IDEuMiA1NSAyLjkgNTcuOC4zLjUuNC43LjQuN3MxMi41IDEgMzcuNi0xNC41YzEzLjQtOC4zIDI5LjMtMTcuNiA0Ny40LTE3LjggMTcuNS0uMyAxOC40IDIwLjIgNS4yIDIzLjR6Ii8+PC9zdmc+
               style=height:3em;vertical-align:middle></a><button
               class="css-kapooa e11px6xy6">≡</button></div>
           <div class="css-1syd0he e11px6xy7">
-            <div class="css-1rgujud e11px6xy8"><a href=https://next.yarnpkg.com/>Home </a> </div>
+            <div class="css-1rgujud e11px6xy8"><a href=https://yarnpkg.com/>Home </a> </div>
                 <div class="css-1rgujud e11px6xy8"><a
-                  href=https://next.yarnpkg.com/getting-started>Getting started</a> </div> <div
+                  href=https://yarnpkg.com/getting-started>Getting started</a> </div> <div
                   class="css-1rgujud e11px6xy8"><a
-                    href=https://next.yarnpkg.com/configuration>Configuration </a> </div> <div
-                    class="css-1rgujud e11px6xy8"><a href=https://next.yarnpkg.com/features>Features
+                    href=https://yarnpkg.com/configuration>Configuration </a> </div> <div
+                    class="css-1rgujud e11px6xy8"><a href=https://yarnpkg.com/features>Features
                       </a> </div> <div class="css-1rgujud e11px6xy8"><a
-                        href=https://next.yarnpkg.com/cli>CLI </a> </div> <div
+                        href=https://yarnpkg.com/cli>CLI </a> </div> <div
                         class="css-1rgujud e11px6xy8"><a
-                          href=https://next.yarnpkg.com/advanced>Advanced </a> </div> </div>
+                          href=https://yarnpkg.com/advanced>Advanced </a> </div> </div>
                           </header> </div> <main class="main-content">
                           <h1>THE YARN V2 DOCS HAVE MOVED</h1>
                           <p>If your browser does not redirect you <a
-                              href="https://next.yarnpkg.com">click here to visit the new
+                              href="https://yarnpkg.com">click here to visit the new
                               documentation site</a>.
                           </p>
                           </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
 <meta name=twitter:title content="Redirecting to new documentation site...">
 <meta name=twitter:description content="Fast, reliable, and secure dependency management.">
 <meta name=theme-color content=#2188b6>
-<script>window.location = "https://next.yarnpkg.com" + window.location.pathname.replace("/berry", "") + window.location.search + window.location.hash</script>
+<script>window.location = "https://yarnpkg.com" + window.location.pathname.replace("/berry", "") + window.location.search + window.location.hash</script>
 <style data-emotion-css=1rgujud>
   body {
     font-family: "Open Sans", sans-serif;
@@ -184,30 +184,30 @@
 <body><noscript>This app works best with JavaScript enabled.</noscript>
   <div>
     <div style=outline:none tabindex=-1 role=group>
-      <div class="css-1iw4wyv e11px6xy0"><a href=https://next.yarnpkg.com
+      <div class="css-1iw4wyv e11px6xy0"><a href=https://yarnpkg.com
           class="css-17lg5tj e11px6xy1"><span class="css-ol3iif e11px6xy2">Important:</span> This
           documentation covers the v2 onwards and is actively being worked on. Come help us!</a>
         <header class="css-1tbqck0 e11px6xy3">
           <div class="css-k008qs e11px6xy4"><a class="css-114nkxc e11px6xy5"
-              href=https://next.yarnpkg.com/> <img alt=Yarn
+              href=https://yarnpkg.com/> <img alt=Yarn
               src=data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTE1NC44IDUxOCI+PHN0eWxlPi5zdDB7ZmlsbDojMmM4ZWJifS5zdDF7ZmlsbDojZmZmfTwvc3R5bGU+PHBhdGggY2xhc3M9InN0MCIgZD0iTTcxOC42IDI1Ny44Yy04IDI3LjYtMjAuOCA0Ny42LTM1LjIgNjMuNlYxODFjMC05LjYtOC40LTE3LjYtMjEuNi0xNy42LTUuNiAwLTEwLjQgMi44LTEwLjQgNi44IDAgMi44IDEuNiA1LjIgMS42IDEyLjh2NjQuNGMtNC44IDI4LTE2LjggNTQtMzIuOCA1NC0xMS42IDAtMTguNC0xMS42LTE4LjQtMzMuMiAwLTMzLjYgNC40LTUxLjIgMTEuNi04MC44IDEuNi02IDEzLjItMjItNi40LTIyLTIxLjIgMC0xOC40IDgtMjEuMiAxNC44IDAgMC0xMy40IDQ3LjYtMTMuNCA5MCAwIDM0LjggMTQuNiA1Ny42IDQxLjQgNTcuNiAxNy4yIDAgMjkuNi0xMS42IDM5LjItMjcuNlYzNTFjLTI2LjQgMjMuMi00OS42IDQzLjYtNDkuNiA4NCAwIDI1LjYgMTYgNDYgMzguNCA0NiAyMC40IDAgNDEuNi0xNC44IDQxLjYtNTYuOFYzNTVjMjEuNi0xOC44IDQ0LjgtNDIuNCA1OC40LTg4LjguNC0xLjYuNC0zLjYuNC00IDAtNy42LTcuNi0xNi40LTE0LTE2LjQtNCAwLTcuMiAzLjYtOS42IDEyem0tNzYuOCAxOThjLTYuNCAwLTEwLjQtOS42LTEwLjQtMjIgMC0yNCA4LjgtMzkuMiAyMS42LTUyLjR2NDIuOGMwIDcuNiAxLjYgMzEuNi0xMS4yIDMxLjZ6Ii8+PHBhdGggY2xhc3M9InN0MCIgZD0iTTgzMy40IDMwMWMtOS42IDAtMTMuNi05LjYtMTMuNi0xOC40di02NmMwLTkuNi04LjQtMTcuNi0yMS42LTE3LjYtNS42IDAtMTAuNCAyLjgtMTAuNCA2LjggMCAyLjggMS42IDUuMiAxLjYgMTIuOHY2MS42Qzc4NSAyOTEuNCA3NzcuOCAzMDEgNzY3IDMwMWMtMTQgMC0yMi44LTEyLTIyLjgtMzIuOCAwLTU3LjYgMzUuNi04My42IDY2LTgzLjYgNCAwIDggLjggMTEuNi44IDQgMCA1LjItMi40IDUuMi05LjIgMC0xMC40LTcuNi0xNi44LTE4LjQtMTYuOC00OC44IDAtOTUuMiA0MC44LTk1LjIgMTA3LjYgMCAzNCAxNi40IDYwLjQgNDcuNiA2MC40IDE1LjIgMCAyNi40LTcuMiAzNC40LTE2LjQgNiA5LjYgMTYuOCAxNi40IDMwLjggMTYuNCAzNC40IDAgNTAuNC0zNiA1Ny4yLTYyLjQuNC0xLjYuNC0yLjQuNC0yLjggMC03LjYtNy42LTE2LjQtMTQtMTYuNC00IDAtOCAzLjYtOS42IDEyLTMuNiAxNy42LTEwLjggNDMuMi0yNi44IDQzLjJ6Ii8+PHBhdGggY2xhc3M9InN0MCIgZD0iTTk0OSAzMjcuNGMzNC40IDAgNTAtMzYgNTcuMi02Mi40IDAtLjguNC0xLjYuNC0yLjggMC03LjYtNy42LTE2LjQtMTQtMTYuNC00IDAtOCAzLjYtOS42IDEyLTMuNiAxNy42LTEwLjQgNDMuMi0yOC44IDQzLjItMTAuOCAwLTE2LTEwLjQtMTYtMjEuNiAwLTQwIDE4LTg3LjIgMTgtOTIgMS42LTkuMi0xNC40LTIyLjQtMTkuMi0yMi40aC0yMC44Yy00IDAtOCAwLTIxLjItMS42LTQuNC0xNi40LTE1LjYtMjEuMi0yNS4yLTIxLjItMTAuNCAwLTIwIDcuMi0yMCAxOC40IDAgMTEuNiA3LjIgMjAgMTcuMiAyNS42LS40IDIwLjQtMiA1My42LTYuNCA2OS42LTMuNiAxMy42IDE3LjIgMjggMjIuNCAxMS4yIDcuMi0yMy4yIDkuNi01OCAxMC03My42aDM0LjhjLTEyLjggMzQuNC0yMCA2Mi44LTIwIDg4LjQgMCAzNS4yIDIyLjQgNDUuNiA0MS4yIDQ1LjZ6Ii8+PHBhdGggY2xhc3M9InN0MCIgZD0iTTk4NC42IDMwOS44YzAgMTQuOCAxMS4yIDE3LjYgMTkuMiAxNy42IDExLjYgMCAxMS4yLTkuNiAxMS4yLTE3LjJ2LTU4LjRjMi44LTMxLjYgMjcuNi02NiAzOS4yLTY2IDcuNiAwIDguNCAxMC40IDguNCAyMi44djgxLjJjMCAyMC40IDEyLjQgMzcuNiAzMy42IDM3LjYgMzQuNCAwIDUxLjQtMzYgNTguMi02Mi40LjQtMS42LjQtMi40LjQtMi44IDAtNy42LTcuNi0xNi40LTE0LTE2LjQtNCAwLTggMy42LTkuNiAxMi0zLjYgMTcuNi0xMS44IDQzLjItMjcuOCA0My4yLTEwLjQgMC0xMC40LTE0LjgtMTAuNC0xOC40di04Mi44YzAtMTguNC02LjQtNDAuNC0zMy4yLTQwLjQtMTkuNiAwLTM0IDE3LjItNDQuOCAzOS42di0xOGMwLTkuNi04LjQtMTcuNi0yMS42LTE3LjYtNS42IDAtMTAuNCAyLjgtMTAuNCA2LjggMCAyLjggMS42IDUuMiAxLjYgMTIuOHYxMjYuOHpNMjU5IDBjMTQzIDAgMjU5IDExNiAyNTkgMjU5UzQwMiA1MTggMjU5IDUxOCAwIDQwMiAwIDI1OSAxMTYgMCAyNTkgMHoiLz48cGF0aCBjbGFzcz0ic3QxIiBkPSJNNDM1LjIgMzM3LjVjLTEuOC0xNC4yLTEzLjgtMjQtMjkuMi0yMy44LTIzIC4zLTQyLjMgMTIuMi01NS4xIDIwLjEtNSAzLjEtOS4zIDUuNC0xMyA3LjEuOC0xMS42LjEtMjYuOC01LjktNDMuNS03LjMtMjAtMTcuMS0zMi4zLTI0LjEtMzkuNCA4LjEtMTEuOCAxOS4yLTI5IDI0LjQtNTUuNiA0LjUtMjIuNyAzLjEtNTgtNy4yLTc3LjgtMi4xLTQtNS42LTYuOS0xMC04LjEtMS44LS41LTUuMi0xLjUtMTEuOS40QzI5My4xIDk2IDI4OS42IDkzLjggMjg2LjkgOTJjLTUuNi0zLjYtMTIuMi00LjQtMTguNC0yLjEtOC4zIDMtMTUuNCAxMS0yMi4xIDI1LjItMSAyLjEtMS45IDQuMS0yLjcgNi4xLTEyLjcuOS0zMi43IDUuNS00OS42IDIzLjgtMi4xIDIuMy02LjIgNC0xMC41IDUuNmguMWMtOC44IDMuMS0xMi44IDEwLjMtMTcuNyAyMy4zLTYuOCAxOC4yLjIgMzYuMSA3LjEgNDcuNy05LjQgOC40LTIxLjkgMjEuOC0yOC41IDM3LjUtOC4yIDE5LjQtOS4xIDM4LjQtOC44IDQ4LjctNyA3LjQtMTcuOCAyMS4zLTE5IDM2LjktMS42IDIxLjggNi4zIDM2LjYgOS44IDQyIDEgMS42IDIuMSAyLjkgMy4zIDQuMi0uNCAyLjctLjUgNS42LjEgOC42IDEuMyA3IDUuNyAxMi43IDEyLjQgMTYuMyAxMy4yIDcgMzEuNiAxMCA0NS44IDIuOSA1LjEgNS40IDE0LjQgMTAuNiAzMS4zIDEwLjZoMWM0LjMgMCA1OC45LTIuOSA3NC44LTYuOCA3LjEtMS43IDEyLTQuNyAxNS4yLTcuNCAxMC4yLTMuMiAzOC40LTEyLjggNjUtMzAgMTguOC0xMi4yIDI1LjMtMTQuOCAzOS4zLTE4LjIgMTMuNi0zLjMgMjIuMS0xNS43IDIwLjQtMjkuNHptLTIzLjggMTQuN2MtMTYgMy44LTI0LjEgNy4zLTQzLjkgMjAuMi0zMC45IDIwLTY0LjcgMjkuMy02NC43IDI5LjNzLTIuOCA0LjItMTAuOSA2LjFjLTE0IDMuNC02Ni43IDYuMy03MS41IDYuNC0xMi45LjEtMjAuOC0zLjMtMjMtOC42LTYuNy0xNiA5LjYtMjMgOS42LTIzcy0zLjYtMi4yLTUuNy00LjJjLTEuOS0xLjktMy45LTUuNy00LjUtNC4zLTIuNSA2LjEtMy44IDIxLTEwLjUgMjcuNy05LjIgOS4zLTI2LjYgNi4yLTM2LjkuOC0xMS4zLTYgLjgtMjAuMS44LTIwLjFzLTYuMSAzLjYtMTEtMy44Yy00LjQtNi44LTguNS0xOC40LTcuNC0zMi43IDEuMi0xNi4zIDE5LjQtMzIuMSAxOS40LTMyLjFzLTMuMi0yNC4xIDcuMy00OC44YzkuNS0yMi41IDM1LjEtNDAuNiAzNS4xLTQwLjZzLTIxLjUtMjMuOC0xMy41LTQ1LjJjNS4yLTE0IDcuMy0xMy45IDktMTQuNSA2LTIuMyAxMS44LTQuOCAxNi4xLTkuNSAyMS41LTIzLjIgNDguOS0xOC44IDQ4LjktMTguOHMxMy0zOS41IDI1LTMxLjhjMy43IDIuNCAxNyAzMiAxNyAzMnMxNC4yLTguMyAxNS44LTUuMmM4LjYgMTYuNyA5LjYgNDguNiA1LjggNjgtNi40IDMyLTIyLjQgNDkuMi0yOC44IDYwLTEuNSAyLjUgMTcuMiAxMC40IDI5IDQzLjEgMTAuOSAyOS45IDEuMiA1NSAyLjkgNTcuOC4zLjUuNC43LjQuN3MxMi41IDEgMzcuNi0xNC41YzEzLjQtOC4zIDI5LjMtMTcuNiA0Ny40LTE3LjggMTcuNS0uMyAxOC40IDIwLjIgNS4yIDIzLjR6Ii8+PC9zdmc+
               style=height:3em;vertical-align:middle></a><button
               class="css-kapooa e11px6xy6">≡</button></div>
           <div class="css-1syd0he e11px6xy7">
-            <div class="css-1rgujud e11px6xy8"><a href=https://next.yarnpkg.com/>Home </a> </div>
+            <div class="css-1rgujud e11px6xy8"><a href=https://yarnpkg.com/>Home </a> </div>
                 <div class="css-1rgujud e11px6xy8"><a
-                  href=https://next.yarnpkg.com/getting-started>Getting started</a> </div> <div
+                  href=https://yarnpkg.com/getting-started>Getting started</a> </div> <div
                   class="css-1rgujud e11px6xy8"><a
-                    href=https://next.yarnpkg.com/configuration>Configuration </a> </div> <div
-                    class="css-1rgujud e11px6xy8"><a href=https://next.yarnpkg.com/features>Features
+                    href=https://yarnpkg.com/configuration>Configuration </a> </div> <div
+                    class="css-1rgujud e11px6xy8"><a href=https://yarnpkg.com/features>Features
                       </a> </div> <div class="css-1rgujud e11px6xy8"><a
-                        href=https://next.yarnpkg.com/cli>CLI </a> </div> <div
+                        href=https://yarnpkg.com/cli>CLI </a> </div> <div
                         class="css-1rgujud e11px6xy8"><a
-                          href=https://next.yarnpkg.com/advanced>Advanced </a> </div> </div>
+                          href=https://yarnpkg.com/advanced>Advanced </a> </div> </div>
                           </header> </div> <main class="main-content">
                           <h1>THE YARN V2 DOCS HAVE MOVED</h1>
                           <p>If your browser does not redirect you <a
-                              href="https://next.yarnpkg.com">click here to visit the new
+                              href="https://yarnpkg.com">click here to visit the new
                               documentation site</a>.
                           </p>
                           </main>

--- a/packages/gatsby/content/advanced/contributing.md
+++ b/packages/gatsby/content/advanced/contributing.md
@@ -87,7 +87,7 @@ yarn test:lint --fix
 
 ## Preparing your PR to be released
 
-In order to track which packages need to be released we use the workflow described in the [following document](https://next.yarnpkg.com/advanced/managing-releases). To summarize, you must run `yarn version check --interactive` on each PR you make, and select which packages should be released again for your changes to be effective (and to which version), if any.
+In order to track which packages need to be released we use the workflow described in the [following document](https://yarnpkg.com/advanced/managing-releases). To summarize, you must run `yarn version check --interactive` on each PR you make, and select which packages should be released again for your changes to be effective (and to which version), if any.
 
 If you expect a package to have to be released again but Yarn doesn't offer you this choice, first check whether the name of your local branch is `master`. If that's the case, Yarn might not be able to detect your changes (since it will do it against `master`, which is yourself). Run the following commands:
 

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -77,7 +77,7 @@ We now need to inject some variables into the environment for Node to be able to
 
 ### Setup your IDE accordingly
 
-We've written a [guide](https://next.yarnpkg.com/advanced/editor-sdks) entirely designed to explain you how to use Yarn with your IDE. Make sure to take a look at it, and maybe contribute to it if some instructions are unclear or missing!
+We've written a [guide](https://yarnpkg.com/advanced/editor-sdks) entirely designed to explain you how to use Yarn with your IDE. Make sure to take a look at it, and maybe contribute to it if some instructions are unclear or missing!
 
 ### Update your configuration to the new settings
 

--- a/packages/gatsby/content/advanced/questions-and-answers.md
+++ b/packages/gatsby/content/advanced/questions-and-answers.md
@@ -64,7 +64,7 @@ If you're not using Zero-Installs:
 
 ### Details
 
-- `.yarn/unplugged` and `.yarn/build-state.yml` should likely always be ignored since they typically hold machine-specific build artifacts. Ignoring them might however prevent [Zero-Installs](https://next.yarnpkg.com/features/zero-installs) from working (to prevent this, set [`enableScripts`](/configuration/yarnrc#enableScripts) to `false`).
+- `.yarn/unplugged` and `.yarn/build-state.yml` should likely always be ignored since they typically hold machine-specific build artifacts. Ignoring them might however prevent [Zero-Installs](https://yarnpkg.com/features/zero-installs) from working (to prevent this, set [`enableScripts`](/configuration/yarnrc#enableScripts) to `false`).
 
 - `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).
 

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -220,7 +220,7 @@ export const Header = ({children}) => {
       <NewsContainer>
         <NewsOverlay href={`https://github.com/yarnpkg/berry`} />
         <NewsInner>
-          <Highlight>Important:</Highlight> This documentation covers Yarn 2. For the 1.x doc, check <a href={`https://legacy.yarnpkg.com`}>legacy.yarnpkg.com</a>.
+          <Highlight>Important:</Highlight> This documentation covers Yarn 2. For the 1.x doc, check <a href={`https://classic.yarnpkg.com`}>classic.yarnpkg.com</a>.
         </NewsInner>
       </NewsContainer>
 

--- a/packages/gatsby/static/_redirects
+++ b/packages/gatsby/static/_redirects
@@ -1,53 +1,53 @@
-/install.sh https://legacy.yarnpkg.com/install.sh 301
+/install.sh https://classic.yarnpkg.com/install.sh 301
 
-/downloads/* https://legacy.yarnpkg.com/downloads/:splat 301
+/downloads/* https://classic.yarnpkg.com/downloads/:splat 301
 
-/latest-version https://legacy.yarnpkg.com/latest-version 301
-/latest-rc-version https://legacy.yarnpkg.com/latest-rc-version 301
+/latest-version https://classic.yarnpkg.com/latest-version 301
+/latest-rc-version https://classic.yarnpkg.com/latest-rc-version 301
 
-/latest.tar.gz https://legacy.yarnpkg.com/latest.tar.gz 301
-/latest.tar.gz.asc https://legacy.yarnpkg.com/latest.tar.gz.asc 301
-/latest.msi https://legacy.yarnpkg.com/latest.msi 301
-/latest.deb https://legacy.yarnpkg.com/latest.deb 301
-/latest.rpm https://legacy.yarnpkg.com/latest.rpm 301
+/latest.tar.gz https://classic.yarnpkg.com/latest.tar.gz 301
+/latest.tar.gz.asc https://classic.yarnpkg.com/latest.tar.gz.asc 301
+/latest.msi https://classic.yarnpkg.com/latest.msi 301
+/latest.deb https://classic.yarnpkg.com/latest.deb 301
+/latest.rpm https://classic.yarnpkg.com/latest.rpm 301
 
-/latest-rc.tar.gz https://legacy.yarnpkg.com/latest-rc.tar.gz 301
-/latest-rc.tar.gz.asc https://legacy.yarnpkg.com/latest-rc.tar.gz.asc 301
-/latest-rc.msi https://legacy.yarnpkg.com/latest-rc.msi 301
-/latest-rc.deb https://legacy.yarnpkg.com/latest-rc.deb 301
-/latest-rc.rpm https://legacy.yarnpkg.com/latest-rc.rpm 301
+/latest-rc.tar.gz https://classic.yarnpkg.com/latest-rc.tar.gz 301
+/latest-rc.tar.gz.asc https://classic.yarnpkg.com/latest-rc.tar.gz.asc 301
+/latest-rc.msi https://classic.yarnpkg.com/latest-rc.msi 301
+/latest-rc.deb https://classic.yarnpkg.com/latest-rc.deb 301
+/latest-rc.rpm https://classic.yarnpkg.com/latest-rc.rpm 301
 
-/blog/* https://legacy.yarnpkg.com/blog/:splat 301
+/blog/* https://classic.yarnpkg.com/blog/:splat 301
 
-/lang/en/* https://legacy.yarnpkg.com/en/:splat 301
-/en/* https://legacy.yarnpkg.com/en/:splat 301
+/lang/en/* https://classic.yarnpkg.com/en/:splat 301
+/en/* https://classic.yarnpkg.com/en/:splat 301
 
-/lang/es-ES/* https://legacy.yarnpkg.com/es-ES/:splat 301
-/es-ES/* https://legacy.yarnpkg.com/es-ES/:splat 301
+/lang/es-ES/* https://classic.yarnpkg.com/es-ES/:splat 301
+/es-ES/* https://classic.yarnpkg.com/es-ES/:splat 301
 
-/lang/fr/* https://legacy.yarnpkg.com/fr/:splat 301
-/fr/* https://legacy.yarnpkg.com/fr/:splat 301
+/lang/fr/* https://classic.yarnpkg.com/fr/:splat 301
+/fr/* https://classic.yarnpkg.com/fr/:splat 301
 
-/lang/id-ID/* https://legacy.yarnpkg.com/id-ID/:splat 301
-/id-ID/* https://legacy.yarnpkg.com/id-ID/:splat 301
+/lang/id-ID/* https://classic.yarnpkg.com/id-ID/:splat 301
+/id-ID/* https://classic.yarnpkg.com/id-ID/:splat 301
 
-/lang/ja/* https://legacy.yarnpkg.com/ja/:splat 301
-/ja/* https://legacy.yarnpkg.com/ja/:splat 301
+/lang/ja/* https://classic.yarnpkg.com/ja/:splat 301
+/ja/* https://classic.yarnpkg.com/ja/:splat 301
 
-/lang/pt-BR/* https://legacy.yarnpkg.com/pt-BR/:splat 301
-/pt-BR/* https://legacy.yarnpkg.com/pt-BR/:splat 301
+/lang/pt-BR/* https://classic.yarnpkg.com/pt-BR/:splat 301
+/pt-BR/* https://classic.yarnpkg.com/pt-BR/:splat 301
 
-/lang/ru/* https://legacy.yarnpkg.com/ru/:splat 301
-/ru/* https://legacy.yarnpkg.com/ru/:splat 301
+/lang/ru/* https://classic.yarnpkg.com/ru/:splat 301
+/ru/* https://classic.yarnpkg.com/ru/:splat 301
 
-/lang/tr/* https://legacy.yarnpkg.com/tr/:splat 301
-/tr/* https://legacy.yarnpkg.com/tr/:splat 301
+/lang/tr/* https://classic.yarnpkg.com/tr/:splat 301
+/tr/* https://classic.yarnpkg.com/tr/:splat 301
 
-/lang/uk/* https://legacy.yarnpkg.com/uk/:splat 301
-/uk/* https://legacy.yarnpkg.com/uk/:splat 301
+/lang/uk/* https://classic.yarnpkg.com/uk/:splat 301
+/uk/* https://classic.yarnpkg.com/uk/:splat 301
 
-/lang/zh-Hans/* https://legacy.yarnpkg.com/zh-Hans/:splat 301
-/zh-Hans/* https://legacy.yarnpkg.com/zh-Hans/:splat 301
+/lang/zh-Hans/* https://classic.yarnpkg.com/zh-Hans/:splat 301
+/zh-Hans/* https://classic.yarnpkg.com/zh-Hans/:splat 301
 
-/lang/zh-Hant/* https://legacy.yarnpkg.com/zh-Hant/:splat 301
-/zh-Hant/* https://legacy.yarnpkg.com/zh-Hant/:splat 301
+/lang/zh-Hant/* https://classic.yarnpkg.com/zh-Hant/:splat 301
+/zh-Hant/* https://classic.yarnpkg.com/zh-Hant/:splat 301

--- a/packages/plugin-compat/README.md
+++ b/packages/plugin-compat/README.md
@@ -8,5 +8,5 @@ This plugin is included by default in Yarn.
 
 ## Compatibility Features
 
-- [`typescript`](https://next.yarnpkg.com/package?typescript): Auto-merge of [#35206](https://github.com/microsoft/TypeScript/pull/35206)
-- [`resolve`](https://next.yarnpkg.com/package/?resolve): Implements [`normalize-options.js`](https://github.com/browserify/resolve/pull/174)
+- [`typescript`](https://yarnpkg.com/package?typescript): Auto-merge of [#35206](https://github.com/microsoft/TypeScript/pull/35206)
+- [`resolve`](https://yarnpkg.com/package/?resolve): Implements [`normalize-options.js`](https://github.com/browserify/resolve/pull/174)

--- a/packages/plugin-constraints/README.md
+++ b/packages/plugin-constraints/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/plugin-constraints`
 
-This plugin adds support for [constraints](https://next.yarnpkg.com/features/constraints) to Yarn.
+This plugin adds support for [constraints](https://yarnpkg.com/features/constraints) to Yarn.
 
 ## Install
 

--- a/packages/plugin-constraints/bin/@yarnpkg/plugin-constraints.js
+++ b/packages/plugin-constraints/bin/@yarnpkg/plugin-constraints.js
@@ -10211,7 +10211,7 @@ module.exports = {
 
         If the \`--fix\` flag is used, Yarn will attempt to automatically fix the issues the best it can, following a multi-pass process (with a maximum of 10 iterations). Some ambiguous patterns cannot be autofixed, in which case you'll have to manually specify the right resolution.
 
-        For more information as to how to write constraints, please consult our dedicated page on our website: https://next.yarnpkg.com/features/constraints.
+        For more information as to how to write constraints, please consult our dedicated page on our website: https://yarnpkg.com/features/constraints.
       `,
     examples: [[`Check that all constraints are satisfied`, `yarn constraints`], [`Autofix all unmet constraints`, `yarn constraints --fix`]]
   });

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -22,7 +22,7 @@ export default class ConstraintsCheckCommand extends BaseCommand {
 
       If the \`--fix\` flag is used, Yarn will attempt to automatically fix the issues the best it can, following a multi-pass process (with a maximum of 10 iterations). Some ambiguous patterns cannot be autofixed, in which case you'll have to manually specify the right resolution.
 
-      For more information as to how to write constraints, please consult our dedicated page on our website: https://next.yarnpkg.com/features/constraints.
+      For more information as to how to write constraints, please consult our dedicated page on our website: https://yarnpkg.com/features/constraints.
     `,
     examples: [[
       `Check that all constraints are satisfied`,

--- a/packages/plugin-dlx/README.md
+++ b/packages/plugin-dlx/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/plugin-dlx`
 
-This plugin adds support for [yarn dlx](https://next.yarnpkg.com/cli/dlx) to Yarn.
+This plugin adds support for [yarn dlx](https://yarnpkg.com/cli/dlx) to Yarn.
 
 ## Install
 

--- a/packages/plugin-interactive-tools/README.md
+++ b/packages/plugin-interactive-tools/README.md
@@ -10,4 +10,4 @@ yarn plugin import interactive-tools
 
 ## Commands
 
-- [`yarn upgrade-interactive`](https://next.yarnpkg.com/cli/upgrade-interactive)
+- [`yarn upgrade-interactive`](https://yarnpkg.com/cli/upgrade-interactive)

--- a/packages/plugin-node-modules/README.md
+++ b/packages/plugin-node-modules/README.md
@@ -12,7 +12,7 @@ nodeLinker: node-modules
 
 ## Word of caution
 
-While they are supported by virtually every tool, installs using the `node_modules` strategy have various fundamental issues that the default Plug'n'Play installations don't suffer from (for more details, check out our [documentation](https://next.yarnpkg.com/features/pnp)). Carefully consider the pros and cons before enabling this plugin.
+While they are supported by virtually every tool, installs using the `node_modules` strategy have various fundamental issues that the default Plug'n'Play installations don't suffer from (for more details, check out our [documentation](https://yarnpkg.com/features/pnp)). Carefully consider the pros and cons before enabling this plugin.
 
 ## Known issues
 

--- a/packages/plugin-npm-cli/README.md
+++ b/packages/plugin-npm-cli/README.md
@@ -8,6 +8,6 @@ This plugin is included by default in Yarn.
 
 ## Commands
 
-- [`yarn npm login`](https://next.yarnpkg.com/cli/npm/login)
-- [`yarn npm publish`](https://next.yarnpkg.com/cli/npm/publish)
-- [`yarn npm whoami`](https://next.yarnpkg.com/cli/npm/whoami)
+- [`yarn npm login`](https://yarnpkg.com/cli/npm/login)
+- [`yarn npm publish`](https://yarnpkg.com/cli/npm/publish)
+- [`yarn npm whoami`](https://yarnpkg.com/cli/npm/whoami)

--- a/packages/plugin-pack/README.md
+++ b/packages/plugin-pack/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/plugin-pack`
 
-This plugin adds support for the [`yarn pack`](https://next.yarnpkg.com/cli/pack) command.
+This plugin adds support for the [`yarn pack`](https://yarnpkg.com/cli/pack) command.
 
 ## Install
 

--- a/packages/plugin-pnp/README.md
+++ b/packages/plugin-pnp/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/plugin-pnp`
 
-This plugin adds support for installing packages according to the [Plug'n'Play specification](https://next.yarnpkg.com/features/pnp).
+This plugin adds support for installing packages according to the [Plug'n'Play specification](https://yarnpkg.com/features/pnp).
 
 ## Install
 

--- a/packages/plugin-stage/README.md
+++ b/packages/plugin-stage/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/plugin-stage`
 
-This plugin adds support for the [`yarn stage`](https://next.yarnpkg.com/cli/stage) command.
+This plugin adds support for the [`yarn stage`](https://yarnpkg.com/cli/stage) command.
 
 ## Install
 

--- a/packages/plugin-version/README.md
+++ b/packages/plugin-version/README.md
@@ -1,6 +1,6 @@
 # `@yarnpkg/plugin-version`
 
-This plugin adds support for the new [release workflow](https://next.yarnpkg.com/features/release-workflow).
+This plugin adds support for the new [release workflow](https://yarnpkg.com/features/release-workflow).
 
 ## Install
 

--- a/packages/plugin-workspace-tools/README.md
+++ b/packages/plugin-workspace-tools/README.md
@@ -10,4 +10,4 @@ yarn plugin import workspace-tools
 
 ## Commands
 
-- [`yarn workspaces foreach`](https://next.yarnpkg.com/cli/workspaces/foreach)
+- [`yarn workspaces foreach`](https://yarnpkg.com/cli/workspaces/foreach)

--- a/packages/yarnpkg-doctor/README.md
+++ b/packages/yarnpkg-doctor/README.md
@@ -94,5 +94,5 @@ This rule is a temporary measure to address this [issue](https://github.com/webp
 
 ## Further reading
 
-* [Yarn 2 docs](https://next.yarnpkg.com)
-* [Introduction to `plug-n-play`](https://next.yarnpkg.com/features/pnp)
+* [Yarn 2 docs](https://yarnpkg.com)
+* [Introduction to `plug-n-play`](https://yarnpkg.com/features/pnp)

--- a/packages/yarnpkg-pnpify/sources/cli.ts
+++ b/packages/yarnpkg-pnpify/sources/cli.ts
@@ -25,7 +25,7 @@ function help(error: boolean) {
   logFn(`Usage: yarn pnpify <program> [...argv]`);
   logFn();
   logFn(`Setups a TypeScript sdk for use within your VSCode editor instance`);
-  logFn(`More info at https://next.yarnpkg.com/advanced/pnpify`);
+  logFn(`More info at https://yarnpkg.com/advanced/pnpify`);
 }
 
 function sdk() {


### PR DESCRIPTION
Replaces `legacy.yarnpkg.com` to `classic.yarnpkg.com` as per the discussion in #766:

> The Yarn Classic documentation will be moved once again to be hosted at classic.yarnpkg.com

Replaces `next.yarnpkg.com` with `yarnpkg.com` now that the v2 site is the default one.

References #766