### PR TITLE
Add types for got

### DIFF
--- a/.yarn/versions/09c8bf16.yml
+++ b/.yarn/versions/09c8bf16.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -39,4 +39,11 @@ export const packageExtensions: Array<[string, any]> = [
       },
     },
   }],
+  // https://github.com/sindresorhus/got/pull/1125
+  [`got@*`, {
+    dependencies: {
+      [`@types/responselike`]: `^1.0.0`,
+      [`@types/keyv`]: `^3.1.1`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -46,4 +46,10 @@ export const packageExtensions: Array<[string, any]> = [
       [`@types/keyv`]: `^3.1.1`,
     },
   }],
+  // https://github.com/szmarczak/cacheable-lookup/pull/12
+  [`cacheable-lookup@*`, {
+    dependencies: {
+      [`@types/keyv`]: `^3.1.1`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running a typecheck with Yarn 2 failed because of missing types.
![Screenshot 2020-03-20 at 09 25 48](https://user-images.githubusercontent.com/597828/77149556-22cf4580-6a92-11ea-8049-54f8c803ae63.png)

**How did you fix it?**

- opened https://github.com/sindresorhus/got/pull/1125
- added missing types for `responselike` and `keyv`
