### PR TITLE
[gatsby] refine targets for header hyperlinks

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -289,9 +289,9 @@ export const Header = ({children}) => {
   return <>
     <HeaderContainer>
       <NewsContainer>
-        <NewsOverlay href={`https://github.com/yarnpkg/berry`} />
+        <NewsOverlay />
         <NewsInner>
-          <Highlight>Important:</Highlight> This documentation covers Yarn 2. For the 1.x doc, check <a href={`https://classic.yarnpkg.com`}>classic.yarnpkg.com</a>.
+          <Highlight>Important:</Highlight> This documentation covers <a href={`https://github.com/yarnpkg/berry`}>Yarn 2</a>. For 1.x docs, see <a href={`https://classic.yarnpkg.com`}>classic.yarnpkg.com</a>.
         </NewsInner>
       </NewsContainer>
 

--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -289,9 +289,9 @@ export const Header = ({children}) => {
   return <>
     <HeaderContainer>
       <NewsContainer>
-        <NewsOverlay />
+        <NewsOverlay href={`https://classic.yarnpkg.com`}/>
         <NewsInner>
-          <Highlight>Important:</Highlight> This documentation covers <a href={`https://github.com/yarnpkg/berry`}>Yarn 2</a>. For 1.x docs, see <a href={`https://classic.yarnpkg.com`}>classic.yarnpkg.com</a>.
+          <Highlight>Important:</Highlight> This documentation covers Yarn 2. For 1.x docs, see classic.yarnpkg.com.
         </NewsInner>
       </NewsContainer>
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When I hover over the banner that says,
     "For the 1.x doc", I get a hyperlink, and so I clicked that
     expecting to be taken to v1 documentation.

Unfortunately that part of the sentence is linked to the berry
repository. When I arrived there, I assumed that I just needed to switch
to a v1.x branch or tag, but no such things exist on that repository.

After bouncing around a bit more, the second time I clicked on the
correct portion of the banner and was taken to production documentation.


**How did you fix it?**

I removed the banner-wide hyperlink to this repository homepage and replaced it with one ~on the phrase "Yarn 2."~ for the classic docs. This way, ~people that want to get to that code can, but~ people just trying to get to the production documentation won't be lead further astray.

I'm hoping that this change can help others avoid my confusion.
