### PR TITLE
Use correct variable as pluginUrl when importing a plugin from URL

### DIFF
--- a/.yarn/versions/deb6cd80.yml
+++ b/.yarn/versions/deb6cd80.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -71,7 +71,7 @@ export default class PluginDlCommand extends BaseCommand {
           }
 
           pluginSpec = this.name;
-          pluginUrl = name;
+          pluginUrl = this.name;
         } else {
           const ident = structUtils.parseIdent(this.name.replace(/^((@yarnpkg\/)?plugin-)?/, `@yarnpkg/plugin-`));
           const identStr = structUtils.stringifyIdent(ident);


### PR DESCRIPTION
**What's the problem this PR addresses?**

```
$ yarn plugin import https://github.com/bgotink/yarn-plugin-angular/raw/master/bin/%40yarnpkg/plugin-angular.js
➤ YN0001: ReferenceError: name is not defined
    at i.StreamReport.start (/Users/bram/Workspaces/Private/iapetos/.yarn/releases/yarn-rc.js:58:32837)
➤ YN0000: Failed with errors in 0.14s
```
