### PR TITLE
fix(doctor): don't warn on node_modules/.cache usage

### DIFF
--- a/.yarn/versions/fbe88b92.yml
+++ b/.yarn/versions/fbe88b92.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": prerelease

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -104,7 +104,7 @@ function checkForUnsafeWebpackLoaderAccess(workspace: Workspace, initializerNode
 }
 
 function checkForNodeModuleStrings(stringishNode: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral | ts.TemplateExpression , {configuration, report}: {configuration: Configuration, report: Report}) {
-  const match = /node_modules/g.test(stringishNode.getText());
+  const match = /node_modules(?!(\\{0,2}|\/)\.cache)/g.test(stringishNode.getText());
   if (match) {
     const prettyLocation = ast.prettyNodeLocation(configuration, stringishNode);
     report.reportWarning(MessageName.UNNAMED, `${prettyLocation}: Strings should avoid referencing the node_modules directory (prefer require.resolve)`);

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -104,7 +104,7 @@ function checkForUnsafeWebpackLoaderAccess(workspace: Workspace, initializerNode
 }
 
 function checkForNodeModuleStrings(stringishNode: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral | ts.TemplateExpression , {configuration, report}: {configuration: Configuration, report: Report}) {
-  const match = /node_modules(?!(\\{0,2}|\/)\.cache)/g.test(stringishNode.getText());
+  const match = /node_modules(?!(\\{2}|\/)\.cache)/g.test(stringishNode.getText());
   if (match) {
     const prettyLocation = ast.prettyNodeLocation(configuration, stringishNode);
     report.reportWarning(MessageName.UNNAMED, `${prettyLocation}: Strings should avoid referencing the node_modules directory (prefer require.resolve)`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/doctor` reports usage of `node_modules/.cache` as a warning.

**How did you fix it?**

Use a negative lookahead in the regex to not match `node_modules/.cache` and `node_modules\\.cache`