### PR TITLE
Improves satisfiesWithPrereleases

### DIFF
--- a/.yarn/versions/6ad9369f.yml
+++ b/.yarn/versions/6ad9369f.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -1,18 +1,17 @@
 import semver from 'semver';
 
 /**
- * Returns whether the given semver version satisfies the given range. Notably this supports
- * prerelease versions so that "2.0.0-rc.0" satisfies the range ">=1.0.0", for example.
+ * Returns whether the given semver version satisfies the given range. Notably
+ * this supports prerelease versions so that "2.0.0-rc.0" satisfies the range
+ * ">=1.0.0", for example.
  *
- * This function exists because the semver.satisfies method does not include pre releases. This means
- * ranges such as * would not satisfy 1.0.0-rc. Setting includePrerelease to true fixes the issue
- * but introduces a subtle problem where a range such as ^1.0.0 is satisfied by the version 2.0.0-rc.
- * This method is similar to the semver.satisfies with includeRerelease set to true without the inclusion
- * of major version pre releases as highlighted above.
+ * This function exists because the semver.satisfies method does not include
+ * pre releases. This means ranges such as * would not satisfy 1.0.0-rc. The
+ * includePrerelease flag has a weird behavior and cannot be used (if you want
+ * to try it out, just run the `semverUtils` testsuite using this flag instead
+ * of our own implementation, and you'll see the failing cases).
  *
- * See https://github.com/yarnpkg/berry/issues/575 and https://github.com/yarnpkg/berry/issues/575
- * for more context.
- *
+ * See https://github.com/yarnpkg/berry/issues/575 for more context.
  */
 export function satisfiesWithPrereleases(version: string | null, range: string, loose: boolean = false): boolean {
   let semverRange;
@@ -28,33 +27,20 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
   let semverVersion: semver.SemVer;
   try {
     semverVersion = new semver.SemVer(version, semverRange.loose);
+    semverVersion.prerelease.length = 0;
   } catch (err) {
     return false;
   }
 
-  // A range has multiple sets of comparators. A version must satisfy all comparators in a set
-  // and at least one set to satisfy the range.
+  // A range has multiple sets of comparators. A version must satisfy all
+  // comparators in a set and at least one set to satisfy the range.
   return semverRange.set.some(comparatorSet => {
-    // node-semver converts ~ and ^ ranges into pairs of >= and < ranges but the upper bounds don't
-    // properly exclude prerelease versions. For example, "^1.0.0" is converted to ">=1.0.0 <2.0.0",
-    // which includes "2.0.0-pre" since prerelease versions are lower than their non-prerelease
-    // counterparts. As a practical workaround we make upper-bound ranges exclude prereleases and
-    // convert "<2.0.0" to "<2.0.0-0", for example.
-    comparatorSet = comparatorSet.map(comparator => {
-      if (comparator.operator !== '<' || !comparator.value || comparator.semver.prerelease.length)
-        return comparator;
+    for (const comparator of comparatorSet)
+      if (comparator.semver.prerelease)
+        comparator.semver.prerelease.length = 0;
 
-
-      // "0" is the lowest prerelease version. Note the typings for inc() are incorrect
-      // and the following massages the types to achieve the same functionality as the
-      // yarn v1 functionality.
-      comparator.semver.inc('pre' as semver.ReleaseType, 0 as unknown as string);
-
-      const comparatorString = comparator.operator + comparator.semver.version;
-      // $FlowFixMe: Add a definition for the Comparator class
-      return new semver.Comparator(comparatorString, comparator.loose);
+    return comparatorSet.every(comparator => {
+      return comparator.test(semverVersion);
     });
-
-    return !comparatorSet.some(comparator => !comparator.test(semverVersion));
   });
 }

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -27,7 +27,9 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
   let semverVersion: semver.SemVer;
   try {
     semverVersion = new semver.SemVer(version, semverRange.loose);
-    semverVersion.prerelease.length = 0;
+    if (semverVersion.prerelease) {
+      semverVersion.prerelease = [];
+    }
   } catch (err) {
     return false;
   }
@@ -37,7 +39,7 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
   return semverRange.set.some(comparatorSet => {
     for (const comparator of comparatorSet)
       if (comparator.semver.prerelease)
-        comparator.semver.prerelease.length = 0;
+        comparator.semver.prerelease = [];
 
     return comparatorSet.every(comparator => {
       return comparator.test(semverVersion);

--- a/packages/yarnpkg-core/tests/semverUtils.test.ts
+++ b/packages/yarnpkg-core/tests/semverUtils.test.ts
@@ -1,0 +1,27 @@
+import * as semverUtils from '../sources/semverUtils';
+
+const SPECS: Array<[string, string, boolean]> = [
+  // Those three are different from includePrerelease
+  [`^5.0.0`, `5.0.0-beta.13`, true],
+  [`^1.0.0`, `1.0.0-rc1`, true],
+  [`2.x`, `3.0.0-pre.0`, false],
+
+  [`2.x`, `2.0.0-pre.0`, true],
+  [`2.x`, `2.1.0-pre.0`, true],
+  [`*`, `1.0.0-rc1`, true],
+  [`^1.0.0-0`, `1.0.1-rc1`, true],
+  [`^1.0.0-rc2`, `1.0.1-rc1`, true],
+  [`^1.0.0`, `1.0.1-rc1`, true],
+  [`^1.0.0`, `1.1.0-rc1`, true],
+
+  [`^1.0.0`, `2.0.0-rc1`, false],
+  [`^1.2.3-rc2`, `2.0.0`, false],
+];
+
+describe(`semverUtils`, () => {
+  for (const [range, version, satisfied] of SPECS) {
+    it(`should satisfy ${range} with ${version}`, () => {
+      expect(semverUtils.satisfiesWithPrereleases(version, range)).toEqual(satisfied);
+    });
+  }
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current implementation was reporting that `5.0.0-beta.13` wasn't matching `^5.0.0` (we're only talking about the "peer dependency warning" here). Since we've decided a long time ago that prerelease versions shouldn't be taken into account when checking peer dependencies, this led to incorrect warnings.

**How did you fix it?**

I reimplemented `satisfiesWithPrereleases` to drop all prereleases from the comparison. Also added unit tests to prevent regressions.
