### PR TITLE
Fixes the dynamic require in `--sdk`

### DIFF
--- a/.yarn/versions/a9a6cf57.yml
+++ b/.yarn/versions/a9a6cf57.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -86,7 +86,7 @@ class Wrapper {
     if (pkgInformation === null)
       throw new Error(`Assertion failed: Package ${this.name} isn't a dependency of the top-level`);
 
-    const manifest = dynamicRequire(`${this.name}/package.json`);
+    const manifest = dynamicRequire(npath.join(pkgInformation.packageLocation, `package.json`));
 
     await xfs.mkdirpPromise(ppath.dirname(absWrapperPath));
     await xfs.writeFilePromise(absWrapperPath, JSON.stringify({


### PR DESCRIPTION
**What's the problem this PR addresses?**

The dynamic require was causing `typescript` to be resolved relative to the `pnpify` package (or the top-level when it was a direct dependency), thus failing when invoked through `yarn dlx`.

**How did you fix it?**

We now make the require call by going through the resolved location.
