### PR TITLE
ci: run tests on node 14

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -63,6 +63,7 @@ jobs:
         - 10
         - 12
         - 13
+        - 14
         platform:
         - ubuntu-latest
         - windows-latest

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -62,7 +62,6 @@ jobs:
         node:
         - 10
         - 12
-        - 13
         - 14
         platform:
         - ubuntu-latest

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -141,7 +141,7 @@ describe(`Commands`, () => {
 
         await run(`install`);
 
-        await fsUtils.writeFile(`${path}/lib/foo.js`);
+        await fsUtils.writeFile(`${path}/lib/foo.js`, ``);
 
         const {stdout} = await run(`pack`, `--dry-run`);
         await expect(stdout).toMatch(/lib\/foo\.js/);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Things seem *a bit* broken on Node 14. (e.g. #1236)

~~I've just done a quick check locally (only including the files mentioned below) and:~~
~~- 12/18 tests fail for `script.test.js`~~
~~- 8/12 tests fail for `require.test.js`~~
~~- 3/62 tests fail for `pnp.test.js`~~
~~- 3/8 tests fail for `node-modules.test.ts`~~
Edit: Apparently that only happens locally to me, that's why I made the PR, to see if it reproduces on CI. It seems there's only one error with Node 14, and it's not one of the original ones I got. Sorry for the heart attack. 😄

**How did you fix it?**

For now, I made the tests also run on Node 14 on CI, so we can see everything that's failing more easily.
