### PR TITLE
Resolves plugins relative to the repo root

### DIFF
--- a/.yarn/versions/8e604a7d.yml
+++ b/.yarn/versions/8e604a7d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/builder": prerelease
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -3,6 +3,7 @@ import {Configuration, MessageName, StreamReport, execUtils} from '@yarnpkg/core
 import {Filename, PortablePath, npath, ppath, xfs}           from '@yarnpkg/fslib';
 import {Command, Usage}                                      from 'clipanion';
 import {tmpdir}                                              from 'os';
+import path                                                  from 'path';
 
 import {setVersion}                                          from '../version';
 
@@ -29,8 +30,8 @@ const UPDATE_WORKFLOW = ({branch}: {branch: string}) => [
   [`git`, `clean`, `-dfx`],
 ];
 
-const BUILD_WORKFLOW = ({plugins, noMinify}: {noMinify: boolean, plugins: Array<string>}) => [
-  [`yarn`, `build:cli`, ...new Array<string>().concat(...plugins.map(plugin => [`--plugin`, plugin])), ...noMinify ? [`--no-minify`] : [], `|`],
+const BUILD_WORKFLOW = ({plugins, noMinify}: {noMinify: boolean, plugins: Array<string>}, target: PortablePath) => [
+  [`yarn`, `build:cli`, ...new Array<string>().concat(...plugins.map(plugin => [`--plugin`, path.resolve(target, plugin)])), ...noMinify ? [`--no-minify`] : [], `|`],
 ];
 
 // eslint-disable-next-line arca/no-default-export
@@ -135,7 +136,7 @@ export default class SetVersionCommand extends BaseCommand {
       report.reportInfo(MessageName.UNNAMED, `Building a fresh bundle`);
       report.reportSeparator();
 
-      await runWorkflow(BUILD_WORKFLOW(this));
+      await runWorkflow(BUILD_WORKFLOW(this, target));
 
       report.reportSeparator();
 

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -48,7 +48,7 @@ export default class BuildBundleCommand extends Command {
   @Command.Path(`build`, `bundle`)
   async execute() {
     const basedir = process.cwd();
-    const plugins = findPlugins({basedir, profile: this.profile, plugins: this.plugins});
+    const plugins = findPlugins({basedir, profile: this.profile, plugins: this.plugins.map(plugin => path.resolve(plugin))});
     const modules = [...getDynamicLibs().keys()].concat(plugins);
     const output = `${basedir}/bundles/yarn.js`;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's difficult to use the `--plugin` option from `set version from sources`, because the plugin paths are relative to the `sources/tools` directory - which doesn't really makes sense.

**How did you fix it?**

- `yarn build:cli --plugin <path>` will be relative to `yarnpkg-cli`
- `yarn set version from sources --plugin <path>` will be relative to the repository root
