### PR TITLE
docs: fix some minor yarnrc errors

### DIFF
--- a/packages/gatsby/src/pages/configuration/yarnrc.js
+++ b/packages/gatsby/src/pages/configuration/yarnrc.js
@@ -313,7 +313,7 @@ const YarnrcDoc = () => <>
       />
       <SymlScalarProperty
         name={`pnpEnableInlining`}
-        placeholder={`true`}
+        placeholder={true}
         description={<>
           If true (the default), Yarn will generate a single <code>.pnp.js</code> file that contains all the required data for your project to work properly. If toggled off, Yarn will also generate a <code>.pnp.data.json</code> file meant to be consumed by the <code>@yarnpkg/pnp</code> package.
         </>}
@@ -341,7 +341,7 @@ const YarnrcDoc = () => <>
       />
       <SymlScalarProperty
         name={`pnpUnpluggedFolder`}
-        placeholder={`./yarn/unplugged`}
+        placeholder={`./.yarn/unplugged`}
         description={<>
           The path where unplugged packages will be stored on the disk.
         </>}


### PR DESCRIPTION
**What's the problem this PR addresses?**

- `pnpEnableInlining` takes a boolean, not a string
- `pnpUnpluggedFolder` has a default of `./.yarn/unplugged`, not `./yarn/unplugged`

**How did you fix it?**

Updated the docs to be correct.