### PR TITLE
Fixes "yarn doctor" filtering

### DIFF
--- a/.yarn/versions/5e3ff569.yml
+++ b/.yarn/versions/5e3ff569.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": prerelease

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -381,12 +381,12 @@ class EntryCommand extends Command {
               if (!workspace)
                 return;
 
-              const patterns = [`**/*`];
+              const patterns = [`${manifestFolder}/**`];
               const ignore = [];
 
               for (const otherManifestFolder of allManifestFolders) {
                 const sub = ppath.contains(manifestFolder, otherManifestFolder);
-                if (sub !== `.`) {
+                if (sub !== null && sub !== `.`) {
                   ignore.push(`${otherManifestFolder}/**`);
                 }
               }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The doctor doesn't filter properly workspace files. In particular, it seems it was only able to run on the root workspace but not nested projects.

Fixes https://twitter.com/bitfalls/status/1227619834571169794

**How did you fix it?**

The filtering has been fixed so that each workspace can retrieve the files it contains.