### PR TITLE
Support for Azure Artifacts

### DIFF
--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -8,6 +8,7 @@ import inquirer                             from 'inquirer';
 type Credentials = {
   name: string,
   password: string,
+  azure?: boolean,
 }
 
 // eslint-disable-next-line arca/no-default-export
@@ -106,6 +107,7 @@ async function getCredentials(prompt: any, {registry, report}: {registry: string
   report.reportInfo(MessageName.UNNAMED, `Logging in to ${registry}`);
 
   let isToken = false;
+  let azure = false;
 
   if (registry.match(/^https:\/\/npm\.pkg\.github\.com(\/|$)/)) {
     report.reportInfo(MessageName.UNNAMED, `You seem to be using the GitHub Package Registry. Tokens must be generated with the 'repo', 'write:packages', and 'read:packages' permissions.`);
@@ -115,6 +117,7 @@ async function getCredentials(prompt: any, {registry, report}: {registry: string
   if (registry.match(/^https:\/\/pkgs\.dev\.azure\.com(\/|$)/)) {
     report.reportInfo(MessageName.UNNAMED, `You seem to be using the Azure Artifacts Registry. Tokens must be generated with the narrow scope of 'Packaging (read & write)'.`);
     isToken = true;
+    azure = true;
   }
 
   report.reportSeparator();
@@ -136,6 +139,7 @@ async function getCredentials(prompt: any, {registry, report}: {registry: string
   return {
     name: username,
     password,
+    azure,
   };
 }
 

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -5,6 +5,11 @@ import {npmConfigUtils, npmHttpUtils}       from '@yarnpkg/plugin-npm';
 import {Command, Usage}                     from 'clipanion';
 import inquirer                             from 'inquirer';
 
+type Credentials = {
+  name: string,
+  password: string,
+}
+
 // eslint-disable-next-line arca/no-default-export
 export default class NpmLoginCommand extends BaseCommand {
   @Command.String(`-s,--scope`)
@@ -90,7 +95,7 @@ async function setAuthToken(registry: string, npmAuthToken: string, {configurati
   });
 }
 
-async function getCredentials(prompt: any, {registry, report}: {registry: string, report: Report}) {
+async function getCredentials(prompt: any, {registry, report}: {registry: string, report: Report}): Promise<Credentials> {
   if (process.env.TEST_ENV) {
     return {
       name: process.env.TEST_NPM_USER || '',

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -107,6 +107,11 @@ async function getCredentials(prompt: any, {registry, report}: {registry: string
     isToken = true;
   }
 
+  if (registry.match(/^https:\/\/pkgs\.dev\.azure\.com(\/|$)/)) {
+    report.reportInfo(MessageName.UNNAMED, `You seem to be using the Azure Artifacts Registry. Tokens must be generated with the narrow scope of 'Packaging (read & write)'.`);
+    isToken = true;
+  }
+
   report.reportSeparator();
 
   const {username, password} = await prompt([{

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -34,7 +34,7 @@ export function getIdentUrl(ident: Ident) {
   }
 }
 
-export async function get(path: string, {configuration, headers, ident, authType, registry, ...rest}: Options) {
+export async function get(path: string, {attemptedAs, configuration, headers, ident, authType, registry, ...rest}: Options & {attemptedAs?: string}) {
   if (ident && typeof registry === `undefined`)
     registry = npmConfigUtils.getScopeRegistry(ident.scope, {configuration});
   if (ident && ident.scope && typeof authType === `undefined`)
@@ -58,7 +58,7 @@ export async function get(path: string, {configuration, headers, ident, authType
     return await httpUtils.get(url.href, {configuration, headers, ...rest});
   } catch (error) {
     if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-      throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (as ${await whoami(registry, headers, {configuration})})`);
+      throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headers, {configuration})}` : `attempted as ${attemptedAs}`})`);
     } else {
       throw error;
     }

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -81,6 +81,10 @@ export async function put(path: string, body: httpUtils.Body, {attemptedAs, conf
   } catch (error) {
     if (!isOtpError(error)) {
       if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
+        if (error.response.body?.reason?.indexOf('feed already contains the package') !== -1) {
+          error.response.body.error = error.response.body.reason;
+          throw error;
+        }
         throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headers, {configuration})}` : `attempted as ${attemptedAs}`})`);
       } else {
         throw error;


### PR DESCRIPTION
Hey guys, first PR here, so let me know what can be done to improve this PR (add docs, tests?).

I noticed some integration tests failed, so I'll have a look at that, but it seems as if entire yarn bundles are being logged when the tests fail, making the logs ~~unusable~~ (jest json output here: [integration-output.txt](https://github.com/yarnpkg/berry/files/4327213/integration-output.txt)). Anyone have an idea what might be causing that? 

**What's the problem this PR addresses?**

Azure Artifacts does not seem to implement most of the 'standard' npm registry APIs. This makes it incompatible with commands such as `yarn login --scope epiccoolguy` or `yarn npm publish`.

**How did you fix it?**

1. Added a notice to remind users about the required scope of their personal access token (just like Github Packages)
2. When detecting a modern Azure DevOps URL, perform a GET call to the registry using basic auth to verify the users' credentials and store those as a base64-encoded `username:password` string in `npmAuthIdent`. (As compared to doing a PUT and storing the received token in `npmAuthToken` with "regular" npm registries.)
3. Added an additional check when receiving errors such as "package already published". (This might be unnecessarily bloating or requires more thought put into how to do this more cleanly.