### PR TITLE
Uses hashes when building the bundle

### DIFF
--- a/.yarn/versions/ac63a01f.yml
+++ b/.yarn/versions/ac63a01f.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/builder": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -48,7 +48,7 @@
     "build:cli+hook": "run build:pnp:hook && builder build bundle",
     "build:cli": "builder build bundle",
     "run:cli": "builder run",
-    "update-local": "run build:cli && rsync -a --delete bundles/ bin/"
+    "update-local": "run build:cli --no-git-hash && rsync -a --delete bundles/ bin/"
   },
   "publishConfig": {
     "main": "./lib/index.js",


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's sometimes difficult to know what's the version currently in use, and how up-to-date it is compared to master - especially when using `yarn set version` (since all builds share the same version number).

**How did you fix it?**

The builder will now automatically add a git suffix unless the `--no-git-hash` option is set (only used for our internal releases):

```
2.0.0-rc.28.git.20200210.35e40e23
```
