### PR TITLE
Don't suggest the workspaces unless it matches the request

### DIFF
--- a/.yarn/versions/1ec30f83.yml
+++ b/.yarn/versions/1ec30f83.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -164,6 +164,13 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
   if (!(maxResults >= 0))
     throw new Error(`Invalid maxResults (${maxResults})`);
 
+  if (request.range !== `unknown`) {
+    return [{
+      descriptor: request,
+      reason: `Unambiguous explicit request`,
+    }];
+  }
+
   const existing = typeof workspace !== `undefined` && workspace !== null
     ? workspace.manifest[target].get(request.identHash) || null
     : null;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The core returns suggestions even when the descriptor doesn't need them. This is problematic when running things like:

```
yarn up foo@1.2.3
```

Because if `foo` is a workspace, then the command will fail with:

```
➤ BR0027: bar@workspace:foo has multiple possible upgrade strategies; use -i to disambiguate manually
```

**How did you fix it?**

We won't offer suggestions unless the range is loose (ie `yarn add foo -i` will have suggestions, but `yarn add foo@1.2.3 -i` won't).
