### PR TITLE
[node-modules] Fixes race between `mkdirp` and `remove`

### DIFF
--- a/.yarn/versions/37861a83.yml
+++ b/.yarn/versions/37861a83.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -317,7 +317,7 @@ function getLocationMap(installState: NodeModulesLocatorMap) {
   return locationMap;
 }
 
-const removeDir = async (dir: PortablePath, options?: {innerLoop?: boolean, excludeNodeModules?: boolean}): Promise<any> => {
+const removeDir = async (dir: PortablePath, options?: {innerLoop?: boolean}): Promise<any> => {
   try {
     if (!options || !options.innerLoop) {
       const stats = await xfs.lstatPromise(dir);
@@ -330,7 +330,7 @@ const removeDir = async (dir: PortablePath, options?: {innerLoop?: boolean, excl
     for (const entry of entries) {
       const targetPath = ppath.join(dir, toFilename(entry.name));
       if (entry.isDirectory()) {
-        if (entry.name !== NODE_MODULES || !options || !options.excludeNodeModules) {
+        if (entry.name !== NODE_MODULES || (options && options.innerLoop)) {
           await removeDir(targetPath, {innerLoop: true});
         }
       } else {
@@ -447,7 +447,7 @@ const buildLocationTree = (locatorMap: NodeModulesLocatorMap | null, {skipPrefix
 const symlinkPromise = async (srcDir: PortablePath, dstDir: PortablePath) =>
   xfs.symlinkPromise(process.platform !== 'win32' ? ppath.relative(ppath.dirname(dstDir), srcDir) : srcDir, dstDir, process.platform === 'win32' ? 'junction' : undefined);
 
-const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs}: {baseFs: FakeFS<PortablePath>}) => {
+const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs, innerLoop}: {baseFs: FakeFS<PortablePath>, innerLoop?: boolean}) => {
   await xfs.mkdirpPromise(dstDir);
   const entries = await baseFs.readdirPromise(srcDir, {withFileTypes: true});
 
@@ -472,7 +472,9 @@ const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs}:
     const srcPath = ppath.join(srcDir, toFilename(entry.name));
     const dstPath = ppath.join(dstDir, toFilename(entry.name));
     if (entry.isDirectory()) {
-      await copyPromise(dstPath, srcPath, {baseFs});
+      if (entry.name !== NODE_MODULES || innerLoop) {
+        await copyPromise(dstPath, srcPath, {baseFs, innerLoop: true});
+      }
     } else {
       await copy(dstPath, srcPath, entry);
     }
@@ -596,9 +598,9 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
     }
   };
 
-  const cloneModule = async (srcDir: PortablePath, dstDir: PortablePath, options?: { keepSrcNodeModules?: boolean, innerLoop?: boolean }) => {
+  const cloneModule = async (srcDir: PortablePath, dstDir: PortablePath, options?: { innerLoop?: boolean }) => {
     const promise: Promise<any> = (async () => {
-      const cloneDir = async (srcDir: PortablePath, dstDir: PortablePath, options?: { keepSrcNodeModules?: boolean, innerLoop?: boolean }) => {
+      const cloneDir = async (srcDir: PortablePath, dstDir: PortablePath, options?: { innerLoop?: boolean }) => {
         try {
           if (!options || !options.innerLoop)
             await xfs.mkdirpPromise(dstDir);
@@ -611,13 +613,13 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
             const src = ppath.join(srcDir, entry.name);
             const dst = ppath.join(dstDir, entry.name);
 
-            if (entry.name !== NODE_MODULES || !options || !options.keepSrcNodeModules) {
-              if (entry.isDirectory()) {
+            if (entry.isDirectory()) {
+              if (entry.name !== NODE_MODULES || (options && options.innerLoop)) {
                 await xfs.mkdirpPromise(dst);
-                await cloneDir(src, dst, {keepSrcNodeModules: false, innerLoop: true});
-              } else {
-                await xfs.copyFilePromise(src, dst, fs.constants.COPYFILE_FICLONE);
+                await cloneDir(src, dst, {innerLoop: true});
               }
+            } else {
+              await xfs.copyFilePromise(src, dst, fs.constants.COPYFILE_FICLONE);
             }
           }
         } catch (e) {
@@ -641,10 +643,10 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
   };
 
   const deleteQueue: Promise<any>[] = [];
-  const deleteModule = async ({dstDir, keepNodeModules}: {dstDir: PortablePath, keepNodeModules: boolean}) => {
+  const deleteModule = async (dstDir: PortablePath) => {
     const promise: Promise<any> = (async () => {
       try {
-        await removeDir(dstDir, {excludeNodeModules: keepNodeModules});
+        await removeDir(dstDir);
       } catch (e) {
         e.message = `While removing ${dstDir} ${e.message}`;
         throw e;
@@ -658,18 +660,19 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
 
 
   // Delete locations that no longer exist
-  const deleteList: Array<{dstDir: PortablePath, keepNodeModules: boolean}> = [];
+  const deleteList = new Set<PortablePath>();
+  // Delete locations of inner node_modules
+  const innerDeleteList = new Set<PortablePath>();
   for (const {locations} of preinstallState.locatorMap.values()) {
     for (const location of locations) {
       const {locationRoot, segments} = parseLocation(location, {
         skipPrefix: project.cwd,
       });
 
+      let prevNode = prevLocationTree.get(locationRoot);
       let node = locationTree.get(locationRoot);
       let curLocation = locationRoot;
-      if (!node) {
-        deleteList.push({dstDir: curLocation, keepNodeModules: false});
-      } else {
+      if (node) {
         for (const segment of segments) {
           // '.' segment exists only for top-level locator, skip it
           if (segment === '.')
@@ -677,8 +680,15 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
 
           curLocation = ppath.join(curLocation, segment);
           node = node.children.get(segment);
+          if (prevNode)
+            prevNode = prevNode.children.get(segment);
+
           if (!node) {
-            deleteList.push({dstDir: curLocation, keepNodeModules: false});
+            deleteList.add(curLocation);
+            // If previous install had inner node_modules folder, we should explicitely list it for
+            // `removeDir` to delete it, but we need to delete it first, so we add it to inner delete list
+            if (prevNode && prevNode.children.has(NODE_MODULES))
+              innerDeleteList.add(ppath.join(curLocation, NODE_MODULES));
             break;
           }
         }
@@ -686,11 +696,17 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
     }
   }
 
-  for (const {dstDir, keepNodeModules} of deleteList)
-    await deleteModule({dstDir, keepNodeModules});
+  // Handle inner node_modules deletions first
+  for (const dstDir of innerDeleteList)
+    await deleteModule(dstDir);
+  await Promise.all(deleteQueue);
+  deleteQueue.length = 0;
+
+  for (const dstDir of deleteList)
+    await deleteModule(dstDir);
 
   // Update changed locations
-  const addList: Array<{srcDir: PortablePath, dstDir: PortablePath, linkType: LinkType, keepNodeModules: boolean}> = [];
+  const addList: Array<{srcDir: PortablePath, dstDir: PortablePath, linkType: LinkType}> = [];
   for (const [prevLocator, {locations}] of preinstallState.locatorMap.entries()) {
     for (const location of locations) {
       const {locationRoot, segments} = parseLocation(location, {
@@ -712,10 +728,9 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
           const srcDir = info.target;
           const dstDir = curLocation;
           const linkType = info.linkType;
-          const keepNodeModules = node.children.size > 0;
           if (srcDir !== dstDir) {
-            deleteList.push({dstDir, keepNodeModules});
-            addList.push({srcDir, dstDir, linkType, keepNodeModules});
+            deleteList.add(dstDir);
+            addList.push({srcDir, dstDir, linkType});
           }
         }
       }
@@ -745,17 +760,15 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
         node = node!.children.get(segment);
 
       if (!prevTreeNode) {
-        const keepNodeModules = node!.children.size > 0;
-        deleteList.push({dstDir, keepNodeModules});
-        addList.push({srcDir, dstDir, linkType, keepNodeModules});
+        deleteList.add(dstDir);
+        addList.push({srcDir, dstDir, linkType});
       } else {
         for (const segment of segments) {
           curLocation = ppath.join(curLocation, segment);
           prevTreeNode = prevTreeNode.children.get(segment);
           if (!prevTreeNode) {
-            const keepNodeModules = node!.children.size > 0;
-            deleteList.push({dstDir, keepNodeModules});
-            addList.push({srcDir, dstDir, linkType, keepNodeModules});
+            deleteList.add(dstDir);
+            addList.push({srcDir, dstDir, linkType});
             break;
           }
         }
@@ -767,10 +780,7 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
   const reportedProgress = report.reportProgress(progress);
 
   try {
-    const persistedLocations = new Map<PortablePath, {
-      dstDir: PortablePath,
-      keepNodeModules: boolean,
-    }>();
+    const persistedLocations = new Map<PortablePath, PortablePath>();
 
     // For the first pass we'll only want to install a single copy for each
     // source directory. We'll later use the resulting install directories for
@@ -778,7 +788,7 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
     // crawl the zip archives for each package).
     for (const entry of addList) {
       if (entry.linkType === LinkType.SOFT || !persistedLocations.has(entry.srcDir)) {
-        persistedLocations.set(entry.srcDir, {dstDir: entry.dstDir, keepNodeModules: entry.keepNodeModules});
+        persistedLocations.set(entry.srcDir, entry.dstDir);
         await addModule({...entry});
       }
     }
@@ -789,9 +799,9 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
 
     // Second pass: clone module duplicates
     for (const entry of addList) {
-      const locationInfo = persistedLocations.get(entry.srcDir)!;
-      if (entry.linkType !== LinkType.SOFT && entry.dstDir !== locationInfo.dstDir) {
-        await cloneModule(locationInfo.dstDir, entry.dstDir, {keepSrcNodeModules: locationInfo.keepNodeModules});
+      const persistedDir = persistedLocations.get(entry.srcDir)!;
+      if (entry.linkType !== LinkType.SOFT && entry.dstDir !== persistedDir) {
+        await cloneModule(persistedDir, entry.dstDir);
       }
     }
 

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -318,6 +318,9 @@ function getLocationMap(installState: NodeModulesLocatorMap) {
 }
 
 const removeDir = async (dir: PortablePath, options?: {innerLoop?: boolean}): Promise<any> => {
+  if (dir.split(ppath.sep).indexOf(NODE_MODULES) < 0)
+    throw new Error(`Assertion failed: trying to remove dir that doesn't contain node_modules: ${dir}`);
+
   try {
     if (!options || !options.innerLoop) {
       const stats = await xfs.lstatPromise(dir);


### PR DESCRIPTION
**What's the problem this PR addresses?**

We have observed one case of a race condition in `node-modules` linker between `mkdirp` and `remove` operations, during persisting of packages into `node_modules`

The error message looks like:
```
Error: While persisting /D:/a/berry/berry/.yarn/cache/@emotion-hash-npm-0.7.1-cc52d429a7-2.zip/node_modules/@emotion/hash -> /D:/a/berry/berry/node_modules/@emotion/serialize/node_modules/@emotion/hash ENOENT: no such file or directory, mkdir 'D:\a\berry\berry\node_modules\@emotion\serialize\node_modules'
```

**How did you fix it?**

I have tweaked the order of operations, so that all `remove`'s were executed first and only after they had been finished all the other file operations were performed.

Another change in this PR is simplification of the code for inner `node_modules` directories handling for the cases like `node_modules/foo/node_modules/bar`. In all the `addModule`, `deleteModule`, `copyDir`, `removeDir` operations that target `node_modules/foo` we now do not remove/copy `node_modules/foo/node_modules` and to actually delete `node_modules/foo/node_modules`, the `removeDir('`node_modules/foo/node_modules`')` should be called. All the inner `node_modules` deletions are performed at the very beginning of linking before all other copying/cloning operations. This way the code is seriously simplified.

cc @nicolo-ribaudo 