### PR TITLE
Fixes exec: protocol resolution

### DIFF
--- a/.yarn/versions/cd3456dd.yml
+++ b/.yarn/versions/cd3456dd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-exec": prerelease

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -113,6 +113,7 @@ export class ExecFetcher implements Fetcher {
           buildDir: npath.fromPortablePath(buildDir),
           locator: structUtils.stringifyLocator(locator),
         };
+
         await xfs.writeFilePromise(envFile, `
           // Expose 'Module' as a global variable
           Object.defineProperty(global, 'Module', {
@@ -136,10 +137,12 @@ export class ExecFetcher implements Fetcher {
             enumerable: true,
           });
         `);
+
         const envRequire = `--require ${npath.fromPortablePath(envFile)}`;
-        let NODE_OPTIONS = env.NODE_OPTIONS || ``;
-        NODE_OPTIONS = NODE_OPTIONS ? `${NODE_OPTIONS} ${envRequire}` : envRequire;
-        env.NODE_OPTIONS = NODE_OPTIONS;
+
+        env.NODE_OPTIONS = env.NODE_OPTIONS
+          ? `${env.NODE_OPTIONS} ${envRequire}`
+          : envRequire;
 
         stdout.write(`# This file contains the result of Yarn generating a package (${structUtils.stringifyLocator(locator)})\n`);
         stdout.write(`\n`);

--- a/packages/plugin-exec/sources/execUtils.ts
+++ b/packages/plugin-exec/sources/execUtils.ts
@@ -58,7 +58,8 @@ export async function loadGeneratorFile(range: string, protocol: string, opts: F
     parentFetch.releaseFs();
 
   const generatorFs = effectiveParentFetch.packageFs;
+  const generatorPath = ppath.resolve(effectiveParentFetch.prefixPath, path);
 
-  return await generatorFs.readFilePromise(path, `utf8`);
+  return await generatorFs.readFilePromise(generatorPath, `utf8`);
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The path wasn't being resolved relative to the localPath, so the `exec:` protocol used by workspaces was causing the file from being loaded relative to the cwd - likely the project root.

**How did you fix it?**

We now properly resolve the path, similar to what we do in the FileFetcher.
