### PR TITLE
add file for pnpfying typescript lib (Typescript SDK)

### DIFF
--- a/.yarn/versions/0d62487b.yml
+++ b/.yarn/versions/0d62487b.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -140,6 +140,7 @@ const generateTypescriptWrapper = async (pnpApi: PnpApi, target: PortablePath) =
 
   await wrapper.writeFile(`lib/tsc.js` as PortablePath);
   await wrapper.writeFile(`lib/tsserver.js` as PortablePath);
+  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
 
   await addVSCodeWorkspaceSettings(pnpApi, {
     [`typescript.tsdk`]: npath.fromPortablePath(


### PR DESCRIPTION
**What's the problem this PR addresses?**
as seen in: https://github.com/vuejs/vetur/pull/1737
Some third-party services/extensions require the typescript library (as opposed to the CLI only)
This PR makes it available in the typescript pnpfied SDK.

**How did you fix it?**

This adds a one-liner to write a third file to the typescript patch folder, thus exposing the typescript module to the world