### PR TITLE
Remove `gen_invalid_dependency` constraints recipe

### DIFF
--- a/packages/gatsby/content/features/constraints.md
+++ b/packages/gatsby/content/features/constraints.md
@@ -192,13 +192,13 @@ We define a rule that says that for each dependency of each workspace in our pro
 ### Prevent two workspaces from depending on conflicting versions of a same dependency
 
 ```prolog
-gen_invalid_dependency(WorkspaceCwd, DependencyIdent, DependencyType, 'This dependency conflicts with another one from another workspace') :-
+gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange2, DependencyType) :-
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, DependencyType),
-  workspace_has_dependency(_, DependencyIdent, DependencyRange2, _),
+  workspace_has_dependency(OtherWorkspaceCwd, DependencyIdent, DependencyRange2, DependencyType2),
   DependencyRange \= DependencyRange2.
 ```
 
-We define a `gen_invalid_dependency` rule that is true for each dependency of each package (first `workspace_has_dependency`) if it also exists another dependency of another package (second `workspace_has_dependency`) that has the same name but a different range (`\=` operator).
+We define a `gen_enforced_dependency` rule that requires each dependency of each package (first `workspace_has_dependency`) if it also exists another dependency of another package (second `workspace_has_dependency`) that has the same name but a different range (`\=` operator).
 
 ### Force all workspace dependencies to be made explicit
 
@@ -208,4 +208,4 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, 'workspace:*', Dependency
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, DependencyType).
 ```
 
-We define a `gen_enforced_dependency` that requires the dependency range `workspace:*` to be used if the dependency name is also the name of a valid workspace. The final `workspace_has_dependency` check is there to ensure that this rule is only applied on workspace that currently depend on the specified workspace in the first place (if it wasn't there, the rule would instead force all workspaces to depend on one another).
+We define a `gen_enforced_dependency` rule that requires the dependency range `workspace:*` to be used if the dependency name is also the name of a valid workspace. The final `workspace_has_dependency` check is there to ensure that this rule is only applied on workspace that currently depend on the specified workspace in the first place (if it wasn't there, the rule would instead force all workspaces to depend on one another).


### PR DESCRIPTION
**What's the problem this PR addresses?**

Replaces `gen_invalid_dependency` with `gen_enforced_dependency` in the constraints recipe that demonstrates how to enforce consistent dependency versions across workspaces.

I ran into trouble trying to use the original recipe, and it appears the `gen_invalid_dependency` rule was removed by https://github.com/yarnpkg/berry/pull/338.

**How did you fix it?**

I copied/merged what I found in Yarn's [constraints.pro](https://github.com/yarnpkg/berry/blob/6ffb3c478c2aac7c942aebbc0f01279f203744d1/constraints.pro) configuration.