### PR TITLE
Adds ignore for the YARN_WRAP_OUTPUT environment value

### DIFF
--- a/.yarn/versions/8f6f8510.yml
+++ b/.yarn/versions/8f6f8510.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -52,6 +52,10 @@ const IGNORED_ENV_VARIABLES = new Set([
   // https://classic.yarnpkg.com/install.sh
   `profile`,
   `gpg`,
+
+  // "wrapOutput" was a variable used to indicate nested "yarn run" processes
+  // back in Yarn 1.
+  `wrapOutput`,
 ]);
 
 export const ENVIRONMENT_PREFIX = `yarn_`;


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running Yarn 2 within a environment created by a Yarn 1 lifecycle script causes an error to be generated.

**How did you fix it?**

We now ignore the `YARN_WRAP_OUTPUT` environment variable.
