### PR TITLE
fix(fslib): mark options for zipfs as required

### DIFF
--- a/.yarn/versions/c808a1ce.yml
+++ b/.yarn/versions/c808a1ce.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/fslib": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -157,8 +157,8 @@ export class ZipFS extends BasePortableFakeFS {
   private ready = false;
   private readOnly = false;
 
-  constructor(p: PortablePath, opts?: ZipPathOptions);
-  constructor(data: Buffer, opts?: ZipBufferOptions);
+  constructor(p: PortablePath, opts: ZipPathOptions);
+  constructor(data: Buffer, opts: ZipBufferOptions);
 
   constructor(source: PortablePath | Buffer, opts: ZipPathOptions | ZipBufferOptions) {
     super();


### PR DESCRIPTION
**What's the problem this PR addresses?**

The constructor for ZipFS says that the options are optional, but they're actually required.

**How did you fix it?**

Marked the options as required.