### PR TITLE
docs(cli): generate "plugin required" information for some cli commands

### DIFF
--- a/.yarn/versions/06552549.yml
+++ b/.yarn/versions/06552549.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/gatsby/gatsby-plugin-clipanion-cli/gatsby-node.js
+++ b/packages/gatsby/gatsby-plugin-clipanion-cli/gatsby-node.js
@@ -18,6 +18,16 @@ exports.sourceNodes = ({actions, createNodeId, createContentDigest}, opts) => {
       `---\n`,
     ].join(``));
 
+    if (!command.plugin.isDefault) {
+      const [, pluginName] = /^@yarnpkg\/plugin-(.+)$/.exec(command.plugin.name);
+
+      sections.push([
+        `> **Plugin**\n`,
+        `>\n`,
+        `> To use this command, first install the \`${pluginName}\` plugin: \`yarn plugin import ${pluginName}\`\n`,
+      ].join(``));
+    }
+
     if (command.description) {
       sections.push([
         `${command.description[0].toUpperCase()}${command.description.slice(1, -1)}.\n`,

--- a/packages/plugin-essentials/sources/commands/entries/clipanion.ts
+++ b/packages/plugin-essentials/sources/commands/entries/clipanion.ts
@@ -1,12 +1,52 @@
-import {CommandContext} from '@yarnpkg/core';
-import {Command}        from 'clipanion';
+import {CommandContext, Configuration} from '@yarnpkg/core';
+import {Command, Cli}                  from 'clipanion';
+
+type ClipanionDefinition = ReturnType<Cli['definitions']>[number];
+type ExtendedDefinition = ClipanionDefinition & {
+  plugin: {
+    name: string,
+    isDefault: boolean,
+  },
+};
 
 // eslint-disable-next-line arca/no-default-export
 export default class ClipanionCommand extends Command<CommandContext> {
   @Command.Path(`--clipanion=definitions`)
   async execute() {
+    const {plugins} = await Configuration.find(this.context.cwd, this.context.plugins);
+
+    const pluginDefinitions: Array<[string, ClipanionDefinition[]]>  = [];
+    for (const plugin of plugins) {
+      const {commands} = plugin[1];
+      if (commands) {
+        const cli = Cli.from(commands);
+        const definitions = cli.definitions();
+        pluginDefinitions.push([plugin[0], definitions]);
+      }
+    }
+
+    const clipanionDefinitions = this.cli.definitions() as ExtendedDefinition[];
+
+    const arePathsEqual = (path1: string, path2: string) =>
+      path1.split(' ').slice(1).join() === path2.split(' ').slice(1).join();
+
+    const defaultPlugins: string[] = require(`@yarnpkg/cli/package.json`)[`@yarnpkg/builder`].bundles.standard;
+
+    for (const pluginDefinition of pluginDefinitions) {
+      const definitions = pluginDefinition[1];
+
+      for (const definition of definitions) {
+        clipanionDefinitions
+          .find(clipanionDefinition => arePathsEqual(clipanionDefinition.path, definition.path))!
+          .plugin = {
+            name: pluginDefinition[0],
+            isDefault: defaultPlugins.includes(pluginDefinition[0]),
+          };
+      }
+    }
+
     this.context.stdout.write(`${JSON.stringify({
-      commands: this.cli.definitions(),
+      commands: clipanionDefinitions,
     }, null, 2)}\n`);
   }
 }

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -19,9 +19,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     category: `Interactive commands`,
     description: `open the upgrade interface`,
     details: `
-      > In order to use this command you will need to add \`@yarnpkg/plugin-interactive-tools\` to your plugins. Check the documentation for \`yarn plugin import\` for more details.
-
-      This command opens a fullscreen terminal interace where you can see the packages used by your application, their status compared to the latest versions available on the remote registry, and let you upgrade.
+      This command opens a fullscreen terminal interface where you can see the packages used by your application, their status compared to the latest versions available on the remote registry, and let you upgrade.
     `,
     examples: [[
       `Open the upgrade window`,

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -78,8 +78,6 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     category: `Workspace-related commands`,
     description: `run a command on all workspaces`,
     details: `
-      > In order to use this command you will need to add \`@yarnpkg/plugin-workspace-tools\` to your plugins. Check the documentation for \`yarn plugin import\` for more details.
-
       This command will run a given sub-command on current and all its descendant workspaces. Various flags can alter the exact behavior of the command:
 
       - If \`-p,--parallel\` is set, the commands will be ran in parallel; they'll by default be limited to a number of parallel tasks roughly equal to half your core number, but that can be overridden via \`-j,--jobs\`.


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently, there's ~~no information~~ (Edit: Actually there is some, but only for `yarn workspaces foreach` and `yarn upgrade-interactive`, but it's a bit hidden down inside the `Details` section and it is not automatically generated) in the CLI documentation about which commands require the user to install a plugin.

**How did you fix it?**

I made the `yarn --clipanion=definitions` output also include the originating plugins of commands:
```ts
definitions.commands[].plugin: {
  name: string;
  isDefault: boolean;
}
```
Now there's information about required plugins displayed at the top of the command pages from the CLI section on the website.