### PR TITLE
[node-modules] Link: protocol support fix

### DIFF
--- a/.yarn/versions/6581a588.yml
+++ b/.yarn/versions/6581a588.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/6581a588.yml
+++ b/.yarn/versions/6581a588.yml
@@ -1,6 +1,7 @@
 releases:
   "@yarnpkg/cli": prerelease
   "@yarnpkg/plugin-node-modules": prerelease
+  "@yarnpkg/pnpify": prerelease
 
 declined:
   - "@yarnpkg/plugin-constraints"
@@ -16,5 +17,8 @@ declined:
   - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -337,7 +337,7 @@ const removeDir = async (dir: PortablePath, options?: {innerLoop?: boolean}): Pr
 const CONCURRENT_OPERATION_LIMIT = 4;
 
 type LocatorKey = string;
-type LocationNode = { children: Map<Filename, LocationNode>, locator?: LocatorKey, isExternal?: boolean };
+type LocationNode = { children: Map<Filename, LocationNode>, locator?: LocatorKey, isSoftLinkTarget?: boolean };
 type LocationRoot = PortablePath;
 
 /**
@@ -406,7 +406,7 @@ const buildLocationTree = (locatorMap: NodeModulesLocatorMap | null, {skipPrefix
     if (info.linkType === LinkType.SOFT) {
       const node = miscUtils.getFactoryWithDefault(locationTree, info.target, makeNode);
       node.locator = locator;
-      node.isExternal = true;
+      node.isSoftLinkTarget = true;
     }
 
     for (const location of info.locations) {
@@ -528,7 +528,7 @@ async function createBinSymlinkMap(installState: NodeModulesLocatorMap, location
 
   const getBinSymlinks = (location: PortablePath, parentLocatorLocation: PortablePath, node: LocationNode): Map<Filename, PortablePath> => {
     const symlinks = new Map();
-    if (node.locator && !node.isExternal) {
+    if (node.locator && !node.isSoftLinkTarget) {
       const binScripts = locatorScriptMap.get(node.locator)!;
       for (const [filename, scriptPath] of binScripts) {
         const symlinkTarget = ppath.join(location, npath.toPortablePath(scriptPath));
@@ -680,7 +680,7 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
             deleteList.add(curLocation);
             // If previous install had inner node_modules folder, we should explicitely list it for
             // `removeDir` to delete it, but we need to delete it first, so we add it to inner delete list
-            if (!node && prevNode && prevNode.children.has(NODE_MODULES))
+            if ((!node || !node.children.has(NODE_MODULES)) && prevNode && prevNode.children.has(NODE_MODULES))
               innerDeleteList.add(ppath.join(curLocation, NODE_MODULES));
             break;
           }

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -510,7 +510,7 @@ function refineNodeModulesRoots(locationTree: LocationTree, binSymlinks: BinSyml
 
 async function createBinSymlinkMap(installState: NodeModulesLocatorMap, locationTree: LocationTree, {loadManifest}: {loadManifest: (sourceLocation: PortablePath) => Promise<Manifest>}) {
   const locatorScriptMap = new Map<LocatorKey, Map<string, string>>();
-  for (const [locatorKey, {locations, linkType}] of installState) {
+  for (const [locatorKey, {locations}] of installState) {
     const manifest = await loadManifest(locations[0]);
 
     const bin = new Map();

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -828,9 +828,9 @@ async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlink
     for (const name of prevSymlinks.keys()) {
       if (!symlinks.has(name)) {
         // Remove outdated symlinks
-        await xfs.unlinkPromise(ppath.join(binDir, name));
+        await xfs.removePromise(ppath.join(binDir, name));
         if (process.platform === 'win32') {
-          await xfs.unlinkPromise(ppath.join(binDir, toFilename(`${name}.cmd`)));
+          await xfs.removePromise(ppath.join(binDir, toFilename(`${name}.cmd`)));
         }
       }
     }
@@ -845,7 +845,7 @@ async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlink
       if (process.platform === 'win32') {
         await cmdShim(npath.fromPortablePath(target), npath.fromPortablePath(symlinkPath), {createPwshFile: false});
       } else {
-        await xfs.unlinkPromise(symlinkPath);
+        await xfs.removePromise(symlinkPath);
         await symlinkPromise(target, symlinkPath);
       }
     }

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -403,7 +403,8 @@ const buildLocationTree = (locatorMap: NodeModulesLocatorMap | null, {skipPrefix
   });
 
   for (const [locator, info] of locatorMap.entries()) {
-    if (info.linkType === LinkType.SOFT) {
+    const isPortal = locator.substring(locator.indexOf('@', 1) + 1).split('#').slice(-1)[0].startsWith('portal:');
+    if (info.linkType === LinkType.SOFT && !isPortal) {
       const node = miscUtils.getFactoryWithDefault(locationTree, info.target, makeNode);
       node.locator = locator;
     }

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -403,10 +403,12 @@ const buildLocationTree = (locatorMap: NodeModulesLocatorMap | null, {skipPrefix
   });
 
   for (const [locator, info] of locatorMap.entries()) {
-    const isPortal = locator.substring(locator.indexOf('@', 1) + 1).split('#').slice(-1)[0].startsWith('portal:');
-    if (info.linkType === LinkType.SOFT && !isPortal) {
-      const node = miscUtils.getFactoryWithDefault(locationTree, info.target, makeNode);
-      node.locator = locator;
+    if (info.linkType === LinkType.SOFT) {
+      const internalPath = ppath.contains(skipPrefix, info.target);
+      if (internalPath !== null) {
+        const node = miscUtils.getFactoryWithDefault(locationTree, info.target, makeNode);
+        node.locator = locator;
+      }
     }
 
     for (const location of info.locations) {
@@ -694,7 +696,6 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
       // Location is changed and will be occupied by a different locator - clean it
       if (node.locator !== prevNode.locator)
         deleteList.add(location);
-
 
       for (const [segment, childNode] of node.children) {
         let prevChildNode = prevNode.children.get(segment);

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -828,7 +828,10 @@ async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlink
     for (const name of prevSymlinks.keys()) {
       if (!symlinks.has(name)) {
         // Remove outdated symlinks
-        await xfs.removePromise(ppath.join(binDir, name));
+        await xfs.unlinkPromise(ppath.join(binDir, name));
+        if (process.platform === 'win32') {
+          await xfs.unlinkPromise(ppath.join(binDir, toFilename(`${name}.cmd`)));
+        }
       }
     }
 
@@ -842,7 +845,7 @@ async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlink
       if (process.platform === 'win32') {
         await cmdShim(npath.fromPortablePath(target), npath.fromPortablePath(symlinkPath), {createPwshFile: false});
       } else {
-        await xfs.removePromise(symlinkPath);
+        await xfs.unlinkPromise(symlinkPath);
         await symlinkPromise(target, symlinkPath);
       }
     }

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -68,7 +68,7 @@ export const getArchivePath = (packagePath: PortablePath): PortablePath | null =
  * @returns hoisted `node_modules` directories representation in-memory
  */
 export const buildNodeModulesTree = (pnp: PnpApi, options: NodeModulesTreeOptions): NodeModulesTree => {
-  const packageTree = buildPackageTree(pnp);
+  const packageTree = buildPackageTree(pnp, options);
   const hoistedTree = hoist(packageTree);
 
   return populateNodeModulesTree(pnp, hoistedTree, options);
@@ -117,12 +117,13 @@ export const buildLocatorMap = (nodeModulesTree: NodeModulesTree): NodeModulesLo
  *
  * @returns package tree, packages info and locators
  */
-const buildPackageTree = (pnp: PnpApi): HoisterTree => {
+const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): HoisterTree => {
   const pnpRoots = pnp.getDependencyTreeRoots();
 
   const topPkg = pnp.getPackageInformation(pnp.topLevel);
   if (topPkg === null)
     throw new Error(`Assertion failed: Expected the top-level package to have been registered`);
+  const projectRoot = npath.toPortablePath(topPkg.packageLocation);
 
   const topLocator = pnp.findPackageLocator(topPkg.packageLocation);
   if (topLocator === null)
@@ -165,8 +166,8 @@ const buildPackageTree = (pnp: PnpApi): HoisterTree => {
 
     parent.dependencies.add(node);
 
-    const isPortal = locator.reference.split('#').slice(-1)[0].startsWith('portal:');
-    if (!isSeen && !isPortal) {
+    const internalPath = ppath.contains(projectRoot, getTargetLocatorPath(locator, pnp, options).target);
+    if (!isSeen && internalPath !== null) {
       for (const [name, referencish] of pkg.packageDependencies) {
         if (referencish !== null && !node.peerNames.has(name)) {
           const depLocator = pnp.getLocator(name, referencish);
@@ -191,6 +192,33 @@ const buildPackageTree = (pnp: PnpApi): HoisterTree => {
   return packageTree;
 };
 
+function getTargetLocatorPath(locator: PhysicalPackageLocator, pnp: PnpApi, options: NodeModulesTreeOptions): {linkType: LinkType, target: PortablePath} {
+  const pkgLocator = pnp.getLocator(locator.name.replace(/^\$wsroot\$/, ''), locator.reference);
+
+  const info = pnp.getPackageInformation(pkgLocator);
+  if (info === null)
+    throw new Error(`Assertion failed: Expected the package to be registered`);
+
+  let linkType;
+  let target;
+  if (options.pnpifyFs) {
+    // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
+    // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
+    // To make this fs layout work with legacy tools we make
+    // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
+    // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
+    target = npath.toPortablePath(info.packageLocation);
+    linkType = LinkType.SOFT;
+  } else {
+    const truePath = pnp.resolveVirtual && locator.reference && locator.reference.startsWith('virtual:')
+      ? pnp.resolveVirtual(info.packageLocation)
+      : info.packageLocation;
+
+    target = npath.toPortablePath(truePath || info.packageLocation);
+    linkType = info.linkType;
+  }
+  return {linkType, target};
+}
 
 /**
  * Converts hoisted tree to node modules map
@@ -206,30 +234,7 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
   const tree: NodeModulesTree = new Map();
 
   const makeLeafNode = (locator: PhysicalPackageLocator, aliases: string[]): {locator: LocatorKey, target: PortablePath, linkType: LinkType, aliases: string[]} => {
-    const pkgLocator = pnp.getLocator(locator.name.replace(/^\$wsroot\$/, ''), locator.reference);
-
-    const info = pnp.getPackageInformation(pkgLocator);
-    if (info === null)
-      throw new Error(`Assertion failed: Expected the package to be registered`);
-
-    let linkType;
-    let target;
-    if (options.pnpifyFs) {
-      // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
-      // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
-      // To make this fs layout work with legacy tools we make
-      // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
-      // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
-      target = npath.toPortablePath(info.packageLocation);
-      linkType = LinkType.SOFT;
-    } else {
-      const truePath = pnp.resolveVirtual && locator.reference && locator.reference.startsWith('virtual:')
-        ? pnp.resolveVirtual(info.packageLocation)
-        : info.packageLocation;
-
-      target = npath.toPortablePath(truePath || info.packageLocation);
-      linkType = info.linkType;
-    }
+    const {linkType, target} = getTargetLocatorPath(locator, pnp, options);
 
     return {
       locator: stringifyLocator(locator),
@@ -347,7 +352,7 @@ const benchmarkBuildTree = (pnp: PnpApi, options: NodeModulesTreeOptions): numbe
   const iterCount = 100;
   const startTime = Date.now();
   for (let iter = 0; iter < iterCount; iter++) {
-    const packageTree = buildPackageTree(pnp);
+    const packageTree = buildPackageTree(pnp, options);
     const hoistedTree = hoist(packageTree);
     populateNodeModulesTree(pnp, hoistedTree, options);
   }

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -165,7 +165,7 @@ const buildPackageTree = (pnp: PnpApi): HoisterTree => {
 
     parent.dependencies.add(node);
 
-    if (!isSeen) {
+    if (!isSeen && !locator.reference.startsWith('portal:')) {
       for (const [name, referencish] of pkg.packageDependencies) {
         if (referencish !== null && !node.peerNames.has(name)) {
           const depLocator = pnp.getLocator(name, referencish);

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -165,7 +165,8 @@ const buildPackageTree = (pnp: PnpApi): HoisterTree => {
 
     parent.dependencies.add(node);
 
-    if (!isSeen && !locator.reference.startsWith('portal:')) {
+    const isPortal = locator.reference.split('#').slice(-1)[0].startsWith('portal:');
+    if (!isSeen && !isPortal) {
       for (const [name, referencish] of pkg.packageDependencies) {
         if (referencish !== null && !node.peerNames.has(name)) {
           const depLocator = pnp.getLocator(name, referencish);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The link: protocol support was broken in node-modules linker because linker didn't handle when the locator of the node changes.

**How did you fix it?**

Now linker checks whether locator of the node in the tree changes and delete the old node first and only after that adds new locator to the same location.

This PR also fixes another race condition - the linker started adding new modules and removing old modules simultaneously, now we really wait for old modules to be deleted first

Another fix is directory removal, now location tree-aware algorithm is used, this solves issues with proper cleanup after other package manager on new install