### PR TITLE
Generate a valid tarball url when publishing

### DIFF
--- a/.yarn/versions/768f0faa.yml
+++ b/.yarn/versions/768f0faa.yml
@@ -1,0 +1,3 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-npm-cli": prerelease

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -162,7 +162,6 @@ async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, ta
   // other registries such as verdaccio.
   const tarballName = `${name}-${version}.tgz`;
   const tarballURL = new URL(`${name}/-/${tarballName}`, registry);
-  if (tarballURL.protocol === "https:") tarballURL.protocol = "http:";
 
   return {
     _id: name,

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -100,6 +100,7 @@ export default class NpmPublishCommand extends BaseCommand {
         const body = await makePublishBody(workspace, buffer, {
           access: this.access,
           tag: this.tag,
+          registry,
         });
 
         try {
@@ -130,7 +131,7 @@ export default class NpmPublishCommand extends BaseCommand {
   }
 }
 
-async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, tag}: {access: string | undefined, tag: string}) {
+async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, tag, registry}: {access: string | undefined, tag: string, registry: string}) {
   const configuration = workspace.project.configuration;
 
   const ident = workspace.manifest.name!;
@@ -155,10 +156,18 @@ async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, ta
 
   const raw = await packUtils.genPackageManifest(workspace);
 
+  // This matches Lerna's logic:
+  // https://github.com/evocateur/libnpmpublish/blob/latest/publish.js#L142
+  // While the npm registry ignores the provided tarball URL, it's used by
+  // other registries such as verdaccio.
+  const tarballName = `${name}-${version}.tgz`;
+  const tarballURL = new URL(`${name}/-/${tarballName}`, registry);
+  if (tarballURL.protocol === "https:") tarballURL.protocol = "http:";
+
   return {
     _id: name,
     _attachments: {
-      [`${name}-${version}.tgz`]: {
+      [tarballName]: {
         [`content_type`]: `application/octet-stream`,
         data: buffer.toString(`base64`),
         length: buffer.length,
@@ -186,7 +195,7 @@ async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, ta
           integrity,
 
           // the npm registry requires a tarball path, but it seems useless 🤷
-          tarball: `https://example.org/yarn/was/here.tgz`,
+          tarball: tarballURL.toString(),
         },
       },
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**

Packages published on a verdaccio registry had the wrong tarball URL, making it impossible to download them.

**How did you fix it?**

I copied the logic used by lerna (https://github.com/evocateur/libnpmpublish/blob/latest/publish.js#L142).
I couldn't find any test for the `npm publish` command, but I'll check if this works with Babel.
