### PR TITLE
Fix normalizeRepoUrl

### DIFF
--- a/.yarn/versions/68d1c5d9.yml
+++ b/.yarn/versions/68d1c5d9.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-git": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
+++ b/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
@@ -14,7 +14,7 @@ exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#tag=hello 1`] =
 
 exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#workspace=foo 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#workspace=foo"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo2bar.js 1`] = `"GitHubOrg/foo2bar.js"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo2bar.js 1`] = `"https://github.com/GitHubOrg/foo2bar.js.git"`;
 
 exports[`gitUtils should properly normalize git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
 

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -124,7 +124,7 @@ export function normalizeRepoUrl(url: string) {
   url = url.replace(/^git\+https:/, `https:`);
 
   // We support this as an alias to GitHub repositories
-  url = url.replace(/^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
+  url = url.replace(/^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
 
   return url;
 }


### PR DESCRIPTION
`normalizeRepoUrl` uses a different regex compared to the `gitPatterns` regex used in `isGitUrl`.  It is missing the 0-9 bit, which means that Urls that are correctly marked as git urls in `isGitUrl` fail when being processed by `lsRemote`

This fix fixes that so that an address that passes isGitRepo will also successfully be parsed by normalizeRepoUrl

This can be tested by doing:
```yarn add @openzeppelin/cli --dev```
This command installs Web3-js@1.2.2 which listed `"scrypt-shim": "github:web3-js/scrypt-shim",` as a dependency.  (Not in package.json or anywhere easy to find mind, that would be searchable and we wouldn't want that)

**How did you fix it?**

Add 0-9 to normalizeRepoUrl, installed openzeppellin.  Swore at computer a great deal.  One of those two actions may have done it, not sure which.
