### PR TITLE
fix(libzip): add missing @types/emscripten

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -6738,6 +6738,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/yarnpkg-libzip/",
           "packageDependencies": [
             ["@yarnpkg/libzip", "workspace:packages/yarnpkg-libzip"],
+            ["@types/emscripten", "npm:1.38.0"],
             ["@types/prettier", "npm:1.19.0"],
             ["prettier", "npm:1.19.1"]
           ],

--- a/.yarn/versions/0aca03e0.yml
+++ b/.yarn/versions/0aca03e0.yml
@@ -1,0 +1,10 @@
+releases:
+  "@yarnpkg/libzip": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-patch"
+  - vscode-zipfs
+  - "@yarnpkg/core"
+  - "@yarnpkg/fslib"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-libzip/package.json
+++ b/packages/yarnpkg-libzip/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "@types/prettier": "1.19.0",
     "prettier": "^1.19.1"
+  },
+  "dependencies": {
+    "@types/emscripten": "^1.38.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4992,6 +4992,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/libzip@workspace:packages/yarnpkg-libzip"
   dependencies:
+    "@types/emscripten": ^1.38.0
     "@types/prettier": 1.19.0
     prettier: ^1.19.1
   languageName: unknown


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/libzip` depends on `@types/emscripten` but doesn't list it.

Fixes https://github.com/yarnpkg/berry/issues/746

**How did you fix it?**

Added `@types/emscripten` as a dependency.