### PR TITLE
Add changesetBaseRef configuration option for versioning (#1195)

### DIFF
--- a/.yarn/versions/b62cfa7b.yml
+++ b/.yarn/versions/b62cfa7b.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-version": prerelease
+
+declined:
+  - "@yarnpkg/cli"

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -17,7 +17,7 @@
       "default": "./.yarn/cache"
     },
     "changesetBaseRefs": {
-      "description": "The base git ref that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, and upstream/master. Supports git branches, tags, and commits.",
+      "description": "The base git refs that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, and upstream/master. Supports git branches, tags, and commits.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -16,6 +16,11 @@
       "format": "uri-reference",
       "default": "./.yarn/cache"
     },
+    "changesetBaseRef": {
+      "description": "The base git ref that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, and upstream/master. Supports git branches, tags, and commits.",
+      "type": "string",
+      "default": null
+    },
     "checksumBehavior": {
       "description": "If `throw` (the default), Yarn will throw an exception on `yarn install` if it detects that a package doesn't match the checksum stored within the lockfile. If `update`, the lockfile checksum will be updated to match the new value. If `ignore`, the checksum check will not happen.",
       "enum": ["throw", "update", "ignore"],

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -16,10 +16,13 @@
       "format": "uri-reference",
       "default": "./.yarn/cache"
     },
-    "changesetBaseRef": {
+    "changesetBaseRefs": {
       "description": "The base git ref that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, and upstream/master. Supports git branches, tags, and commits.",
-      "type": "string",
-      "default": null
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["master", "origin/master", "upstream/master"]
     },
     "checksumBehavior": {
       "description": "If `throw` (the default), Yarn will throw an exception on `yarn install` if it detects that a package doesn't match the checksum stored within the lockfile. If `update`, the lockfile checksum will be updated to match the new value. If `ignore`, the checksum check will not happen.",

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -6,10 +6,12 @@ import version                from './commands/version';
 
 const plugin: Plugin = {
   configuration: {
-    changesetBaseRef: {
+    changesetBaseRefs: {
       description: 'The base git ref that the current HEAD is compared against when detecting changes. Supports git branches, tags, and commits.',
       type: SettingsType.STRING,
-      default: null,
+      isArray: true,
+      isNullable: false,
+      default: [`master`, `origin/master`, `upstream/master`],
     },
     deferredVersionFolder: {
       description: `Folder where are stored the versioning files`,

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -7,7 +7,7 @@ import version                from './commands/version';
 const plugin: Plugin = {
   configuration: {
     changesetBaseRefs: {
-      description: 'The base git ref that the current HEAD is compared against when detecting changes. Supports git branches, tags, and commits.',
+      description: 'The base git refs that the current HEAD is compared against when detecting changes. Supports git branches, tags, and commits.',
       type: SettingsType.STRING,
       isArray: true,
       isNullable: false,

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -6,6 +6,11 @@ import version                from './commands/version';
 
 const plugin: Plugin = {
   configuration: {
+    changesetBaseRef: {
+      description: 'The base git ref that the current HEAD is compared against when detecting changes. Supports git branches, tags, and commits.',
+      type: SettingsType.STRING,
+      default: null,
+    },
     deferredVersionFolder: {
       description: `Folder where are stored the versioning files`,
       type: SettingsType.ABSOLUTE_PATH,

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -19,8 +19,8 @@ export enum Decision {
 export type Releases =
   Map<Workspace, Exclude<Decision, Decision.UNDECIDED>>;
 
-export async function fetchBase(root: PortablePath) {
-  const candidateBases = [`master`, `origin/master`, `upstream/master`];
+export async function fetchBase(root: PortablePath, {baseRef}: {baseRef?: string | null}) {
+  const candidateBases = baseRef !== null ? [baseRef] : [`master`, `origin/master`, `upstream/master`];
   const ancestorBases = [];
 
   for (const candidate of candidateBases) {
@@ -194,7 +194,7 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
   const root = await fetchRoot(configuration.projectCwd);
 
   const base = root !== null
-    ? await fetchBase(root)
+    ? await fetchBase(root, {baseRef: configuration.get('changesetBaseRef')})
     : null;
 
   const changedFiles = root !== null

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -20,6 +20,9 @@ export type Releases =
   Map<Workspace, Exclude<Decision, Decision.UNDECIDED>>;
 
 export async function fetchBase(root: PortablePath, {baseRefs}: {baseRefs: string[]}) {
+  if (baseRefs.length === 0)
+    throw new UsageError(`Can't run this command with zero base refs specified.`);
+
   const ancestorBases = [];
 
   for (const candidate of baseRefs) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR implements issue #1195

**How did you fix it?**

* Add changesetBaseRef, allowing for comparing files against non-master refs

* Update yarnrc documentation accordingly