### PR TITLE
@yarnpkg/pnpify: Specify in pnpify-generated manifests type=commonjs

### DIFF
--- a/.yarn/versions/01d5b008.yml
+++ b/.yarn/versions/01d5b008.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -93,6 +93,7 @@ class Wrapper {
       name: this.name,
       version: `${manifest.version}-pnpify`,
       main: manifest.main,
+      type: 'commonjs',
     }, null, 2));
   }
 

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -93,7 +93,7 @@ class Wrapper {
       name: this.name,
       version: `${manifest.version}-pnpify`,
       main: manifest.main,
-      type: 'commonjs',
+      type: `commonjs`,
     }, null, 2));
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

This is a follow up on #1028. Since the pnpified tools follow commonjs format, it is required to specify `{"type": "commonjs"}` for their `package.json`s.

**How did you fix it?**

Added `type: 'commonjs'` to the `generateStack.writeManifest` function.
