### PR TITLE
docs(sdk): Add Emacs documentation and emit a typescript-language-server wrapper for (Emacs') LSP support

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -352,6 +352,18 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       [
         "typescript",
         "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"
+      ],
+      [
+        "typescript-language-server",
+        "npm:0.4.0"
+      ],
+      [
+        "vscode-jsonrpc",
+        "npm:5.0.1"
+      ],
+      [
+        "vscode-languageserver-protocol",
+        "npm:3.15.3"
       ]
     ],
     "locationBlacklistData": [
@@ -391,7 +403,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-environment-node", "npm:24.5.0"],
             ["jest-junit", "npm:5.2.0"],
             ["micromatch", "npm:4.0.2"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"]
+            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"],
+            ["typescript-language-server", "npm:0.4.0"],
+            ["vscode-jsonrpc", "npm:5.0.1"],
+            ["vscode-languageserver-protocol", "npm:3.15.3"]
           ],
           "linkType": "SOFT",
         }]
@@ -6158,7 +6173,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-environment-node", "npm:24.5.0"],
             ["jest-junit", "npm:5.2.0"],
             ["micromatch", "npm:4.0.2"],
-            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"]
+            ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"],
+            ["typescript-language-server", "npm:0.4.0"],
+            ["vscode-jsonrpc", "npm:5.0.1"],
+            ["vscode-languageserver-protocol", "npm:3.15.3"]
           ],
           "linkType": "SOFT",
         }]
@@ -10454,6 +10472,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["command-exists", [
+        ["npm:1.2.6", {
+          "packageLocation": "./.yarn/cache/command-exists-npm-1.2.6-cee2bf53c4-2.zip/node_modules/command-exists/",
+          "packageDependencies": [
+            ["command-exists", "npm:1.2.6"]
+          ],
+          "linkType": "HARD",
+        }],
         ["npm:1.2.8", {
           "packageLocation": "./.yarn/cache/command-exists-npm-1.2.8-a2d15bd73c-2.zip/node_modules/command-exists/",
           "packageDependencies": [
@@ -22017,6 +22042,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD",
         }]
       ]],
+      ["p-debounce", [
+        ["npm:1.0.0", {
+          "packageLocation": "./.yarn/cache/p-debounce-npm-1.0.0-eca8d89a70-2.zip/node_modules/p-debounce/",
+          "packageDependencies": [
+            ["p-debounce", "npm:1.0.0"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
       ["p-defer", [
         ["npm:1.0.0", {
           "packageLocation": "./.yarn/cache/p-defer-npm-1.0.0-4dfd0013f5-2.zip/node_modules/p-defer/",
@@ -27394,6 +27428,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD",
         }]
       ]],
+      ["tempy", [
+        ["npm:0.2.1", {
+          "packageLocation": "./.yarn/cache/tempy-npm-0.2.1-732e631420-2.zip/node_modules/tempy/",
+          "packageDependencies": [
+            ["tempy", "npm:0.2.1"],
+            ["temp-dir", "npm:1.0.0"],
+            ["unique-string", "npm:1.0.0"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
       ["term-size", [
         ["npm:1.2.0", {
           "packageLocation": "./.yarn/unplugged/term-size-npm-1.2.0-7629e52ca8/node_modules/term-size/",
@@ -28286,6 +28331,22 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/cache/typescript-patch-44be79f87b-2.zip/node_modules/typescript/",
           "packageDependencies": [
             ["typescript", "patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=270b6c"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["typescript-language-server", [
+        ["npm:0.4.0", {
+          "packageLocation": "./.yarn/unplugged/typescript-language-server-npm-0.4.0-c491a3c644/node_modules/typescript-language-server/",
+          "packageDependencies": [
+            ["typescript-language-server", "npm:0.4.0"],
+            ["command-exists", "npm:1.2.6"],
+            ["commander", "npm:2.19.0"],
+            ["fs-extra", "npm:7.0.1"],
+            ["p-debounce", "npm:1.0.0"],
+            ["tempy", "npm:0.2.1"],
+            ["vscode-languageserver", "npm:5.3.0-next.10"],
+            ["vscode-uri", "npm:1.0.8"]
           ],
           "linkType": "HARD",
         }]
@@ -29231,6 +29292,64 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["url-join", "npm:1.1.0"],
             ["yauzl", "npm:2.10.0"],
             ["yazl", "npm:2.5.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["vscode-jsonrpc", [
+        ["npm:5.0.1", {
+          "packageLocation": "./.yarn/cache/vscode-jsonrpc-npm-5.0.1-7a11dfc031-2.zip/node_modules/vscode-jsonrpc/",
+          "packageDependencies": [
+            ["vscode-jsonrpc", "npm:5.0.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["vscode-languageserver", [
+        ["npm:5.3.0-next.10", {
+          "packageLocation": "./.yarn/cache/vscode-languageserver-npm-5.3.0-next.10-4c6c72f82e-2.zip/node_modules/vscode-languageserver/",
+          "packageDependencies": [
+            ["vscode-languageserver", "npm:5.3.0-next.10"],
+            ["vscode-languageserver-protocol", "npm:3.15.3"],
+            ["vscode-textbuffer", "npm:1.0.0"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["vscode-languageserver-protocol", [
+        ["npm:3.15.3", {
+          "packageLocation": "./.yarn/cache/vscode-languageserver-protocol-npm-3.15.3-3308354642-2.zip/node_modules/vscode-languageserver-protocol/",
+          "packageDependencies": [
+            ["vscode-languageserver-protocol", "npm:3.15.3"],
+            ["vscode-jsonrpc", "npm:5.0.1"],
+            ["vscode-languageserver-types", "npm:3.15.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["vscode-languageserver-types", [
+        ["npm:3.15.1", {
+          "packageLocation": "./.yarn/cache/vscode-languageserver-types-npm-3.15.1-8e8f17df39-2.zip/node_modules/vscode-languageserver-types/",
+          "packageDependencies": [
+            ["vscode-languageserver-types", "npm:3.15.1"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["vscode-textbuffer", [
+        ["npm:1.0.0", {
+          "packageLocation": "./.yarn/cache/vscode-textbuffer-npm-1.0.0-a682e536bd-2.zip/node_modules/vscode-textbuffer/",
+          "packageDependencies": [
+            ["vscode-textbuffer", "npm:1.0.0"]
+          ],
+          "linkType": "HARD",
+        }]
+      ]],
+      ["vscode-uri", [
+        ["npm:1.0.8", {
+          "packageLocation": "./.yarn/cache/vscode-uri-npm-1.0.8-93e0fe9bae-2.zip/node_modules/vscode-uri/",
+          "packageDependencies": [
+            ["vscode-uri", "npm:1.0.8"]
           ],
           "linkType": "HARD",
         }]

--- a/.yarn/versions/4d235eca.yml
+++ b/.yarn/versions/4d235eca.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/.yarn/versions/4d235eca.yml
+++ b/.yarn/versions/4d235eca.yml
@@ -1,4 +1,5 @@
 releases:
+  "@yarnpkg/plugin-compat": prerelease
   "@yarnpkg/pnpify": prerelease
 
 declined:

--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -65,6 +65,49 @@ yarn pnpify --sdk
 
 3. Set [`tsserver.tsdk`](https://github.com/neoclide/coc-tsserver#configuration-options) to `.vscode/pnpify/typescript/lib`
 
+### Emacs
+
+The SDK comes with a typescript-language-server wrapper which enables you to use the ts-ls LSP client.
+
+1. Add PnPify to your dependencies:
+
+```bash
+yarn add @yarnpkg/pnpify
+```
+
+2. Run the following command, which will generate a new directory called `.vscode/pnpify`:
+
+```bash
+yarn pnpify --sdk
+```
+
+3. Create a `.dir-locals.el` with the following content to enable Flycheck and LSP support:
+
+```lisp
+((typescript-mode
+  . (
+     ;; Enable typescript-language-server and eslint LSP clients.
+     (lsp-enabled-clients . (ts-ls eslint))
+     (eval . (let ((project-directory (car (dir-locals-find-file "."))))
+               (set (make-local-variable 'flycheck-javascript-eslint-executable)
+                    (concat project-directory ".vscode/pnpify/eslint/bin/eslint.js"))
+
+               (lsp-dependency 'typescript-language-server
+                               `(:system ,(concat project-directory ".vscode/pnpify/typescript-language-server/lib/cli.js")))
+               (lsp-dependency 'typescript
+                               `(:system ,(concat project-directory ".vscode/pnpify/typescript/bin/tsserver")))
+
+               ;; Re-(start) LSP to pick up the dependency changes above.
+               (lsp)
+               )))))
+```
+
+4. You may have to install `vscode-jsonrpc` and `vscode-languageserver-protocol` manually if `typescript-language-server` fails to start (they are not listed in its dependencies as of this writing):
+
+```bash
+yarn add vscode-jsonrpc vscode-languageserver-protocol
+```
+
 ## Caveat
 
 - Since the Yarn packages are kept within their archives, editors need to understand how to work with such paths should you want to actually open the files (for example when command-clicking on an import path originating from an external package). This can only be implemented by those editors, and we can't do much more than opening issues to ask for this feature to be implemented (for example, here's the VSCode issue: [#75559](https://github.com/microsoft/vscode/issues/75559)).

--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -102,12 +102,6 @@ yarn pnpify --sdk
                )))))
 ```
 
-4. You may have to install `vscode-jsonrpc` and `vscode-languageserver-protocol` manually if `typescript-language-server` fails to start (they are not listed in its dependencies as of this writing):
-
-```bash
-yarn add vscode-jsonrpc vscode-languageserver-protocol
-```
-
 ## Caveat
 
 - Since the Yarn packages are kept within their archives, editors need to understand how to work with such paths should you want to actually open the files (for example when command-clicking on an import path originating from an external package). This can only be implemented by those editors, and we can't do much more than opening issues to ask for this feature to be implemented (for example, here's the VSCode issue: [#75559](https://github.com/microsoft/vscode/issues/75559)).

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -52,4 +52,11 @@ export const packageExtensions: Array<[string, any]> = [
       [`@types/keyv`]: `^3.1.1`,
     },
   }],
+  // https://github.com/theia-ide/typescript-language-server/issues/144
+  [`typescript-language-server@*`, {
+    dependencies: {
+      [`vscode-jsonrpc`]: `^5.0.1`,
+      [`vscode-languageserver-protocol`]: `^3.15.0`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -131,29 +131,6 @@ class Wrapper {
   }
 }
 
-const generateTypescriptWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
-  const wrapper = new Wrapper(`typescript` as PortablePath, {pnpApi, target});
-
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`bin/tsc` as PortablePath);
-  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
-
-  await wrapper.writeFile(`lib/tsc.js` as PortablePath);
-  await wrapper.writeFile(`lib/tsserver.js` as PortablePath);
-  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
-
-  await addVSCodeWorkspaceSettings(pnpApi, {
-    [`typescript.tsdk`]: npath.fromPortablePath(
-      ppath.dirname(
-        wrapper.getProjectPathTo(
-          `lib/tsserver.js` as PortablePath,
-        ),
-      ),
-    ),
-  });
-};
-
 export const generateEslintWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
@@ -189,9 +166,41 @@ export const generatePrettierWrapper = async (pnpApi: PnpApi, target: PortablePa
   });
 };
 
+export const generateTypescriptLanguageServerWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`lib/cli.js` as PortablePath);
+};
+
+const generateTypescriptWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`typescript` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`bin/tsc` as PortablePath);
+  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
+
+  await wrapper.writeFile(`lib/tsc.js` as PortablePath);
+  await wrapper.writeFile(`lib/tsserver.js` as PortablePath);
+  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
+
+  await addVSCodeWorkspaceSettings(pnpApi, {
+    [`typescript.tsdk`]: npath.fromPortablePath(
+      ppath.dirname(
+        wrapper.getProjectPathTo(
+          `lib/tsserver.js` as PortablePath,
+        ),
+      ),
+    ),
+  });
+};
+
 const SDKS: Array<[string, (pnpApi: PnpApi, target: PortablePath) => Promise<void>]> = [
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
+  [`typescript-language-server`, generateTypescriptLanguageServerWrapper],
   [`typescript`, generateTypescriptWrapper],
 ];
 


### PR DESCRIPTION
This PR adds SDK documentation for Emacs which utilizes the generated binary wrappers for VS Code and supplies a new wrapper for https://github.com/theia-ide/typescript-language-server, enabling LSP support within Emacs.

Additionally, this also sorts SDK wrappers by name.

