### PR TITLE
🔧add the nodeLinker yarnrc.yml config

### DIFF
--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -113,7 +113,7 @@
     "nodeLinker": {
       "description": "Defines what linker should be used (useful to enable the node-modules plugin)",
       "type": "string",
-      "default": "pnp-loose"
+      "default": "pnp"
     },
     "npmAlwaysAuth": {
       "description": "If true, Yarn will always send the authentication credentials when making a request to the registries. This typically shouldn't be needed.",

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -335,7 +335,7 @@
       "default": "^\\./subdir/.*"
     },
     "pnpMode": {
-      "description": "TODO",
+      "description": "If 'strict', Yarn won't allow modules to require packages they don't explicitly list in their own dependencies. If 'loose', Yarn will allow access to the packages that would have been hoisted to the top-level under 1.x installs. Note that, even in loose mode, such calls are unsafe (hoisting rules aren't predictable) and should be discouraged.",
       "type": "string",
       "enum": ["strict", "loose"],
       "default": "strict"

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -113,7 +113,7 @@
     "nodeLinker": {
       "description": "Defines what linker should be used (useful to enable the node-modules plugin)",
       "type": "string",
-      "default": "???"
+      "default": "pnp-loose"
     },
     "npmAlwaysAuth": {
       "description": "If true, Yarn will always send the authentication credentials when making a request to the registries. This typically shouldn't be needed.",

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -110,6 +110,11 @@
       "format": "uri-reference",
       "default": "yarn.lock"
     },
+    "nodeLinker": {
+      "description": "Defines what linker should be used (useful to enable the node-modules plugin)",
+      "type": "string",
+      "default": "???"
+    },
     "npmAlwaysAuth": {
       "description": "If true, Yarn will always send the authentication credentials when making a request to the registries. This typically shouldn't be needed.",
       "type": "boolean",

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -113,6 +113,7 @@
     "nodeLinker": {
       "description": "Defines what linker should be used (useful to enable the node-modules plugin)",
       "type": "string",
+      "enum": ["pnp", "node-modules"],
       "default": "pnp"
     },
     "npmAlwaysAuth": {
@@ -332,6 +333,12 @@
       "type": "string",
       "format": "regex",
       "default": "^\\./subdir/.*"
+    },
+    "pnpMode": {
+      "description": "TODO",
+      "type": "string",
+      "enum": ["strict", "loose"],
+      "default": "strict"
     },
     "pnpShebang": {
       "description": "A header that will be prepended to the generated `.pnp.js` file. You're allowed to write multiple lines, but this is slightly frowned upon.",


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://yarnpkg.com/configuration/yarnrc does not list `nodeLinker` as a possible config while https://yarnpkg.com/advanced/migration#if-required-install-the-node-modules-plugin references it

**How did you fix it?**

Add nodeLinker to the `.yarnrc.yml` documentation file
