### PR TITLE
Adds suggestion to the doctor

### DIFF
--- a/.yarn/versions/e4b5e209.yml
+++ b/.yarn/versions/e4b5e209.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": prerelease

--- a/packages/yarnpkg-doctor/fixtures/pre-post-scripts/package.json
+++ b/packages/yarnpkg-doctor/fixtures/pre-post-scripts/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "serve": "foo",
+    "preserve": "bar"
+  }
+}

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -290,8 +290,8 @@ async function processWorkspace(workspace: Workspace, {configuration, fileList, 
   const reportedProgress = report.reportProgress(progress);
 
   for (const scriptName of workspace.manifest.scripts.keys())
-    if (scriptName.match(/^(pre|post)(?!install$)/))
-      report.reportWarning(MessageName.UNNAMED, `Scripts prefixed with "pre" or "post" (like "${scriptName}") will not be called automatically anymore; prefer calling prologues and epilogues explicitly in your scripts`);
+    if (scriptName.match(/^(pre|post)(?!(install|pack)$)/))
+      report.reportWarning(MessageName.UNNAMED, `User scripts prefixed with "pre" or "post" (like "${scriptName}") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly`);
 
   for (const p of fileList) {
     const parsed = await parseFile(p);

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -290,7 +290,7 @@ async function processWorkspace(workspace: Workspace, {configuration, fileList, 
   const reportedProgress = report.reportProgress(progress);
 
   for (const scriptName of workspace.manifest.scripts.keys())
-    if (scriptName.match(/^(pre|post)/))
+    if (scriptName.match(/^(pre|post)(?!install$)/))
       report.reportWarning(MessageName.UNNAMED, `Scripts prefixed with "pre" or "post" (like "${scriptName}") will not be called automatically anymore; prefer calling prologues and epilogues explicitly in your scripts`);
 
   for (const p of fileList) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `pre` / `post` scripts auto-run logic has been removed from 2.x (this is intentional; there are little reason for them to exist as they provide a fringe convenience that can be easily implemented by the users in a more explicit and less confusing way).

**How did you fix it?**

Running `yarn dlx @yarnpkg/doctor .` will now report that the `pre` and `post` scripts are discouraged.
