### PR TITLE
Fixes publishing scoped package publish auth

### DIFF
--- a/.yarn/versions/4c989b5e.yml
+++ b/.yarn/versions/4c989b5e.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-npm-cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -104,6 +104,7 @@ export default class NpmPublishCommand extends BaseCommand {
           await npmHttpUtils.put(npmHttpUtils.getIdentUrl(ident), body, {
             configuration,
             registry,
+            ident,
             json: true,
           });
         } catch (error) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Since the ident wasn't passed to the `put` function from the publish command, it wasn't detecting the package scope and thus was ignoring the scope configuration.

**How did you fix it?**

We now pass the ident, so the scope configuration will be taken into account.
