### PR TITLE
fix(www): consistent spacing with Copyable container

### DIFF
--- a/packages/gatsby/src/components/details/Copyable.js
+++ b/packages/gatsby/src/components/details/Copyable.js
@@ -22,6 +22,8 @@ const Button = styled.button`
   white-space: nowrap;
   cursor: pointer;
   font-size: 0.9em;
+  padding: 0;
+  margin: 0;
 
   &:focus {
     outline: none;
@@ -41,7 +43,7 @@ const Button = styled.button`
 const CopyableContent = styled.section`
   display: flex;
   width: 100%;
-  margin: 8px 0;
+  margin: 0;
   font-size: 1em;
   color: #666666;
   whitespace: no-wrap;


### PR DESCRIPTION
**What's the problem this PR addresses?**

<img width="368" alt="Screenshot 2020-02-04 at 10 30 09" src="https://user-images.githubusercontent.com/6270048/73731841-78959b80-4739-11ea-91a3-c1c8ccb7f1b7.png">


**How did you fix it?**

<img width="373" alt="Screenshot 2020-02-04 at 10 29 56" src="https://user-images.githubusercontent.com/6270048/73731863-7cc1b900-4739-11ea-8793-1f605d3f2f96.png">

