### PR TITLE
feat(dlx): `yarn create <starter-kit-package>` as an alias to `yarn dlx create-<starter-kit-package>`

### DIFF
--- a/.yarn/versions/45eb25fd.yml
+++ b/.yarn/versions/45eb25fd.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/plugin-dlx": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__create-test-app-1.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__create-test-app-1.0.0/bin.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const {writeFileSync} = require(`fs`);
+const path = require(`path`);
+
+writeFileSync(path.join(process.cwd(), `hello.txt`), `Hello World`);
+
+console.log(`Successfully generated \`hello.txt\``);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__create-test-app-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__create-test-app-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__create-test-app-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__create-test-app-1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@scoped/create-test-app",
+  "version": "1.0.0",
+  "bin": {
+      "create-test-app": "./bin.js"
+  },
+  "dependencies": {
+      "no-deps": "1.0.0"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/create-test-app-1.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/create-test-app-1.0.0/bin.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const {writeFileSync} = require(`fs`);
+const path = require(`path`);
+
+writeFileSync(path.join(process.cwd(), `hello.txt`), `Hello World`);
+
+console.log(`Successfully generated \`hello.txt\``);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/create-test-app-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/create-test-app-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/create-test-app-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/create-test-app-1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "create-test-app",
+  "version": "1.0.0",
+  "bin": {
+      "create-test-app": "./bin.js"
+  },
+  "dependencies": {
+      "no-deps": "1.0.0"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/create.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/create.test.js
@@ -1,0 +1,22 @@
+const {join} = require(`path`);
+const {xfs} = require(`@yarnpkg/fslib`);
+
+describe(`Commands`, () => {
+  describe(`create`, () => {
+    test(
+      `it should generate \`hello.txt\` correctly using a starter-kit-package`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`create`, `-q`, `test-app`);
+        expect(xfs.readFileSync(join(path, `hello.txt`), `utf8`)).toEqual(`Hello World`);
+      }),
+    );
+
+    test(
+      `it should generate \`hello.txt\` correctly using a scoped starter-kit-package`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`create`, `-q`, `@scoped/test-app`);
+        expect(xfs.readFileSync(join(path, `hello.txt`), `utf8`)).toEqual(`Hello World`);
+      }),
+    );
+  });
+});

--- a/packages/plugin-dlx/sources/commands/create.ts
+++ b/packages/plugin-dlx/sources/commands/create.ts
@@ -1,6 +1,6 @@
 import {BaseCommand} from '@yarnpkg/cli';
+import {structUtils} from '@yarnpkg/core';
 import {Command}     from 'clipanion';
-import {structUtils} from 'packages/yarnpkg-core/sources';
 
 // eslint-disable-next-line arca/no-default-export
 export default class CreateCommand extends BaseCommand {

--- a/packages/plugin-dlx/sources/commands/create.ts
+++ b/packages/plugin-dlx/sources/commands/create.ts
@@ -1,5 +1,6 @@
 import {BaseCommand} from '@yarnpkg/cli';
 import {Command}     from 'clipanion';
+import {structUtils} from 'packages/yarnpkg-core/sources';
 
 // eslint-disable-next-line arca/no-default-export
 export default class CreateCommand extends BaseCommand {
@@ -22,6 +23,10 @@ export default class CreateCommand extends BaseCommand {
       flags.push(`--package`, this.pkg);
     if (this.quiet)
       flags.push(`--quiet`);
-    this.cli.run([`dlx`, ...flags, `create-${this.command}`, ...this.args]);
+
+    const ident = structUtils.parseIdent(this.command);
+    const modified = structUtils.makeIdent(ident.scope, `create-${ident.name}`);
+
+    return this.cli.run([`dlx`, ...flags, structUtils.stringifyIdent(modified), ...this.args]);
   }
 }

--- a/packages/plugin-dlx/sources/commands/create.ts
+++ b/packages/plugin-dlx/sources/commands/create.ts
@@ -21,7 +21,7 @@ export default class CreateCommand extends BaseCommand {
     if (this.pkg)
       flags.push(`--package`, this.pkg);
     if (this.quiet)
-      flags.push('--quiet');
+      flags.push(`--quiet`);
     this.cli.run([`dlx`, ...flags, `create-${this.command}`, ...this.args]);
   }
 }

--- a/packages/plugin-dlx/sources/commands/create.ts
+++ b/packages/plugin-dlx/sources/commands/create.ts
@@ -1,0 +1,27 @@
+import {BaseCommand} from '@yarnpkg/cli';
+import {Command}     from 'clipanion';
+
+// eslint-disable-next-line arca/no-default-export
+export default class CreateCommand extends BaseCommand {
+  @Command.String(`-p,--package`)
+  pkg: string | undefined;
+
+  @Command.Boolean(`-q,--quiet`)
+  quiet: boolean = false;
+
+  @Command.String()
+  command!: string;
+
+  @Command.Proxy()
+  args: Array<string> = [];
+
+  @Command.Path(`create`)
+  async execute() {
+    const flags = [];
+    if (this.pkg)
+      flags.push(`--package`, this.pkg);
+    if (this.quiet)
+      flags.push('--quiet');
+    this.cli.run([`dlx`, ...flags, `create-${this.command}`, ...this.args]);
+  }
+}

--- a/packages/plugin-dlx/sources/index.ts
+++ b/packages/plugin-dlx/sources/index.ts
@@ -1,9 +1,11 @@
 import {Plugin} from '@yarnpkg/core';
 
+import create   from './commands/create';
 import dlx      from './commands/dlx';
 
 const plugin: Plugin = {
   commands: [
+    create,
     dlx,
   ],
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn create` was removed in Yarn v2 as the `yarn dlx` command got added. 

The problem is that many of the starter-kit projects still only list `yarn create`:
- React - [create-react-app](https://create-react-app.dev/docs/getting-started#yarn)
- Next - [create-next-app](https://nextjs.org/docs/getting-started#setup)
- Nuxt - [create-nuxt-app](https://nuxtjs.org/guide/installation#using-code-create-nuxt-app-code-)
- Electron Forge - [create-electron-app](https://www.electronforge.io/#the-basics)

This can cause confusion to people who don't happen to read the `CLI` page on our website, as there's no other place where this change is mentioned.

You can also consider it as a small Yarn-exclusive QoL change. 😄 

**How did you fix it?**

I added the `yarn create` command back as a hidden alias to `yarn dlx`.

`yarn create [flags] <starter-kit-package> ...` is now an alias to `yarn dlx [flags] create-<starter-kit-package> ...`.