### PR TITLE
feat(pnpify): set typescript.enablePromptUseWorkspaceTsdk to true

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
   "eslint.nodePath": ".vscode/pnpify",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/.yarn/versions/64c38a0f.yml
+++ b/.yarn/versions/64c38a0f.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -197,6 +197,7 @@ const generateTypescriptWrapper = async (pnpApi: PnpApi, target: PortablePath) =
         ),
       ),
     ),
+    [`typescript.enablePromptUseWorkspaceTsdk`]: true,
   });
 };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

VSCode merged https://github.com/microsoft/vscode/pull/95566 which makes the editor ask users if they want to use the workspace version of typescript if `typescript.enablePromptUseWorkspaceTsdk` is set to true. `pnpify --sdk` should set it automatically

**How did you fix it?**

Updated `pnpify --sdk` to set `typescript.enablePromptUseWorkspaceTsdk` to true