### PR TITLE
docs(config): boolean option consistency

### DIFF
--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -54,12 +54,12 @@
       "default": "./.yarn/versions"
     },
     "enableAbsoluteVirtuals": {
-      "description": "If true, the virtual symlinks will use absolute paths if required [non portable!!]",
+      "description": "If true, the virtual symlinks will use absolute (non-portable!) paths if required.",
       "type": "boolean",
       "default": false
     },
     "enableColors": {
-      "description": "If true, Yarn will format its pretty-print its output by using colors to differentiate important parts of its messages.",
+      "description": "If true (by default detects terminal capabilities), Yarn will format its pretty-print its output by using colors to differentiate important parts of its messages.",
       "type": "boolean",
       "default": true
     },
@@ -69,7 +69,7 @@
       "default": false
     },
     "enableHyperlinks": {
-      "description": "If true, the CLI is allowed to use hyperlinks in its output.",
+      "description": "If true (by default detects terminal capabilities), the CLI is allowed to use hyperlinks in its output.",
       "type": "boolean",
       "default": true
     },
@@ -84,39 +84,39 @@
       "default": false
     },
     "enableInlineBuilds": {
-      "description": "If true, Yarn will print the build output directly within the terminal instead of buffering it in a log file. This is the default for CI environments.",
+      "description": "If true (the default on CI environments), Yarn will print the build output directly within the terminal instead of buffering it in a log file.",
       "type": "boolean",
       "default": false
     },
     "enableMirror": {
-      "description": "If enabled (which is the default), Yarn will use the global folder as indirection between the network and the actual cache. This makes installs much faster for projects that don't already benefit from Zero-Installs.",
+      "description": "If true (the default), Yarn will use the global folder as indirection between the network and the actual cache. This makes installs much faster for projects that don't already benefit from Zero-Installs.",
       "type": "boolean",
       "default": true
     },
     "enableNetwork": {
-      "description": "If disabled, Yarn will never make any request to the network by itself, and will throw an exception rather than let it happen. It's a very useful setting for CI, which typically want to make sure they aren't loading their dependencies from the network by mistake.",
+      "description": "If false, Yarn will never make any request to the network by itself, and will throw an exception rather than let it happen. It's a very useful setting for CI, which typically want to make sure they aren't loading their dependencies from the network by mistake.",
       "type": "boolean",
       "default": true
     },
     "enableProgressBars": {
-      "description": "If true, Yarn will show progress bars for long-running events. It's disabled by default for CI environments.",
+      "description": "If true (the default outside of CI environments), Yarn will show progress bars for long-running events.",
       "type": "boolean",
       "default": true
     },
     "enableScripts": {
-      "description": "If disabled, Yarn will not execute the `postInstall` scripts when installing the project. Note that you can now also disable scripts on a per-package basis thanks to `dependenciesMeta`.",
+      "description": "If false, Yarn will not execute the `postInstall` scripts when installing the project. Note that you can now also disable scripts on a per-package basis thanks to `dependenciesMeta`.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "enableTimers": {
-      "description": "If true, Yarn will print the time spent running each sub-step when running various commands. Disabling this feature is typically needed for testing purposes, when you want each execution to have exactly the same output as the previous ones.",
+      "description": "If false, Yarn will not print the time spent running each sub-step when running various commands. This is typically needed for testing purposes, when you want each execution to have exactly the same output as the previous ones.",
       "type": "boolean",
       "default": true
     },
     "enableTransparentWorkspaces": {
-      "description": "If disabled, Yarn won't anymore link workspaces just because their versions happen to match a semver range. Using this setting will require that all workspace accesses are made through the `workspace:` protocol. This is usually only needed in some very specific circumstances.",
+      "description": "If false, Yarn won't anymore link workspaces just because their versions happen to match a semver range. Disabling this setting will require that all workspace accesses are made through the `workspace:` protocol. This is usually only needed in some very specific circumstances.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "globalFolder": {
       "description": "The path where all system-global files (for example the list of all packages registered through `yarn link`) are stored.",
@@ -184,7 +184,7 @@
     "npmAlwaysAuth": {
       "description": "If true, Yarn will always send the authentication credentials when making a request to the registries. This typically shouldn't be needed.",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "npmAuthIdent": {
       "description": "Defines the authentication credentials to use by default when accessing your registries (equivalent to `_auth` in the v1). This settings is strongly discouraged in favor of `npmAuthToken`.",
@@ -424,7 +424,7 @@
     "preferInteractive": {
       "description": "If true, Yarn will ask for your guidance when some actions would be improved by being disambiguated. Enabling this setting also unlocks some features (for example the `yarn add` command will suggest to reuse the same dependencies as other workspaces if pertinent).",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "progressBarStyle": {
       "description": "Which style of progress bar should be used (only when progress bars are enabled). Valid values can be found [here](https://github.com/yarnpkg/berry/blob/ac2668904bdcd804e531291c749b9d17b8d3acd7/packages/yarnpkg-core/sources/StreamReport.ts#L40).",


### PR DESCRIPTION
**What's the problem this PR addresses?**

The config options docs page handles the phrasing for boolean options quite inconsistently.

**How did you fix it?**

I tried to follow the pattern that was partially but not consistently
already in place:
* set the shown example to the default
  * if the default depends, to the default on most dev machines
* use only 'If true' or 'If false' sentences
* if the sentence talks describes the default, mention '(the default)'
  * if the default depends, mention what it depends on