### PR TITLE
[node-modules] Add support for `yarn run` in build scripts

### DIFF
--- a/.yarn/versions/02747fd6.yml
+++ b/.yarn/versions/02747fd6.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -68,4 +68,30 @@ describe('Node_Modules', () => {
       },
     ),
   );
+
+  test(
+    `should support 'yarn run' from within build scripts`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          pkg: `file:./pkg`,
+        },
+      },
+      async ({path, run, source}) => {
+        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
+          nodeLinker: "node-modules"
+        `);
+
+        await writeJson(npath.toPortablePath(`${path}/pkg/package.json`), {
+          name: `pkg`,
+          scripts: {
+            postinstall: `yarn run foo`,
+            foo: `pwd`,
+          },
+        });
+
+        await expect(run(`install`)).resolves.toBeTruthy();
+      },
+    ),
+  );
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR fixes: #715

**How did you fix it?**

Linker now consults with location tree to find the owner locator of the given path.
