### PR TITLE
Various shell fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 /packages/yarnpkg-libzip/sources/libzipAsync.js
 /packages/yarnpkg-libzip/sources/libzipSync.js
+
+# The parsers are auto-generated
+/packages/yarnpkg-parsers/sources/grammars/*.js

--- a/.yarn/versions/395d6de1.yml
+++ b/.yarn/versions/395d6de1.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/parsers": prerelease
+  "@yarnpkg/shell": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-parsers/sources/grammars/shell.d.ts
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.d.ts
@@ -12,11 +12,14 @@ export type ArgumentSegment =
   | {type: `variable`, name: string, defaultValue?: Array<ValueArgument>, quoted: boolean};
 
 export type Argument =
-  | {type: `redirection`, subtype: `>` | `<` | `>>` | `<<<`, args: Array<ValueArgument>}
+  | RedirectArgument
   | ValueArgument;
 
+export type RedirectArgument =
+  | {type: `redirection`, subtype: `>` | `<` | `>>` | `<<<`, args: Array<ValueArgument>};
+
 export type ValueArgument =
-| {type: `argument`, segments: Array<ArgumentSegment>};
+  | {type: `argument`, segments: Array<ArgumentSegment>};
 
 export type EnvSegment = {
   name: string,
@@ -30,6 +33,7 @@ export type Command = {
 } | {
   type: `subshell`,
   subshell: ShellLine,
+  args: Array<RedirectArgument>,
 } | {
   type: `envs`,
   envs: Array<EnvSegment>

--- a/packages/yarnpkg-parsers/sources/grammars/shell.js
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.js
@@ -28,35 +28,35 @@ peg$subclass(peg$SyntaxError, Error);
 
 peg$SyntaxError.buildMessage = function(expected, found) {
   var DESCRIBE_EXPECTATION_FNS = {
-    literal: function(expectation) {
-      return `"${literalEscape(expectation.text)}"`;
-    },
+        literal: function(expectation) {
+          return "\"" + literalEscape(expectation.text) + "\"";
+        },
 
-    "class": function(expectation) {
-      var escapedParts = "",
-        i;
+        "class": function(expectation) {
+          var escapedParts = "",
+              i;
 
-      for (i = 0; i < expectation.parts.length; i++)
-        escapedParts += expectation.parts[i] instanceof Array
-          ? `${classEscape(expectation.parts[i][0])}-${classEscape(expectation.parts[i][1])}`
-          : classEscape(expectation.parts[i]);
+          for (i = 0; i < expectation.parts.length; i++) {
+            escapedParts += expectation.parts[i] instanceof Array
+              ? classEscape(expectation.parts[i][0]) + "-" + classEscape(expectation.parts[i][1])
+              : classEscape(expectation.parts[i]);
+          }
 
+          return "[" + (expectation.inverted ? "^" : "") + escapedParts + "]";
+        },
 
-      return `[${expectation.inverted ? "^" : ""}${escapedParts}]`;
-    },
+        any: function(expectation) {
+          return "any character";
+        },
 
-    any: function(expectation) {
-      return "any character";
-    },
+        end: function(expectation) {
+          return "end of input";
+        },
 
-    end: function(expectation) {
-      return "end of input";
-    },
-
-    other: function(expectation) {
-      return expectation.description;
-    },
-  };
+        other: function(expectation) {
+          return expectation.description;
+        }
+      };
 
   function hex(ch) {
     return ch.charCodeAt(0).toString(16).toUpperCase();
@@ -70,8 +70,8 @@ peg$SyntaxError.buildMessage = function(expected, found) {
       .replace(/\t/g, '\\t')
       .replace(/\n/g, '\\n')
       .replace(/\r/g, '\\r')
-      .replace(/[\x00-\x0F]/g,          function(ch) { return `\\x0${hex(ch)}`; })
-      .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) { return `\\x${hex(ch)}`; });
+      .replace(/[\x00-\x0F]/g,          function(ch) { return '\\x0' + hex(ch); })
+      .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) { return '\\x'  + hex(ch); });
   }
 
   function classEscape(s) {
@@ -84,8 +84,8 @@ peg$SyntaxError.buildMessage = function(expected, found) {
       .replace(/\t/g, '\\t')
       .replace(/\n/g, '\\n')
       .replace(/\r/g, '\\r')
-      .replace(/[\x00-\x0F]/g,          function(ch) { return `\\x0${hex(ch)}`; })
-      .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) { return `\\x${hex(ch)}`; });
+      .replace(/[\x00-\x0F]/g,          function(ch) { return '\\x0' + hex(ch); })
+      .replace(/[\x10-\x1F\x7F-\x9F]/g, function(ch) { return '\\x'  + hex(ch); });
   }
 
   function describeExpectation(expectation) {
@@ -94,11 +94,11 @@ peg$SyntaxError.buildMessage = function(expected, found) {
 
   function describeExpected(expected) {
     var descriptions = new Array(expected.length),
-      i, j;
+        i, j;
 
-    for (i = 0; i < expected.length; i++)
+    for (i = 0; i < expected.length; i++) {
       descriptions[i] = describeExpectation(expected[i]);
-
+    }
 
     descriptions.sort();
 
@@ -117,20 +117,20 @@ peg$SyntaxError.buildMessage = function(expected, found) {
         return descriptions[0];
 
       case 2:
-        return `${descriptions[0]} or ${descriptions[1]}`;
+        return descriptions[0] + " or " + descriptions[1];
 
       default:
-        return `${descriptions.slice(0, -1).join(", ")
-        }, or ${
-          descriptions[descriptions.length - 1]}`;
+        return descriptions.slice(0, -1).join(", ")
+          + ", or "
+          + descriptions[descriptions.length - 1];
     }
   }
 
   function describeFound(found) {
-    return found ? `"${literalEscape(found)}"` : "end of input";
+    return found ? "\"" + literalEscape(found) + "\"" : "end of input";
   }
 
-  return `Expected ${describeExpected(expected)} but ${describeFound(found)} found.`;
+  return "Expected " + describeExpected(expected) + " but " + describeFound(found) + " found.";
 };
 
 function peg$parse(input, options) {
@@ -138,109 +138,109 @@ function peg$parse(input, options) {
 
   var peg$FAILED = {},
 
-    peg$startRuleFunctions = {Start: peg$parseStart},
-    peg$startRuleFunction  = peg$parseStart,
+      peg$startRuleFunctions = { Start: peg$parseStart },
+      peg$startRuleFunction  = peg$parseStart,
 
-    peg$c0 = function(line) { return line ? line : []; },
-    peg$c1 = function(main, then) { return [main].concat(then || []); },
-    peg$c2 = ";",
-    peg$c3 = peg$literalExpectation(";", false),
-    peg$c4 = function(then) { return then; },
-    peg$c5 = function(chain, then) { return then ? {chain, then} : {chain}; },
-    peg$c6 = function(type, then) { return {type, line: then}; },
-    peg$c7 = "&&",
-    peg$c8 = peg$literalExpectation("&&", false),
-    peg$c9 = "||",
-    peg$c10 = peg$literalExpectation("||", false),
-    peg$c11 = function(main, then) { return then ? {...main, then} : main; },
-    peg$c12 = function(type, then) { return {type, chain: then}; },
-    peg$c13 = "|&",
-    peg$c14 = peg$literalExpectation("|&", false),
-    peg$c15 = "|",
-    peg$c16 = peg$literalExpectation("|", false),
-    peg$c17 = "=",
-    peg$c18 = peg$literalExpectation("=", false),
-    peg$c19 = function(name, arg) { return {name, args: [arg]}; },
-    peg$c20 = function(name) { return {name, args: []}; },
-    peg$c21 = "(",
-    peg$c22 = peg$literalExpectation("(", false),
-    peg$c23 = ")",
-    peg$c24 = peg$literalExpectation(")", false),
-    peg$c25 = function(subshell) { return {type: `subshell`, subshell}; },
-    peg$c26 = function(envs, args) { return {type: `command`, args, envs}; },
-    peg$c27 = function(envs) { return {type: `envs`, envs}; },
-    peg$c28 = function(args) { return args; },
-    peg$c29 = ">>",
-    peg$c30 = peg$literalExpectation(">>", false),
-    peg$c31 = ">",
-    peg$c32 = peg$literalExpectation(">", false),
-    peg$c33 = "<<<",
-    peg$c34 = peg$literalExpectation("<<<", false),
-    peg$c35 = "<",
-    peg$c36 = peg$literalExpectation("<", false),
-    peg$c37 = function(redirect, arg) { return {type: `redirection`, subtype: redirect, args: [arg]}; },
-    peg$c38 = function(arg) { return arg; },
-    peg$c39 = function(segments) { return {type: `argument`, segments: [].concat(...segments)}; },
-    peg$c40 = function(string) { return string; },
-    peg$c41 = "'",
-    peg$c42 = peg$literalExpectation("'", false),
-    peg$c43 = function(text) { return [{type: `text`, text}]; },
-    peg$c44 = "\"",
-    peg$c45 = peg$literalExpectation("\"", false),
-    peg$c46 = function(segments) { return segments; },
-    peg$c47 = function(shell) { return {type: `shell`, shell, quoted: true}; },
-    peg$c48 = function(variable) { return {type: `variable`, ...variable, quoted: true}; },
-    peg$c49 = function(text) { return {type: `text`, text}; },
-    peg$c50 = function(shell) { return {type: `shell`, shell, quoted: false}; },
-    peg$c51 = function(variable) { return {type: `variable`, ...variable, quoted: false}; },
-    peg$c52 = "\\",
-    peg$c53 = peg$literalExpectation("\\", false),
-    peg$c54 = peg$anyExpectation(),
-    peg$c55 = function(c) { return c; },
-    peg$c56 = /^[^']/,
-    peg$c57 = peg$classExpectation(["'"], true, false),
-    peg$c58 = function(chars) { return chars.join(``); },
-    peg$c59 = /^[^$"]/,
-    peg$c60 = peg$classExpectation(["$", "\""], true, false),
-    peg$c61 = "$(",
-    peg$c62 = peg$literalExpectation("$(", false),
-    peg$c63 = function(command) { return command; },
-    peg$c64 = "${",
-    peg$c65 = peg$literalExpectation("${", false),
-    peg$c66 = ":-",
-    peg$c67 = peg$literalExpectation(":-", false),
-    peg$c68 = "}",
-    peg$c69 = peg$literalExpectation("}", false),
-    peg$c70 = function(name, arg) { return {name, defaultValue: arg}; },
-    peg$c71 = ":-}",
-    peg$c72 = peg$literalExpectation(":-}", false),
-    peg$c73 = function(name) { return {name, defaultValue: []}; },
-    peg$c74 = function(name) { return {name}; },
-    peg$c75 = "$",
-    peg$c76 = peg$literalExpectation("$", false),
-    peg$c77 = /^[a-zA-Z0-9_]/,
-    peg$c78 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
-    peg$c79 = function() { return text(); },
-    peg$c80 = /^[@*?#a-zA-Z0-9_\-]/,
-    peg$c81 = peg$classExpectation(["@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
-    peg$c82 = /^[(){}<>$|&; \t"']/,
-    peg$c83 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
-    peg$c84 = /^[ \t]/,
-    peg$c85 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c0 = function(line) { return line ? line : [] },
+      peg$c1 = function(main, then) { return [ main ].concat(then || []) },
+      peg$c2 = ";",
+      peg$c3 = peg$literalExpectation(";", false),
+      peg$c4 = function(then) { return then },
+      peg$c5 = function(chain, then) { return then ? { chain, then } : { chain } },
+      peg$c6 = function(type, then) { return { type, line: then } },
+      peg$c7 = "&&",
+      peg$c8 = peg$literalExpectation("&&", false),
+      peg$c9 = "||",
+      peg$c10 = peg$literalExpectation("||", false),
+      peg$c11 = function(main, then) { return then ? { ...main, then } : main },
+      peg$c12 = function(type, then) { return { type, chain: then } },
+      peg$c13 = "|&",
+      peg$c14 = peg$literalExpectation("|&", false),
+      peg$c15 = "|",
+      peg$c16 = peg$literalExpectation("|", false),
+      peg$c17 = "=",
+      peg$c18 = peg$literalExpectation("=", false),
+      peg$c19 = function(name, arg) { return { name, args: [arg] } },
+      peg$c20 = function(name) { return { name, args: [] } },
+      peg$c21 = "(",
+      peg$c22 = peg$literalExpectation("(", false),
+      peg$c23 = ")",
+      peg$c24 = peg$literalExpectation(")", false),
+      peg$c25 = function(subshell, args) { return { type: `subshell`, subshell, args } },
+      peg$c26 = function(envs, args) { return { type: `command`, args, envs } },
+      peg$c27 = function(envs) { return { type: `envs`, envs } },
+      peg$c28 = function(args) { return args },
+      peg$c29 = function(arg) { return arg },
+      peg$c30 = ">>",
+      peg$c31 = peg$literalExpectation(">>", false),
+      peg$c32 = ">",
+      peg$c33 = peg$literalExpectation(">", false),
+      peg$c34 = "<<<",
+      peg$c35 = peg$literalExpectation("<<<", false),
+      peg$c36 = "<",
+      peg$c37 = peg$literalExpectation("<", false),
+      peg$c38 = function(redirect, arg) { return { type: `redirection`, subtype: redirect, args: [arg] } },
+      peg$c39 = function(segments) { return { type: `argument`, segments: [].concat(... segments) } },
+      peg$c40 = function(string) { return string },
+      peg$c41 = "'",
+      peg$c42 = peg$literalExpectation("'", false),
+      peg$c43 = function(text) { return [ { type: `text`, text } ] },
+      peg$c44 = "\"",
+      peg$c45 = peg$literalExpectation("\"", false),
+      peg$c46 = function(segments) { return segments },
+      peg$c47 = function(shell) { return { type: `shell`, shell, quoted: true } },
+      peg$c48 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
+      peg$c49 = function(text) { return { type: `text`, text } },
+      peg$c50 = function(shell) { return { type: `shell`, shell, quoted: false } },
+      peg$c51 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
+      peg$c52 = "\\",
+      peg$c53 = peg$literalExpectation("\\", false),
+      peg$c54 = peg$anyExpectation(),
+      peg$c55 = function(c) { return c },
+      peg$c56 = /^[^']/,
+      peg$c57 = peg$classExpectation(["'"], true, false),
+      peg$c58 = function(chars) { return chars.join(``) },
+      peg$c59 = /^[^$"]/,
+      peg$c60 = peg$classExpectation(["$", "\""], true, false),
+      peg$c61 = "$(",
+      peg$c62 = peg$literalExpectation("$(", false),
+      peg$c63 = function(command) { return command },
+      peg$c64 = "${",
+      peg$c65 = peg$literalExpectation("${", false),
+      peg$c66 = ":-",
+      peg$c67 = peg$literalExpectation(":-", false),
+      peg$c68 = "}",
+      peg$c69 = peg$literalExpectation("}", false),
+      peg$c70 = function(name, arg) { return { name, defaultValue: arg } },
+      peg$c71 = ":-}",
+      peg$c72 = peg$literalExpectation(":-}", false),
+      peg$c73 = function(name) { return { name, defaultValue: [] } },
+      peg$c74 = function(name) { return { name } },
+      peg$c75 = "$",
+      peg$c76 = peg$literalExpectation("$", false),
+      peg$c77 = /^[a-zA-Z0-9_]/,
+      peg$c78 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
+      peg$c79 = function() { return text() },
+      peg$c80 = /^[@*?#a-zA-Z0-9_\-]/,
+      peg$c81 = peg$classExpectation(["@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
+      peg$c82 = /^[(){}<>$|&; \t"']/,
+      peg$c83 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
+      peg$c84 = /^[ \t]/,
+      peg$c85 = peg$classExpectation([" ", "\t"], false, false),
 
-    peg$currPos          = 0,
-    peg$savedPos         = 0,
-    peg$posDetailsCache  = [{line: 1, column: 1}],
-    peg$maxFailPos       = 0,
-    peg$maxFailExpected  = [],
-    peg$silentFails      = 0,
+      peg$currPos          = 0,
+      peg$savedPos         = 0,
+      peg$posDetailsCache  = [{ line: 1, column: 1 }],
+      peg$maxFailPos       = 0,
+      peg$maxFailExpected  = [],
+      peg$silentFails      = 0,
 
-    peg$result;
+      peg$result;
 
   if ("startRule" in options) {
-    if (!(options.startRule in peg$startRuleFunctions))
-      throw new Error(`Can't start parsing from rule "${options.startRule}".`);
-
+    if (!(options.startRule in peg$startRuleFunctions)) {
+      throw new Error("Can't start parsing from rule \"" + options.startRule + "\".");
+    }
 
     peg$startRuleFunction = peg$startRuleFunctions[options.startRule];
   }
@@ -249,14 +249,12 @@ function peg$parse(input, options) {
     return input.substring(peg$savedPos, peg$currPos);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function location() {
     return peg$computeLocation(peg$savedPos, peg$currPos);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function expected(description, location) {
-    location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos);
+    location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos)
 
     throw peg$buildStructuredError(
       [peg$otherExpectation(description)],
@@ -265,31 +263,30 @@ function peg$parse(input, options) {
     );
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function error(message, location) {
-    location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos);
+    location = location !== void 0 ? location : peg$computeLocation(peg$savedPos, peg$currPos)
 
     throw peg$buildSimpleError(message, location);
   }
 
   function peg$literalExpectation(text, ignoreCase) {
-    return {type: "literal", text: text, ignoreCase: ignoreCase};
+    return { type: "literal", text: text, ignoreCase: ignoreCase };
   }
 
   function peg$classExpectation(parts, inverted, ignoreCase) {
-    return {type: "class", parts: parts, inverted: inverted, ignoreCase: ignoreCase};
+    return { type: "class", parts: parts, inverted: inverted, ignoreCase: ignoreCase };
   }
 
   function peg$anyExpectation() {
-    return {type: "any"};
+    return { type: "any" };
   }
 
   function peg$endExpectation() {
-    return {type: "end"};
+    return { type: "end" };
   }
 
   function peg$otherExpectation(description) {
-    return {type: "other", description: description};
+    return { type: "other", description: description };
   }
 
   function peg$computePosDetails(pos) {
@@ -299,14 +296,14 @@ function peg$parse(input, options) {
       return details;
     } else {
       p = pos - 1;
-      while (!peg$posDetailsCache[p])
+      while (!peg$posDetailsCache[p]) {
         p--;
-
+      }
 
       details = peg$posDetailsCache[p];
       details = {
         line:   details.line,
-        column: details.column,
+        column: details.column
       };
 
       while (p < pos) {
@@ -327,24 +324,24 @@ function peg$parse(input, options) {
 
   function peg$computeLocation(startPos, endPos) {
     var startPosDetails = peg$computePosDetails(startPos),
-      endPosDetails   = peg$computePosDetails(endPos);
+        endPosDetails   = peg$computePosDetails(endPos);
 
     return {
       start: {
         offset: startPos,
         line:   startPosDetails.line,
-        column: startPosDetails.column,
+        column: startPosDetails.column
       },
       end: {
         offset: endPos,
         line:   endPosDetails.line,
-        column: endPosDetails.column,
-      },
+        column: endPosDetails.column
+      }
     };
   }
 
   function peg$fail(expected) {
-    if (peg$currPos < peg$maxFailPos)  return;
+    if (peg$currPos < peg$maxFailPos) { return; }
 
     if (peg$currPos > peg$maxFailPos) {
       peg$maxFailPos = peg$currPos;
@@ -372,9 +369,9 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$parseShellLine();
-    if (s1 === peg$FAILED)
+    if (s1 === peg$FAILED) {
       s1 = null;
-
+    }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c0(s1);
@@ -391,9 +388,9 @@ function peg$parse(input, options) {
     s1 = peg$parseCommandLine();
     if (s1 !== peg$FAILED) {
       s2 = peg$parseShellLineThen();
-      if (s2 === peg$FAILED)
+      if (s2 === peg$FAILED) {
         s2 = null;
-
+      }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c1(s1, s2);
@@ -479,9 +476,9 @@ function peg$parse(input, options) {
     s1 = peg$parseCommandChain();
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCommandLineThen();
-      if (s2 === peg$FAILED)
+      if (s2 === peg$FAILED) {
         s2 = null;
-
+      }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c5(s1, s2);
@@ -584,9 +581,9 @@ function peg$parse(input, options) {
     s1 = peg$parseCommand();
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCommandChainThen();
-      if (s2 === peg$FAILED)
+      if (s2 === peg$FAILED) {
         s2 = null;
-
+      }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c11(s1, s2);
@@ -764,7 +761,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseCommand() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
     s1 = [];
@@ -813,9 +810,31 @@ function peg$parse(input, options) {
                   s8 = peg$parseS();
                 }
                 if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c25(s4);
-                  s0 = s1;
+                  s8 = [];
+                  s9 = peg$parseRedirectArgument();
+                  while (s9 !== peg$FAILED) {
+                    s8.push(s9);
+                    s9 = peg$parseRedirectArgument();
+                  }
+                  if (s8 !== peg$FAILED) {
+                    s9 = [];
+                    s10 = peg$parseS();
+                    while (s10 !== peg$FAILED) {
+                      s9.push(s10);
+                      s10 = peg$parseS();
+                    }
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c25(s4, s8);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1005,7 +1024,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseArgument() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
@@ -1015,50 +1034,11 @@ function peg$parse(input, options) {
       s2 = peg$parseS();
     }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c29) {
-        s2 = peg$c29;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c30); }
-      }
-      if (s2 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 62) {
-          s2 = peg$c31;
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c32); }
-        }
-        if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c33) {
-            s2 = peg$c33;
-            peg$currPos += 3;
-          } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c34); }
-          }
-          if (s2 === peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 60) {
-              s2 = peg$c35;
-              peg$currPos++;
-            } else {
-              s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c36); }
-            }
-          }
-        }
-      }
+      s2 = peg$parseRedirectArgument();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseValueArgument();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c37(s2, s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+        peg$savedPos = s0;
+        s1 = peg$c29(s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1079,7 +1059,7 @@ function peg$parse(input, options) {
         s2 = peg$parseValueArgument();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c38(s2);
+          s1 = peg$c29(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1089,6 +1069,73 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseRedirectArgument() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parseS();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parseS();
+    }
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c30) {
+        s2 = peg$c30;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
+      }
+      if (s2 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 62) {
+          s2 = peg$c32;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+        }
+        if (s2 === peg$FAILED) {
+          if (input.substr(peg$currPos, 3) === peg$c34) {
+            s2 = peg$c34;
+            peg$currPos += 3;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c35); }
+          }
+          if (s2 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 60) {
+              s2 = peg$c36;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c37); }
+            }
+          }
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseValueArgument();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c38(s2, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
@@ -1108,7 +1155,7 @@ function peg$parse(input, options) {
       s2 = peg$parseStrictValueArgument();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s2);
+        s1 = peg$c29(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1393,49 +1440,45 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
     }
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c52;
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s3 = peg$c52;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      }
+      if (s3 !== peg$FAILED) {
+        if (input.length > peg$currPos) {
+          s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c54); }
         }
-        if (s3 !== peg$FAILED) {
-          if (input.length > peg$currPos) {
-            s4 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c54); }
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s2;
-            s3 = peg$c55(s4);
-            s2 = s3;
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
-          }
+        if (s4 !== peg$FAILED) {
+          peg$savedPos = s2;
+          s3 = peg$c55(s4);
+          s2 = s3;
         } else {
           peg$currPos = s2;
           s2 = peg$FAILED;
         }
-        if (s2 === peg$FAILED) {
-          if (peg$c56.test(input.charAt(peg$currPos))) {
-            s2 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c57); }
-          }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 === peg$FAILED) {
+        if (peg$c56.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
       }
-    } else {
-      s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -1998,9 +2041,9 @@ function peg$parse(input, options) {
   if (peg$result !== peg$FAILED && peg$currPos === input.length) {
     return peg$result;
   } else {
-    if (peg$result !== peg$FAILED && peg$currPos < input.length)
+    if (peg$result !== peg$FAILED && peg$currPos < input.length) {
       peg$fail(peg$endExpectation());
-
+    }
 
     throw peg$buildStructuredError(
       peg$maxFailExpected,
@@ -2014,5 +2057,5 @@ function peg$parse(input, options) {
 
 module.exports = {
   SyntaxError: peg$SyntaxError,
-  parse:       peg$parse,
+  parse:       peg$parse
 };

--- a/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
@@ -32,7 +32,7 @@ VariableAssignment
   / name:EnvVariable '=' S* { return { name, args: [] } }
 
 Command
-  = S* "(" S* subshell:ShellLine S* ")" S* { return { type: `subshell`, subshell } }
+  = S* "(" S* subshell:ShellLine S* ")" S* args:RedirectArgument* S* { return { type: `subshell`, subshell, args } }
   / S* envs:VariableAssignment* S* args:Argument+ S* { return { type: `command`, args, envs } }
   / S* envs:VariableAssignment+ S* { return { type: `envs`, envs } }
 
@@ -40,8 +40,11 @@ CommandString
   = S* args:ValueArgument+ S* { return args }
 
 Argument
-  = S* redirect:(">>" / ">" / "<<<" / "<") arg:ValueArgument { return { type: `redirection`, subtype: redirect, args: [arg] } }
+  = S* arg:RedirectArgument { return arg }
   / S* arg:ValueArgument { return arg }
+
+RedirectArgument
+  = S* redirect:(">>" / ">" / "<<<" / "<") arg:ValueArgument { return { type: `redirection`, subtype: redirect, args: [arg] } }
 
 ValueArgument
   = S* arg:StrictValueArgument { return arg }
@@ -74,7 +77,7 @@ PlainStringSegment
   / text:PlainStringText { return { type: `text`, text } }
 
 SglQuoteStringText
-  = chars:('\\' c:. { return c } / [^'])+ { return chars.join(``) }
+  = chars:('\\' c:. { return c } / [^'])* { return chars.join(``) }
 
 DblQuoteStringText
   = chars:('\\' c:. { return c } / [^$"])+ { return chars.join(``) }

--- a/packages/yarnpkg-shell/sources/pipe.ts
+++ b/packages/yarnpkg-shell/sources/pipe.ts
@@ -15,7 +15,7 @@ export type Stdio = [
   any
 ];
 
-type ProcessImplementation = (
+export type ProcessImplementation = (
   stdio: Stdio,
 ) => {
   stdin: Writable,

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -331,6 +331,22 @@ describe(`Simple shell features`, () => {
     });
   });
 
+  it(`should interpolate subshells with the proper split`, async () => {
+    await expect(bufferResult(
+      `echo $(echo foo)bar`,
+    )).resolves.toMatchObject({
+      stdout: `foobar\n`,
+    });
+  });
+
+  it(`should interpolate subshells with the proper split`, async () => {
+    await expect(bufferResult(
+      `echo $(echo 'foo      bar')bar`,
+    )).resolves.toMatchObject({
+      stdout: `foo barbar\n`,
+    });
+  });
+
   it(`should support setting env variable without command`, async () => {
     await expect(bufferResult([
       `FOO=1`,
@@ -484,5 +500,17 @@ describe(`Simple shell features`, () => {
     )).resolves.toMatchObject({
       stdout: `foo bar baz\nhello world\n`,
     });
+  });
+
+  it(`should support redirections on subshells`, async () => {
+    const file = npath.toPortablePath(fileSync({discardDescriptor: true}).name);
+
+    await expect(bufferResult(
+      `(echo "hello world") > "${file}"`,
+    )).resolves.toMatchObject({
+      stdout: ``,
+    });
+
+    await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`hello world\n`);
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

The shell implementations hit a few edge cases:

- Redirects weren't parsed when they covered a subprocess (`(...) > foo`) (fixes #752)
- The `FOO=''` syntax didn't parse (`FOO=` or `FOO=""` did) (fixes #797)
- The subprocess interpolation was closing the final argument early (fixes #865)
