### PR TITLE
Implements "yarn workspaces focus"

### DIFF
--- a/.yarn/versions/5996c9ac.yml
+++ b/.yarn/versions/5996c9ac.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/plugin-workspace-tools": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/5996c9ac.yml
+++ b/.yarn/versions/5996c9ac.yml
@@ -27,3 +27,4 @@ declined:
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -1,0 +1,72 @@
+import {ppath, xfs} from '@yarnpkg/fslib';
+
+describe(`Commands`, () => {
+  describe(`workspaces focus`, () => {
+    test(
+      `should install the dependencies for the focused workspace only`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, {
+            cwd: ppath.join(path, `packages/foo`),
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-npm-1.0.0-`),
+          ]);
+        }
+      )
+    );
+
+    test(
+      `should follow local workspace dependencies`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, {
+            cwd: ppath.join(path, `packages/baz`),
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-npm-2.0.0-`),
+          ]);
+        }
+      )
+    );
+  });
+});
+
+async function setupProject(path) {
+  await xfs.writeFilePromise(ppath.join(path, `.yarnrc.yml`), `plugins:\n  - ${JSON.stringify(require.resolve(`@yarnpkg/monorepo/scripts/plugin-workspace-tools.js`))}\n`);
+
+  const pkg = async (name, dependencies) => {
+    await xfs.mkdirpPromise(ppath.join(path, `packages/${name}`));
+    await xfs.writeJsonPromise(ppath.join(path, `packages/${name}/package.json`), {name, dependencies});
+  };
+
+  await pkg(`foo`, {[`no-deps`]: `1.0.0`});
+  await pkg(`bar`, {[`no-deps`]: `2.0.0`});
+  await pkg(`baz`, {[`bar`]: `workspace:*`});
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -30,6 +30,34 @@ describe(`Commands`, () => {
     );
 
     test(
+      `should install the dependencies for specified workspaces only`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, `foo`, `bar`, {
+            cwd: ppath.join(path, `packages/foo`),
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-npm-1.0.0-`),
+            expect.stringContaining(`no-deps-npm-2.0.0-`),
+          ]);
+        }
+      )
+    );
+
+    test(
       `should follow local workspace dependencies`,
       makeTemporaryEnv(
         {
@@ -55,18 +83,74 @@ describe(`Commands`, () => {
         }
       )
     );
+
+    test(
+      `should install development dependencies by default`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, `qux`, {
+            cwd: path,
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-bins-npm-1.0.0-`),
+            expect.stringContaining(`no-deps-npm-1.0.0-`),
+          ]);
+        }
+      )
+    );
+
+    test(
+      `should only install production dependencies if requested`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, `qux`, `--production`, {
+            cwd: path,
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-npm-1.0.0-`),
+          ]);
+        }
+      )
+    );
   });
 });
 
 async function setupProject(path) {
   await xfs.writeFilePromise(ppath.join(path, `.yarnrc.yml`), `plugins:\n  - ${JSON.stringify(require.resolve(`@yarnpkg/monorepo/scripts/plugin-workspace-tools.js`))}\n`);
 
-  const pkg = async (name, dependencies) => {
+  const pkg = async (name, dependencies, devDependencies) => {
     await xfs.mkdirpPromise(ppath.join(path, `packages/${name}`));
-    await xfs.writeJsonPromise(ppath.join(path, `packages/${name}/package.json`), {name, dependencies});
+    await xfs.writeJsonPromise(ppath.join(path, `packages/${name}/package.json`), {name, dependencies, devDependencies});
   };
 
   await pkg(`foo`, {[`no-deps`]: `1.0.0`});
   await pkg(`bar`, {[`no-deps`]: `2.0.0`});
   await pkg(`baz`, {[`bar`]: `workspace:*`});
+  await pkg(`qux`, {[`no-deps`]: `1.0.0`}, {[`no-deps-bins`]: `1.0.0`});
 }

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -1,8 +1,6 @@
-import {BaseCommand}                                                              from '@yarnpkg/cli';
-import {Configuration, Project, StreamReport, structUtils, Descriptor, Workspace} from '@yarnpkg/core';
-import {Command, Usage}                                                           from 'clipanion';
-
-const DEPENDENCY_TYPES = ['devDependencies', 'dependencies'];
+import {BaseCommand}                                                                        from '@yarnpkg/cli';
+import {Configuration, Manifest, Project, StreamReport, structUtils, Descriptor, Workspace} from '@yarnpkg/core';
+import {Command, Usage}                                                                     from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesListCommand extends BaseCommand {
@@ -16,6 +14,8 @@ export default class WorkspacesListCommand extends BaseCommand {
     category: `Workspace-related commands`,
     description: `list all available workspaces`,
     details: `
+      This command will print the list of all workspaces in the project. If both the \`-v,--verbose\` and \`--json\` options are set, Yarn will also return the cross-dependencies between each workspaces (useful when you wish to automatically generate Buck / Bazel rules).
+
       If the \`--json\` flag is set the output will follow a JSON-stream output also known as NDJSON (https://github.com/ndjson/ndjson-spec).
     `,
   });
@@ -38,7 +38,7 @@ export default class WorkspacesListCommand extends BaseCommand {
           const workspaceDependencies = new Set<Workspace>();
           const mismatchedWorkspaceDependencies = new Set<Descriptor>();
 
-          for (const dependencyType of DEPENDENCY_TYPES) {
+          for (const dependencyType of Manifest.hardDependencies) {
             for (const [identHash, descriptor]  of manifest.getForScope(dependencyType)) {
               const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
 

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,0 +1,78 @@
+import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
+import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
+import {Command, Usage}                                                   from 'clipanion';
+
+// eslint-disable-next-line arca/no-default-export
+export default class WorkspacesFocus extends BaseCommand {
+  @Command.Boolean(`--json`)
+  json: boolean = false;
+
+  static usage: Usage = Command.Usage({
+    category: `Workspace-related commands`,
+    description: `install a single workspace and its dependencies`,
+    details: `
+      This command will run an install as if the current workspace (and all other workspaces it depends on) was the only one in the project.
+
+      Note that this command is only very moderately useful when using zero-installs, since the cache will contain all the packages anyway - meaning that the only difference between a full install and a focused install would just be a few extra lines in the \`.pnp.js\` file, at the cost of introducing an extra complexity.
+
+      If the \`--json\` flag is set the output will follow a JSON-stream output also known as NDJSON (https://github.com/ndjson/ndjson-spec).
+    `,
+  });
+
+  @Command.Path(`workspaces`, `focus`)
+  async execute() {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
+    const cache = await Cache.find(configuration);
+
+    if (!workspace)
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
+
+    const requiredWorkspaces = new Set<Workspace>([workspace]);
+
+    // First we compute the dependency chain to see what workspaces are
+    // dependencies of the one we're trying to focus on.
+    //
+    // Note: remember that new elements can be added in a set even while
+    // iterating over it (because they're added at the end)
+
+    for (const workspace of requiredWorkspaces) {
+      for (const dependencyType of Manifest.hardDependencies) {
+        for (const descriptor  of workspace.manifest.getForScope(dependencyType).values()) {
+          const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
+
+          if (matchingWorkspace === null)
+            continue;
+
+          requiredWorkspaces.add(matchingWorkspace);
+        }
+      }
+    }
+
+    // Then we go over each workspace that didn't get selected, and remove all
+    // their dependencies.
+
+    for (const workspace of project.workspaces) {
+      if (requiredWorkspaces.has(workspace))
+        continue;
+
+      workspace.manifest.dependencies.clear();
+      workspace.manifest.peerDependencies.clear();
+    }
+
+    // And finally we can run the install, but we have to make sure we don't
+    // persist the project state on the disk (otherwise all workspaces would
+    // lose their dependencies!).
+
+    const report = await StreamReport.start({
+      configuration,
+      json: this.json,
+      stdout: this.context.stdout,
+      includeLogs: true,
+    }, async (report: StreamReport) => {
+      await project.install({cache, report, persistProject: false});
+    });
+
+    return report.exitCode();
+  }
+}

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,19 +1,28 @@
 import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
 import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
+import {structUtils}                                                      from '@yarnpkg/core';
 import {Command, Usage}                                                   from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
+  @Command.Rest()
+  workspaces: Array<string> = [];
+
   @Command.Boolean(`--json`)
   json: boolean = false;
+
+  @Command.Boolean(`--production`)
+  production: boolean = false;
 
   static usage: Usage = Command.Usage({
     category: `Workspace-related commands`,
     description: `install a single workspace and its dependencies`,
     details: `
-      This command will run an install as if the current workspace (and all other workspaces it depends on) was the only one in the project.
+      This command will run an install as if the specified workspaces (and all other workspaces they depend on) were the only ones in the project. If no workspaces are explicitly listed, the active one will be assumed.
 
       Note that this command is only very moderately useful when using zero-installs, since the cache will contain all the packages anyway - meaning that the only difference between a full install and a focused install would just be a few extra lines in the \`.pnp.js\` file, at the cost of introducing an extra complexity.
+
+      If the \`--production\` flag is set, only regular dependencies will be installed, and dev dependencies will be omitted.
 
       If the \`--json\` flag is set the output will follow a JSON-stream output also known as NDJSON (https://github.com/ndjson/ndjson-spec).
     `,
@@ -25,10 +34,17 @@ export default class WorkspacesFocus extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
+    let requiredWorkspaces: Set<Workspace>;
+    if (this.workspaces.length === 0) {
+      if (!workspace)
+        throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
-    const requiredWorkspaces = new Set<Workspace>([workspace]);
+      requiredWorkspaces = new Set([workspace]);
+    } else {
+      requiredWorkspaces = new Set(this.workspaces.map(name => {
+        return project.getWorkspaceByIdent(structUtils.parseIdent(name));
+      }));
+    }
 
     // First we compute the dependency chain to see what workspaces are
     // dependencies of the one we're trying to focus on.
@@ -53,11 +69,15 @@ export default class WorkspacesFocus extends BaseCommand {
     // their dependencies.
 
     for (const workspace of project.workspaces) {
-      if (requiredWorkspaces.has(workspace))
-        continue;
-
-      workspace.manifest.dependencies.clear();
-      workspace.manifest.peerDependencies.clear();
+      if (requiredWorkspaces.has(workspace)) {
+        if (this.production) {
+          workspace.manifest.devDependencies.clear();
+        }
+      } else {
+        workspace.manifest.dependencies.clear();
+        workspace.manifest.devDependencies.clear();
+        workspace.manifest.peerDependencies.clear();
+      }
     }
 
     // And finally we can run the install, but we have to make sure we don't

--- a/packages/plugin-workspace-tools/sources/index.ts
+++ b/packages/plugin-workspace-tools/sources/index.ts
@@ -1,9 +1,11 @@
 import {Plugin} from '@yarnpkg/core';
 
+import focus    from './commands/focus';
 import foreach  from './commands/foreach';
 
 const plugin: Plugin = {
   commands: [
+    focus,
     foreach,
   ],
 };

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -60,6 +60,7 @@ export type InstallOptions = {
   report: Report,
   immutable?: boolean,
   lockfileOnly?: boolean,
+  persistProject?: boolean,
 };
 
 export class Project {
@@ -1458,10 +1459,14 @@ export class Project {
 
     await opts.report.startTimerPromise(`Fetch step`, async () => {
       await this.fetchEverything(opts);
-      await this.cacheCleanup(opts);
+
+      if (typeof opts.persistProject === `undefined` || opts.persistProject) {
+        await this.cacheCleanup(opts);
+      }
     });
 
-    await this.persist();
+    if (typeof opts.persistProject === `undefined` || opts.persistProject)
+      await this.persist();
 
     await opts.report.startTimerPromise(`Link step`, async () => {
       await this.linkEverything(opts);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fix #489 

**How did you fix it?**

The `yarn workspaces focus` command will only install the dependencies for one single workspace (unless it depends on other workspaces).

If we ever implement something like `--production` I think we'll do it here. But I really don't see any point in it (whereas I can see some for focused workspaces when users don't use Zero Installs), so I didn't implement it.
