### PR TITLE
[node-modules] Remove self-references from node_modules tree

### DIFF
--- a/.yarn/versions/e0cb4c4c.yml
+++ b/.yarn/versions/e0cb4c4c.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -303,23 +303,6 @@ async function findInstallState(project: Project, {unrollAliases = false}: {unro
   return {locatorMap, binSymlinks, locationTree: buildLocationTree(locatorMap, {skipPrefix: project.cwd})};
 };
 
-function getLocationMap(installState: NodeModulesLocatorMap) {
-  const locationMap: LocationMap = new Map();
-
-  for (const [locatorKey, val] of installState) {
-    const locator = structUtils.parseLocator(locatorKey);
-
-    if (val.linkType === LinkType.SOFT)
-      locationMap.set(val.target, locator);
-
-    for (const location of val.locations) {
-      locationMap.set(location, locator);
-    }
-  }
-
-  return locationMap;
-}
-
 const removeDir = async (dir: PortablePath, options?: {innerLoop?: boolean}): Promise<any> => {
   if (dir.split(ppath.sep).indexOf(NODE_MODULES) < 0)
     throw new Error(`Assertion failed: trying to remove dir that doesn't contain node_modules: ${dir}`);

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -264,6 +264,9 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
     seenNodes.add(pkg);
 
     for (const dep of pkg.dependencies) {
+      // We do not want self-references in node_modules, since they confuse existing tools
+      if (dep === pkg)
+        continue;
       const references = Array.from(dep.references).sort();
       const locator = {name: dep.name, reference: references[0]};
       const {name, scope} = getPackageName(locator);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The linker created self-referencing symlink for top-level package, this has confused some build toolchains, for example Vue.

Reproduction steps on Windows:
```
npx @vue/cli create repro
cd repro && yarn set version v2
printf "console.log(undefined ?? 'false')" > src/main.js
printf "yarnPath: ".yarn/releases/yarn-berry.js"\nnodeLinker: 'node-modules'" > .yarnrc.yml
printf "module.exports = {\nconfigureWebpack: {\nresolve: {\nsymlinks: false\n},\n}\n}" > vue.config.js
yarn && yarn build
```

**How did you fix it?**

I have removed creation of self-references altogether during node_modules tree creation.