### PR TITLE
Prevents the patch folders from being garbage collected

### DIFF
--- a/.yarn/versions/31781f15.yml
+++ b/.yarn/versions/31781f15.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-patch": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -160,6 +160,7 @@ export async function extractPackageToDisk(locator: Locator, {cache, project}: {
   const fetchResult = await fetcher.fetch(locator, {cache, project, fetcher, checksums, report});
 
   const temp = await xfs.mktempPromise();
+
   await xfs.copyPromise(temp, fetchResult.prefixPath, {
     baseFs: fetchResult.packageFs,
   });
@@ -168,5 +169,6 @@ export async function extractPackageToDisk(locator: Locator, {cache, project}: {
     locator: structUtils.stringifyLocator(locator),
   });
 
+  xfs.detachTemp(temp);
   return temp;
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The recent changes to the `mktemp` API led to the folder being mistakenly removed.

Fixes #1089

**How did you fix it?**

Detaches the temporary folder used for the patch.