### PR TITLE
Add .pnp.cjs support to pnpify CLI

### DIFF
--- a/.yarn/versions/af44e1ad.yml
+++ b/.yarn/versions/af44e1ad.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/cli.ts
+++ b/packages/yarnpkg-pnpify/sources/cli.ts
@@ -34,6 +34,7 @@ function sdk(cwd: NativePath) {
   let nextProjectRoot = npath.toPortablePath(cwd);
   let currProjectRoot = null;
 
+  let isCJS = '';
   while (nextProjectRoot !== currProjectRoot) {
     currProjectRoot = nextProjectRoot;
     nextProjectRoot = ppath.dirname(currProjectRoot);
@@ -41,12 +42,16 @@ function sdk(cwd: NativePath) {
     if (xfs.existsSync(ppath.join(currProjectRoot, `.pnp.js` as Filename))) {
       break;
     }
+    if (xfs.existsSync(ppath.join(currProjectRoot, `.pnp.cjs` as Filename))) {
+      isCJS = 'c';
+      break;
+    }
   }
 
   if (nextProjectRoot === currProjectRoot)
     throw new Error(`This tool can only be used with projects using Yarn Plug'n'Play`);
 
-  const pnpPath = ppath.join(currProjectRoot, `.pnp.js` as Filename);
+  const pnpPath = ppath.join(currProjectRoot, `.pnp.${isCJS}js` as Filename);
   const pnpApi = dynamicRequire(pnpPath);
 
   generateSdk(pnpApi).catch(error => {

--- a/packages/yarnpkg-pnpify/sources/cli.ts
+++ b/packages/yarnpkg-pnpify/sources/cli.ts
@@ -39,9 +39,9 @@ function sdk(cwd: NativePath) {
     currProjectRoot = nextProjectRoot;
     nextProjectRoot = ppath.dirname(currProjectRoot);
 
-    if (xfs.existsSync(ppath.join(currProjectRoot, `.pnp.js` as Filename))) {
+    if (xfs.existsSync(ppath.join(currProjectRoot, `.pnp.js` as Filename)))
       break;
-    }
+
     if (xfs.existsSync(ppath.join(currProjectRoot, `.pnp.cjs` as Filename))) {
       isCJS = 'c';
       break;


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn pnpify` fails with `Error: This tool can only be used with projects using Yarn Plug'n'Play` when `package.json` uses `{ "type": "module"}` and therefore `.pnp.cjs` is created instead of `.pnp.js`.

**How did you fix it?**

Added a check for presence of `.pnp.cjs` and if it exists, it is used instead.
