### PR TITLE
Outputs the workspace name in the foreach

### DIFF
--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -173,6 +173,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
         if (!this.parallel && this.verbose && commandIndex > 1)
           report.reportSeparator();
 
+        report.reportInfo(MessageName.UNNAMED, `> ${workspace.computeCandidateName()}`);
         const prefix = getPrefix(workspace, {configuration, verbose: this.verbose, commandIndex});
 
         const [stdout, stdoutEnd] = createStream(report, {prefix, interlaced});


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using `yarn workspace foreach` I don't know which module the build logs come from

**How did you fix it?**

By adding the name before the logging, effectively a dupe of https://github.com/yarnpkg/yarn/pull/7722


