### PR TITLE
fix(plugin-npm): fix tag regex

### DIFF
--- a/.yarn/versions/ff3089cd.yml
+++ b/.yarn/versions/ff3089cd.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-npm": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -1,12 +1,10 @@
-import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
-import {structUtils}                                                               from '@yarnpkg/core';
-import {Descriptor, Locator, Package}                                              from '@yarnpkg/core';
+import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions, TAG_REGEXP} from '@yarnpkg/core';
+import {structUtils}                                                                           from '@yarnpkg/core';
+import {Descriptor, Locator, Package}                                                          from '@yarnpkg/core';
 
-import {NpmSemverFetcher}                                                          from './NpmSemverFetcher';
-import {PROTOCOL}                                                                  from './constants';
-import * as npmHttpUtils                                                           from './npmHttpUtils';
-
-export const TAG_REGEXP = /^(?!v)[a-z0-9-]+$/i;
+import {NpmSemverFetcher}                                                                      from './NpmSemverFetcher';
+import {PROTOCOL}                                                                              from './constants';
+import * as npmHttpUtils                                                                       from './npmHttpUtils';
 
 export class NpmTagResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {

--- a/packages/yarnpkg-core/sources/ProtocolResolver.ts
+++ b/packages/yarnpkg-core/sources/ProtocolResolver.ts
@@ -4,7 +4,7 @@ import {Resolver, ResolveOptions, MinimalResolveOptions} from './Resolver';
 import * as structUtils                                  from './structUtils';
 import {Descriptor, Locator, DescriptorHash, Package}    from './types';
 
-export const TAG_REGEXP = /^[a-z]+$/;
+export const TAG_REGEXP = /^(?!v)[a-z0-9-\.]+$/i;
 
 export class ProtocolResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -19,6 +19,7 @@ export {AllDependencies, HardDependencies, Manifest, DependencyMeta, PeerDepende
 export {MessageName}                                                                                     from './MessageName';
 export {CommandContext, Hooks, Plugin}                                                                   from './Plugin';
 export {Project}                                                                                         from './Project';
+export {TAG_REGEXP}                                                                                      from './ProtocolResolver';
 export {ReportError, Report}                                                                             from './Report';
 export {Resolver, ResolveOptions, MinimalResolveOptions}                                                 from './Resolver';
 export {StreamReport}                                                                                    from './StreamReport';


### PR DESCRIPTION
**What's the problem this PR addresses?**

The tag regex in `@yarnpkg/plugin-npm` doesn't include dots, which can cause problems.

Also, the tag regex in the `ProtocolResolver` from `@yarnpkg/core` doesn't even include numbers or dashes and is case sensitive, so some tags aren't remapped correctly.

Fixes #1267.

**How did you fix it?**

I unified the tag regexes into a single one exported from `ProtocolResolver` and I made it also include dots.
