### PR TITLE
Fix issue for updating yarn to berry.

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -32,7 +32,7 @@ cd ~/path/to/project
 
 ```bash
 yarn policies set-version berry # below v1.22
-yarn set version berry          # on v1.22+
+yarn set version latest          # on v1.22+
 ```
 
 4. Commit the `.yarn` and `.yarnrc.yml` changes

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -32,7 +32,7 @@ cd ~/path/to/project
 
 ```bash
 yarn policies set-version berry # below v1.22
-yarn set version latest          # on v1.22+
+yarn set version berry          # on v1.22+
 ```
 
 4. Commit the `.yarn` and `.yarnrc.yml` changes

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -65,6 +65,6 @@ yarn remove [package]
 ### Upgrading Yarn itself
 
 ```bash
-yarn policies set-version berry
-yarn set version berry   
+yarn set version latest
+yarn set version from sources
 ```

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -65,6 +65,6 @@ yarn remove [package]
 ### Upgrading Yarn itself
 
 ```bash
-yarn set version 2
-yarn set version from sources
+yarn policies set-version berry
+yarn set version berry   
 ```


### PR DESCRIPTION
See this issue for more info:
https://github.com/yarnpkg/berry/issues/1130

Updating yarn to Berry.

...

**How did you fix it?**

```yarn set version latest ```
This is because the latest is already berry.

...

Closes #1130