### PR TITLE
feat: improve validation step and add warning for resolutions not declared at the project root

### DIFF
--- a/.yarn/versions/88316f5e.yml
+++ b/.yarn/versions/88316f5e.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/CorePlugin.ts
+++ b/packages/yarnpkg-core/sources/CorePlugin.ts
@@ -1,6 +1,8 @@
+import {MessageName}              from './MessageName';
 import {Plugin}                   from './Plugin';
 import {Project}                  from './Project';
 import {Resolver, ResolveOptions} from './Resolver';
+import {Workspace}                from './Workspace';
 import * as structUtils           from './structUtils';
 import {Descriptor, Locator}      from './types';
 
@@ -28,6 +30,35 @@ export const CorePlugin: Plugin = {
       }
 
       return dependency;
+    },
+
+    validateProject: async (project: Project, report: {
+      reportWarning: (name: MessageName, text: string) => void,
+      reportError: (name: MessageName, text: string) => void,
+    }) => {
+      for (const workspace of project.workspaces) {
+        const workspaceName = structUtils.prettyWorkspace(project.configuration, workspace);
+
+        await project.configuration.triggerHook(hooks => {
+          return hooks.validateWorkspace;
+        }, workspace, {
+          reportWarning: (name: MessageName, text: string) => report.reportWarning(name, `${workspaceName}: ${text}`),
+          reportError: (name: MessageName, text: string) => report.reportError(name, `${workspaceName}: ${text}`),
+        });
+      }
+    },
+
+    validateWorkspace: async (workspace: Workspace, report: {
+      reportWarning: (name: MessageName, text: string) => void,
+      reportError: (name: MessageName, text: string) => void,
+    }) => {
+      // Validate manifest
+      const {manifest} = workspace;
+      if (manifest.resolutions.length && workspace.cwd !== workspace.project.cwd)
+        manifest.errors.push(new Error(`Resolutions field will be ignored`));
+      for (const manifestError of manifest.errors) {
+        report.reportWarning(MessageName.INVALID_MANIFEST, manifestError.message);
+      }
     },
   },
 };

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -72,7 +72,7 @@ export class Manifest {
   /**
    * errors found in the raw manifest while loading
    */
-  public readonly errors: Array<Error> = [];
+  public errors: Array<Error> = [];
 
   static readonly fileName = `package.json` as Filename;
 

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -72,7 +72,7 @@ export class Manifest {
   /**
    * errors found in the raw manifest while loading
    */
-  public errors: ReadonlyArray<Error> = [];
+  public readonly errors: Array<Error> = [];
 
   static readonly fileName = `package.json` as Filename;
 

--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -5,8 +5,10 @@ import {Writable, Readable}                                     from 'stream';
 import {SettingsDefinition, PluginConfiguration, Configuration} from './Configuration';
 import {Fetcher}                                                from './Fetcher';
 import {Linker}                                                 from './Linker';
+import {MessageName}                                            from './MessageName';
 import {Project}                                                from './Project';
 import {Resolver, ResolveOptions}                               from './Resolver';
+import {Workspace}                                              from './Workspace';
 import {Locator, Descriptor}                                    from './types';
 
 type ProcessEnvironment = {[key: string]: string};
@@ -88,6 +90,26 @@ export type Hooks = {
   afterAllInstalled?: (
     project: Project,
   ) => void,
+
+  // Called during the `Validation step` of the `install` method from the `Project`
+  // class.
+  validateProject?: (
+    project: Project,
+    report: {
+      reportWarning: (name: MessageName, text: string) => void,
+      reportError: (name: MessageName, text: string) => void,
+    }
+  ) => void;
+
+  // Called during the `Validation step` of the `install` method from the `Project`
+  // class by the `validateProject` hook.
+  validateWorkspace?: (
+    workspace: Workspace,
+    report: {
+      reportWarning: (name: MessageName, text: string) => void,
+      reportError: (name: MessageName, text: string) => void,
+    }
+  ) => void;
 };
 
 export type Plugin<PluginHooks = any> = {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -470,6 +470,26 @@ export class Project {
     return null;
   }
 
+  async validateEverything(opts: {
+    validationWarnings: Array<{name: MessageName, text: string}>,
+    validationErrors: Array<{name: MessageName, text: string}>,
+    problemCount: number,
+    report: Report,
+  }) {
+    const progress = Report.progressViaCounter(opts.problemCount);
+    opts.report.reportProgress(progress);
+
+    for (const warning of opts.validationWarnings) {
+      opts.report.reportWarning(warning.name, warning.text);
+      progress.tick();
+    }
+
+    for (const error of opts.validationErrors) {
+      opts.report.reportError(error.name, error.text);
+      progress.tick();
+    }
+  }
+
   async resolveEverything(opts: {report: Report, lockfileOnly: true, resolver?: Resolver} | {report: Report, lockfileOnly?: boolean, cache: Cache, resolver?: Resolver}) {
     if (!this.workspacesByCwd || !this.workspacesByIdent)
       throw new Error(`Workspaces must have been setup before calling this function`);
@@ -1367,19 +1387,21 @@ export class Project {
   }
 
   async install(opts: InstallOptions) {
-    const validationErrors: Array<string> = [];
-    for (const workspace of this.workspaces) {
-      for (const manifestError of workspace.manifest.errors) {
-        const workspaceName = structUtils.prettyWorkspace(this.configuration, workspace);
-        validationErrors.push(`${workspaceName}: ${manifestError.message}`);
-      }
-    }
+    const validationWarnings: Array<{name: MessageName, text: string}> = [];
+    const validationErrors: Array<{name: MessageName, text: string}> = [];
 
-    if (validationErrors.length > 0) {
+    await this.configuration.triggerHook(hooks => {
+      return hooks.validateProject;
+    }, this, {
+      reportWarning: (name: MessageName, text:string) => validationWarnings.push({name, text}),
+      reportError: (name: MessageName, text:string) => validationErrors.push({name, text}),
+    });
+
+    const problemCount = validationWarnings.length + validationErrors.length;
+
+    if (problemCount > 0) {
       await opts.report.startTimerPromise(`Validation step`, async () => {
-        for (const validationError of validationErrors) {
-          opts.report.reportWarning(MessageName.INVALID_MANIFEST, validationError);
-        }
+        await this.validateEverything({validationWarnings, validationErrors, problemCount, report: opts.report});
       });
     }
 

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -473,20 +473,13 @@ export class Project {
   async validateEverything(opts: {
     validationWarnings: Array<{name: MessageName, text: string}>,
     validationErrors: Array<{name: MessageName, text: string}>,
-    problemCount: number,
     report: Report,
   }) {
-    const progress = Report.progressViaCounter(opts.problemCount);
-    opts.report.reportProgress(progress);
-
-    for (const warning of opts.validationWarnings) {
+    for (const warning of opts.validationWarnings)
       opts.report.reportWarning(warning.name, warning.text);
-      progress.tick();
-    }
 
     for (const error of opts.validationErrors) {
       opts.report.reportError(error.name, error.text);
-      progress.tick();
     }
   }
 
@@ -1401,7 +1394,7 @@ export class Project {
 
     if (problemCount > 0) {
       await opts.report.startTimerPromise(`Validation step`, async () => {
-        await this.validateEverything({validationWarnings, validationErrors, problemCount, report: opts.report});
+        await this.validateEverything({validationWarnings, validationErrors, report: opts.report});
       });
     }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently, there's no warning for resolutions not declared at the project root.

**How did you fix it?**

I added a warning for resolutions not declared at the project root.

In the process, I improved the `Validation step`:
- There are 2 new core hooks:
  - `validateProject` - called during the validation step
  - `validateWorkspace` - called during the validation step by `validateWorkspace`
Both of them have `reportWarning` and `reportError` parameters
- The manifest validation is now done inside the core implementation of `validateWorkspace`, where contextual errors (the ones that require `project` or `workspace`) are also pushed. I also ~~made `Manifest.errors` a `readonly Array<Error>` instead of a `ReadonlyArray<Error>`, to reduce the number of `// @ts-ignore`s required.~~ dropped the `readonly` as there's no easy way to make TS happy.
- I moved as much validation logic as I could to a new `validateEverything` method, to preserve consistency with the other steps.
- I made the reporting of errors and warnings include the progress (based on the combined lengths of the `validationErrors` and `validationWarnings` arrays), to preserve consistency with the other steps.