### PR TITLE
Implement tryWorkspaceByFilePath (#1194)

### DIFF
--- a/.yarn/versions/4ebc8ee9.yml
+++ b/.yarn/versions/4ebc8ee9.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-version": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -61,6 +61,8 @@ export async function fetchRoot(initialCwd: PortablePath) {
   return match;
 }
 
+// Note: This returns all changed files from the git diff, which can include
+// files not belonging to a workspace
 export async function fetchChangedFiles(root: PortablePath, {base}: {base: string}) {
   const {stdout: localStdout} = await execUtils.execvp(`git`, [`diff`, `--name-only`, `${base}`], {cwd: root, strict: true});
   const trackedFiles = localStdout.split(/\r\n|\r|\n/).filter(file => file.length > 0).map(file => ppath.resolve(root, npath.toPortablePath(file)));
@@ -207,7 +209,15 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
   if (versionFiles.length > 1)
     throw new UsageError(`Your current branch contains multiple versioning files; this isn't supported:\n- ${versionFiles.join(`\n- `)}`);
 
-  const changedWorkspaces = new Set(changedFiles.map(file => project.getWorkspaceByFilePath(file)));
+  const changedWorkspaces: Set<Workspace> = new Set(miscUtils.mapAndFilter<PortablePath, Workspace>(changedFiles, file => {
+    const workspace = project.tryWorkspaceByFilePath(file);
+    if (workspace === null)
+      return miscUtils.mapAndFilter.skip;
+
+    return workspace;
+  }));
+
+
   if (versionFiles.length === 0 && changedWorkspaces.size === 0 && !allowEmpty)
     return null;
 

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -209,14 +209,13 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
   if (versionFiles.length > 1)
     throw new UsageError(`Your current branch contains multiple versioning files; this isn't supported:\n- ${versionFiles.join(`\n- `)}`);
 
-  const changedWorkspaces: Set<Workspace> = new Set(miscUtils.mapAndFilter<PortablePath, Workspace>(changedFiles, file => {
+  const changedWorkspaces: Set<Workspace> = new Set(miscUtils.mapAndFilter(changedFiles, file => {
     const workspace = project.tryWorkspaceByFilePath(file);
     if (workspace === null)
       return miscUtils.mapAndFilter.skip;
 
     return workspace;
   }));
-
 
   if (versionFiles.length === 0 && changedWorkspaces.size === 0 && !allowEmpty)
     return null;

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -311,7 +311,7 @@ export class Project {
     return workspace;
   }
 
-  getWorkspaceByFilePath(filePath: PortablePath) {
+  tryWorkspaceByFilePath(filePath: PortablePath) {
     let bestWorkspace = null;
 
     for (const workspace of this.workspaces) {
@@ -326,9 +326,17 @@ export class Project {
     }
 
     if (!bestWorkspace)
-      throw new Error(`Workspace not found (${filePath})`);
+      return null;
 
     return bestWorkspace;
+  }
+
+  getWorkspaceByFilePath(filePath: PortablePath) {
+    const workspace = this.tryWorkspaceByFilePath(filePath);
+    if (!workspace)
+      throw new Error(`Workspace not found (${filePath})`);
+
+    return workspace;
   }
 
   tryWorkspaceByIdent(ident: Ident) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR solves issue #1194

**How did you fix it?**

* Implement tryWorkspaceByFilePath followng the common try/get structure

* Use tryWorkspaceByFilePath in versioning plugin to account for out-of-workspace files

* Add note remarking fetchChangedFiles can include out-of-workspace files
