### PR TITLE
fix(cli): fix --cwd

### DIFF
--- a/.yarn/versions/c0ece226.yml
+++ b/.yarn/versions/c0ece226.yml
@@ -3,12 +3,20 @@ releases:
   "@yarnpkg/core": prerelease
 
 declined:
+  - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
   - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
@@ -17,4 +25,5 @@ declined:
   - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
   - "@yarnpkg/doctor"

--- a/.yarn/versions/c0ece226.yml
+++ b/.yarn/versions/c0ece226.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/c0ece226.yml
+++ b/.yarn/versions/c0ece226.yml
@@ -1,5 +1,6 @@
 releases:
   "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
 
 declined:
   - "@yarnpkg/plugin-constraints"
@@ -16,5 +17,4 @@ declined:
   - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
-  - "@yarnpkg/core"
   - "@yarnpkg/doctor"

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -131,6 +131,11 @@
       "format": "uri",
       "default": "http://proxy:4040"
     },
+    "ignoreCwd": {
+      "description": "If true, the `--cwd` flag will be ignored.",
+      "type": "boolean",
+      "default": false
+    },
     "ignorePath": {
       "description": "If true, the local executable will be ignored when using the global one.",
       "type": "boolean",

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -20,6 +20,7 @@ function runBinary(path: PortablePath) {
       env: {
         ...process.env,
         YARN_IGNORE_PATH: `1`,
+        YARN_IGNORE_CWD: `1`,
       },
     });
   } else {
@@ -28,6 +29,7 @@ function runBinary(path: PortablePath) {
       env: {
         ...process.env,
         YARN_IGNORE_PATH: `1`,
+        YARN_IGNORE_CWD: `1`,
       },
     });
   }
@@ -60,6 +62,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
 
     const yarnPath: PortablePath = configuration.get(`yarnPath`);
     const ignorePath = configuration.get(`ignorePath`);
+    const ignoreCwd = configuration.get(`ignoreCwd`);
 
     if (yarnPath !== null && !ignorePath) {
       if (!xfs.existsSync(yarnPath)) {
@@ -85,12 +88,11 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
       // @ts-ignore: The cwd is a global option defined by BaseCommand
       const cwd: string | undefined = command.cwd;
 
-      if (typeof cwd !== `undefined`) {
+      if (typeof cwd !== `undefined` && !ignoreCwd) {
         const iAmHere = realpathSync(process.cwd());
         const iShouldBeHere = realpathSync(cwd);
 
         if (iAmHere !== iShouldBeHere) {
-          process.argv.splice(process.argv.findIndex((arg) => arg === `--cwd`), 2);
           process.chdir(cwd);
           return await run();
         }

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -90,6 +90,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
         const iShouldBeHere = realpathSync(cwd);
 
         if (iAmHere !== iShouldBeHere) {
+          process.argv.splice(process.argv.findIndex((arg) => arg === `--cwd`), 2);
           process.chdir(cwd);
           return await run();
         }

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -172,6 +172,11 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.BOOLEAN,
     default: false,
   },
+  ignoreCwd: {
+    description: `If true, the \`--cwd\` flag will be ignored`,
+    type: SettingsType.BOOLEAN,
+    default: false,
+  },
 
   // Settings related to the package manager internal names
   globalFolder: {


### PR DESCRIPTION
**What's the problem this PR addresses?**

There are 2 code paths here: https://github.com/yarnpkg/berry/blob/215455f2c303a14fcb10e5513bdbbf82b5320d3d/packages/yarnpkg-cli/sources/main.ts#L64
The `--cwd` option is only checked for on the `else` branch, so when [`run`](https://github.com/yarnpkg/berry/blob/215455f2c303a14fcb10e5513bdbbf82b5320d3d/packages/yarnpkg-cli/sources/main.ts#L94) is called after `--cwd` is encountered, there is a possibility that the `if` branch will execute with the `--cwd` option that was already encountered.

This causes commands to be executed in the wrong directory in some cases.

This PR closes #1056.

**How did you fix it?**

I made the `--cwd` flag and its argument get removed from `process.argv` when `--cwd` is encountered.
