### PR TITLE
feat(compat): add @styled-icons/* to extensions

### DIFF
--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -39,4 +39,13 @@ export const packageExtensions: Array<[string, any]> = [
       },
     },
   }],
+  // https://github.com/jacobwgillespie/styled-icons/pull/1156
+  ...['boxicons-logos', 'boxicons-regular', 'boxicons-solid', 'crypto', 'evil', 'fa-brands', 'fa-regular', 'fa-solid', 'feather', 'icomoon', 'material', 'octicons', 'remix-fill', 'remix-line', 'typicons'].map<[string, any]>(name => (
+    [`@styled-icons/${name}@*`, {
+      peerDependencies: {
+        [`react`]: `*`,
+        [`styled-components`]: `*`,
+      },
+    }]
+  )),
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Can't use `styled-icons` because the `@styled-icons/*` packages doesn't declare react and styled-components as peer dependencies

**How did you fix it?**

Added react and styled-components as peer dependencies of the `@styled-icons/*` packages in plugin-compat's extensions

See [PR 1159 in jacobwgillespie/styled-icons](https://github.com/jacobwgillespie/styled-icons/pull/1156)