### PR TITLE
docs: add note about relative paths

### DIFF
--- a/packages/gatsby/src/pages/configuration/manifest.json
+++ b/packages/gatsby/src/pages/configuration/manifest.json
@@ -226,7 +226,7 @@
       }
     },
     "resolutions": {
-      "description": "This field allows you to instruct Yarn to use a specific resolution instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.",
+      "description": "This field allows you to instruct Yarn to use a specific resolution instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.",
       "type": "object",
       "patternProperties": {
         "^relay-compiler$": {

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -298,7 +298,7 @@
       }
     },
     "packageExtensions": {
-      "description": "Some packages may have been specified incorrectly with regard to their dependencies - for example with one dependency being missing, causing Yarn to refuse it the access. The `packageExtensions` fields offer a way to extend the existing package definitions with additional information. If you use it, consider sending a PR upstream and contributing your extension to the [`plugin-compat` database](https://github.com/yarnpkg/berry/blob/master/packages/plugin-compat/sources/extensions.ts).",
+      "description": "Some packages may have been specified incorrectly with regard to their dependencies - for example with one dependency being missing, causing Yarn to refuse it the access. The `packageExtensions` fields offer a way to extend the existing package definitions with additional information. If you use it, consider sending a PR upstream and contributing your extension to the [`plugin-compat` database](https://github.com/yarnpkg/berry/blob/master/packages/plugin-compat/sources/extensions.ts).\nNote: This field is made to add dependencies; if you need to rewrite existing ones, prefer the [`resolutions`](/configuration/manifest#resolutions) field.",
       "type": "object",
       "patternProperties": {
         "^(?:@([^/]+?)/)?([^/]+?)(?:@(.+))$": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Relative paths aren't resolved relative to the path of the project when used inside protocols inside the `packageExtensions` field. This can cause confusion. (#1127)

**How did you fix it?**

I added a note about it.
