### PR TITLE
fix(essentials/set/version): convert PortablePath to NativePath

### DIFF
--- a/.yarn/versions/0ca53cd6.yml
+++ b/.yarn/versions/0ca53cd6.yml
@@ -1,0 +1,20 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                                               from '@yarnpkg/cli';
 import {Configuration, Project, StreamReport, MessageName, Report} from '@yarnpkg/core';
 import {execUtils, httpUtils, semverUtils}                         from '@yarnpkg/core';
-import {Filename, PortablePath, ppath, xfs}                        from '@yarnpkg/fslib';
+import {Filename, PortablePath, ppath, xfs, npath}                 from '@yarnpkg/fslib';
 import {Command, Usage, UsageError}                                from 'clipanion';
 import semver                                                      from 'semver';
 
@@ -71,7 +71,7 @@ export async function setVersion(project: Project, bundleVersion: string | null,
       const temporaryPath = ppath.join(tmpDir, `yarn.js` as Filename);
       await xfs.writeFilePromise(temporaryPath, bundleBuffer);
 
-      const {stdout} = await execUtils.execvp(process.execPath, [temporaryPath, `--version`], {
+      const {stdout} = await execUtils.execvp(process.execPath, [npath.fromPortablePath(temporaryPath), `--version`], {
         cwd: project.cwd,
         env: {...process.env, YARN_IGNORE_PATH: `1`},
       });


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn set version latest` doesn't work on Windows, because the Node process is invoked with a `PortablePath` instead of a `NativePath`.

Fixes #1248.

**How did you fix it?**

I replaced `temporaryPath` with `npath.fromPortablePath(temporaryPath)`.
