### PR TITLE
Improves the tag resolver

### DIFF
--- a/.yarn/versions/25a73b1a.yml
+++ b/.yarn/versions/25a73b1a.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-npm": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -6,7 +6,7 @@ import {NpmSemverFetcher}                                                       
 import {PROTOCOL}                                                                  from './constants';
 import * as npmHttpUtils                                                           from './npmHttpUtils';
 
-export const TAG_REGEXP = /^[a-z]+$/;
+export const TAG_REGEXP = /^(?!v)[a-z0-9-]+$/i;
 
 export class NpmTagResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Tags like `foo-2` are valid npm tags.

Fixes #1075

**How did you fix it?**

n/a
