### PR TITLE
docs(api): change typedoc mode to `modules`

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -6055,6 +6055,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["remark-parse", "npm:6.0.3"],
             ["typedoc", "virtual:118b26a6cee620b5aa3e7e8d8b8e34cd9e486f75b92701001168da9be550fadd8c9d9b12643c642e2d528c2624fd8fe7e128eec9d715340efac44400432a0e0c#npm:0.17.0-3"],
             ["typedoc-neo-theme", "npm:1.0.7"],
+            ["typedoc-plugin-yarn", "portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby"],
             ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"],
             ["unescape-html", "npm:1.1.0"],
             ["unfetch", "npm:4.1.0"],
@@ -28277,11 +28278,40 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["shelljs", "npm:0.8.3"],
             ["typedoc-default-themes", "npm:0.8.0-0"],
             ["typedoc-neo-theme", "npm:1.0.7"],
+            ["typedoc-plugin-yarn", "portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby"],
             ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"]
           ],
           "packagePeers": [
             "typedoc-neo-theme",
             "@strictsoftware/typedoc-plugin-monorepo",
+            "typedoc-plugin-yarn",
+            "typescript"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:258c95d7dd1da51c9c624f238593e0bc1c34b7bd8de0b85fefd9552f2220a4555cad458eb72d96f0c7b341784726b6a8e9c8b4e838a9d27aac3796b29de01981#npm:0.17.0-3", {
+          "packageLocation": "./.yarn/$$virtual/typedoc-virtual-0344ad4939/0/cache/typedoc-npm-0.17.0-3-0ce05847cf-2.zip/node_modules/typedoc/",
+          "packageDependencies": [
+            ["typedoc", "virtual:258c95d7dd1da51c9c624f238593e0bc1c34b7bd8de0b85fefd9552f2220a4555cad458eb72d96f0c7b341784726b6a8e9c8b4e838a9d27aac3796b29de01981#npm:0.17.0-3"],
+            ["@strictsoftware/typedoc-plugin-monorepo", null],
+            ["@types/minimatch", "npm:3.0.3"],
+            ["fs-extra", "npm:8.1.0"],
+            ["handlebars", "npm:4.7.3"],
+            ["highlight.js", "npm:9.18.1"],
+            ["lodash", "npm:4.17.15"],
+            ["marked", "npm:0.8.1"],
+            ["minimatch", "npm:3.0.4"],
+            ["progress", "npm:2.0.3"],
+            ["shelljs", "npm:0.8.3"],
+            ["typedoc-default-themes", "npm:0.8.0-0"],
+            ["typedoc-neo-theme", null],
+            ["typedoc-plugin-yarn", "portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby"],
+            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"]
+          ],
+          "packagePeers": [
+            "typedoc-neo-theme",
+            "@strictsoftware/typedoc-plugin-monorepo",
+            "typedoc-plugin-yarn",
             "typescript"
           ],
           "linkType": "HARD",
@@ -28302,11 +28332,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["shelljs", "npm:0.8.3"],
             ["typedoc-default-themes", "npm:0.7.2"],
             ["typedoc-neo-theme", "npm:1.0.7"],
+            ["typedoc-plugin-yarn", null],
             ["typescript", "patch:typescript@npm%3A3.7.5#builtin<compat/typescript>::version=3.7.5&hash=270b6c"]
           ],
           "packagePeers": [
             "typedoc-neo-theme",
-            "@strictsoftware/typedoc-plugin-monorepo"
+            "@strictsoftware/typedoc-plugin-monorepo",
+            "typedoc-plugin-yarn"
           ],
           "linkType": "HARD",
         }]
@@ -28343,6 +28375,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["typedoc", "virtual:d8a22236835ea6a343a6f368c384af7c307d527652163c1cfc56292a2b4e7d055c3e2d0ac6817157cd52f801ddf4aeddee76e681fa2e9a53e9fb60482401a352#npm:0.16.0"]
           ],
           "linkType": "HARD",
+        }]
+      ]],
+      ["typedoc-plugin-yarn", [
+        ["portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby", {
+          "packageLocation": "./packages/gatsby/typedoc-plugin-yarn/",
+          "packageDependencies": [
+            ["typedoc-plugin-yarn", "portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby"],
+            ["typedoc", "virtual:258c95d7dd1da51c9c624f238593e0bc1c34b7bd8de0b85fefd9552f2220a4555cad458eb72d96f0c7b341784726b6a8e9c8b4e838a9d27aac3796b29de01981#npm:0.17.0-3"],
+            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"]
+          ],
+          "linkType": "SOFT",
         }]
       ]],
       ["typescript", [

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -51,6 +51,8 @@ packageExtensions:
       "sync-request": "*"
   "typedoc@*":
     peerDependenciesMeta:
+      "typedoc-plugin-yarn":
+        optional: true
       "typedoc-neo-theme":
         optional: true
       "@strictsoftware/typedoc-plugin-monorepo":

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -50,6 +50,7 @@
     "remark-parse": "^6.0.3",
     "typedoc": "next",
     "typedoc-neo-theme": "^1.0.7",
+    "typedoc-plugin-yarn": "portal:./typedoc-plugin-yarn",
     "typescript": "^3.8.3",
     "unescape-html": "^1.1.0",
     "unfetch": "^4.1.0",

--- a/packages/gatsby/typedoc-plugin-yarn/index.js
+++ b/packages/gatsby/typedoc-plugin-yarn/index.js
@@ -1,0 +1,7 @@
+const plugin = require('./plugin');
+
+module.exports = (PluginHost) => {
+  const app = PluginHost.owner;
+
+  app.converter.addComponent('yarn-plugin', plugin.YarnPlugin);
+};

--- a/packages/gatsby/typedoc-plugin-yarn/package.json
+++ b/packages/gatsby/typedoc-plugin-yarn/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "typedoc-plugin-yarn",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "typedoc": "next",
+    "typescript": "^3.8.3"
+  }
+}

--- a/packages/gatsby/typedoc-plugin-yarn/plugin.js
+++ b/packages/gatsby/typedoc-plugin-yarn/plugin.js
@@ -5,8 +5,8 @@ const {CommentPlugin} = require(`typedoc/dist/lib/converter/plugins/CommentPlugi
 const {ReflectionKind} = require(`typedoc/dist/lib/models/reflections/abstract`);
 
 exports.YarnPlugin = class YarnPlugin extends ConverterComponent {
-  constructor() {
-    super();
+  constructor(owner) {
+    super(owner);
     this.name = `yarn-plugin`;
   }
 

--- a/packages/gatsby/typedoc-plugin-yarn/plugin.js
+++ b/packages/gatsby/typedoc-plugin-yarn/plugin.js
@@ -5,7 +5,10 @@ const {CommentPlugin} = require(`typedoc/dist/lib/converter/plugins/CommentPlugi
 const {ReflectionKind} = require(`typedoc/dist/lib/models/reflections/abstract`);
 
 exports.YarnPlugin = class YarnPlugin extends ConverterComponent {
-  name = 'yarn-plugin';
+  constructor() {
+    super();
+    this.name = `yarn-plugin`;
+  }
 
   initialize() {
     this.listenTo(this.owner, {

--- a/packages/gatsby/typedoc-plugin-yarn/plugin.js
+++ b/packages/gatsby/typedoc-plugin-yarn/plugin.js
@@ -1,0 +1,35 @@
+const {ConverterComponent} = require(`typedoc/dist/lib/converter/components`);
+
+const {Converter} = require(`typedoc/dist/lib/converter/converter`);
+const {CommentPlugin} = require(`typedoc/dist/lib/converter/plugins/CommentPlugin`);
+const {ReflectionKind} = require(`typedoc/dist/lib/models/reflections/abstract`);
+
+exports.YarnPlugin = class YarnPlugin extends ConverterComponent {
+  name = 'yarn-plugin';
+
+  initialize() {
+    this.listenTo(this.owner, {
+      [Converter.EVENT_CREATE_DECLARATION]: this.onDeclarationBegin,
+    });
+  }
+
+  onDeclarationBegin(context, reflection) {
+    // Remove unnecessary reflections generated from virtual files
+    if (reflection.sources && reflection.sources[0].fileName.includes(`.yarn/$$virtual/`)) {
+      CommentPlugin.removeReflection(context.project, reflection);
+      console.log(
+        `Removing unnecessary reflection generated from virtual file: `,
+        reflection.sources[0].fileName,
+      );
+    }
+
+    // Remove unnecessary reference reflections
+    if (reflection.kind === ReflectionKind.Reference) {
+      CommentPlugin.removeReflection(context.project, reflection);
+      console.log(
+        `Removing unnecessary reference reflection: `,
+        reflection.name,
+      );
+    }
+  }
+};

--- a/packages/gatsby/typedoc.json
+++ b/packages/gatsby/typedoc.json
@@ -5,7 +5,7 @@
   "out": "./static/api",
   "theme": "../../.yarn/unplugged/typedoc-neo-theme-npm-1.0.7-d8a2223683/node_modules/typedoc-neo-theme/bin/default",
   "plugin": ["typedoc-neo-theme", "@strictsoftware/typedoc-plugin-monorepo"],
-  "external-modulemap": "^(?:(?!\\.yarn\\\/\\$\\$virtual\\\/).)*packages\\\/([^\\\/]+)\\\/.*$",
+  "external-modulemap": ".*packages\/([^\/]+)\/.*",
   "ignoreCompilerErrors": true,
   "links": [
     {

--- a/packages/gatsby/typedoc.json
+++ b/packages/gatsby/typedoc.json
@@ -4,7 +4,7 @@
   "mode": "modules",
   "out": "./static/api",
   "theme": "../../.yarn/unplugged/typedoc-neo-theme-npm-1.0.7-d8a2223683/node_modules/typedoc-neo-theme/bin/default",
-  "plugin": ["typedoc-neo-theme", "@strictsoftware/typedoc-plugin-monorepo"],
+  "plugin": ["typedoc-plugin-yarn", "typedoc-neo-theme", "@strictsoftware/typedoc-plugin-monorepo"],
   "external-modulemap": ".*packages\/([^\/]+)\/.*",
   "ignoreCompilerErrors": true,
   "links": [

--- a/packages/gatsby/typedoc.json
+++ b/packages/gatsby/typedoc.json
@@ -1,7 +1,7 @@
 {
   "name": "Yarn API",
   "inputFiles": ["../."],
-  "mode": "library",
+  "mode": "modules",
   "out": "./static/api",
   "theme": "../../.yarn/unplugged/typedoc-neo-theme-npm-1.0.7-d8a2223683/node_modules/typedoc-neo-theme/bin/default",
   "plugin": ["typedoc-neo-theme", "@strictsoftware/typedoc-plugin-monorepo"],

--- a/packages/gatsby/typedoc.json
+++ b/packages/gatsby/typedoc.json
@@ -5,7 +5,7 @@
   "out": "./static/api",
   "theme": "../../.yarn/unplugged/typedoc-neo-theme-npm-1.0.7-d8a2223683/node_modules/typedoc-neo-theme/bin/default",
   "plugin": ["typedoc-neo-theme", "@strictsoftware/typedoc-plugin-monorepo"],
-  "external-modulemap": ".*packages\/([^\/]+)\/.*",
+  "external-modulemap": "^(?:(?!\\.yarn\\\/\\$\\$virtual\\\/).)*packages\\\/([^\\\/]+)\\\/.*$",
   "ignoreCompilerErrors": true,
   "links": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5033,6 +5033,7 @@ __metadata:
     remark-parse: ^6.0.3
     typedoc: next
     typedoc-neo-theme: ^1.0.7
+    typedoc-plugin-yarn: "portal:./typedoc-plugin-yarn"
     typescript: ^3.8.3
     unescape-html: ^1.1.0
     unfetch: ^4.1.0
@@ -24840,6 +24841,15 @@ resolve@^1.10.1:
   checksum: 2/c789b77158b76108ec1257e78760297f23495e258e1bc25896e87fd21feea45c83c63f5dc584c8ee75ec00ca395b1c4669737f179ee04f6303aa842b6e09d064
   languageName: node
   linkType: hard
+
+"typedoc-plugin-yarn@portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby":
+  version: 0.0.0-use.local
+  resolution: "typedoc-plugin-yarn@portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby"
+  dependencies:
+    typedoc: next
+    typescript: ^3.8.3
+  languageName: node
+  linkType: soft
 
 "typedoc@npm:0.16.0":
   version: 0.16.0


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently, TypeDoc elements that are exported in more than one file are duplicated (examples in [yarnpkg-cli](https://yarnpkg.com/api/modules/yarnpkg_cli.html), [yarnpkg-core](https://yarnpkg.com/api/modules/yarnpkg_core.html) etc.).
This is caused by having TypeDoc in `library` mode. In my original PR, I set it to `library` before adding `@strictsoftware/typedoc-plugin-monorepo`, since it seemed to produce the most useful output. After adding the plugin, I forgot to retest the other modes.

**How did you fix it?**

This PR changes the TypeDoc mode from `library` to `modules`. This causes TypeDoc to classify re-exports as references and to not duplicate elements. Unfortunately, they are currently dead references (probably caused by `@strictsoftware/typedoc-plugin-monorepo`). I think a possible solution would be removing the dead references with a custom theme, since they aren't that useful.
