### PR TITLE
plugin-compat: extension for http-link-dataloader

### DIFF
--- a/.yarn/versions/3b24285f.yml
+++ b/.yarn/versions/3b24285f.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -52,4 +52,10 @@ export const packageExtensions: Array<[string, any]> = [
       [`@types/keyv`]: `^3.1.1`,
     },
   }],
+  // https://github.com/prisma-labs/http-link-dataloader/pull/22
+  [`http-link-dataloader@*`, {
+    peerDependencies: {
+      [`graphql`]: `^0.13.1 || ^14.0.0`,
+    },
+  }],
 ];


### PR DESCRIPTION
See https://github.com/prisma-labs/http-link-dataloader/pull/22

<br>

**What's the problem this PR addresses?**

[`http-link-dataloader`](https://github.com/prisma-labs/http-link-dataloader) doesn't list its transitive peer dep `graphql`

**How did you fix it?**

Added it to `extensions.ts` of plugin-compat and created a PR
