### PR TITLE
Document the removal of `yarn global`

### DIFF
--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -31,6 +31,10 @@ Run `npx @yarnpkg/doctor .` (or `yarn dlx @yarnpkg/doctor .`) in your project to
 
 Note that the doctor is intended to report any potential issue - it's then up to you to decide whether they are a false positive or not (for example it won't traverse Git repositories). For this reason we don't recommend using it as a CI tool.
 
+### Use `yarn dlx` instead of `yarn global`
+
+`yarn dlx` is designed to execute one off scripts that may have been installed as global packages with `yarn 1.x`. Managing system-wide packages is outside of the scope of `yarn`. To reflect this, `yarn global` has been removed. [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821).
+
 ### Make sure you use `resolve@1.9+`
 
 Older releases don't support Plug'n'Play at all. Since the `resolve` package is used by pretty much everything nowadays, making sure that you use a modern release can go a long way to solve the most obnoxious bugs you may have.


### PR DESCRIPTION
Not sure of the wording desired here but this confused me a bit when I migrated until I came across #821. I'm confident other people will be left confused as well. Wrote this based on what I read in the aforementioned issue.

**What's the problem this PR addresses?**

A lack of documentation regarding the removal of the `yarn global` command.

**How did you fix it?**

Wrote a note in the migration guide with a reference to the issue where I learned more about it.
