### PR TITLE
Adds the 'lists' module to the Prolog engine

### DIFF
--- a/.yarn/versions/c5d29d8b.yml
+++ b/.yarn/versions/c5d29d8b.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-constraints": prerelease
+
+declined:
+  - "@yarnpkg/cli"

--- a/.yarn/versions/c5d29d8b.yml
+++ b/.yarn/versions/c5d29d8b.yml
@@ -2,4 +2,8 @@ releases:
   "@yarnpkg/plugin-constraints": prerelease
 
 declined:
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-npm"
   - "@yarnpkg/cli"

--- a/packages/plugin-constraints/sources/Constraints.ts
+++ b/packages/plugin-constraints/sources/Constraints.ts
@@ -2,14 +2,14 @@
 
 import {Ident, MessageName, Project, ReportError, Workspace} from '@yarnpkg/core';
 import {miscUtils, structUtils}                              from '@yarnpkg/core';
-import {xfs, ppath, PortablePath, toFilename}                from '@yarnpkg/fslib';
+import {xfs, ppath, PortablePath}                            from '@yarnpkg/fslib';
 // @ts-ignore
 import plLists                                               from 'tau-prolog/modules/lists';
 import pl                                                    from 'tau-prolog';
 
-plLists(pl);
-
 import {linkProjectToSession}                                from './tauModule';
+
+plLists(pl);
 
 export type EnforcedDependency = {
   workspace: Workspace,

--- a/packages/plugin-constraints/sources/Constraints.ts
+++ b/packages/plugin-constraints/sources/Constraints.ts
@@ -3,7 +3,11 @@
 import {Ident, MessageName, Project, ReportError, Workspace} from '@yarnpkg/core';
 import {miscUtils, structUtils}                              from '@yarnpkg/core';
 import {xfs, ppath, PortablePath, toFilename}                from '@yarnpkg/fslib';
+// @ts-ignore
+import plLists                                               from 'tau-prolog/modules/lists';
 import pl                                                    from 'tau-prolog';
+
+plLists(pl);
 
 import {linkProjectToSession}                                from './tauModule';
 
@@ -97,6 +101,7 @@ class Session {
     this.session = pl.create();
     linkProjectToSession(this.session, project);
 
+    this.session.consult(`:- use_module(library(lists)).`);
     this.session.consult(source);
   }
 

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -1,5 +1,5 @@
 import {execUtils, scriptUtils, structUtils, tgzUtils}                     from '@yarnpkg/core';
-import {Locator, MessageName}                                              from '@yarnpkg/core';
+import {Locator}                                                           from '@yarnpkg/core';
 import {Fetcher, FetchOptions, MinimalFetchOptions}                        from '@yarnpkg/core';
 import {Filename, PortablePath, npath, ppath, toFilename, xfs, NativePath} from '@yarnpkg/fslib';
 

--- a/packages/plugin-file/sources/FileFetcher.ts
+++ b/packages/plugin-file/sources/FileFetcher.ts
@@ -1,5 +1,5 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
-import {Locator, MessageName}                       from '@yarnpkg/core';
+import {Locator}                                    from '@yarnpkg/core';
 import {miscUtils, structUtils, tgzUtils}           from '@yarnpkg/core';
 import {NodeFS, PortablePath, ppath}                from '@yarnpkg/fslib';
 

--- a/packages/plugin-http/sources/TarballHttpFetcher.ts
+++ b/packages/plugin-http/sources/TarballHttpFetcher.ts
@@ -1,5 +1,5 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
-import {Locator, MessageName}                       from '@yarnpkg/core';
+import {Locator}                                    from '@yarnpkg/core';
 import {httpUtils, structUtils, tgzUtils}           from '@yarnpkg/core';
 
 import {TARBALL_REGEXP, PROTOCOL_REGEXP}            from './constants';

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -1,5 +1,5 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
-import {Locator, MessageName}                       from '@yarnpkg/core';
+import {Locator}                                    from '@yarnpkg/core';
 import {structUtils, tgzUtils}                      from '@yarnpkg/core';
 import semver                                       from 'semver';
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some common Prolog functions (notably 'member/2') aren't available.

**How did you fix it?**

I've added the `lists` module by default to the Prolog runtime. I didn't add others since they seem relatively forgettable except for this one.
