### PR TITLE
Improves the documentation

### DIFF
--- a/.github/workflows/e2e-angular-workflow.yml
+++ b/.github/workflows/e2e-angular-workflow.yml
@@ -32,9 +32,10 @@ jobs:
         source scripts/e2e-setup-ci.sh;
 
         yarn dlx -p @angular/cli@next ng new berry-angular --interactive=false
+
         cd berry-angular
+        echo 'nodeLinker: node-modules' >> .yarnrc.yml
 
-        yarn add @yarnpkg/pnpify @angular-devkit/core@next @babel/preset-env @babel/core -D
+        yarn add @angular-devkit/core@next @babel/preset-env @babel/core -D
 
-        yarn unplug @angular/platform-browser @angular/core @angular/common
-        yarn pnpify ng build --aot
+        yarn ng build --aot

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -33,7 +33,7 @@ jobs:
         yarn init
 
         # Required
-        yarn add next@^9.1.5-canary.0 react react-dom
+        yarn add next@canary react react-dom
 
         # Test itself
         yarn add raw-loader

--- a/packages/gatsby/content/advanced/lifecycle-scripts.md
+++ b/packages/gatsby/content/advanced/lifecycle-scripts.md
@@ -1,4 +1,4 @@
- ---
+---
 category: advanced
 path: /advanced/lifecycle-scripts
 title: "Lifecycle Scripts"

--- a/packages/gatsby/content/advanced/lifecycle-scripts.md
+++ b/packages/gatsby/content/advanced/lifecycle-scripts.md
@@ -1,4 +1,4 @@
----
+ ---
 category: advanced
 path: /advanced/lifecycle-scripts
 title: "Lifecycle Scripts"
@@ -17,6 +17,8 @@ Packages can define in the `scripts` field of their manifest various actions tha
 - **postinstall** is called after a package got successfully installed on the disk. It is guaranteed .
 
 Note that we don't support every single lifecycle script originally present in npm. This is a deliberate decision based on the observation that too many lifecycle scripts make it difficult to know which one to use in which circumstances, leading to confusion and mistakes. We are open to add the missing ones on a case-by-case basis if compelling use cases are provided.
+
+> In particular, we intentionally don't support arbitrary `pre` and `post` hooks for user-defined scripts (such as `prestart`). This behavior, inherited from npm, caused scripts to be implicit rather than explicit, obfuscating the execution flow. It also led to surprising executions with `yarn serve` also running `yarn preserve`.
 
 ## A note about `postinstall`
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The documentation didn't reference that pre/post user scripts aren't supported anymore.

**How did you fix it?**

Updated the lifecycle scripts page, added a note in the migration guide.
Also fixed the E2E tests for Angular.

Fixes #995 
