### PR TITLE
Check .pnp.cjs when looking for a PnP API

### DIFF
--- a/.yarn/versions/36d37cca.yml
+++ b/.yarn/versions/36d37cca.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+  "@yarnpkg/pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-pnp/sources/loader/makeManager.ts
+++ b/packages/yarnpkg-pnp/sources/loader/makeManager.ts
@@ -77,6 +77,10 @@ export function makeManager(pnpapi: PnpApi, opts: MakeManagerOptions) {
       if (xfs.existsSync(candidate) && xfs.statSync(candidate).isFile())
         return candidate;
 
+      const cjsCandidate = ppath.join(curr, `.pnp.cjs` as Filename);
+      if (xfs.existsSync(cjsCandidate) && xfs.statSync(cjsCandidate).isFile())
+        return cjsCandidate;
+
       next = ppath.dirname(curr);
     } while (curr !== PortablePath.root);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Projects with `type: "module"` in their package manifest can't load any of the pnpified VS Code plugins.

**How did you fix it?**

`findApiPathFor` now takes `.pnp.cjs` files into account.
