### PR TITLE
Folds output by default on CI

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -1,3 +1,4 @@
+#
 on:
   schedule:
   - cron: '0 */4 * * *'

--- a/.yarn/versions/e24d46f3.yml
+++ b/.yarn/versions/e24d46f3.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -21,6 +21,12 @@ const PROGRESS_INTERVAL = 80;
 const FORGETTABLE_NAMES = new Set<MessageName | null>([MessageName.FETCH_NOT_CACHED, MessageName.UNUSED_CACHE_ENTRY]);
 const FORGETTABLE_BUFFER_SIZE = 5;
 
+const GROUP = process.env.GITHUB_ACTIONS
+  ? {start: (what: string) => `::group::${what}\n`, end: (what: string) => `::endgroup::\n`}
+  : process.env.TRAVIS
+    ? {start: (what: string) => `travis_fold:start:${what}\n`, end: (what: string) => `travis_fold:end:${what}\n`}
+    : null;
+
 const now = new Date();
 
 // We only want to support environments that will out-of-the-box accept the
@@ -157,6 +163,9 @@ export class StreamReport extends Report {
   async startTimerPromise<T>(what: string, cb: () => Promise<T>) {
     this.reportInfo(null, `┌ ${what}`);
 
+    if (GROUP !== null)
+      this.stdout.write(GROUP.start(what));
+
     const before = Date.now();
     this.indent += 1;
 
@@ -168,6 +177,9 @@ export class StreamReport extends Report {
     } finally {
       const after = Date.now();
       this.indent -= 1;
+
+      if (GROUP !== null)
+        this.stdout.write(GROUP.end(what));
 
       if (this.configuration.get(`enableTimers`)) {
         this.reportInfo(null, `└ Completed in ${this.formatTiming(after - before)}`);

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -25,7 +25,9 @@ const GROUP = process.env.GITHUB_ACTIONS
   ? {start: (what: string) => `::group::${what}\n`, end: (what: string) => `::endgroup::\n`}
   : process.env.TRAVIS
     ? {start: (what: string) => `travis_fold:start:${what}\n`, end: (what: string) => `travis_fold:end:${what}\n`}
-    : null;
+    : process.env.GITLAB_CI
+      ? {start: (what: string) => `section_start:${Date.now() / 1000}:${what}\n`, end: (what: string) => `section_end:${Date.now() / 1000}:${what}\n`}
+      : null;
 
 const now = new Date();
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

CI systems can't benefit from forgettable lines, so the output can be at times very verbose.

**How did you fix it?**

On systems that support it (only GitHub Actions and Travis, I didn't find something similar for CircleCI), we now print the right fences to fold the sections.
