### PR TITLE
Add install instructions for yarn v1.21

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -27,7 +27,8 @@ cd ~/path/to/project
 3. Run the following command:
 
 ```bash
-yarn set version berry
+yarn policies set-version berry # below v1.22
+yarn set version berry          # on v1.22+
 ```
 
 4. Commit the `.yarn` and `.yarnrc.yml` changes


### PR DESCRIPTION
As of this writing, the official Debian/Ubuntu package of yarn is v1.21,
which does not support the suggested berry installation command:

    $ yarn set version berry
    error Command "set" not found.
    info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

This is described in issue #904.

This commit adds a v1.21-compatible variant (as suggested by @arcanis)
to the installation guide.