### PR TITLE
docs(config): hint at using enableGlobalCache instead of cacheFolder

### DIFF
--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -11,7 +11,7 @@
       "default": "./.yarn/build-state.yml"
     },
     "cacheFolder": {
-      "description": "The path where the downloaded packages are stored on your system. They'll be normalized, compressed, and saved under the form of zip archives with standardized names. The cache is deemed to be relatively safe to be shared by multiple projects, even when multiple Yarn instances run at the same time on different projects.",
+      "description": "The path where the downloaded packages are stored on your system. They'll be normalized, compressed, and saved under the form of zip archives with standardized names. The cache is deemed to be relatively safe to be shared by multiple projects, even when multiple Yarn instances run at the same time on different projects. For setting a global cache folder, you should use `enableGlobalCache` instead.",
       "type": "string",
       "format": "uri-reference",
       "default": "./.yarn/cache"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Readers may think setting `cacheFolder` to something global that they come up with is a good idea, especially because of the note on sharing it between projects.

**How did you fix it?**

Mention that there is `enableGlobalCache` for this.