### PR TITLE
website: fix null titles in images and links.

### DIFF
--- a/packages/gatsby/src/components/details/Markdown.js
+++ b/packages/gatsby/src/components/details/Markdown.js
@@ -73,19 +73,19 @@ const renderAndEscapeMarkdown = ({source, repository}) => {
     renderer.image = (href, title, text) =>
       `<img src="${prefixImage(
         sanitizeSvg(href)
-      )}" title="${title}" alt="${text}"/>`;
+      )}" title="${title || ''}" alt="${text}"/>`;
 
     renderer.link = (href, title, text) => {
       // No need to prefix hashes
       if (href.startsWith('#'))
-        return `<a href="${href}" title="${title}">${text}</a>`;
+        return `<a href="${href}" title="${title || ''}">${text}</a>`;
 
       // wrongly linked comments
       // see https://github.com/yarnpkg/website/issues/685
       if (text.startsWith('!--'))
         return '';
 
-      return `<a href="${prefixLink(href)}" title="${title}">${text}</a>`;
+      return `<a href="${prefixLink(href)}" title="${title || ''}">${text}</a>`;
     };
 
     renderer.html = function(html) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
Images and links are displaying `"null"` titles
![yarnpkg-null-title](https://user-images.githubusercontent.com/13869336/76641130-d9ca3f00-652f-11ea-8438-613c7c0cbc64.gif)