### PR TITLE
Adds stylelint to the PnPify SDK

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -12999,9 +12999,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["comment-json", "npm:2.2.0"],
             ["cross-spawn", "npm:6.0.5"],
             ["eslint", "npm:5.16.0"],
+            ["stylelint", null],
             ["typescript", "patch:typescript@npm%3A3.7.5#builtin<compat/typescript>::version=3.7.5&hash=273569"]
           ],
           "packagePeers": [
+            "stylelint",
             "typescript"
           ],
           "linkType": "SOFT",
@@ -13020,10 +13022,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["comment-json", "npm:2.2.0"],
             ["cross-spawn", "npm:6.0.5"],
             ["eslint", "npm:5.16.0"],
+            ["stylelint", null],
             ["typescript", "patch:typescript@npm%3A3.7.5#builtin<compat/typescript>::version=3.7.5&hash=273569"]
           ],
           "packagePeers": [
             "eslint",
+            "stylelint",
             "typescript"
           ],
           "linkType": "SOFT",

--- a/.yarn/versions/77b88e19.yml
+++ b/.yarn/versions/77b88e19.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@yarnpkg/pnpify"

--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -15,6 +15,7 @@ Smart IDEs (such as VSCode or IntelliJ) require special configuration for TypeSc
 | VS Code TypeScript Server | [typescript](https://yarnpkg.com/package/typescript) |
 | [vscode-eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
 | [prettier-vscode extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
+| [vscode-stylelint extension](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) | [stylelint](https://yarnpkg.com/package/stylelint) |
 
 If you'd like to contribute more, [take a look here!](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-pnpify/sources/generateSdk.ts)
 

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -22,10 +22,14 @@
   },
   "peerDependencies": {
     "eslint": "*",
+    "stylelint": "*",
     "typescript": "*"
   },
   "peerDependenciesMeta": {
     "eslint": {
+      "optional": true
+    },
+    "stylelint": {
       "optional": true
     },
     "typescript": {

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -187,9 +187,26 @@ export const generatePrettierWrapper = async (pnpApi: PnpApi, target: PortablePa
   });
 };
 
+export const generateStylelintWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`stylelint` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`lib/index.js` as PortablePath);
+
+  await addVSCodeWorkspaceSettings(pnpApi, {
+    [`stylelint.stylelintPath`]: npath.fromPortablePath(
+      wrapper.getProjectPathTo(
+        `lib/index.js` as PortablePath,
+      ),
+    ),
+  });
+};
+
 const SDKS: Array<[string, (pnpApi: PnpApi, target: PortablePath) => Promise<void>]> = [
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
+  [`stylelint`, generateStylelintWrapper],
   [`typescript`, generateTypescriptWrapper],
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,9 +5512,12 @@ __metadata:
     typescript: ^3.7.5
   peerDependencies:
     eslint: "*"
+    stylelint: "*"
     typescript: "*"
   peerDependenciesMeta:
     eslint:
+      optional: true
+    stylelint:
       optional: true
     typescript:
       optional: true


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR adds support for the [stylelint VSCode extension](https://github.com/stylelint/vscode-stylelint) to pnpify.

...

**How did you fix it?**

I added stylelint support with reference to prettier support.

...

refs #369, https://github.com/stylelint/vscode-stylelint/issues/44