### PR TITLE
Adds support for scoped auth settings

### DIFF
--- a/.yarn/versions/94e1cb0e.yml
+++ b/.yarn/versions/94e1cb0e.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-npm": prerelease
+  "@yarnpkg/plugin-npm-cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/auth.test.js
@@ -85,6 +85,32 @@ describe(`Auth tests`, () => {
   );
 
   test(
+    `it should install scoped packages which require authentication if an authentication token is configured at the scope level`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmScopes:`,
+          `  private:`,
+          `    npmRegistryServer: "${url}"`,
+          `    npmAuthToken: ${AUTH_TOKEN}`,
+        ].join(`\n`));
+
+        await run(`install`);
+
+        await expect(source(`require('@private/package')`)).resolves.toMatchObject({
+          name: `@private/package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  test(
     `it should install unscoped packages which require authentication if npmAlwaysAuth is set to true and an authentication token is present`,
     makeTemporaryEnv(
       {
@@ -126,6 +152,32 @@ describe(`Auth tests`, () => {
       },
       async ({path, run, source}) => {
         await writeFile(`${path}/.yarnrc.yml`, `npmAuthIdent: "${AUTH_IDENT}"\n`);
+
+        await run(`install`);
+
+        await expect(source(`require('@private/package')`)).resolves.toMatchObject({
+          name: `@private/package`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  test(
+    `it should install scoped packages which require authentication if an authentication ident is configured at the scope level`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmScopes:`,
+          `  private:`,
+          `    npmRegistryServer: "${url}"`,
+          `    npmAuthIdent: ${AUTH_IDENT}`,
+        ].join(`\n`));
 
         await run(`install`);
 

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -190,11 +190,26 @@
             "npmRegistryServer": {
               "$ref": "#/properties/npmRegistryServer",
               "$comment": "{ \"anchor\": \"npmScopes.npmRegistryServer\" }"
+            },
+            "npmAlwaysAuth": {
+              "$ref": "#/properties/npmAlwaysAuth",
+              "$comment": "{ \"anchor\": \"npmRegistries.npmAlwaysAuth\" }"
+            },
+            "npmAuthIdent": {
+              "$ref": "#/properties/npmAuthIdent",
+              "$comment": "{ \"anchor\": \"npmRegistries.npmAuthIdent\" }"
+            },
+            "npmAuthToken": {
+              "$ref": "#/properties/npmAuthToken",
+              "$comment": "{ \"anchor\": \"npmRegistries.npmAuthToken\" }"
             }
           },
           "default": {
             "npmPublishRegistry": {},
-            "npmRegistryServer": {}
+            "npmRegistryServer": {},
+            "npmAlwaysAuth": {},
+            "npmAuthIdent": {},
+            "npmAuthToken": {}
           }
         }
       },

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -55,6 +55,7 @@ const plugin: Plugin = {
         description: ``,
         type: SettingsType.SHAPE,
         properties: {
+          ...authSettings,
           ...registrySettings,
         },
       },

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -1,4 +1,4 @@
-import {Configuration, Manifest} from '@yarnpkg/core';
+import {Configuration, Manifest, Ident} from '@yarnpkg/core';
 
 export enum RegistryType {
   FETCH_REGISTRY = 'npmRegistryServer',
@@ -70,3 +70,13 @@ export function getScopeConfiguration(scope: string | null, {configuration}: {co
   return scopeConfiguration;
 }
 
+export function getAuthConfiguration(registry: string, {configuration, ident}: {configuration: Configuration, ident?: Ident}): MapLike {
+  const scopeConfiguration = ident && getScopeConfiguration(ident.scope, {configuration});
+
+  if (scopeConfiguration?.get('npmAuthIdent') || scopeConfiguration?.get('npmAuthToken'))
+    return scopeConfiguration;
+
+  const registryConfiguration = getRegistryConfiguration(registry, {configuration});
+
+  return registryConfiguration || configuration;
+}

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -20,7 +20,7 @@ type RegistryOptions = {
   ident: Ident,
   registry?: string,
 } | {
-  ident?: void,
+  ident?: Ident,
   registry: string;
 };
 
@@ -43,7 +43,7 @@ export async function get(path: string, {configuration, headers, ident, authType
   if (typeof registry !== `string`)
     throw new Error(`Assertion failed: The registry should be a string`);
 
-  const auth = getAuthenticationHeader(registry, {authType, configuration});
+  const auth = getAuthenticationHeader(registry, {authType, configuration, ident});
   if (auth)
     headers = {...headers, authorization: auth};
 
@@ -72,7 +72,7 @@ export async function put(path: string, body: httpUtils.Body, {attemptedAs, conf
   if (typeof registry !== `string`)
     throw new Error(`Assertion failed: The registry should be a string`);
 
-  const auth = getAuthenticationHeader(registry, {authType, configuration});
+  const auth = getAuthenticationHeader(registry, {authType, configuration, ident});
   if (auth)
     headers = {...headers, authorization: auth};
 
@@ -103,11 +103,10 @@ export async function put(path: string, body: httpUtils.Body, {attemptedAs, conf
   }
 }
 
-function getAuthenticationHeader(registry: string, {authType = AuthType.CONFIGURATION, configuration}: {authType?: AuthType, configuration: Configuration}) {
-  const registryConfiguration = npmConfigUtils.getRegistryConfiguration(registry, {configuration});
-  const effectiveConfiguration = registryConfiguration || configuration;
-
+function getAuthenticationHeader(registry: string, {authType = AuthType.CONFIGURATION, configuration, ident}: {authType?: AuthType, configuration: Configuration, ident: RegistryOptions['ident']}) {
+  const effectiveConfiguration = npmConfigUtils.getAuthConfiguration(registry, {configuration, ident});
   const mustAuthenticate = shouldAuthenticate(effectiveConfiguration, authType);
+
   if (!mustAuthenticate)
     return null;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Adds support for scoped auth settings, useful when using the same registry with different tokens (eg: github's package registry)

**How did you fix it?**
```yml
npmScopes:
  my-company:
    npmRegistryServer: "https://registry.yarnpkg.com"
    npmAuthIdent: "username1:password1"

  my-company2:
    npmRegistryServer: "https://registry.yarnpkg.com"
    npmAuthToken: "ffffffff-ffff-ffff-ffff-fffffffffff2"
```

Edit: Updated the description example, first one was incorrect.

Closes https://github.com/yarnpkg/berry/issues/1030