### PR TITLE
make sure lockPromise from FakeFS does not throw error

### DIFF
--- a/.yarn/versions/0793bac6.yml
+++ b/.yarn/versions/0793bac6.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/fslib": prerelease

--- a/packages/yarnpkg-fslib/sources/FakeFS.ts
+++ b/packages/yarnpkg-fslib/sources/FakeFS.ts
@@ -451,8 +451,12 @@ export abstract class FakeFS<P extends Path> {
     try {
       return await callback();
     } finally {
-      await this.closePromise(fd);
-      await this.unlinkPromise(lockPath);
+      try {
+        await this.unlinkPromise(lockPath);
+        await this.closePromise(fd);
+      } catch (error) {
+        // noop
+      }
     }
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Ran into the following issue when doing `yarn install` for multiple projects in parallel.
```
1708 ➤ YN0001: │ Error: esrecurse@npm:4.2.1: ENOENT: no such file or directory, unlink '/root/.yarn/berry/cache/esrecurse-npm-4.2.1-9ebee4c3b1-2.zip.flock'
1709 ➤ YN0001: │ Error: esprima@npm:4.0.1: ENOENT: no such file or directory, unlink '/root/.yarn/berry/cache/esprima-npm-4.0.1-1084e98778-2.zip.flock'
1710 ➤ YN0001: │ Error: esquery@npm:1.3.1: ENOENT: no such file or directory, unlink '/root/.yarn/berry/cache/esquery-npm-1.3.1-2ba3c93f30-2.zip.flock'
```

**How did you fix it?**

According to the conversation https://discordapp.com/channels/226791405589233664/654372321225605128/703546908341436477

Wrap the finally block with an additional try catch and make sure it doesn't throw 
