### PR TITLE
Makes yarn init able to initialize workspaces

### DIFF
--- a/.yarn/versions/fdc7a7ef.yml
+++ b/.yarn/versions/fdc7a7ef.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-init": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -13,6 +13,12 @@ export default class InitCommand extends BaseCommand {
   @Command.Boolean(`-p,--private`)
   private: boolean = false;
 
+  @Command.Boolean(`-w,--workspace`)
+  workspace: boolean = false;
+
+  @Command.Boolean(`-l,--latest`)
+  latest: boolean = false;
+
   @Command.String(`-i,--install`)
   install?: string;
 
@@ -21,9 +27,13 @@ export default class InitCommand extends BaseCommand {
     details: `
       This command will setup a new package in your local directory.
 
-      If the \`-p,--private\` option is set, the package will be private by default.
+      If the \`-p,--private\` or \`-w,--workspace\` options are set, the package will be private by default.
+
+      If the \`-w,--workspace\` option is set, the package will be configured to accept a set of workspaces in the \`packages/\` directory.
 
       If the \`-i,--install\` option is given a value, Yarn will first download it using \`yarn set version\` and only then forward the init call to the newly downloaded bundle.
+
+      If the \`-l,--latest\` option is set, \`--install latest\` will be assumed.
 
       The following settings can be used in order to affect what the generated package.json will look like:
 
@@ -39,7 +49,10 @@ export default class InitCommand extends BaseCommand {
       `yarn init -p`,
     ], [
       `Create a new package and store the Yarn release inside`,
-      `yarn init -i berry`,
+      `yarn init -i latest`,
+    ], [
+      `Create a new private package and defines it as a workspace root`,
+      `yarn init -w`,
     ]],
   });
 
@@ -50,14 +63,20 @@ export default class InitCommand extends BaseCommand {
 
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
-    if (typeof this.install !== `undefined`) {
-      return await this.executeProxy(configuration);
+    const install = typeof this.install !== `undefined`
+      ? this.install
+      : this.latest
+        ? `latest`
+        : null;
+
+    if (install !== null) {
+      return await this.executeProxy(configuration, install);
     } else {
       return await this.executeRegular(configuration);
     }
   }
 
-  async executeProxy(configuration: Configuration) {
+  async executeProxy(configuration: Configuration, version: string) {
     if (configuration.get(`yarnPath`) !== null)
       throw new UsageError(`Cannot use the --install flag when the current directory already uses yarnPath (from ${configuration.sources.get(`yarnPath`)})`);
 
@@ -71,7 +90,7 @@ export default class InitCommand extends BaseCommand {
     if (!xfs.existsSync(lockfilePath))
       await xfs.writeFilePromise(lockfilePath, ``);
 
-    const versionExitCode = await this.cli.run([`set`, `version`, this.install!]);
+    const versionExitCode = await this.cli.run([`set`, `version`, version]);
     if (versionExitCode !== 0)
       return versionExitCode;
 
@@ -80,8 +99,12 @@ export default class InitCommand extends BaseCommand {
     const args: Array<string> = [];
     if (this.private)
       args.push(`-p`);
+    if (this.workspace)
+      args.push(`-w`);
     if (this.yes)
       args.push(`-y`);
+    if (this.latest)
+      args.push(`-l`);
 
     return await xfs.mktempPromise(async binFolder => {
       const {code} = await execUtils.pipevp(`yarn`, [`init`, ...args], {
@@ -103,8 +126,15 @@ export default class InitCommand extends BaseCommand {
     const manifest = new Manifest();
     manifest.name = structUtils.makeIdent(configuration.get(`initScope`), ppath.basename(this.context.cwd));
     manifest.version = configuration.get(`initVersion`);
-    manifest.private = this.private;
+    manifest.private = this.private || this.workspace;
     manifest.license = configuration.get(`initLicense`);
+
+    if (this.workspace) {
+      await xfs.mkdirpPromise(ppath.join(this.context.cwd, `packages` as Filename));
+      manifest.workspaceDefinitions = [{
+        pattern: `packages/*`,
+      }];
+    }
 
     const serialized: any = {};
     manifest.exportTo(serialized);

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -7,6 +7,9 @@ import {inspect}                             from 'util';
 
 // eslint-disable-next-line arca/no-default-export
 export default class InitCommand extends BaseCommand {
+  @Command.Boolean(`-2`, {hidden: true})
+  usev2: boolean = false;
+
   @Command.Boolean(`-y,--yes`, {hidden: true})
   yes: boolean = false;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's annoying to have to edit the package.json just to add the same `packages/*` workspace declaration right after initialization.

**How did you fix it?**

Running `yarn init -w` will now generate a workspace-aware project (I've also added the `-l` flag as an alias for `-i latest`, so running `yarn init -2lw` will create a Yarn 2 workspace project using the latest official release).
