### PR TITLE
Implements preferUnplugged

### DIFF
--- a/.yarn/versions/73788921.yml
+++ b/.yarn/versions/73788921.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/73788921.yml
+++ b/.yarn/versions/73788921.yml
@@ -1,6 +1,7 @@
 releases:
   "@yarnpkg/cli": prerelease
   "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
   "@yarnpkg/plugin-pnp": prerelease
 
 declined:
@@ -16,7 +17,6 @@ declined:
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
   - "@yarnpkg/plugin-link"
-  - "@yarnpkg/plugin-node-modules"
   - "@yarnpkg/plugin-npm"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-false-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-false-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-false-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-false-1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "prefer-unplugged-false",
+    "version": "1.0.0",
+    "preferUnplugged": false,
+    "scripts": {
+      "postinstall": "echo hello"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-true-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-true-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-true-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prefer-unplugged-true-1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "prefer-unplugged-true",
+    "version": "1.0.0",
+    "preferUnplugged": true
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1221,6 +1221,36 @@ describe(`Plug'n'Play`, () => {
   );
 
   test(
+    `it should allow packages to define whether they should be unplugged (true)`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`prefer-unplugged-true`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        const listing = await xfs.readdirPromise(`${path}/.yarn/unplugged`);
+        expect(listing).toHaveLength(1);
+      },
+    ),
+  );
+
+  test(
+    `it should allow packages to define whether they should be unplugged (false)`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`prefer-unplugged-false`]: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        const listing = await xfs.readdirPromise(`${path}/.yarn/unplugged`);
+        expect(listing).toHaveLength(0);
+      },
+    ),
+  );
+
+  test(
     `it should not cache the postinstall artifacts`,
     makeTemporaryEnv(
       {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1244,8 +1244,7 @@ describe(`Plug'n'Play`, () => {
       async ({path, run, source}) => {
         await run(`install`);
 
-        const listing = await xfs.readdirPromise(`${path}/.yarn/unplugged`);
-        expect(listing).toHaveLength(0);
+        expect(xfs.existsSync(`${path}/.yarn/unplugged`)).toEqual(false);
       },
     ),
   );

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -58,12 +58,12 @@ export class NodeModulesLinker implements Linker {
 }
 
 class NodeModulesInstaller extends AbstractPnpInstaller {
-  async getBuildScripts(locator: Locator, fetchResult: FetchResult) {
+  async getBuildScripts(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult) {
     return [];
   }
 
-  async transformPackage(locator: Locator, dependencyMeta: DependencyMeta, packageFs: FakeFS<PortablePath>, flags: {hasBuildScripts: boolean}) {
-    return packageFs;
+  async transformPackage(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta, flags: {hasBuildScripts: boolean}) {
+    return fetchResult.packageFs;
   }
 
   async finalizeInstallWithPnp(pnpSettings: PnpSettings) {

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -42,7 +42,7 @@ export abstract class AbstractPnpInstaller implements Installer {
       !this.opts.project.tryWorkspaceByLocator(pkg);
 
     const manifest = !hasVirtualInstances
-      ? await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs})
+      ? await Manifest.tryFind(fetchResult.prefixPath, {baseFs: fetchResult.packageFs})
       : null;
 
     const buildScripts = !hasVirtualInstances

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -1,9 +1,9 @@
-import {Installer, LinkOptions, LinkType, MessageName, DependencyMeta, FinalizeInstallStatus} from '@yarnpkg/core';
-import {FetchResult, Descriptor, Locator, Package, BuildDirective}                            from '@yarnpkg/core';
-import {miscUtils, structUtils}                                                               from '@yarnpkg/core';
-import {FakeFS, PortablePath, ppath}                                                          from '@yarnpkg/fslib';
-import {PackageRegistry, PnpSettings}                                                         from '@yarnpkg/pnp';
-import mm                                                                                     from 'micromatch';
+import {Installer, LinkOptions, LinkType, MessageName, DependencyMeta, FinalizeInstallStatus, Manifest} from '@yarnpkg/core';
+import {FetchResult, Descriptor, Locator, Package, BuildDirective}                                      from '@yarnpkg/core';
+import {miscUtils, structUtils}                                                                         from '@yarnpkg/core';
+import {FakeFS, PortablePath, ppath}                                                                    from '@yarnpkg/fslib';
+import {PackageRegistry, PnpSettings}                                                                   from '@yarnpkg/pnp';
+import mm                                                                                               from 'micromatch';
 
 export abstract class AbstractPnpInstaller implements Installer {
   private readonly packageRegistry: PackageRegistry = new Map();
@@ -17,14 +17,14 @@ export abstract class AbstractPnpInstaller implements Installer {
   /**
    * Called in order to know whether the specified package has build scripts.
    */
-  abstract getBuildScripts(locator: Locator, fetchResult: FetchResult): Promise<Array<BuildDirective>>;
+  abstract getBuildScripts(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult): Promise<Array<BuildDirective>>;
 
   /**
    * Called to transform the package before it's stored in the PnP map. For
    * example we use this in the PnP linker to materialize the packages within
    * their own directories when they have build scripts.
    */
-  abstract transformPackage(locator: Locator, dependencyMeta: DependencyMeta, packageFs: FakeFS<PortablePath>, flags: {hasBuildScripts: boolean}): Promise<FakeFS<PortablePath>>;
+  abstract transformPackage(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta, flags: {hasBuildScripts: boolean}): Promise<FakeFS<PortablePath>>;
 
   /**
    * Called with the full settings, ready to be used by the @yarnpkg/pnp
@@ -41,8 +41,12 @@ export abstract class AbstractPnpInstaller implements Installer {
       !structUtils.isVirtualLocator(pkg) &&
       !this.opts.project.tryWorkspaceByLocator(pkg);
 
+    const manifest = !hasVirtualInstances
+      ? await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs})
+      : null;
+
     const buildScripts = !hasVirtualInstances
-      ? await this.getBuildScripts(pkg, fetchResult)
+      ? await this.getBuildScripts(pkg, manifest, fetchResult)
       : [];
 
     if (buildScripts.length > 0 && !this.opts.project.configuration.get(`enableScripts`)) {
@@ -63,7 +67,7 @@ export abstract class AbstractPnpInstaller implements Installer {
     }
 
     const packageFs = !hasVirtualInstances && pkg.linkType !== LinkType.SOFT
-      ? await this.transformPackage(pkg, dependencyMeta, fetchResult.packageFs, {hasBuildScripts: buildScripts.length > 0})
+      ? await this.transformPackage(pkg, manifest, fetchResult, dependencyMeta, {hasBuildScripts: buildScripts.length > 0})
       : fetchResult.packageFs;
 
     const packageRawLocation = ppath.resolve(packageFs.getRealPath(), ppath.relative(PortablePath.root, fetchResult.prefixPath));

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -103,7 +103,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
   }
 
   async transformPackage(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta, {hasBuildScripts}: {hasBuildScripts: boolean}) {
-    if (hasBuildScripts || this.isUnplugged(locator, manifest, fetchResult, dependencyMeta)) {
+    if (this.isUnplugged(locator, manifest, fetchResult, dependencyMeta, {hasBuildScripts})) {
       return this.unplugPackage(locator, fetchResult.packageFs);
     } else {
       return fetchResult.packageFs;
@@ -207,7 +207,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
     return new CwdFS(unplugPath);
   }
 
-  private isUnplugged(ident: Ident, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta) {
+  private isUnplugged(ident: Ident, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta, {hasBuildScripts}: {hasBuildScripts: boolean}) {
     if (typeof dependencyMeta.unplugged !== `undefined`)
       return dependencyMeta.unplugged;
 
@@ -217,7 +217,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
     if (manifest !== null && manifest.preferUnplugged !== null)
       return manifest.preferUnplugged;
 
-    if (fetchResult.packageFs.getExtractHint({relevantExtensions:FORCED_UNPLUG_FILETYPES}))
+    if (hasBuildScripts || fetchResult.packageFs.getExtractHint({relevantExtensions:FORCED_UNPLUG_FILETYPES}))
       return true;
 
     return false;

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -84,30 +84,29 @@ export class PnpInstaller extends AbstractPnpInstaller {
 
   private readonly unpluggedPaths: Set<string> = new Set();
 
-  async getBuildScripts(locator: Locator, fetchResult: FetchResult): Promise<Array<BuildDirective>> {
-    if (!await fetchResult.packageFs.existsPromise(ppath.resolve(fetchResult.prefixPath, toFilename(`package.json`))))
+  async getBuildScripts(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult): Promise<Array<BuildDirective>> {
+    if (manifest === null)
       return [];
 
     const buildScripts: Array<BuildDirective> = [];
-    const {scripts} = await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs});
 
     for (const scriptName of [`preinstall`, `install`, `postinstall`])
-      if (scripts.has(scriptName))
+      if (manifest.scripts.has(scriptName))
         buildScripts.push([BuildType.SCRIPT, scriptName]);
 
     // Detect cases where a package has a binding.gyp but no install script
     const bindingFilePath = ppath.resolve(fetchResult.prefixPath, toFilename(`binding.gyp`));
-    if (!scripts.has(`install`) && fetchResult.packageFs.existsSync(bindingFilePath))
+    if (!manifest.scripts.has(`install`) && fetchResult.packageFs.existsSync(bindingFilePath))
       buildScripts.push([BuildType.SHELLCODE, `node-gyp rebuild`]);
 
     return buildScripts;
   }
 
-  async transformPackage(locator: Locator, dependencyMeta: DependencyMeta, packageFs: FakeFS<PortablePath>, {hasBuildScripts}: {hasBuildScripts: boolean}) {
-    if (hasBuildScripts || this.isUnplugged(locator, dependencyMeta, packageFs)) {
-      return this.unplugPackage(locator, packageFs);
+  async transformPackage(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta, {hasBuildScripts}: {hasBuildScripts: boolean}) {
+    if (hasBuildScripts || this.isUnplugged(locator, manifest, dependencyMeta)) {
+      return this.unplugPackage(locator, fetchResult.packageFs);
     } else {
-      return packageFs;
+      return fetchResult.packageFs;
     }
   }
 
@@ -208,12 +207,15 @@ export class PnpInstaller extends AbstractPnpInstaller {
     return new CwdFS(unplugPath);
   }
 
-  private isUnplugged(ident: Ident, dependencyMeta: DependencyMeta, packageFs: FakeFS<PortablePath>) {
-    if (dependencyMeta.unplugged)
-      return true;
+  private isUnplugged(ident: Ident, manifest: Manifest | null, dependencyMeta: DependencyMeta, packageFs: FakeFS<PortablePath>) {
+    if (typeof dependencyMeta.unplugged !== `undefined`)
+      return dependencyMeta.unplugged;
 
     if (FORCED_UNPLUG_PACKAGES.has(ident.identHash))
       return true;
+
+    if (manifest !== null && manifest.preferUnplugged !== null)
+      return manifest.preferUnplugged;
 
     if (packageFs.getExtractHint({relevantExtensions:FORCED_UNPLUG_FILETYPES}))
       return true;

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -103,7 +103,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
   }
 
   async transformPackage(locator: Locator, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta, {hasBuildScripts}: {hasBuildScripts: boolean}) {
-    if (hasBuildScripts || this.isUnplugged(locator, manifest, dependencyMeta)) {
+    if (hasBuildScripts || this.isUnplugged(locator, manifest, fetchResult, dependencyMeta)) {
       return this.unplugPackage(locator, fetchResult.packageFs);
     } else {
       return fetchResult.packageFs;
@@ -207,7 +207,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
     return new CwdFS(unplugPath);
   }
 
-  private isUnplugged(ident: Ident, manifest: Manifest | null, dependencyMeta: DependencyMeta, packageFs: FakeFS<PortablePath>) {
+  private isUnplugged(ident: Ident, manifest: Manifest | null, fetchResult: FetchResult, dependencyMeta: DependencyMeta) {
     if (typeof dependencyMeta.unplugged !== `undefined`)
       return dependencyMeta.unplugged;
 
@@ -217,7 +217,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
     if (manifest !== null && manifest.preferUnplugged !== null)
       return manifest.preferUnplugged;
 
-    if (packageFs.getExtractHint({relevantExtensions:FORCED_UNPLUG_FILETYPES}))
+    if (fetchResult.packageFs.getExtractHint({relevantExtensions:FORCED_UNPLUG_FILETYPES}))
       return true;
 
     return false;

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -79,8 +79,22 @@ export class Manifest {
   static readonly allDependencies: Array<AllDependencies> = [`dependencies`, `devDependencies`, `peerDependencies`];
   static readonly hardDependencies: Array<HardDependencies> = [`dependencies`, `devDependencies`];
 
-  static async find(path: PortablePath, {baseFs = new NodeFS()}: {baseFs?: FakeFS<PortablePath>} = {}) {
-    return await Manifest.fromFile(ppath.join(path, toFilename(`package.json`)), {baseFs});
+  static async tryFind(path: PortablePath, {baseFs = new NodeFS()}: {baseFs?: FakeFS<PortablePath>} = {}) {
+    const manifestPath = ppath.join(path, toFilename(`package.json`));
+
+    if (!baseFs.existsPromise(manifestPath))
+      return null;
+
+    return await Manifest.fromFile(manifestPath, {baseFs});
+  }
+
+  static async find(path: PortablePath, {baseFs}: {baseFs?: FakeFS<PortablePath>} = {}) {
+    const manifest = await Manifest.tryFind(path, {baseFs});
+
+    if (manifest === null)
+      throw new Error(`Manifest not found`);
+
+    return manifest;
   }
 
   static async fromFile(path: PortablePath, {baseFs = new NodeFS()}: {baseFs?: FakeFS<PortablePath>} = {}) {

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -82,7 +82,7 @@ export class Manifest {
   static async tryFind(path: PortablePath, {baseFs = new NodeFS()}: {baseFs?: FakeFS<PortablePath>} = {}) {
     const manifestPath = ppath.join(path, toFilename(`package.json`));
 
-    if (!baseFs.existsPromise(manifestPath))
+    if (!await baseFs.existsPromise(manifestPath))
       return null;
 
     return await Manifest.fromFile(manifestPath, {baseFs});

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -65,6 +65,8 @@ export class Manifest {
   public files: Set<PortablePath> | null = null;
   public publishConfig: PublishConfig | null = null;
 
+  public preferUnplugged: boolean | null = null;
+
   public raw: {[key: string]: any} = {};
 
   /**
@@ -383,6 +385,9 @@ export class Manifest {
       }
     }
 
+    if (typeof data.preferUnplugged === `boolean`)
+      this.preferUnplugged = data.preferUnplugged;
+
     this.errors = errors;
   }
 
@@ -651,6 +656,11 @@ export class Manifest {
       data.files = Array.from(this.files);
     else
       delete data.files;
+
+    if (this.preferUnplugged !== null)
+      data.preferUnplugged = this.preferUnplugged;
+    else
+      delete data.preferUnplugged;
 
     return data;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

A package with `preferUnplugged` will be able to instruct Yarn to either force-extract its content on the disk (useful when for example you need to ship executable binaries for a reason or another), or to force it to stay within its archive (useful when you want your package to contain ALL the sources, including shellscripts, but they aren't useful for runtime purposes).
