### PR TITLE
Cleanup .bin folders from node_modules

### DIFF
--- a/.yarn/versions/1007e617.yml
+++ b/.yarn/versions/1007e617.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1371,6 +1371,7 @@ describe(`Plug'n'Play`, () => {
   test(
     `it should remove lingering folders from the node_modules even when they contain dot-folders`,
     makeTemporaryEnv({}, async ({path, run, source}) => {
+      await xfs.mkdirpPromise(`${path}/node_modules/.bin`);
       await xfs.mkdirpPromise(`${path}/node_modules/.cache`);
       await xfs.mkdirpPromise(`${path}/node_modules/foo`);
 

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -178,7 +178,7 @@ export class PnpInstaller extends AbstractPnpInstaller {
       });
 
       const nonCacheEntries = directoryListing.filter(entry => {
-        return !entry.isDirectory() || !entry.name.startsWith(`.`);
+        return !entry.isDirectory() || entry.name === '.bin' || !entry.name.startsWith(`.`);
       });
 
       if (nonCacheEntries.length === directoryListing.length) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Pnp linker cleans up all node_modules folders except dot folders inside them. This leaves out `.bin` folders that are certainly not needed for pnp mode.

**How did you fix it?**

Added removal of `.bin` entries inside `node_modules` as well.