### PR TITLE
[node-modules] Fix - do not create bin symlinks if target files are not present

### DIFF
--- a/.yarn/versions/6581a588.yml
+++ b/.yarn/versions/6581a588.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Bin symlinks were attempted to be created always, even when target files do not exist. This worked well for package from npm, but it lead to problems with local packages, that have not been built yet and target files were missing.

**How did you fix it?**

On each install we check whether target bin files exist and create or remove bin symlinks accordingly.

Another problem that is fixed in this PR, are mistakes with bin symlinks data structures building:
1. Bin symlinks of root workspaces were overwriting symlinks in `node_modules/.bin`
2. Previous bin symlinks state were incorrectly restored from the state file - I forgot to convert relative locations from the file into absolute locations.
