### PR TITLE
Small fixes in documentation

### DIFF
--- a/packages/gatsby/src/pages/configuration/manifest.json
+++ b/packages/gatsby/src/pages/configuration/manifest.json
@@ -17,7 +17,7 @@
       "default": "1.2.3"
     },
     "type": {
-      "description": "A Node.js v13.x [option](https://nodejs.org/api/esm.html#esm_package_json_type_field). Possible values are `commonjs`(the default) and `module`. If `module`, Yarn will generate a `.pnp.cjs` file when using PnP. If `commonjs`, Yarn will generate a `.pnp.js` file when using PnP.",
+      "description": "A Node.js v13.x [option](https://nodejs.org/api/esm.html#esm_package_json_type_field). Possible values are `commonjs` (the default) and `module`. If `module`, Yarn will generate a `.pnp.cjs` file when using PnP. If `commonjs`, Yarn will generate a `.pnp.js` file when using PnP.",
       "type": "string",
       "enum": ["commonjs", "module"],
       "default": "commonjs"

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -389,7 +389,7 @@
       "default": "^\\./subdir/.*"
     },
     "pnpMode": {
-      "description": "If `strict`, Yarn won't allow modules to require packages they don't explicitly list in their own dependencies. If `loose`, Yarn will allow access to the packages that would have been hoisted to the top-level under 1.x installs. Note that, even in loose mode, such calls are unsafe (hoisting rules aren't predictable) and should be discouraged.",
+      "description": "If `strict` (the default), Yarn won't allow modules to require packages they don't explicitly list in their own dependencies. If `loose`, Yarn will allow access to the packages that would have been hoisted to the top-level under 1.x installs. Note that, even in loose mode, such calls are unsafe (hoisting rules aren't predictable) and should be discouraged.",
       "type": "string",
       "enum": ["strict", "loose"],
       "default": "strict"


### PR DESCRIPTION
Few fixes for the documentation:

- There is a missing space in the documentation:
<img width="425" alt="Screenshot 2020-04-01 at 09 57 34" src="https://user-images.githubusercontent.com/6972399/78112949-3f0ea300-73ff-11ea-832f-30120f096059.png">

- Adds `the default` qualifier for `strict` `pnpMode` value (it should be changed for `loose` once 2.1 is out as stated in https://yarnpkg.com/features/pnp#pnp-loose-mode).