### PR TITLE
feat(plugin-essentials): yarn plugin runtime --json

### DIFF
--- a/.yarn/versions/d91964bd.yml
+++ b/.yarn/versions/d91964bd.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/builder"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-essentials/sources/commands/plugin/runtime.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/runtime.ts
@@ -4,6 +4,9 @@ import {Command, Usage}              from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class PluginListCommand extends BaseCommand {
+  @Command.Boolean(`--json`)
+  json: boolean = false;
+
   static usage: Usage = Command.Usage({
     category: `Plugin-related commands`,
     description: `list the active plugins`,
@@ -22,14 +25,18 @@ export default class PluginListCommand extends BaseCommand {
 
     const report = await StreamReport.start({
       configuration,
+      json: this.json,
       stdout: this.context.stdout,
     }, async report => {
       for (const name of configuration.plugins.keys()) {
-        if (this.context.plugins.plugins.has(name)) {
-          report.reportInfo(null, `${name} [builtin]`);
-        } else {
-          report.reportInfo(null, `${name}`);
-        }
+        const builtin  = this.context.plugins.plugins.has(name);
+        let label = name;
+
+        if (builtin)
+          label += ` [builtin]`;
+
+        report.reportJson({name, builtin});
+        report.reportInfo(null, `${label}`);
       }
     });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR adds the `--json` flag to the `yarn plugin runtime` command.

**How did you fix it?**

I added the `--json` flag to the `yarn plugin runtime` command. It behaves exactly like the `--json` flag of other commands. The output is NDJSON.