### PR TITLE
GitHub has a capital H, GitLab has a capital L

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Those plugins typically come bundled with Yarn. You don't need to do anything sp
 - [★ plugin-dlx](packages/plugin-dlx) adds support for the [`yarn dlx`](https://yarnpkg.com/cli/dlx) command.
 - [★ plugin-essentials](packages/plugin-essentials) adds various commands deemed necessary for a package manager (add, remove, ...).
 - [★ plugin-file](packages/plugin-file) adds support for using the `file:` protocol within your dependencies.
-- [★ plugin-github](packages/plugin-github) adds support for using Github references as dependencies. [This plugin doesn't use git.](https://stackoverflow.com/a/13636954/880703)
+- [★ plugin-github](packages/plugin-github) adds support for using GitHub references as dependencies. [This plugin doesn't use git.](https://stackoverflow.com/a/13636954/880703)
 - [★ plugin-http](packages/plugin-http) adds support for using straight URL references as dependencies (tgz archives only).
 - [★ plugin-init](packages/plugin-init) adds support for the [`yarn init`](https://yarnpkg.com/cli/init) command.
 - [★ plugin-link](packages/plugin-link) adds support for using `link:` and `portal:` references as dependencies.

--- a/packages/gatsby/content/features/protocols.md
+++ b/packages/gatsby/content/features/protocols.md
@@ -11,8 +11,8 @@ The following protocols can be used by any dependency entry listed in the `depen
 | Semver | `^1.2.3` | Resolves from the default registry |
 | Tag | `latest` | Resolves from the default registry |
 | Npm alias | `npm:name@...` | Resolves from the npm registry |
-| Github | `foo/bar` | Alias for the `github:` protocol |
-| Github | `github:foo/bar` | Downloads a **public** package from Github |
+| GitHub | `foo/bar` | Alias for the `github:` protocol |
+| GitHub | `github:foo/bar` | Downloads a **public** package from GitHub |
 | File | `file:./my-package` | Copies the target location into the cache |
 | Link | `link:./my-folder` | Creates a link to the `./my-folder` folder (ignore dependencies) |
 | Patch | `patch:left-pad@1.0.0#./my-patch.patch` | Creates a patched copy of the original package |

--- a/packages/gatsby/src/components/details/Markdown.js
+++ b/packages/gatsby/src/components/details/Markdown.js
@@ -50,7 +50,7 @@ const renderAndEscapeMarkdown = ({source, repository}) => {
           path,
         })
         : prefixURL(href, {
-          // Github and Gitlab are the same
+          // GitHub and GitLab are the same
           base: `https://${host}`,
           user,
           project,

--- a/packages/gatsby/src/components/details/index.js
+++ b/packages/gatsby/src/components/details/index.js
@@ -334,7 +334,7 @@ export class Details extends Component {
       });
     } else if (host === 'gitlab.com') {
       const getGitlabFile = ({user, project, branch, filePath}) => {
-        // We need to use the Gitlab API because the raw url does not support cors
+        // We need to use the GitLab API because the raw url does not support cors
         // https://gitlab.com/gitlab-org/gitlab-ce/issues/25736
         // So we need to 'translate' raw urls to api urls.
         // E.g (https://gitlab.com/janslow/gitlab-fetch/raw/master/CHANGELOG.md) -> (https://gitlab.com/api/v4/projects/janslow%2Fgitlab-fetch/repository/files/CHANGELOG.md?ref=master)

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -22,7 +22,7 @@ export default class SetVersionCommand extends BaseCommand {
   static usage: Usage = Command.Usage({
     description: `lock the Yarn version used by the project`,
     details: `
-      This command will download a specific release of Yarn directly from the Yarn Github repository, will store it inside your project, and will change the \`yarnPath\` settings from your project \`.yarnrc.yml\` file to point to the new file.
+      This command will download a specific release of Yarn directly from the Yarn GitHub repository, will store it inside your project, and will change the \`yarnPath\` settings from your project \`.yarnrc.yml\` file to point to the new file.
 
       A very good use case for this command is to enforce the version of Yarn used by the any single member of your team inside a same project - by doing this you ensure that you have control on Yarn upgrades and downgrades (including on your deployment servers), and get rid of most of the headaches related to someone using a slightly different version and getting a different behavior than you.
 

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -58,7 +58,7 @@ export function normalizeRepoUrl(url: string) {
   // disambiguate that this URL points to a Git repository.
   url = url.replace(/^git\+https:/, `https:`);
 
-  // We support this as an alias to Github repositories
+  // We support this as an alias to GitHub repositories
   url = url.replace(/^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
 
   return url;

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -41,5 +41,5 @@ export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
 }
 
 export function invalidGithubUrlMessage(url: string): string {
-  return `Input cannot be parsed as a valid Github URL ('${url}').`;
+  return `Input cannot be parsed as a valid GitHub URL ('${url}').`;
 }

--- a/packages/plugin-interactive-tools/bin/@yarnpkg/plugin-interactive-tools.js
+++ b/packages/plugin-interactive-tools/bin/@yarnpkg/plugin-interactive-tools.js
@@ -5446,8 +5446,8 @@ module.exports = {
   /***/ (function(module, exports, __webpack_require__) {
 
   "use strict";
-  
-  
+
+
   module.exports = {
   	"aliceblue": [240, 248, 255],
   	"antiquewhite": [250, 235, 215],
@@ -5770,7 +5770,7 @@ module.exports = {
   })
 
   exports.isCI = !!(
-    env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
+    env.CI || // Travis CI, CircleCI, Cirrus CI, GitLab CI, Appveyor, CodeShip, dsari
     env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
     env.BUILD_NUMBER || // Jenkins, TeamCity
     env.RUN_ID || // TaskCluster, dsari

--- a/packages/plugin-version/bin/@yarnpkg/plugin-version.js
+++ b/packages/plugin-version/bin/@yarnpkg/plugin-version.js
@@ -6204,8 +6204,8 @@ module.exports = {
   /***/ (function(module, exports, __webpack_require__) {
 
   "use strict";
-  
-  
+
+
   module.exports = {
   	"aliceblue": [240, 248, 255],
   	"antiquewhite": [250, 235, 215],
@@ -6528,7 +6528,7 @@ module.exports = {
   })
 
   exports.isCI = !!(
-    env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
+    env.CI || // Travis CI, CircleCI, Cirrus CI, GitLab CI, Appveyor, CodeShip, dsari
     env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
     env.BUILD_NUMBER || // Jenkins, TeamCity
     env.RUN_ID || // TaskCluster, dsari

--- a/scripts/actions/make-commit/entrypoint.sh
+++ b/scripts/actions/make-commit/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 echo
 
 if [[ ${GITHUB_TOKEN:-""} == "" ]]; then
-  echo Expected a valid Github token in GITHUB_TOKEN, got nothing instead
+  echo Expected a valid GitHub token in GITHUB_TOKEN, got nothing instead
   exit 1
 fi
 


### PR DESCRIPTION
Just addressing a pet peeve of mine. Note that this only makes changes to documentation, strings, etc. The code is full of function names like `isGithubUrl`, `parseGithubUrl`, etc: trying to update all of those is probably not worth the trouble.