### PR TITLE
Updates `yarn set version`

### DIFF
--- a/.yarn/versions/0b7c9f55.yml
+++ b/.yarn/versions/0b7c9f55.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,20 +1,14 @@
 import {BaseCommand}                                               from '@yarnpkg/cli';
 import {Configuration, Project, StreamReport, MessageName, Report} from '@yarnpkg/core';
-import {httpUtils}                                                 from '@yarnpkg/core';
+import {execUtils, httpUtils, semverUtils}                         from '@yarnpkg/core';
 import {Filename, PortablePath, ppath, xfs}                        from '@yarnpkg/fslib';
 import {Command, Usage, UsageError}                                from 'clipanion';
-import semver, {SemVer}                                            from 'semver';
-
-const BUNDLE_REGEXP = /^yarn-[0-9]+\.[0-9]+\.[0-9]+\.js$/;
-const BERRY_RANGES = new Set([`berry`, `nightly`, `nightlies`, `rc`]);
+import semver                                                      from 'semver';
 
 // eslint-disable-next-line arca/no-default-export
 export default class SetVersionCommand extends BaseCommand {
   @Command.String()
-  range!: string;
-
-  @Command.Boolean(`--allow-rc`)
-  includePrereleases: boolean = false;
+  version!: string;
 
   @Command.Boolean(`--dry-run`)
   dryRun: boolean = false;
@@ -36,14 +30,11 @@ export default class SetVersionCommand extends BaseCommand {
       `Download the latest release from the Yarn repository`,
       `$0 set version latest`,
     ], [
-      `Download the latest nightly release from the Yarn repository`,
-      `$0 set version nightly`,
+      `Download a specific Yarn 2 build`,
+      `$0 set version 2.0.0-rc.30`,
     ], [
-      `Switch back to Yarn v1`,
-      `$0 set version ^1`,
-    ], [
-      `Switch back to a specific release`,
-      `$0 set version 1.14.0`,
+      `Switch back to a specific Yarn 1 release`,
+      `$0 set version 1.22.1`,
     ]],
   });
 
@@ -52,154 +43,55 @@ export default class SetVersionCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project} = await Project.find(configuration, this.context.cwd);
 
+    let bundleUrl: string;
+
+    if (this.version === `latest`)
+      bundleUrl = `https://github.com/yarnpkg/berry/raw/master/packages/yarnpkg-cli/bin/yarn.js`;
+    else if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`))
+      bundleUrl = `https://github.com/yarnpkg/berry/raw/%40yarnpkg/cli/${this.version}/packages/yarnpkg-cli/bin/yarn.js`;
+    else if (semverUtils.satisfiesWithPrereleases(this.version, `^0.x || ^1.x`))
+      bundleUrl = `https://github.com/yarnpkg/yarn/releases/download/v${this.version}/yarn-${this.version}.js`;
+    else if (semver.validRange(this.version))
+      throw new UsageError(`Support for ranges got removed - please use the exact version you want to install, or 'latest' to get the latest build available`);
+    else
+      throw new UsageError(`Invalid version descriptor "${this.version}"`);
+
     const report = await StreamReport.start({
       configuration,
       stdout: this.context.stdout,
     }, async (report: StreamReport) => {
-      if (this.range === `latest`)
-        this.range = `*`;
+      report.reportInfo(MessageName.UNNAMED, `Downloading ${configuration.format(bundleUrl, `green`)}`);
+      const bundleBuffer = await httpUtils.get(bundleUrl, {configuration});
 
-      let candidates: Array<string> = [];
-
-      let bundleUrl: string;
-      let bundleVersion: string;
-
-      if (BERRY_RANGES.has(this.range)) {
-        bundleUrl = `https://github.com/yarnpkg/berry/raw/master/packages/yarnpkg-cli/bin/yarn.js`;
-        bundleVersion = `rc`;
-        candidates = [bundleVersion];
-      } else if (this.range === `nightly-v1`) {
-        bundleUrl = `https://nightly.yarnpkg.com/latest.js`;
-        bundleVersion = `classic`;
-        candidates = [bundleVersion];
-      } else if (semver.valid(this.range)) {
-        const {releases} = await fetchReleases(configuration, {
-          includePrereleases: true,
-        });
-
-        const release = releases.find(release => semver.eq(release.version, this.range));
-        if (!release)
-          throw new Error(`No matching release found for version ${this.range}.`);
-
-        const asset = getBundleAsset(release);
-        if (!asset)
-          throw new Error(`Assertion failed: The bundle asset should exist`);
-
-        bundleUrl = asset.browser_download_url;
-        bundleVersion = release.version.version;
-        candidates = [bundleVersion];
-      } else if (semver.validRange(this.range)) {
-        const {releases, prereleases} = await fetchReleases(configuration, {
-          includePrereleases: this.includePrereleases,
-        });
-
-        const satisfying = releases.filter(release => semver.satisfies(release.version, this.range)).sort((a, b) => {
-          return semver.rcompare(a.version, b.version);
-        });
-
-        if (satisfying.length === 0) {
-          if (prereleases.find(release => semver.satisfies(release.version, this.range))) {
-            throw new Error(`No matching release found for range ${this.range}, but a candidate prerelease was found - run with --allow-rc to use it.`);
-          } else {
-            throw new Error(`No matching release found for range ${this.range}.`);
-          }
-        }
-
-        const release = satisfying[0];
-        const asset = getBundleAsset(release);
-        if (!asset)
-          throw new Error(`Assertion failed: The bundle asset should exist`);
-
-        bundleUrl = asset.browser_download_url;
-        bundleVersion = release.version.version;
-        candidates = satisfying.map(release => release.version.version);
-      } else {
-        throw new UsageError(`Invalid version descriptor "${this.range}"`);
-      }
-
-      if (candidates.length === 1)
-        report.reportInfo(MessageName.UNNAMED, `Found matching release with ${configuration.format(bundleVersion, `#87afff`)}`);
-      else
-        report.reportInfo(MessageName.UNNAMED, `Selecting the highest release amongst ${configuration.format(bundleVersion, `#87afff`)} and ${candidates.length - 1} other${candidates.length === 2 ? `` : `s`}`);
-
-
-      if (!this.dryRun) {
-        report.reportInfo(MessageName.UNNAMED, `Downloading ${configuration.format(bundleUrl, `green`)}`);
-        const bundleBuffer = await httpUtils.get(bundleUrl, {configuration});
-
-        await setVersion(project, bundleVersion, bundleBuffer, {report});
-      }
+      await setVersion(project, null, bundleBuffer, {report});
     });
 
     return report.exitCode();
   }
 }
 
-type ReleaseAsset = {
-  id: any,
-
-  name: string,
-  browser_download_url: string,
-};
-
-type Release = {
-  id: any,
-
-  draft: boolean,
-  prerelease: boolean,
-
-  tag_name: string,
-  version: SemVer,
-
-  assets: Array<ReleaseAsset>,
-};
-
-function getBundleAsset(release: Release): ReleaseAsset | undefined {
-  return release.assets.find(asset => {
-    return BUNDLE_REGEXP.test(asset.name);
-  });
-}
-
 type FetchReleasesOptions = {
   includePrereleases: boolean,
 };
 
-export async function fetchReleases(configuration: Configuration, {includePrereleases = false}: Partial<FetchReleasesOptions> = {}): Promise<{releases: Array<Release>, prereleases: Array<Release>}> {
-  const request = await httpUtils.get(`https://api.github.com/repos/yarnpkg/yarn/releases`, {configuration});
-  const apiData = (JSON.parse(request.toString()) as Array<Release>);
+export async function setVersion(project: Project, bundleVersion: string | null, bundleBuffer: Buffer, {report}: {report: Report}) {
+  if (bundleVersion === null) {
+    await xfs.mktempPromise(async tmpDir => {
+      const temporaryPath = ppath.join(tmpDir, `yarn.js` as Filename);
+      await xfs.writeFilePromise(temporaryPath, bundleBuffer);
 
-  const allReleases = apiData.filter(release => {
-    if (release.draft)
-      return false;
+      const {stdout} = await execUtils.execvp(process.execPath, [temporaryPath, `--version`], {
+        cwd: project.cwd,
+        env: {...process.env, YARN_IGNORE_PATH: `1`},
+      });
 
-    const coercedVersion = semver.coerce(release.tag_name);
-    if (!coercedVersion)
-      return false;
+      bundleVersion = stdout.trim();
+      if (!semver.valid(bundleVersion)) {
+        throw new Error(`Invalid semver version`);
+      }
+    });
+  }
 
-    release.version = coercedVersion;
-
-    if (!getBundleAsset(release))
-      return false;
-
-    return true;
-  });
-
-  allReleases.sort((a, b) => {
-    return -semver.compare(a.version, b.version);
-  });
-
-  const prereleases = allReleases.filter(release => {
-    return release.prerelease;
-  });
-
-  const releases = includePrereleases ? allReleases : allReleases.filter(release => {
-    return !release.prerelease;
-  });
-
-  return {releases, prereleases};
-}
-
-export async function setVersion(project: Project, bundleVersion: string, bundleBuffer: Buffer, {report}: {report: Report}) {
   const releaseFolder = ppath.resolve(project.cwd, `.yarn/releases` as PortablePath);
   const absolutePath = ppath.resolve(releaseFolder, `yarn-${bundleVersion}.js` as Filename);
 

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -10,21 +10,12 @@ export default class SetVersionCommand extends BaseCommand {
   @Command.String()
   version!: string;
 
-  @Command.Boolean(`--dry-run`)
-  dryRun: boolean = false;
-
   static usage: Usage = Command.Usage({
     description: `lock the Yarn version used by the project`,
     details: `
       This command will download a specific release of Yarn directly from the Yarn GitHub repository, will store it inside your project, and will change the \`yarnPath\` settings from your project \`.yarnrc.yml\` file to point to the new file.
 
       A very good use case for this command is to enforce the version of Yarn used by the any single member of your team inside a same project - by doing this you ensure that you have control on Yarn upgrades and downgrades (including on your deployment servers), and get rid of most of the headaches related to someone using a slightly different version and getting a different behavior than you.
-
-      The command will by default only consider stable releases as valid candidates, but releases candidates can be downloaded as well provided you add the \`--allow-rc\` flag or use an exact tag.
-
-      Note that because you're on the v2 alpha trunk, running the command without parameter will always download the latest build straight from the repository. This behavior will be tweaked near the release to only download stable releases once more.
-
-      Adding the \`--dry-run\` flag will cause Yarn not to persist the changes on the disk.
     `,
     examples: [[
       `Download the latest release from the Yarn repository`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The previous implementation wasn't allowing us to easily switch from one 2.x build to another - we could only ever go to the latest builds.

**How did you fix it?**

The command now accepts arbitrary version number.

Because the GitHub API was too limited to retrieve the full list of available versions (we store them in tags, and GitHub only returns a very limited subset of tags), I've removed the ability to use ranges altogether. You can still use `latest` to get the latest 2.x release, though.

Last notable point: the releases will now use a filename mirroring the actual version (even when using `latest`).
