### PR TITLE
Update Vue CLI E2E workflow, reflecting changes in Vue CLI 4.2

### DIFF
--- a/.github/workflows/e2e-vue-cli-workflow.yml
+++ b/.github/workflows/e2e-vue-cli-workflow.yml
@@ -30,6 +30,5 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        yarn dlx -p @vue/cli@^4.1.0-beta.0 vue create -d my-vue && cd my-vue
-        yarn add vue-cli-plugin-pnp -D
+        yarn dlx -p @vue/cli vue create -d my-vue && cd my-vue
         yarn build


### PR DESCRIPTION
**What's the problem this PR addresses?**

Vue CLI 4.2 has been released with built-in berry support, so no need for an extra plugin.

