### PR TITLE
[node-modules] Use unpacked package.json files to read build scripts

### DIFF
--- a/.yarn/versions/6b579d42.yml
+++ b/.yarn/versions/6b579d42.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -111,7 +111,7 @@ class NodeModulesInstaller extends AbstractPnpInstaller {
 
       const sourceLocation = npath.toPortablePath(installRecord.locations[0]);
 
-      const manifest = await Manifest.find(sourceLocation, {baseFs: xfs});
+      const manifest = await Manifest.find(sourceLocation);
       const buildScripts = await this.getSourceBuildScripts(sourceLocation, manifest);
 
       if (buildScripts.length > 0 && !this.opts.project.configuration.get(`enableScripts`)) {

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -109,9 +109,9 @@ class NodeModulesInstaller extends AbstractPnpInstaller {
       if (pnpEntry === null)
         throw new Error(`Assertion failed: Expected the package to be registered (${structUtils.prettyLocator(this.opts.project.configuration, locator)})`);
 
-      const sourceLocation = npath.toPortablePath(pnpEntry.packageLocation);
+      const sourceLocation = npath.toPortablePath(installRecord.locations[0]);
 
-      const manifest = await Manifest.find(sourceLocation, {baseFs: defaultFsLayer});
+      const manifest = await Manifest.find(sourceLocation, {baseFs: xfs});
       const buildScripts = await this.getSourceBuildScripts(sourceLocation, manifest);
 
       if (buildScripts.length > 0 && !this.opts.project.configuration.get(`enableScripts`)) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

On a big monorepo reading `package.json` files from inside zips takes considerable time (2 seconds on a Babel monorepo)

**How did you fix it?**

`package.json` files from installed locations are read instead (this brings down `yarn install` time on already installed Babel monorepo from 17.3 seconds to 15.3 seconds)