### PR TITLE
Really enable compression level setting

### DIFF
--- a/.yarn/versions/3744b7e3.yml
+++ b/.yarn/versions/3744b7e3.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/fslib": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/compressionLevel.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/compressionLevel.test.ts
@@ -1,0 +1,64 @@
+import {xfs, PortablePath, ppath} from '@yarnpkg/fslib';
+
+function computeCacheSize(cacheDir: PortablePath): number {
+  let totalSize = 0;
+  const zipFilenames = xfs.readdirSync(cacheDir);
+  for (const filename of zipFilenames)
+    totalSize += xfs.statSync(ppath.join(cacheDir, filename)).size;
+
+  return totalSize;
+};
+
+describe(`Features`, () => {
+  describe(`Compression Level`, () => {
+    test(
+      `compression level 6 cache size should be less than default max compression cache size`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`various-requires`]: `1.0.0`,
+          },
+        },
+        async ({path, run}) => {
+          await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, ``);
+          const cacheDir = `${path}/.yarn/cache` as PortablePath;
+
+          await run(`install`);
+
+          const levelMaxCacheSize = computeCacheSize(cacheDir);
+
+          await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, `compressionLevel: 6\nchecksumBehavior: update\n`);
+
+          await run(`install`);
+
+          expect(levelMaxCacheSize).toBeLessThan(computeCacheSize(cacheDir));
+        },
+      ),
+    );
+
+    test(
+      `compression level 0 cache size should be less than compression level 6 cache size`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`various-requires`]: `1.0.0`,
+          },
+        },
+        async ({path, run}) => {
+          await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, `compressionLevel: 6\n`);
+          const cacheDir = `${path}/.yarn/cache` as PortablePath;
+
+          await run(`install`);
+
+          let level6CacheSize = computeCacheSize(cacheDir);
+
+          await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, `compressionLevel: 0\nchecksumBehavior: update\n`);
+
+          await run(`install`);
+
+          expect(level6CacheSize).toBeLessThan(computeCacheSize(cacheDir));
+        },
+      ),
+    );
+  });
+});

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -22,9 +22,9 @@
       "default": "throw"
     },
     "compressionLevel": {
-      "description": "The compression level employed for zip archives, with 0 being 'no compression, faster' and 9 being 'heavy compression, slower'. The default is 'max', which is a variant of 9 where files may be stored uncompressed if the builtin libzip heuristic thinks it will lead to a more sensible result.",
-      "enum": ["max", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "default": "max"
+      "description": "The compression level employed for zip archives, with 0 being 'no compression, faster' and 9 being 'heavy compression, slower'. The default is 'mixed', which is a variant of 9 where files may be stored uncompressed if the builtin libzip heuristic thinks it will lead to a more sensible result.",
+      "enum": ["mixed", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      "default": "mixed"
     },
     "constraintsPath": {
       "description": "The path of the constraints file.",

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -22,9 +22,9 @@
       "default": "throw"
     },
     "compressionLevel": {
-      "description": "The compression level employed for zip archives, with 0 being 'no compression, faster' and 9 being 'heavy compression, slower'. The default is 'mixed', which is a variant of 6 where files may be stored uncompressed if the builtin zlib heuristic thinks it will lead to a more sensible result.",
-      "enum": ["mixed", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "default": "mixed"
+      "description": "The compression level employed for zip archives, with 0 being 'no compression, faster' and 9 being 'heavy compression, slower'. The default is 'max', which is a variant of 9 where files may be stored uncompressed if the builtin libzip heuristic thinks it will lead to a more sensible result.",
+      "enum": ["max", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      "default": "max"
     },
     "constraintsPath": {
       "description": "The path of the constraints file.",

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -197,7 +197,7 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     default: `./.yarn/cache`,
   },
   compressionLevel: {
-    description: `Zip files compression level, from 0 to 9`,
+    description: `Zip files compression level, from 0 to 9 or max (a variant of 9, which stores some files uncompressed, when compression doesn't yield good results)`,
     type: SettingsType.NUMBER,
     values: [`max`, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     default: DEFAULT_COMPRESSION_LEVEL,

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -197,9 +197,9 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     default: `./.yarn/cache`,
   },
   compressionLevel: {
-    description: `Zip files compression level, from 0 to 9 or max (a variant of 9, which stores some files uncompressed, when compression doesn't yield good results)`,
+    description: `Zip files compression level, from 0 to 9 or mixed (a variant of 9, which stores some files uncompressed, when compression doesn't yield good results)`,
     type: SettingsType.NUMBER,
-    values: [`max`, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    values: [`mixed`, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     default: DEFAULT_COMPRESSION_LEVEL,
   },
   virtualFolder: {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -199,7 +199,7 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
   compressionLevel: {
     description: `Zip files compression level, from 0 to 9`,
     type: SettingsType.NUMBER,
-    values: [`mixed`, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    values: [`max`, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     default: DEFAULT_COMPRESSION_LEVEL,
   },
   virtualFolder: {

--- a/packages/yarnpkg-core/sources/tgzUtils.ts
+++ b/packages/yarnpkg-core/sources/tgzUtils.ts
@@ -29,8 +29,9 @@ interface ExtractBufferOptions {
 export async function convertToZip(tgz: Buffer, opts: ExtractBufferOptions) {
   const tmpFolder = await xfs.mktempPromise();
   const tmpFile = ppath.join(tmpFolder, `archive.zip` as Filename);
+  const {compressionLevel, ...bufferOpts} = opts;
 
-  return await extractArchiveTo(tgz, new ZipFS(tmpFile, {create: true, libzip: await getLibzipPromise()}), opts);
+  return await extractArchiveTo(tgz, new ZipFS(tmpFile, {create: true, libzip: await getLibzipPromise(), level: compressionLevel}), bufferOpts);
 }
 
 export async function extractArchiveTo<T extends FakeFS<PortablePath>>(tgz: Buffer, targetFs: T, {stripComponents = 0, prefixPath = PortablePath.dot}: ExtractBufferOptions = {}): Promise<T> {

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -10,8 +10,8 @@ import {NodeFS}                                                                 
 import * as errors                                                                                 from './errors';
 import {FSPath, PortablePath, npath, ppath, Filename}                                              from './path';
 
-export type ZipCompression = `max` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-export const DEFAULT_COMPRESSION_LEVEL: ZipCompression = `max`;
+export type ZipCompression = `mixed` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export const DEFAULT_COMPRESSION_LEVEL: ZipCompression = `mixed`;
 
 const S_IFMT = 0o170000;
 
@@ -710,7 +710,7 @@ export class ZipFS extends BasePortableFakeFS {
 
     try {
       const newIndex = this.libzip.file.add(this.zip, target, lzSource, this.libzip.ZIP_FL_OVERWRITE);
-      if (this.level !== 'max') {
+      if (this.level !== `mixed`) {
         // Use store for level 0, and deflate for 1..9
         let method;
         if (this.level === 0)

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -10,8 +10,8 @@ import {NodeFS}                                                                 
 import * as errors                                                                                 from './errors';
 import {FSPath, PortablePath, npath, ppath, Filename}                                              from './path';
 
-export type ZipCompression = `mixed` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-export const DEFAULT_COMPRESSION_LEVEL: ZipCompression = `mixed`;
+export type ZipCompression = `max` | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export const DEFAULT_COMPRESSION_LEVEL: ZipCompression = `max`;
 
 const S_IFMT = 0o170000;
 
@@ -710,7 +710,7 @@ export class ZipFS extends BasePortableFakeFS {
 
     try {
       const newIndex = this.libzip.file.add(this.zip, target, lzSource, this.libzip.ZIP_FL_OVERWRITE);
-      if (this.level !== `mixed`) {
+      if (this.level !== 'max') {
         // Use store for level 0, and deflate for 1..9
         let method;
         if (this.level === 0)


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently the compression level setting is present, but really ignored by berry.

**How did you fix it?**

Really enables compression level setting.
