### PR TITLE
[node-modules] Update E2E test for `node-modules` linker

### DIFF
--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -51,5 +51,5 @@ jobs:
         source scripts/e2e-setup-ci.sh
         git clone https://github.com/babel/babel.git -b next-8-dev
         cd babel
-        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn --inline-builds
+        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
       shell: bash

--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -51,5 +51,6 @@ jobs:
         source scripts/e2e-setup-ci.sh
         git clone https://github.com/babel/babel.git -b next-8-dev
         cd babel
+        echo hi
         NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
       shell: bash

--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -51,5 +51,5 @@ jobs:
         source scripts/e2e-setup-ci.sh
         git clone https://github.com/babel/babel.git -b next-8-dev
         cd babel
-        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
+        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn --inline-builds
       shell: bash

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -47,5 +47,5 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
         cd -
-        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
+        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn --inline-builds
       shell: bash

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -47,5 +47,5 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
         cd -
-        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn --inline-builds
+        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
       shell: bash

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -47,5 +47,6 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
         cd -
+        echo hi
         NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
       shell: bash


### PR DESCRIPTION
**What's the problem this PR addresses?**

Build logs are lost from whatever reason on CI.

**How did you fix it?**

Added `--inline-builds` option to `yarn`