### PR TITLE
[node-modules] Set execution permission on .bin targets

### DIFF
--- a/.yarn/versions/4fc8bdb2.yml
+++ b/.yarn/versions/4fc8bdb2.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -112,7 +112,11 @@ describe('Node_Modules', () => {
         await writeFile(npath.toPortablePath(`${path}/dist/bin/index.js`), '');
 
         await expect(run(`install`)).resolves.toBeTruthy();
-        await expect(xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/.bin/pkg`))).resolves.toBeDefined();
+        const stats = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/.bin/pkg`));
+
+        expect(stats).toBeDefined();
+        // Check that destination has 0o700 - execute for all permissions set
+        expect(stats.mode & 0o700).toEqual(0o700);
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -115,8 +115,11 @@ describe('Node_Modules', () => {
         const stats = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/.bin/pkg`));
 
         expect(stats).toBeDefined();
-        // Check that destination has 0o700 - execute for all permissions set
-        expect(stats.mode & 0o700).toEqual(0o700);
+
+        if (process.platform !== 'win32') {
+          // Check that destination has 0o700 - execute for all permissions set
+          expect(stats.mode & 0o700).toEqual(0o700);
+        }
       },
     ),
   );

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -871,6 +871,7 @@ async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlink
       } else {
         await xfs.removePromise(symlinkPath);
         await symlinkPromise(target, symlinkPath);
+        await xfs.chmodPromise(target, 0o755);
       }
     }
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some packages distribute their executable files without execution permission properly set and rely that execution permission on bin target should be set by package manager. The yarn 1 has set execution permission on bin targets, so for backward compatibility reasons we should set them too.

**How did you fix it?**

This PR adds the code to set executable permissions on bin targets and amends .bin integration test to check this new behaviour.
