### PR TITLE
Fixes the packagePeers info for workspaces

### DIFF
--- a/.yarn/versions/2f54f272.yml
+++ b/.yarn/versions/2f54f272.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -565,7 +565,7 @@ export const generatePkgDriver = ({
           }
 
           if (data.type === `failure`) {
-            throw data.result;
+            throw {externalException: data.result};
           } else {
             return data.result;
           }

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -536,32 +536,43 @@ export const generatePkgDriver = ({
 
         const source = async (script: string, callDefinition: Record<string, any> = {}): Promise<Record<string, any>> => {
           const scriptWrapper = `
-            Promise.resolve().then(async () => ${script}).then(err => {
+            Promise.resolve().then(async () => ${script}).then(result => {
+              return {type: 'success', result};
+            }, err => {
               if (!(err instanceof Error))
                 return err;
 
-              const copy = JSON.parse(JSON.stringify(err));
-
+              const copy = {message: err.message};
               if (err.code)
                 copy.code = err.code;
               if (err.pnpCode)
                 copy.pnpCode = err.pnpCode;
 
-              return copy;
-            }).then(result => {
-              console.log(JSON.stringify(result));
+              return {type: 'failure', result: copy};
+            }).then(payload => {
+              console.log(JSON.stringify(payload));
             })
           `.replace(/\n/g, ``);
 
-          return JSON.parse((await run(`node`, `-e`, scriptWrapper, callDefinition)).stdout.toString());
+          const result = await run(`node`, `-e`, scriptWrapper, callDefinition);
+          const content = result.stdout.toString();
+
+          let data;
+          try {
+            data = JSON.parse(content);
+          } catch {
+            throw new Error(`Error when parsing JSON payload (${content})`);
+          }
+
+          if (data.type === `failure`) {
+            throw data.result;
+          } else {
+            return data.result;
+          }
         };
 
         try {
-          await fn!({
-            path,
-            run,
-            source,
-          });
+          await fn!({path, run, source});
         } catch (error) {
           error.message = `Temporary fixture folder: ${path}\n\n${error.message}`;
           throw error;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/packageExtensions.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/packageExtensions.test.js
@@ -60,7 +60,12 @@ describe(`Features`, () => {
           await xfs.removePromise(`${path}/.yarnrc.yml`);
           await run(`install`);
 
-          await expect(source(`require('various-requires/invalid-require')`)).rejects.toThrow();
+          await expect(source(`require('various-requires/invalid-require')`)).rejects.toMatchObject({
+            externalException: {
+              code: `MODULE_NOT_FOUND`,
+              pnpCode: `UNDECLARED_DEPENDENCY`,
+            },
+          });
         },
       ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpLoose.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpLoose.test.js
@@ -14,10 +14,11 @@ describe(`Features`, () => {
         async ({path, run, source}) => {
           await run(`install`);
 
-          await expect(source(`require('various-requires/invalid-require')`)).rejects.toBeTruthy();
-          await expect(source(`{ try { require('various-requires/invalid-require') } catch (error) { return error } }`)).resolves.toMatchObject({
-            code: `MODULE_NOT_FOUND`,
-            pnpCode: `UNDECLARED_DEPENDENCY`,
+          await expect(source(`require('various-requires/invalid-require')`)).rejects.toMatchObject({
+            externalException: {
+              code: `MODULE_NOT_FOUND`,
+              pnpCode: `UNDECLARED_DEPENDENCY`,
+            },
           });
         },
       ),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -213,10 +213,11 @@ describe(`Plug'n'Play`, () => {
       async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`require('various-requires/invalid-require')`)).rejects.toBeTruthy();
-        await expect(source(`{ try { require('various-requires/invalid-require') } catch (error) { return error } }`)).resolves.toMatchObject({
-          code: `MODULE_NOT_FOUND`,
-          pnpCode: `UNDECLARED_DEPENDENCY`,
+        await expect(source(`require('various-requires/invalid-require')`)).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+            pnpCode: `UNDECLARED_DEPENDENCY`,
+          },
         });
       },
     ),
@@ -275,10 +276,11 @@ describe(`Plug'n'Play`, () => {
       async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`require('peer-deps')`)).rejects.toBeTruthy();
-        await expect(source(`{ try { require('peer-deps') } catch (error) { return error } }`)).resolves.toMatchObject({
-          code: `MODULE_NOT_FOUND`,
-          pnpCode: `MISSING_PEER_DEPENDENCY`,
+        await expect(source(`require('peer-deps')`)).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+            pnpCode: `MISSING_PEER_DEPENDENCY`,
+          },
         });
       },
     ),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
@@ -1,4 +1,5 @@
-const {npath, xfs} = require(`@yarnpkg/fslib`);
+import {ppath, npath, xfs} from '@yarnpkg/fslib';
+
 const {
   fs: {writeFile, writeJson},
 } = require('pkg-tests-core');
@@ -69,6 +70,109 @@ describe(`Plug'n'Play API`, () => {
           ).resolves.toEqual([
             [`no-deps`, `npm:1.0.0`],
           ]);
+        }),
+      );
+
+      test(
+        `it should return the packages peer dependencies`,
+        makeTemporaryEnv({
+          dependencies: {
+            [`peer-deps`]: `1.0.0`,
+            [`no-deps`]: `1.0.0`,
+          },
+        }, async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(
+            source(`{
+              const pnp = require('pnpapi');
+              const deps = pnp.getPackageInformation(pnp.topLevel).packageDependencies;
+              return [...pnp.getPackageInformation(pnp.getLocator('peer-deps', deps.get('peer-deps'))).packagePeers];
+            }`),
+          ).resolves.toEqual([
+            `no-deps`,
+          ]);
+        }),
+      );
+
+      test(
+        `it should return the workspaces peer dependencies when virtualized`,
+        makeTemporaryEnv({
+          private: true,
+          workspaces: [
+            `packages/*`,
+          ],
+        }, async ({path, run, source}) => {
+          await xfs.mkdirpPromise(ppath.join(path, `packages/foo`));
+          await xfs.writeJsonPromise(ppath.join(path, `packages/foo/package.json`), {
+            name: `foo`,
+            dependencies: {
+              [`bar`]: `workspace:*`,
+              [`no-deps`]: `1.0.0`,
+            },
+          });
+
+          await xfs.mkdirpPromise(ppath.join(path, `packages/bar`));
+          await xfs.writeJsonPromise(ppath.join(path, `packages/bar/package.json`), {
+            name: `bar`,
+            peerDependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+            devDependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(
+            source(`{
+              const pnp = require('pnpapi');
+              const deps = pnp.getPackageInformation({name: 'foo', reference: 'workspace:packages/foo'}).packageDependencies;
+              return [...pnp.getPackageInformation(pnp.getLocator('bar', deps.get('bar'))).packagePeers];
+            }`),
+          ).resolves.toEqual([
+            `no-deps`,
+          ]);
+        }),
+      );
+
+      test(
+        `it shouldn't return the workspaces peer dependencies when accessed as roots`,
+        makeTemporaryEnv({
+          private: true,
+          workspaces: [
+            `packages/*`,
+          ],
+        }, async ({path, run, source}) => {
+          await xfs.mkdirpPromise(ppath.join(path, `packages/foo`));
+          await xfs.writeJsonPromise(ppath.join(path, `packages/foo/package.json`), {
+            name: `foo`,
+            dependencies: {
+              [`bar`]: `workspace:*`,
+              [`no-deps`]: `1.0.0`,
+            },
+          });
+
+          await xfs.mkdirpPromise(ppath.join(path, `packages/bar`));
+          await xfs.writeJsonPromise(ppath.join(path, `packages/bar/package.json`), {
+            name: `bar`,
+            peerDependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+            devDependencies: {
+              [`no-deps`]: `1.0.0`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(
+            source(`{
+              const pnp = require('pnpapi');
+              return [...pnp.getPackageInformation({name: 'bar', reference: 'workspace:packages/bar'}).packagePeers || []];
+            }`),
+          ).resolves.toEqual([]);
         }),
       );
     });
@@ -152,7 +256,7 @@ describe(`Plug'n'Play API`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`(() => { try { require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}) } catch (error) { return error } })()`)).resolves.toMatchObject({
+        await expect(source(`(() => require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}))()`)).rejects.toMatchObject({
           pnpCode: `UNDECLARED_DEPENDENCY`,
         });
       }),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
@@ -256,7 +256,7 @@ describe(`Plug'n'Play API`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`(() => require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}))()`)).rejects.toMatchObject({
+        await expect(source(`(() => require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}))()`)).resolves.toMatchObject({
           pnpCode: `UNDECLARED_DEPENDENCY`,
         });
       }),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
@@ -256,7 +256,7 @@ describe(`Plug'n'Play API`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`(() => require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}))()`)).resolves.toMatchObject({
+        await expect(source(`(() => require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}))()`)).rejects.toMatchObject({
           externalException: {
             pnpCode: `UNDECLARED_DEPENDENCY`,
           },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnpapi.test.js
@@ -257,7 +257,9 @@ describe(`Plug'n'Play API`, () => {
         await run(`install`);
 
         await expect(source(`(() => require('pnpapi').resolveRequest('no-deps', ${JSON.stringify(`${path}/`)}))()`)).resolves.toMatchObject({
-          pnpCode: `UNDECLARED_DEPENDENCY`,
+          externalException: {
+            pnpCode: `UNDECLARED_DEPENDENCY`,
+          },
         });
       }),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
@@ -32,9 +32,11 @@ describe(`Protocols`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(source(`{ try { require('one-fixed-dep') } catch (error) { return error } }`)).resolves.toMatchObject({
-          code: `MODULE_NOT_FOUND`,
-          pnpCode: `UNDECLARED_DEPENDENCY`,
+        await expect(source(`require('one-fixed-dep')`)).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+            pnpCode: `UNDECLARED_DEPENDENCY`,
+          },
         });
       }),
     );

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -76,9 +76,15 @@ export abstract class AbstractPnpInstaller implements Installer {
     const packageDependencies = new Map<string, string | [string, string] | null>();
     const packagePeers = new Set<string>();
 
-    for (const descriptor of pkg.peerDependencies.values()) {
-      packageDependencies.set(structUtils.requirableIdent(descriptor), null);
-      packagePeers.add(structUtils.stringifyIdent(descriptor));
+    // Only virtual packages should have effective peer dependencies, but the
+    // workspaces are a special case because the original packages are kept in
+    // the dependency tree even after being virtualized; so in their case we
+    // just ignore their declared peer dependencies.
+    if (structUtils.isVirtualLocator(pkg)) {
+      for (const descriptor of pkg.peerDependencies.values()) {
+        packageDependencies.set(structUtils.requirableIdent(descriptor), null);
+        packagePeers.add(structUtils.stringifyIdent(descriptor));
+      }
     }
 
     miscUtils.getMapWithDefault(this.packageRegistry, key1).set(key2, {

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -147,28 +147,22 @@ const buildPackageTree = (pnp: PnpApi): HoisterTree => {
   const addPackageToTree = (pkg: PackageInformation<NativePath>, locator: PhysicalPackageLocator, parent: HoisterTree, parentPkg: PackageInformation<NativePath>) => {
     const locatorKey = stringifyLocator(locator);
     let node = nodes.get(locatorKey);
+
     const isSeen = !!node;
     if (!isSeen && locatorKey === topLocatorKey) {
       node = packageTree;
       nodes.set(locatorKey, packageTree);
     }
+
     if (!node) {
-      const {name, reference} = locator;
-
-      // TODO: remove this code when `packagePeers` will not contain regular dependencies
-      const peerNames = new Set<string>();
-      for (const peerName of pkg.packagePeers)
-        if (pkg.packageDependencies.get(peerName) === parentPkg.packageDependencies.get(peerName))
-          peerNames.add(peerName);
-
-      node = {
-        name,
-        reference,
+      nodes.set(locatorKey, node = {
+        name: locator.name,
+        reference: locator.reference,
         dependencies: new Set(),
-        peerNames,
-      };
-      nodes.set(locatorKey, node);
+        peerNames: pkg.packagePeers,
+      });
     }
+
     parent.dependencies.add(node);
 
     if (!isSeen) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `packagePeers` field currently lists peer dependencies for workspaces even under the root context (ie when they're accessed by running a script within their own directory). This causes issues in the linkers that expect these informations to be accurate.

**How did you fix it?**

The workspaces won't store packagePeers infos when under the root context. Added tests.
