### PR TITLE
chore: Fix type definition of renderForm utility

### DIFF
--- a/.yarn/versions/1d201328.yml
+++ b/.yarn/versions/1d201328.yml
@@ -1,0 +1,3 @@
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/libui"

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -3,7 +3,7 @@ import {Cache, Configuration, Project, HardDependencies, miscUtils, structUtils,
 import {ItemOptions}                                                                                                       from '@yarnpkg/libui/sources/components/ItemOptions';
 import {ScrollableItems}                                                                                                   from '@yarnpkg/libui/sources/components/ScrollableItems';
 import {useMinistore}                                                                                                      from '@yarnpkg/libui/sources/hooks/useMinistore';
-import {renderForm}                                                                                                        from '@yarnpkg/libui/sources/misc/renderForm';
+import {renderForm, SubmitInjectedComponent}                                                                               from '@yarnpkg/libui/sources/misc/renderForm';
 import {suggestUtils}                                                                                                      from '@yarnpkg/plugin-essentials';
 import {Command, Usage}                                                                                                    from 'clipanion';
 import {diffWords}                                                                                                         from 'diff';
@@ -156,7 +156,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       </Box>;
     };
 
-    const GlobalListApp = ({useSubmit}: any) => {
+    const GlobalListApp: SubmitInjectedComponent<Map<string, string | null>> = ({useSubmit}) => {
       useSubmit(useMinistore());
 
       const allDependencies = new Map<DescriptorHash, Descriptor>();
@@ -183,7 +183,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       </>;
     };
 
-    const updateRequests = await renderForm<Map<DescriptorHash, string | null>>(GlobalListApp, {});
+    const updateRequests = await renderForm(GlobalListApp, {});
     if (typeof updateRequests === `undefined`)
       return 1;
 

--- a/packages/yarnpkg-libui/sources/misc/renderForm.tsx
+++ b/packages/yarnpkg-libui/sources/misc/renderForm.tsx
@@ -3,7 +3,11 @@ import React, {useContext, useEffect}     from 'react';
 
 import {Application}                      from '../components/Application';
 
-export const renderForm = async function <T>(UserComponent: any, props: any) {
+type InferProps<T> = T extends React.ComponentType<infer P> ? P : never;
+
+export type SubmitInjectedComponent<T, C = React.ComponentType> = React.ComponentType<InferProps<C> & { useSubmit: (value: T) => void }>;
+
+export async function renderForm<T, C = React.ComponentType>(UserComponent: SubmitInjectedComponent<T, C>, props: InferProps<C>) {
   let returnedValue: T | undefined;
 
   const useSubmit = (value: T) => {


### PR DESCRIPTION
Just a simple type-level fix for type-safety