### PR TITLE
ci: make e2e tests fail on unhandled rejections

### DIFF
--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -19,3 +19,6 @@ export YARN_ENABLE_INLINE_BUILDS=1
 # Otherwise git commit doesn't work, and some tools require it
 git config --global user.email "you@example.com"
 git config --global user.name "John Doe"
+
+# We want all e2e tests to fail on unhandled rejections
+export NODE_OPTIONS="--unhandled-rejections=strict"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some of the e2e tests are passing even with missing dependencies (https://github.com/yarnpkg/berry/runs/633342837#step:5:94)

**How did you fix it?**

Set `NODE_OPTIONS="--unhandled-rejections=strict"` for the e2e tests so they fail instead of silently ignoring the error