### PR TITLE
feat(compat): add cordova support

### DIFF
--- a/.github/workflows/e2e-cordova-workflow.yml
+++ b/.github/workflows/e2e-cordova-workflow.yml
@@ -1,0 +1,54 @@
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/workflows/e2e-cordova-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Cordova'
+jobs:
+  chore:
+    name: 'Validating Cordova'
+    runs-on: ubuntu-latest
+
+    env:
+      YARN_PNP_MODE: 'loose'
+      YARN_PNP_FALLBACK_MODE: 'all'
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: 'Use Node.js 10.x'
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.x
+
+    - name: 'Build the standard bundle'
+      run: |
+        node ./scripts/run-yarn.js build:cli
+
+    - name: 'Running the integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        yarn init
+
+        # Required setup
+        yarn add cordova
+        mkdir www
+        echo '<?xml version="1.0" encoding="UTF-8"?><widget id="com.example.app" version="1.0.0"><name>AppName</name></widget>' | tee config.xml
+
+        # Tests npm view and npm install
+        yarn cordova platform add android
+        yarn cordova plugin add cordova-plugin-code-push
+
+        # Tests npm remove
+        yarn cordova plugin remove cordova-plugin-code-push
+        yarn cordova platform remove android
+
+        # Check npm didn't run
+        ls
+        ! test -e package-lock.json

--- a/.pnp.js
+++ b/.pnp.js
@@ -218,7 +218,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@yarnpkg/plugin-npm", ["virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-npm", "workspace:packages/plugin-npm"]],
       ["@yarnpkg/plugin-npm-cli", ["virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-npm-cli", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-npm-cli", "workspace:packages/plugin-npm-cli"]],
       ["@yarnpkg/plugin-pack", ["virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pack", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-pack", "workspace:packages/plugin-pack"]],
-      ["@yarnpkg/plugin-patch", ["virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-patch", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/plugin-patch", "workspace:packages/plugin-patch"]],
+      ["@yarnpkg/plugin-patch", ["virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-patch", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-patch", "workspace:packages/plugin-patch"]],
       ["@yarnpkg/plugin-pnp", ["virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pnp", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-pnp", "workspace:packages/plugin-pnp"]],
       ["@yarnpkg/plugin-stage", ["virtual:6c4ffdc97c0a8fe6a15cb1b353664a2d1556c0bef782dc06790db015a35ca3cd125eaf355368c58a3aaf6330c79507c16275fc3a3c13a847d89839cdae6b509e#workspace:packages/plugin-stage", "virtual:9af797eaca9597d8ce3ab2f300dc3678fe1b6a7e9a9c8f1e28a40ffa76c2f3b3249454b171507aa93cb1cb92455654f3344ae77bd4a79f79fd0fbc16734faa67#workspace:packages/plugin-stage", "workspace:packages/plugin-stage"]],
       ["@yarnpkg/plugin-typescript", ["workspace:packages/plugin-typescript"]],
@@ -8086,7 +8086,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/plugin-npm", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-npm"],
             ["@yarnpkg/plugin-npm-cli", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-npm-cli"],
             ["@yarnpkg/plugin-pack", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pack"],
-            ["@yarnpkg/plugin-patch", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/plugin-patch"],
+            ["@yarnpkg/plugin-patch", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-patch"],
             ["@yarnpkg/plugin-pnp", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pnp"],
             ["@yarnpkg/pnpify", "virtual:16110bda3ce959c103b1979c5d750ceb8ac9cfbd2049c118b6278e46e65aa65fd17e71e04a0ce5f75b7ca3203efd8e9c9b03c948a76c7f4bca807539915b5cfc#workspace:packages/yarnpkg-pnpify"],
             ["@yarnpkg/shell", "workspace:packages/yarnpkg-shell"],
@@ -8408,8 +8408,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-compat-virtual-5fe64685a8/1/packages/plugin-compat/",
           "packageDependencies": [
             ["@yarnpkg/plugin-compat", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-compat"],
+            ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@yarnpkg/plugin-patch", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/plugin-patch"]
+            ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
+            ["@yarnpkg/plugin-patch", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-patch"],
+            ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
             "@yarnpkg/core",
@@ -8421,8 +8424,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-compat-virtual-f9d90af7d7/1/packages/plugin-compat/",
           "packageDependencies": [
             ["@yarnpkg/plugin-compat", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-compat"],
+            ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@yarnpkg/plugin-patch", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-patch"]
+            ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
+            ["@yarnpkg/plugin-patch", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-patch"],
+            ["clipanion", "npm:2.1.5"]
           ],
           "packagePeers": [
             "@yarnpkg/core",
@@ -8434,8 +8440,11 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/plugin-compat/",
           "packageDependencies": [
             ["@yarnpkg/plugin-compat", "workspace:packages/plugin-compat"],
+            ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@yarnpkg/plugin-patch", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/plugin-patch"]
+            ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
+            ["@yarnpkg/plugin-patch", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-patch"],
+            ["clipanion", "npm:2.1.5"]
           ],
           "linkType": "SOFT",
         }]
@@ -9029,6 +9038,23 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@yarnpkg/plugin-patch", [
+        ["virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-patch", {
+          "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-patch-virtual-8a5ab312c8/1/packages/plugin-patch/",
+          "packageDependencies": [
+            ["@yarnpkg/plugin-patch", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-patch"],
+            ["@types/left-pad", "npm:1.2.0"],
+            ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],
+            ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
+            ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
+            ["@yarnpkg/libzip", "workspace:packages/yarnpkg-libzip"],
+            ["clipanion", "npm:2.1.5"]
+          ],
+          "packagePeers": [
+            "@yarnpkg/cli",
+            "@yarnpkg/core"
+          ],
+          "linkType": "SOFT",
+        }],
         ["virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-patch", {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-patch-virtual-be81121af4/1/packages/plugin-patch/",
           "packageDependencies": [
@@ -9042,22 +9068,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],
           "packagePeers": [
             "@yarnpkg/cli",
-            "@yarnpkg/core"
-          ],
-          "linkType": "SOFT",
-        }],
-        ["virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/plugin-patch", {
-          "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-patch-virtual-b67eefea63/1/packages/plugin-patch/",
-          "packageDependencies": [
-            ["@yarnpkg/plugin-patch", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/plugin-patch"],
-            ["@types/left-pad", "npm:1.2.0"],
-            ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
-            ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
-            ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
-            ["@yarnpkg/libzip", "workspace:packages/yarnpkg-libzip"],
-            ["clipanion", "npm:2.1.5"]
-          ],
-          "packagePeers": [
             "@yarnpkg/core"
           ],
           "linkType": "SOFT",

--- a/.yarn/versions/6b85d4fe.yml
+++ b/.yarn/versions/6b85d4fe.yml
@@ -3,6 +3,7 @@ releases:
   "@yarnpkg/plugin-compat": prerelease
 
 declined:
+  - "@yarnpkg/eslint-config"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"

--- a/.yarn/versions/6b85d4fe.yml
+++ b/.yarn/versions/6b85d4fe.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/workspace.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/workspace.test.js
@@ -1,4 +1,3 @@
-
 const {fs: {writeJson}} = require(`pkg-tests-core`);
 
 describe(`Protocols`, () => {

--- a/packages/eslint-config/rules/style.js
+++ b/packages/eslint-config/rules/style.js
@@ -48,6 +48,8 @@ module.exports = {
 
     'comma-dangle': [`error`, `always-multiline`],
 
+    'comma-spacing': 2,
+
     'computed-property-spacing': 2,
 
     'generator-star-spacing': [`error`, {
@@ -65,7 +67,7 @@ module.exports = {
 
     'no-mixed-spaces-and-tabs': 2,
 
-    'no-multiple-empty-lines': 2,
+    'no-multiple-empty-lines': [2, {max: 2, maxBOF: 0}],
 
     'no-tabs': 2,
 

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -2,6 +2,11 @@
   "name": "@yarnpkg/plugin-compat",
   "version": "2.0.0-rc.12",
   "main": "./sources/index.ts",
+  "dependencies": {
+    "@yarnpkg/cli": "workspace:^2.0.0-rc.33",
+    "@yarnpkg/plugin-essentials": "workspace:^2.0.0-rc.27",
+    "clipanion": "^2.1.5"
+  },
   "peerDependencies": {
     "@yarnpkg/core": "^2.0.0-rc.27",
     "@yarnpkg/plugin-patch": "^2.0.0-rc.8"

--- a/packages/plugin-compat/sources/index.ts
+++ b/packages/plugin-compat/sources/index.ts
@@ -2,6 +2,7 @@ import {Hooks as CoreHooks, Plugin, structUtils} from '@yarnpkg/core';
 import {Hooks as PatchHooks}                     from '@yarnpkg/plugin-patch';
 
 import {packageExtensions}                       from './extensions';
+import {commands, hooks}                         from './npm-proxy';
 import {patch as fseventsPatch}                  from './patches/fsevents.patch';
 import {patch as resolvePatch}                   from './patches/resolve.patch';
 import {patch as typescriptPatch}                from './patches/typescript.patch';
@@ -43,7 +44,9 @@ const plugin: Plugin<CoreHooks & PatchHooks> = {
         params: null,
       }));
     },
+    ...hooks,
   },
+  commands: commands,
 };
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-compat/sources/index.ts
+++ b/packages/plugin-compat/sources/index.ts
@@ -46,7 +46,7 @@ const plugin: Plugin<CoreHooks & PatchHooks> = {
     },
     ...hooks,
   },
-  commands: commands,
+  commands,
 };
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-compat/sources/npm-proxy/commands/install.ts
+++ b/packages/plugin-compat/sources/npm-proxy/commands/install.ts
@@ -1,0 +1,35 @@
+import {BaseCommand}           from '@yarnpkg/cli';
+import {Command}               from 'clipanion';
+
+import {enableNpmCompatOutput} from "../index";
+
+export class InstallCommand extends BaseCommand {
+  @Command.Rest()
+  packages: Array<string> = [];
+
+  //#region Ignored
+  @Command.Boolean('--save')
+  save!: boolean;
+
+  @Command.Boolean('-P,--save-prod,--production')
+  production!: boolean;
+  //#endregion
+
+  @Command.Boolean('-D,--save-dev')
+  devDependency: boolean = false;
+
+  @Command.Boolean('-O,--save-optional')
+  optional: boolean = false;
+
+  @Command.Path(`npm`, `install`)
+  @Command.Path(`npm`, `i`)
+  async execute() {
+    enableNpmCompatOutput();
+
+    return this.cli.run([
+      'add',
+      ...this.packages,
+      ...[this.devDependency && '-D', this.optional && '-O'].filter((arg) => arg).join(' '),
+    ]);
+  }
+}

--- a/packages/plugin-compat/sources/npm-proxy/commands/install.ts
+++ b/packages/plugin-compat/sources/npm-proxy/commands/install.ts
@@ -8,17 +8,17 @@ export class InstallCommand extends BaseCommand {
   packages: Array<string> = [];
 
   //#region Ignored
-  @Command.Boolean('--save')
+  @Command.Boolean(`--save`)
   save!: boolean;
 
-  @Command.Boolean('-P,--save-prod,--production')
+  @Command.Boolean(`-P,--save-prod,--production`)
   production!: boolean;
   //#endregion
 
-  @Command.Boolean('-D,--save-dev')
+  @Command.Boolean(`-D,--save-dev`)
   devDependency: boolean = false;
 
-  @Command.Boolean('-O,--save-optional')
+  @Command.Boolean(`-O,--save-optional`)
   optional: boolean = false;
 
   @Command.Path(`npm`, `install`)
@@ -27,9 +27,9 @@ export class InstallCommand extends BaseCommand {
     enableNpmCompatOutput();
 
     return this.cli.run([
-      'add',
+      `add`,
       ...this.packages,
-      ...[this.devDependency && '-D', this.optional && '-O'].filter((arg) => arg).join(' '),
+      ...[this.devDependency && `-D`, this.optional && `-O`].filter(arg => arg).join(` `),
     ]);
   }
 }

--- a/packages/plugin-compat/sources/npm-proxy/commands/uninstall.ts
+++ b/packages/plugin-compat/sources/npm-proxy/commands/uninstall.ts
@@ -1,0 +1,16 @@
+import {BaseCommand} from '@yarnpkg/cli';
+import {Command}     from 'clipanion';
+
+export class UninstallCommand extends BaseCommand {
+  @Command.Rest()
+  packages: Array<string> = [];
+
+  // Ignored default
+  @Command.Boolean('--save')
+  save!: boolean;
+
+  @Command.Path(`npm`, `uninstall`)
+  execute() {
+    return this.cli.run(['remove', ...this.packages]);
+  }
+}

--- a/packages/plugin-compat/sources/npm-proxy/commands/uninstall.ts
+++ b/packages/plugin-compat/sources/npm-proxy/commands/uninstall.ts
@@ -6,11 +6,11 @@ export class UninstallCommand extends BaseCommand {
   packages: Array<string> = [];
 
   // Ignored default
-  @Command.Boolean('--save')
+  @Command.Boolean(`--save`)
   save!: boolean;
 
   @Command.Path(`npm`, `uninstall`)
   execute() {
-    return this.cli.run(['remove', ...this.packages]);
+    return this.cli.run([`remove`, ...this.packages]);
   }
 }

--- a/packages/plugin-compat/sources/npm-proxy/commands/view.ts
+++ b/packages/plugin-compat/sources/npm-proxy/commands/view.ts
@@ -2,7 +2,7 @@ import {BaseCommand} from '@yarnpkg/cli';
 import {Command}     from 'clipanion';
 
 export class ViewCommand extends BaseCommand {
-  @Command.Boolean('--json')
+  @Command.Boolean(`--json`)
   json!: boolean;
 
   @Command.String()
@@ -10,6 +10,6 @@ export class ViewCommand extends BaseCommand {
 
   @Command.Path(`npm`, `view`)
   execute() {
-    return this.cli.run(['npm', 'info', this.package, this.json && '--json'].filter((x) => x) as string[]);
+    return this.cli.run([`npm`, `info`, this.package, this.json && `--json`].filter(x => x) as Array<string>);
   }
 }

--- a/packages/plugin-compat/sources/npm-proxy/commands/view.ts
+++ b/packages/plugin-compat/sources/npm-proxy/commands/view.ts
@@ -1,0 +1,15 @@
+import {BaseCommand} from '@yarnpkg/cli';
+import {Command}     from 'clipanion';
+
+export class ViewCommand extends BaseCommand {
+  @Command.Boolean('--json')
+  json!: boolean;
+
+  @Command.String()
+  package!: string;
+
+  @Command.Path(`npm`, `view`)
+  execute() {
+    return this.cli.run(['npm', 'info', this.package, this.json && '--json'].filter((x) => x) as string[]);
+  }
+}

--- a/packages/plugin-compat/sources/npm-proxy/index.ts
+++ b/packages/plugin-compat/sources/npm-proxy/index.ts
@@ -1,4 +1,3 @@
-
 import {Hooks as CoreHooks, Descriptor, Workspace} from '@yarnpkg/core';
 import {Hooks as EssentialsHooks}                  from '@yarnpkg/plugin-essentials';
 

--- a/packages/plugin-compat/sources/npm-proxy/index.ts
+++ b/packages/plugin-compat/sources/npm-proxy/index.ts
@@ -15,7 +15,7 @@ export function enableNpmCompatOutput() {
 
 export const hooks: EssentialsHooks & CoreHooks = {
   async setupScriptEnvironment(project, env, makePathWrapper) {
-    await makePathWrapper(`npm`, process.execPath, [process.argv[1], 'npm']);
+    await makePathWrapper(`npm`, process.execPath, [process.argv[1], `npm`]);
   },
   async afterWorkspaceDependencyAddition(workspace, target, descriptor) {
     installedDependencies.push([workspace, descriptor]);
@@ -25,7 +25,7 @@ export const hooks: EssentialsHooks & CoreHooks = {
   },
   async afterAllInstalled(project) {
     if (installedDependencies.length && emitNpmCompatOutput) {
-      console.log('NPM compat output:');
+      console.log(`NPM compat output:`);
       for (const [workspace, ident] of installedDependencies) {
         const descriptor = workspace.dependencies.get(ident.identHash)!;
         const resolution = project.storedResolutions.get(descriptor.descriptorHash)!;

--- a/packages/plugin-compat/sources/npm-proxy/index.ts
+++ b/packages/plugin-compat/sources/npm-proxy/index.ts
@@ -1,0 +1,40 @@
+
+import {Hooks as CoreHooks, Descriptor, Workspace} from '@yarnpkg/core';
+import {Hooks as EssentialsHooks}                  from '@yarnpkg/plugin-essentials';
+
+import {InstallCommand}                            from './commands/install';
+import {UninstallCommand}                          from './commands/uninstall';
+import {ViewCommand}                               from './commands/view';
+
+
+const installedDependencies: Array<[Workspace, Descriptor]> = [];
+
+let emitNpmCompatOutput = false;
+export function enableNpmCompatOutput() {
+  emitNpmCompatOutput = true;
+}
+
+export const hooks: EssentialsHooks & CoreHooks = {
+  async setupScriptEnvironment(project, env, makePathWrapper) {
+    await makePathWrapper(`npm`, process.execPath, [process.argv[1], 'npm']);
+  },
+  async afterWorkspaceDependencyAddition(workspace, target, descriptor) {
+    installedDependencies.push([workspace, descriptor]);
+  },
+  async afterWorkspaceDependencyReplacement(workspace, target, from, to) {
+    installedDependencies.push([workspace, to]);
+  },
+  async afterAllInstalled(project) {
+    if (installedDependencies.length && emitNpmCompatOutput) {
+      console.log('NPM compat output:');
+      for (const [workspace, ident] of installedDependencies) {
+        const descriptor = workspace.dependencies.get(ident.identHash)!;
+        const resolution = project.storedResolutions.get(descriptor.descriptorHash)!;
+        const pkg = project.storedPackages.get(resolution)!;
+        console.log(`+ ${pkg.name}@${pkg.version}`);
+      }
+    }
+  },
+};
+
+export const commands = [InstallCommand, ViewCommand, UninstallCommand];

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -116,7 +116,7 @@ function getAuthenticationHeader(registry: string, {authType = AuthType.CONFIGUR
     return `Basic ${effectiveConfiguration.get(`npmAuthIdent`)}`;
 
   if (mustAuthenticate && authType !== AuthType.BEST_EFFORT) {
-    throw new ReportError(MessageName.AUTHENTICATION_NOT_FOUND ,`No authentication configured for request`);
+    throw new ReportError(MessageName.AUTHENTICATION_NOT_FOUND, `No authentication configured for request`);
   } else {
     return null;
   }

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -103,7 +103,7 @@ function checkForUnsafeWebpackLoaderAccess(workspace: Workspace, initializerNode
   report.reportWarning(MessageName.UNNAMED, `${prettyLocation}: Webpack configs from non-private packages should avoid referencing loaders without require.resolve`);
 }
 
-function checkForNodeModuleStrings(stringishNode: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral | ts.TemplateExpression , {configuration, report}: {configuration: Configuration, report: Report}) {
+function checkForNodeModuleStrings(stringishNode: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral | ts.TemplateExpression, {configuration, report}: {configuration: Configuration, report: Report}) {
   const match = /node_modules(?!(\\{2}|\/)\.cache)/g.test(stringishNode.getText());
   if (match) {
     const prettyLocation = ast.prettyNodeLocation(configuration, stringishNode);

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -1,15 +1,15 @@
-import {Dirent, Filename, MkdirOptions,ExtractHintOptions} from '@yarnpkg/fslib';
-import {FSPath, NativePath, PortablePath, npath, ppath}    from '@yarnpkg/fslib';
-import {WatchOptions, WatchCallback, Watcher, toFilename}  from '@yarnpkg/fslib';
-import {NodeFS, FakeFS, WriteFileOptions, ProxiedFS}       from '@yarnpkg/fslib';
-import {CreateReadStreamOptions, CreateWriteStreamOptions} from '@yarnpkg/fslib';
-import {PnpApi}                                            from '@yarnpkg/pnp';
-import fs                                                  from 'fs';
+import {Dirent, Filename, MkdirOptions, ExtractHintOptions} from '@yarnpkg/fslib';
+import {FSPath, NativePath, PortablePath, npath, ppath}     from '@yarnpkg/fslib';
+import {WatchOptions, WatchCallback, Watcher, toFilename}   from '@yarnpkg/fslib';
+import {NodeFS, FakeFS, WriteFileOptions, ProxiedFS}        from '@yarnpkg/fslib';
+import {CreateReadStreamOptions, CreateWriteStreamOptions}  from '@yarnpkg/fslib';
+import {PnpApi}                                             from '@yarnpkg/pnp';
+import fs                                                   from 'fs';
 
-import {WatchManager}                                      from './WatchManager';
-import {NodeModulesTreeOptions, NodeModulesTree}           from './buildNodeModulesTree';
-import {buildNodeModulesTree}                              from './buildNodeModulesTree';
-import {resolveNodeModulesPath, ResolvedPath}              from './resolveNodeModulesPath';
+import {WatchManager}                                       from './WatchManager';
+import {NodeModulesTreeOptions, NodeModulesTree}            from './buildNodeModulesTree';
+import {buildNodeModulesTree}                               from './buildNodeModulesTree';
+import {resolveNodeModulesPath, ResolvedPath}               from './resolveNodeModulesPath';
 
 export type NodeModulesFSOptions = {
   realFs?: typeof fs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6328,8 +6328,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-compat@workspace:packages/plugin-compat"
   dependencies:
+    "@yarnpkg/cli": "workspace:^2.0.0-rc.33"
     "@yarnpkg/core": "workspace:^2.0.0-rc.27"
+    "@yarnpkg/plugin-essentials": "workspace:^2.0.0-rc.27"
     "@yarnpkg/plugin-patch": "workspace:^2.0.0-rc.8"
+    clipanion: ^2.1.5
   peerDependencies:
     "@yarnpkg/core": ^2.0.0-rc.27
     "@yarnpkg/plugin-patch": ^2.0.0-rc.8


### PR DESCRIPTION
**What's the problem this PR addresses?**

Cordova is currently hardcoded to run npm commands which makes using cordova with yarn a bit problematic. Getting them to detect which package manager to use has proven to not be happening any time soon. See https://github.com/apache/cordova-fetch/issues/46 and https://github.com/apache/cordova-cli/pull/292#issuecomment-401331607

**How did you fix it?**

Implement a proxy that translates the required npm commands to yarn commands