### PR TITLE
Prevents the install state file from being in the packfiles

### DIFF
--- a/.yarn/versions/6a9100dd.yml
+++ b/.yarn/versions/6a9100dd.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pack": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -16,6 +16,18 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it shouldn't pack Yarn files by default`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/index.js`, `module.exports = 42;\n`);
+
+        await run(`install`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        await expect(stdout).not.toMatch(/\.yarn\//);
+      }),
+    );
+
+    test(
       `it should only keep the files covered by the "files" field`,
       makeTemporaryEnv({
         files: [

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -30,6 +30,7 @@ const ALWAYS_IGNORE = [
   `.github`,
   `.git`,
   `.hg`,
+  `.yarn`,
   `node_modules`,
 
   `.npmignore`,

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -30,7 +30,6 @@ const ALWAYS_IGNORE = [
   `.github`,
   `.git`,
   `.hg`,
-  `.yarn`,
   `node_modules`,
 
   `.npmignore`,
@@ -183,6 +182,7 @@ export async function genPackList(workspace: Workspace) {
   maybeRejectPath(configuration.get(`bstatePath`));
   maybeRejectPath(configuration.get(`cacheFolder`));
   maybeRejectPath(configuration.get(`globalFolder`));
+  maybeRejectPath(configuration.get(`installStatePath`));
   maybeRejectPath(configuration.get(`virtualFolder`));
   maybeRejectPath(configuration.get(`yarnPath`));
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The install state was stored in the `yarn pack` output.

**How did you fix it?**

We now always blacklist it.
