### PR TITLE
[node_modules] Implement transparent handling of some node_modules roots non-existence

### DIFF
--- a/.yarn/versions/65e318bd.yml
+++ b/.yarn/versions/65e318bd.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -409,7 +409,7 @@ const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs}:
 };
 
 /**
- * This function removes node_modules roots that do not exist on the filesystem.
+ * This function removes node_modules roots that do not exist on the filesystem from the location tree.
  *
  * This is needed to transparently support workflows on CI systems. When
  * user caches only top-level node_modules and forgets to cache node_modules

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -408,10 +408,43 @@ const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs}:
   }
 };
 
+/**
+ * This function removes node_modules roots that do not exist on the filesystem.
+ *
+ * This is needed to transparently support workflows on CI systems. When
+ * user caches only top-level node_modules and forgets to cache node_modules
+ * from deeper workspaces. By removing non-existent node_modules roots
+ * we make our location tree to represent the real tree on the file system.
+ *
+ * Please note, that this function doesn't help with any other inconsistency
+ * on a deeper level inside node_modules tree, it helps only when some node_modules roots
+ * do not exist at all
+ *
+ * @param locationTree location tree
+ *
+ * @returns location tree with non-existent node_modules roots stripped
+ */
+async function refineLocationRoots(locationTree: LocationTree): Promise<LocationTree> {
+  const refinedTree: LocationTree = new Map();
+
+  const promises = [];
+  for (const [nodeModulesRoot, node] of locationTree.entries()) {
+    promises.push(async () => {
+      if (await xfs.existsPromise(nodeModulesRoot)) {
+        refinedTree.set(nodeModulesRoot, node);
+      }
+    });
+  }
+
+  await Promise.all(promises);
+
+  return refinedTree;
+};
+
 async function persistNodeModules(preinstallState: NodeModulesLocatorMap | null, installState: NodeModulesLocatorMap, {baseFs, project, report}: {project: Project, baseFs: FakeFS<PortablePath>, report: Report}) {
   const rootNmDirPath = ppath.join(project.cwd, NODE_MODULES);
 
-  const prevLocationTree = buildLocationTree(preinstallState, {skipPrefix: project.cwd});
+  const prevLocationTree = await refineLocationRoots(buildLocationTree(preinstallState, {skipPrefix: project.cwd}));
   const locationTree = buildLocationTree(installState, {skipPrefix: project.cwd});
 
   const limit = pLimit(ADD_CONCURRENT_LIMIT);


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR adds support for common CI workflow, when user caches only some of `node_modules` roots, top-level `node_modules` root for example and "forgets" to cache them all (or it is difficult for the user to do so)

**How did you fix it?**

When we read previous install state, we now run fast check to see wether all the `node_modules` roots are present on the file system and if some of them do not - we account that the tree branch that starts from non-existent module root is not here and should be installed.

cc @nicolo-ribaudo 