### PR TITLE
Fix the "Accessing the files" instructions

### DIFF
--- a/packages/gatsby/content/advanced/pnp-api.md
+++ b/packages/gatsby/content/advanced/pnp-api.md
@@ -266,8 +266,8 @@ The paths returned in the `PackageInformation` structures are in the native form
 To access such files, you can use the `@yarnpkg/fslib` project which abstracts the filesystem under a multi-layer architecture. For example, the following code would make it possible to access any path, regardless of whether they're stored within a zip archive or not:
 
 ```ts
-const {PosixFS, ZipOpenFS} from '@yarnpkg/fslib';
-const libzip = require('@yarnpkg/libzip').getLibzipSync();
+const {PosixFS, ZipOpenFS} = require(`@yarnpkg/fslib`);
+const libzip = require(`@yarnpkg/libzip`).getLibzipSync();
 
 // This will transparently open zip archives
 const zipOpenFs = new ZipOpenFS({libzip});

--- a/packages/gatsby/content/advanced/pnp-api.md
+++ b/packages/gatsby/content/advanced/pnp-api.md
@@ -267,7 +267,7 @@ To access such files, you can use the `@yarnpkg/fslib` project which abstracts t
 
 ```ts
 const {PosixFS, ZipOpenFS} from '@yarnpkg/fslib';
-const libzip = require('@yarnpkg/libzip').getLibzipSync;
+const libzip = require('@yarnpkg/libzip').getLibzipSync();
 
 // This will transparently open zip archives
 const zipOpenFs = new ZipOpenFS({libzip});

--- a/packages/gatsby/content/advanced/pnp-api.md
+++ b/packages/gatsby/content/advanced/pnp-api.md
@@ -266,13 +266,14 @@ The paths returned in the `PackageInformation` structures are in the native form
 To access such files, you can use the `@yarnpkg/fslib` project which abstracts the filesystem under a multi-layer architecture. For example, the following code would make it possible to access any path, regardless of whether they're stored within a zip archive or not:
 
 ```ts
-import {PosixFS, ZipOpenFS} from '@yarnpkg/fslib';
+const {PosixFS, ZipOpenFS} from '@yarnpkg/fslib';
+const libzip = require('@yarnpkg/libzip').getLibzipSync;
 
 // This will transparently open zip archives
-const zipOpenFs = new ZipOpenFS();
+const zipOpenFs = new ZipOpenFS({libzip});
 
 // This will convert all paths into a Posix variant, required for cross-platform compatibility
-const crossFs = new PosixFS(zipOpenfs);
+const crossFs = new PosixFS(zipOpenFs);
 
 console.log(crossFs.readFileSync(`C:\\path\\to\\archive.zip\\package.json`));
 ```


### PR DESCRIPTION
3 things in this PR:

- using `import` and `require` statements in the same snippet seemed confusing. Change to `require` only.
- Looks like the `ZipOpenFS` constructor must take an object with at least a `libzip` key in it.
- There was a typo in the var name passed to the `PosixFS` constructor

**What's the problem this PR addresses?**

...

**How did you fix it?**

...
