### PR TITLE
chore: explicitly set enableGlobalCache to false

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,7 @@
 initScope: yarnpkg
 npmPublishAccess: public
 preferDeferredVersions: true
+enableGlobalCache: false
 yarnPath: scripts/run-yarn.js
 
 packageExtensions:


### PR DESCRIPTION
**What's the problem this PR addresses?**

Having `enableGlobalCache: true` in a global `.yarnrc.yml` file "disables" zero-installs in the berry repo

**How did you fix it?**

Explicitly set `enableGlobalCache: false` to allow me to have it enabled globally and still be able to run yarn in the repo