### PR TITLE
Add error code advisory to CLI output (#1068)

### DIFF
--- a/.yarn/versions/d436fe71.yml
+++ b/.yarn/versions/d436fe71.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/core"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -14,6 +14,8 @@ Object {
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: Done with warnings
+➤ YN0000: Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes
+➤ YN0000: To silence this message, run `yarn config set error-code-advisory false`
 ",
 }
 `;
@@ -51,6 +53,8 @@ Object {
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: Done with warnings
+➤ YN0000: Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes
+➤ YN0000: To silence this message, run `yarn config set error-code-advisory false`
 ",
 }
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
@@ -421,6 +421,8 @@ Object {
   "stderr": "",
   "stdout": "➤ YN0043: Syntax error: . or operator expected at line 1, column 3
 ➤ YN0000: Failed with errors
+➤ YN0000: Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes
+➤ YN0000: To silence this message, run `yarn config set error-code-advisory false`
 ",
 }
 `;
@@ -431,6 +433,8 @@ Object {
   "stderr": "",
   "stdout": "➤ YN0043: Syntax error: argument expected at line 1, column 11
 ➤ YN0000: Failed with errors
+➤ YN0000: Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes
+➤ YN0000: To silence this message, run `yarn config set error-code-advisory false`
 ",
 }
 `;
@@ -441,6 +445,8 @@ Object {
   "stderr": "",
   "stdout": "➤ YN0044: Existence error: procedure hello_word/1 not found
 ➤ YN0000: Failed with errors
+➤ YN0000: Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes
+➤ YN0000: To silence this message, run `yarn config set error-code-advisory false`
 ",
 }
 `;

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -86,6 +86,11 @@
       "type": "boolean",
       "default": false
     },
+    "errorCodeAdvisory": {
+      "description": "If disabled, Yarn will silence a line of CLI output that points to online documentation for error codes.",
+      "type": "boolean",
+      "default": true
+    },
     "globalFolder": {
       "description": "The path where all system-global files (for example the list of all packages registered through `yarn link`) are stored.",
       "type": "string",

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -244,6 +244,11 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.BOOLEAN,
     default: true,
   },
+  errorCodeAdvisory: {
+    description: `If true, the CLI will print a URL to error code documentation when errors or warnings occur`,
+    type: SettingsType.BOOLEAN,
+    default: true,
+  },
   preferInteractive: {
     description: `If true, the CLI will automatically use the interactive mode when called from a TTY`,
     type: SettingsType.BOOLEAN,

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -331,8 +331,18 @@ export class StreamReport extends Report {
 
     if (this.errorCount > 0) {
       this.reportError(MessageName.UNNAMED, message);
+
+      if (this.configuration.get(`errorCodeAdvisory`)) {
+        this.reportError(MessageName.UNNAMED, `Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes`);
+        this.reportError(MessageName.UNNAMED, `To silence this message, run \`yarn config set errorCodeAdvisory false\``);
+      }
     } else if (this.warningCount > 0) {
       this.reportWarning(MessageName.UNNAMED, message);
+
+      if (this.configuration.get(`errorCodeAdvisory`)) {
+        this.reportWarning(MessageName.UNNAMED, `Confused by error codes (YNxxxx)? See https://yarnpkg.com/advanced/error-codes`);
+        this.reportWarning(MessageName.UNNAMED, `To silence this message, run \`yarn config set error-code-advisory false\``);
+      }
     } else {
       this.reportInfo(MessageName.UNNAMED, message);
     }


### PR DESCRIPTION
This commit is intended to help newcomers diagnose errors or warnings
by expanding CLI output to explain how to recognize error codes
and where to find documentation about them online.

This added line of CLI output can be disabled via a new
`errorCodeAdvisory` configuration option.