### PR TITLE
StreamReport :: Limit fetch logs (YN0013) up to 5

### DIFF
--- a/.yarn/versions/2a95873b.yml
+++ b/.yarn/versions/2a95873b.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -192,9 +192,9 @@ export class StreamReport extends Report {
       if (num === 13) {
         this.forgettableLines.push(text);
         if (this.forgettableLines.length > this.visibleForgettableLineCount) {
-          while (this.forgettableLines.length > this.visibleForgettableLineCount) {
+          while (this.forgettableLines.length > this.visibleForgettableLineCount)
             this.forgettableLines.shift();
-          }
+
           this.writeLines(name, this.forgettableLines);
         } else {
           this.writeLine(`${this.configuration.format(`➤`, `blueBright`)} ${this.formatName(name)}: ${this.formatIndent()}${text}\n`);
@@ -335,7 +335,7 @@ export class StreamReport extends Report {
   }
 
   private writeLines(name: MessageName | null, lines: string[]) {
-    this.clearProgress({ delta: lines.length });
+    this.clearProgress({delta: lines.length});
     lines.forEach(line => {
       this.stdout.write(`${this.configuration.format(`➤`, `blueBright`)} ${this.formatName(name)}: ${this.formatIndent()}${line}\n`);
     });

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -197,7 +197,7 @@ export class StreamReport extends Report {
 
           this.writeLines(name, this.forgettableLines);
         } else {
-          this.writeLine(`${this.configuration.format(`➤`, `blueBright`)} ${this.formatName(name)}: ${this.formatIndent()}${text}\n`);
+          this.writeLine(`${this.configuration.format(`➤`, `blueBright`)} ${this.formatName(name)}: ${this.formatIndent()}${text}`);
         }
       } else {
         this.writeLineWithForgettableReset(`${this.configuration.format(`➤`, `blueBright`)} ${this.formatName(name)}: ${this.formatIndent()}${text}`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR is related to #816.

**How did you fix it?**

I've implemented the request of @arcanis. He advised me to keep the latest 5 fetch (`YN0013`) logs and use escaping characters while doing it.

I basically saved `YN0013` logs by keeping the latest 5 logs in the `forgettableLines` array.
Then, if it has more than 5 logs, the most aged one is dequeued and I started clearing the console up to 5 lines. And printing them back from the array with remaining lines.

If sequence is interrupted with another type of log, we reset the `forgettableLines` array.

Also, I kept them internally (private) and put the number 5 in a class-wide private variable, so it can be changed easily.
