### PR TITLE
Use correct package in example

### DIFF
--- a/packages/yarnpkg-shell/README.md
+++ b/packages/yarnpkg-shell/README.md
@@ -5,7 +5,7 @@ A JavaScript implementation of a bash-like shell (we use it in Yarn 2 to provide
 ## Usage
 
 ```ts
-import {execute} from '@berry/shell';
+import {execute} from '@yarnpkg/shell';
 
 process.exitCode = await execute(`ls "$1" | wc -l`, [process.cwd()]);
 ```


### PR DESCRIPTION
**What's the problem this PR addresses?**
The usage example in the readme of `@yarnpkg/shell` uses an outdated package name. This PR fixes that.