### PR TITLE
Reenable plugin-compat for all the linkers

### DIFF
--- a/.yarn/versions/d27a1090.yml
+++ b/.yarn/versions/d27a1090.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/index.ts
+++ b/packages/plugin-compat/sources/index.ts
@@ -15,16 +15,12 @@ const PATCHES = new Map([
 const plugin: Plugin<CoreHooks & PatchHooks> = {
   hooks: {
     registerPackageExtensions: async (configuration, registerPackageExtension) => {
-      if (configuration.get('nodeLinker') === 'node-modules')
-        return;
       for (const [descriptorStr, extensionData] of packageExtensions) {
         registerPackageExtension(structUtils.parseDescriptor(descriptorStr, true), extensionData);
       }
     },
 
     getBuiltinPatch: async (project, name) => {
-      if (project.configuration.get('nodeLinker') === 'node-modules')
-        return;
       const TAG = `compat/`;
       if (!name.startsWith(TAG))
         return;
@@ -36,8 +32,6 @@ const plugin: Plugin<CoreHooks & PatchHooks> = {
     },
 
     reduceDependency: async (dependency, project, locator, initialDescriptor) => {
-      if (project.configuration.get('nodeLinker') === 'node-modules')
-        return dependency;
       const patch = PATCHES.get(dependency.identHash);
       if (typeof patch === `undefined`)
         return dependency;


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently plugin-compat is turned off for node_modules linker due to perf considerations. However this also mean that lockfile become installation strategy dependent.

**How did you fix it?**

Reenable plugin-compat for all the linkers, because using PnP mode on CI and node_modules locally seems as a valid and important use case and its worth small perf penalty.
