### PR TITLE
[gatsby] highlight top nav

### DIFF
--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -12,16 +12,16 @@ module.exports = {
       link: `/getting-started`,
     }, {
       name: `Configuration`,
-      link: `/configuration/manifest`,
+      link: `/configuration`,
     }, {
       name: `Features`,
-      link: `/features/pnp`,
+      link: `/features`,
     }, {
       name: `CLI`,
-      link: `/cli/install`,
+      link: `/cli`,
     }, {
       name: `Advanced`,
-      link: `/advanced/architecture`,
+      link: `/advanced`,
     }, {
       name: `API`,
       link: `/api`,


### PR DESCRIPTION
Current | New
-|-
![image](https://user-images.githubusercontent.com/22725671/80805739-d2660000-8b86-11ea-8140-36bb727a8118.png) | ![image](https://user-images.githubusercontent.com/22725671/80805878-296bd500-8b87-11ea-8fe6-4721b744f40e.png)

- change urls in the main nav so that they match base endpoints
- use gatsby's `createRedirect` based on netlify's `_redirect` file
- profit