### PR TITLE
fix(pnp): unplug packages with jar files

### DIFF
--- a/.yarn/versions/863be327.yml
+++ b/.yarn/versions/863be327.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -24,7 +24,7 @@ const FORCED_UNPLUG_FILETYPES = new Set([
   // The c/c++ compiler can't read files from zip archives
   '.h', '.hh', '.hpp', '.c', '.cc', '.cpp',
   // The java runtime can't read files from zip archives
-  '.java',
+  '.java', '.jar',
   // Node opens these through dlopen
   '.node',
 ]);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn isn't unplugging packages with `jar` files. When I implemented https://github.com/yarnpkg/berry/pull/853 I forgot to list `.jar` files, even though I had a note about including them.

ref https://github.com/yarnpkg/berry/issues/847

**How did you fix it?**

Added `.jar` to the `FORCED_UNPLUG_FILETYPES` set