### PR TITLE
Speedup fetch step by limiting concurrency on network requests only

### DIFF
--- a/.yarn/versions/f234e0b0.yml
+++ b/.yarn/versions/f234e0b0.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -909,13 +909,12 @@ export class Project {
       return structUtils.stringifyLocator(pkg);
     }]);
 
-    const limit = pLimit(5);
     let firstError = false;
 
     const progress = Report.progressViaCounter(locatorHashes.length);
     report.reportProgress(progress);
 
-    await Promise.all(locatorHashes.map(locatorHash => limit(async () => {
+    await Promise.all(locatorHashes.map(locatorHash => (async () => {
       const pkg = this.storedPackages.get(locatorHash);
       if (!pkg)
         throw new Error(`Assertion failed: The locator should have been registered`);
@@ -941,7 +940,7 @@ export class Project {
       if (fetchResult.releaseFs) {
         fetchResult.releaseFs();
       }
-    }).finally(() => {
+    })().finally(() => {
       progress.tick();
     })));
 

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -107,17 +107,6 @@ export async function request(target: string, body: Body, {configuration, header
   });
 
   return limit(() => gotClient(target) as unknown as Response<any>);
-
-  // const responsePromise = gotClient(target) as Promise<any>;
-  // if (requestPool.length >= NETWORK_CONCURRENCY) {
-  //   console.log('before race', requestPool.length);
-  //   await Promise.race(requestPool);
-  //   console.log('after race', requestPool.length);
-  // } else {
-  //   requestPool.push(responsePromise.finally(() => requestPool.splice(requestPool.indexOf(responsePromise), 1)));
-  // }
-
-  // return await responsePromise;
 }
 
 export async function get(target: string, {configuration, json, ...rest}: Options) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The fetch step can be speedup. Currently we are capping number of concurrently running fetchers. The problem with this approach is that we really want to cap network requests, but fetchers do more than that and directly capping fetchers suboptimal and produces download stalls.

**How did you fix it?**

I am not capping fetchers, but instead cap the network requests directly, this results in 15% speed increase on my laptop of the fetch step (relative to `dns-cache` branch which has limit of 8 concurrent fetcher instead of 5 in master now). 