### PR TITLE
Adds --inspect and --inspect-brk to `yarn run`

### DIFF
--- a/.yarn/versions/46f20c4f.yml
+++ b/.yarn/versions/46f20c4f.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -291,6 +291,7 @@ export async function getWorkspaceAccessibleBinaries(workspace: Workspace) {
 
 type ExecutePackageAccessibleBinaryOptions = {
   cwd: PortablePath,
+  nodeArgs?: Array<string>,
   project: Project,
   stdin: Readable | null,
   stdout: Writable,
@@ -309,7 +310,7 @@ type ExecutePackageAccessibleBinaryOptions = {
  * @param args The arguments to pass to the file
  */
 
-export async function executePackageAccessibleBinary(locator: Locator, binaryName: string, args: Array<string>, {cwd, project, stdin, stdout, stderr}: ExecutePackageAccessibleBinaryOptions) {
+export async function executePackageAccessibleBinary(locator: Locator, binaryName: string, args: Array<string>, {cwd, project, stdin, stdout, stderr, nodeArgs = []}: ExecutePackageAccessibleBinaryOptions) {
   const packageAccessibleBinaries = await getPackageAccessibleBinaries(locator, {project});
 
   const binary = packageAccessibleBinaries.get(binaryName);
@@ -324,7 +325,7 @@ export async function executePackageAccessibleBinary(locator: Locator, binaryNam
 
   let result;
   try {
-    result = await execUtils.pipevp(process.execPath, [binaryPath, ...args], {cwd, env, stdin, stdout, stderr});
+    result = await execUtils.pipevp(process.execPath, [...nodeArgs, binaryPath, ...args], {cwd, env, stdin, stdout, stderr});
   } finally {
     await xfs.removePromise(env.BERRY_BIN_FOLDER as PortablePath);
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's currently quite annoying to run binaries with the `--inspect` mode, despite it being somewhat common. You need to know about `yarn node`, you need to know about `yarn bin <name>`, and you need to know how to make them interact with each other.

**How did you fix it?**

This diff simply adds options to `yarn run` that will be forwarded to Node. As for all `run` options, they have to be passed before the script name in order to be taken into account (ie `yarn run foo --inspect` will send the `--inspect` flag to `foo`).

More options could be supported, but I think those two are the main ones we need. The others can (should?) be sent through the `NODE_OPTIONS` environment variable.