### PR TITLE
Make cwd always a realpath

### DIFF
--- a/.yarn/versions/5552a645.yml
+++ b/.yarn/versions/5552a645.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -200,6 +200,8 @@ async function initializePackageEnvironment(locator: Locator, {project, binFolde
     if (typeof cwd === `undefined`)
       cwd = packageLocation;
 
+    cwd = await packageFs.realpathPromise(cwd);
+
     return {manifest, binFolder, env, cwd};
   }, {
     libzip: await getLibzipPromise(),

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -200,7 +200,7 @@ async function initializePackageEnvironment(locator: Locator, {project, binFolde
     if (typeof cwd === `undefined`)
       cwd = packageLocation;
 
-    cwd = await packageFs.realpathPromise(cwd);
+    cwd = await zipOpenFs.realpathPromise(cwd);
 
     return {manifest, binFolder, env, cwd};
   }, {


### PR DESCRIPTION
**What's the problem this PR addresses?**

When berry runs scripts inside symlinked folders it doesn't run cwd on realpath

**How did you fix it?**

Run realpath on cwd