### PR TITLE
fix: a patch hunk that only adds lines caused failure

### DIFF
--- a/.yarn/versions/93797c98.yml
+++ b/.yarn/versions/93797c98.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-patch": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/tools/apply.ts
+++ b/packages/plugin-patch/sources/tools/apply.ts
@@ -250,7 +250,7 @@ function evaluateHunk(hunk: Hunk, fileLines: Array<string>, offset: number): Mod
         for (const line of part.lines) {
           const originalLine = fileLines[offset];
 
-          if (!linesAreEqual(originalLine, line))
+          if (originalLine == null || !linesAreEqual(originalLine, line))
             return null;
 
           offset += 1;


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes #935

**How did you fix it?**

Previously, `berry` compared lines (original vs patched) even when there wasn't any content in the old line. 

Due to TypeScript not assuming Array access as possibly undefined, the issue wasn't discovered by it.

```ts
const originalLine = fileLines[offset]; // <<== possibly undefined, but resolves to 'string' type
```

I've added a check for the existence of `originalLine` in the `evaluateHunk` function.