### PR TITLE
Deduplicates through resolutions

### DIFF
--- a/.yarn/versions/555de3ec.yml
+++ b/.yarn/versions/555de3ec.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1898,7 +1898,14 @@ function applyVirtualResolutionMutations({
       // generate a hash from it. By checking if this hash is already
       // registered, we know whether we can trim the new version.
       const dependencyHash = hashUtils.makeHash(...[...virtualPackage.dependencies.values()].map(descriptor => {
-        return descriptor.descriptorHash;
+        const resolution = descriptor.range !== `missing:`
+          ? allResolutions.get(descriptor.descriptorHash)
+          : `missing:`;
+
+        if (typeof resolution === `undefined`)
+          throw new Error(`Assertion failed: Expected the resolution to have been registered`);
+
+        return resolution;
       }));
 
       const masterDescriptor = otherVirtualInstances.get(dependencyHash);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The peer dependency deduping was comparing the package dependencies rather than the package resolutions. As a result, in the following case, `X` wouldn't have been deduplicated even if `Y@^1.0.0` and `X@^1.1.0` would happen to resolve to the same package:

```
. -> A -> X ~> Y
       -> Y@^1.0.0
  -> B -> X ~> Y
       -> Y@^1.1.0
```

Ref: https://github.com/yarnpkg/berry/issues/1049

**How did you fix it?**

We now run the dependency check based on the resolved dependencies rather than their ranges.
