### PR TITLE
docs(gatsby): add CLI comparison table to migration

### DIFF
--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -37,28 +37,6 @@ Run `npx @yarnpkg/doctor .` (or `yarn dlx @yarnpkg/doctor .`) in your project to
 
 Note that the doctor is intended to report any potential issue - it's then up to you to decide whether they are a false positive or not (for example it won't traverse Git repositories). For this reason we don't recommend using it as a CI tool.
 
-### Changes in CLI commands
-
-| v1              | v2 substitute              | Notes                         |
-| --------------- | -------------------------- | ----------------------------- |
-| `yarn audit`    | -                          | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
-| `yarn check`    | -                          | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106) |
-| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` will still work as an alias. For new packages, please use the new command instead. [Read more on GitHub](https://github.com/yarnpkg/berry/pull/1138) |
-| `yarn global`   | `yarn dlx`                 | [Read more](#use-yarn-dlx-instead-of-yarn-global) |
-| `yarn import`   | -                          | Not implemented, please import using v1 first |
-| `yarn info`     | `yarn npm info`            ||
-| `yarn licenses` | -                          | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1164) |
-| `yarn list`     | -                          | Not implemented |
-| `yarn login`    | `yarn npm login`           ||
-| `yarn logout`   | -                          | Not implemented, remove the credential from `.yarnrc.yml` instead |
-| `yarn outdated` | `yarn upgrade-interactive` | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749) |
-| `yarn owner`    | -                          | Not implemented |
-| `yarn publish`  | `yarn npm publish`         ||
-| `yarn tag`      | -                          | Not implemented |
-| `yarn team`     | -                          | Not implemented |
-| `yarn unlink`   | -                          | Not implemented, change `resolutions` field in the project-level manifest instead |
-| `yarn upgrade`  | `yarn up`                  | Change in behavior - upgrade across the whole project, not just current workspace |
-
 ### Use `yarn dlx` instead of `yarn global`
 
 `yarn dlx` is designed to execute one off scripts that may have been installed as global packages with `yarn 1.x`. Managing system-wide packages is outside of the scope of `yarn`. To reflect this, `yarn global` has been removed. [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821).
@@ -165,6 +143,47 @@ nodeLinker: node-modules
 This will cause Yarn to install the project just like Yarn 1 used to, by copying the packages into various `node_modules` folders.
 
 [More information about the `nodeLinker` option.](/configuration/yarnrc#nodeLinker)
+
+## CLI Commands
+
+### Renamed
+
+| <div style="width:150px">Yarn Classic (1.x)</div> | <div style="width: 250px">Yarn (2.x)</div> | Notes |
+| ------------------ | -------------------------- | ----------------------------- |
+| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` still work, but prefer using `yarn dlx` |
+| `yarn global`   | `yarn dlx`                 | [Dedicated section](#use-yarn-dlx-instead-of-yarn-global) |
+| `yarn info`     | `yarn npm info`            ||
+| `yarn login`    | `yarn npm login`           ||
+| `yarn outdated` | `yarn upgrade-interactive` | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749) |
+| `yarn publish`  | `yarn npm publish`         ||
+| `yarn upgrade`  | `yarn up`                  | Will now upgrade packages across all workspaces |
+
+### Deprecated
+
+| <div style="width:150px">Yarn Classic (1.x)</div> | Notes |
+| ------------------ | ----------------------------- |
+| `yarn check`    | Cache integrity is now checked on regular installs; [read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106) |
+
+### Removed from core
+
+| <div style="width:150px">Yarn Classic (1.x)</div> | Notes |
+| ------------------ | ----------------------------- |
+| `yarn audit`    | Relied on an undocumented proprietary protocol; [read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
+| `yarn import`   | First import to Classic, then migrate to 2.x |
+| `yarn licenses` | Perfect use case for plugins; [read more on GitHub](https://github.com/yarnpkg/berry/issues/1164) |
+
+### Not implemented yet
+
+Those features simply haven't been implemented yet. Help welcome!
+
+| <div style="width:150px">Yarn Classic (1.x)</div> | Notes |
+| ------------------ | ----------------------------- |
+| `yarn list`     | `yarn why` may provide some information in the meantime |
+| `yarn logout`   | Manually remove the tokens from the `.yarnrc.yml` in the meantime |
+| `yarn owner`    | Will eventually be available as `yarn npm owner` |
+| `yarn tag`      | Will eventually be available as `yarn npm tag` |
+| `yarn team`     | Will eventually be available as `yarn npm team` |
+| `yarn unlink`   | Manually remove the `resolutions` entries from the `package.json` file for now |
 
 ## Troubleshooting
 

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -39,25 +39,24 @@ Note that the doctor is intended to report any potential issue - it's then up to
 
 ### Changes in CLI commands
 
-| v1              | v2 substitute                | Notes                                                               |
-| --------------- | ---------------------------- | ------------------------------------------------------------------- |
-| `yarn audit`    | -                            | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
-| `yarn check`    | `yarn install --check-files` | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106)     |
-| `yarn create`   | -                            | Not implemented                                                     |
-| `yarn global`   | `yarn dlx`                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821)  |
-| `yarn import`   | -                            | Not implemented                                                     |
-| `yarn info`     | `yarn npm info`              |                                                                     |
-| `yarn licenses` | -                            | Not implemented                                                     |
-| `yarn list`     | -                            | Not implemented                                                     |
-| `yarn login`    | `yarn npm login`             |                                                                     |
-| `yarn logout`   | -                            | Not implemented                                                     |
-| `yarn outdated` | `yarn upgrade-interactive`   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749)  |
-| `yarn owner`    | -                            | Not implemented                                                     |
-| `yarn publish`  | `yarn npm publish`           |                                                                     |
-| `yarn tag`      | -                            | Not implemented                                                     |
-| `yarn team`     | -                            | Not implemented                                                     |
-| `yarn unlink`   | -                            | Change `resolutions` field in the project-level manifest instead    |
-| `yarn upgrade`  | `yarn up`                    |                                                                     |
+| v1              | v2 substitute                                | Notes                                                               |
+| --------------- | -------------------------------------------- | ------------------------------------------------------------------- |
+| `yarn audit`    | -                                            | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
+| `yarn check`    | `yarn install --immutable --immutable-cache` | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106)     |
+| `yarn global`   | `yarn dlx`                                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821)  |
+| `yarn import`   | -                                            | Not implemented, please import using v1 first                       |
+| `yarn info`     | `yarn npm info`                              |                                                                     |
+| `yarn licenses` | -                                            | Not implemented                                                     |
+| `yarn list`     | -                                            | Not implemented                                                     |
+| `yarn login`    | `yarn npm login`                             |                                                                     |
+| `yarn logout`   | -                                            | Not implemented, remove the credential from `.yarnrc.yml` instead   |
+| `yarn outdated` | `yarn upgrade-interactive`                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749)  |
+| `yarn owner`    | -                                            | Not implemented                                                     |
+| `yarn publish`  | `yarn npm publish`                           |                                                                     |
+| `yarn tag`      | -                                            | Not implemented                                                     |
+| `yarn team`     | -                                            | Not implemented                                                     |
+| `yarn unlink`   | -                                            | Change `resolutions` field in the project-level manifest instead    |
+| `yarn upgrade`  | `yarn up`                                    | Upgrade across the whole project, not just current workspace        |
 
 ### Enable the PnP plugin when using Webpack 4
 

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -37,9 +37,27 @@ Run `npx @yarnpkg/doctor .` (or `yarn dlx @yarnpkg/doctor .`) in your project to
 
 Note that the doctor is intended to report any potential issue - it's then up to you to decide whether they are a false positive or not (for example it won't traverse Git repositories). For this reason we don't recommend using it as a CI tool.
 
-### Use `yarn dlx` instead of `yarn global`
+### Changes in CLI commands
 
-`yarn dlx` is designed to execute one off scripts that may have been installed as global packages with `yarn 1.x`. Managing system-wide packages is outside of the scope of `yarn`. To reflect this, `yarn global` has been removed. [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821).
+| v1              | v2 substitute                | Notes                                                               |
+| --------------- | ---------------------------- | ------------------------------------------------------------------- |
+| `yarn audit`    | -                            | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
+| `yarn check`    | `yarn install --check-files` | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106)     |
+| `yarn create`   | -                            | Not implemented                                                     |
+| `yarn global`   | `yarn dlx`                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821)  |
+| `yarn import`   | -                            | Not implemented                                                     |
+| `yarn info`     | `yarn npm info`              |                                                                     |
+| `yarn licenses` | -                            | Not implemented                                                     |
+| `yarn list`     | -                            | Not implemented                                                     |
+| `yarn login`    | `yarn npm login`             |                                                                     |
+| `yarn logout`   | -                            | Not implemented                                                     |
+| `yarn outdated` | `yarn upgrade-interactive`   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749)  |
+| `yarn owner`    | -                            | Not implemented                                                     |
+| `yarn publish`  | `yarn npm publish`           |                                                                     |
+| `yarn tag`      | -                            | Not implemented                                                     |
+| `yarn team`     | -                            | Not implemented                                                     |
+| `yarn unlink`   | -                            | Change `resolutions` field in the project-level manifest instead    |
+| `yarn upgrade`  | `yarn up`                    |                                                                     |
 
 ### Enable the PnP plugin when using Webpack 4
 

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -43,7 +43,7 @@ Note that the doctor is intended to report any potential issue - it's then up to
 | --------------- | -------------------------- | ----------------------------- |
 | `yarn audit`    | -                          | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
 | `yarn check`    | -                          | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106) |
-| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` will still work as an alias, for new packages, use the new command instead. [Read more on GitHub](https://github.com/yarnpkg/berry/pull/1138) |
+| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` will still work as an alias. For new packages, please use the new command instead. [Read more on GitHub](https://github.com/yarnpkg/berry/pull/1138) |
 | `yarn global`   | `yarn dlx`                 | [Read more](#use-yarn-dlx-instead-of-yarn-global) |
 | `yarn import`   | -                          | Not implemented, please import using v1 first |
 | `yarn info`     | `yarn npm info`            ||

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -39,24 +39,29 @@ Note that the doctor is intended to report any potential issue - it's then up to
 
 ### Changes in CLI commands
 
-| v1              | v2 substitute                                | Notes                                                               |
-| --------------- | -------------------------------------------- | ------------------------------------------------------------------- |
-| `yarn audit`    | -                                            | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
-| `yarn check`    | `yarn install --immutable --immutable-cache` | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106)     |
-| `yarn global`   | `yarn dlx`                                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821)  |
-| `yarn import`   | -                                            | Not implemented, please import using v1 first                       |
-| `yarn info`     | `yarn npm info`                              |                                                                     |
-| `yarn licenses` | -                                            | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1164) |
-| `yarn list`     | -                                            | Not implemented                                                     |
-| `yarn login`    | `yarn npm login`                             |                                                                     |
-| `yarn logout`   | -                                            | Not implemented, remove the credential from `.yarnrc.yml` instead   |
-| `yarn outdated` | `yarn upgrade-interactive`                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749)  |
-| `yarn owner`    | -                                            | Not implemented                                                     |
-| `yarn publish`  | `yarn npm publish`                           |                                                                     |
-| `yarn tag`      | -                                            | Not implemented                                                     |
-| `yarn team`     | -                                            | Not implemented                                                     |
-| `yarn unlink`   | -                                            | Change `resolutions` field in the project-level manifest instead    |
-| `yarn upgrade`  | `yarn up`                                    | Upgrade across the whole project, not just current workspace        |
+| v1              | v2 substitute              | Notes                         |
+| --------------- | -------------------------- | ----------------------------- |
+| `yarn audit`    | -                          | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1187) |
+| `yarn check`    | -                          | [Read more on GitHub](https://github.com/yarnpkg/rfcs/pull/106) |
+| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` will still work as an alias, for new packages, use the new command instead. [Read more on GitHub](https://github.com/yarnpkg/berry/pull/1138) |
+| `yarn global`   | `yarn dlx`                 | [Read more](#use-yarn-dlx-instead-of-yarn-global) |
+| `yarn import`   | -                          | Not implemented, please import using v1 first |
+| `yarn info`     | `yarn npm info`            ||
+| `yarn licenses` | -                          | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1164) |
+| `yarn list`     | -                          | Not implemented |
+| `yarn login`    | `yarn npm login`           ||
+| `yarn logout`   | -                          | Not implemented, remove the credential from `.yarnrc.yml` instead |
+| `yarn outdated` | `yarn upgrade-interactive` | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749) |
+| `yarn owner`    | -                          | Not implemented |
+| `yarn publish`  | `yarn npm publish`         ||
+| `yarn tag`      | -                          | Not implemented |
+| `yarn team`     | -                          | Not implemented |
+| `yarn unlink`   | -                          | Not implemented, change `resolutions` field in the project-level manifest instead |
+| `yarn upgrade`  | `yarn up`                  | Change in behavior - upgrade across the whole project, not just current workspace |
+
+### Use `yarn dlx` instead of `yarn global`
+
+`yarn dlx` is designed to execute one off scripts that may have been installed as global packages with `yarn 1.x`. Managing system-wide packages is outside of the scope of `yarn`. To reflect this, `yarn global` has been removed. [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821).
 
 ### Enable the PnP plugin when using Webpack 4
 

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -150,7 +150,7 @@ This will cause Yarn to install the project just like Yarn 1 used to, by copying
 
 | <div style="width:150px">Yarn Classic (1.x)</div> | <div style="width: 250px">Yarn (2.x)</div> | Notes |
 | ------------------ | -------------------------- | ----------------------------- |
-| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` still work, but prefer using `yarn dlx` |
+| `yarn create`   | `yarn dlx create-<name>`   | `yarn create` still works, but prefer using `yarn dlx` |
 | `yarn global`   | `yarn dlx`                 | [Dedicated section](#use-yarn-dlx-instead-of-yarn-global) |
 | `yarn info`     | `yarn npm info`            ||
 | `yarn login`    | `yarn npm login`           ||

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -46,7 +46,7 @@ Note that the doctor is intended to report any potential issue - it's then up to
 | `yarn global`   | `yarn dlx`                                   | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/821)  |
 | `yarn import`   | -                                            | Not implemented, please import using v1 first                       |
 | `yarn info`     | `yarn npm info`                              |                                                                     |
-| `yarn licenses` | -                                            | Not implemented                                                     |
+| `yarn licenses` | -                                            | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/1164) |
 | `yarn list`     | -                                            | Not implemented                                                     |
 | `yarn login`    | `yarn npm login`                             |                                                                     |
 | `yarn logout`   | -                                            | Not implemented, remove the credential from `.yarnrc.yml` instead   |

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -74,28 +74,43 @@ The following compatibility table gives you an idea of the integration status wi
 
 **[Suggest an addition to this table](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugnplay.md)**
 
-| Project name                    | Status          | Note                                                                                                                                                                                                                                                                                                |
-| ------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Babel                           | Native          | Starting from `resolve` 1.9+                                                                                                                                                                                                                                                                        |
-| Create-React-App                | Native          | Starting from 2.0+                                                                                                                                                                                                                                                                                  |
-| ESLint                          | Native          | Some compatibility issues w/ shared configs                                                                                                                                                                                                                                                         |
-| Gatsby                          | Native          | No comment                                                                                                                                                                                                                                                                                          |
-| Husky                           | Native          | Starting from 4.0.0-1+                                                                                                                                                                                                                                                                              |
-| Jest                            | Native          | Starting from 24.1+                                                                                                                                                                                                                                                                                 |
-| Prettier                        | Native          | Starting from 1.17+                                                                                                                                                                                                                                                                                 |
-| Rollup                          | Native          | Starting from `resolve` 1.9+                                                                                                                                                                                                                                                                        |
-| TypeScript-ESLint               | Native          | Starting from 2.12+                                                                                                                                                                                                                                                                                 |
-| WebStorm                        | Native          | Starting from 2019.3+; See [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks)                                                                                                                                                                                                                  |
-| TypeScript                      | Transparent     | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by default)                                                                                                                                                                                     |
-| VSCode-ESLint                   | Plugin          | Follow [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks)                                                                                                                                                                                                                                      |
-| VSCode                          | Plugin          | Follow [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks)                                                                                                                                                                                                                                      |
-| Webpack                         | Plugin / Native | Via [`pnp-webpack-plugin`](https://github.com/arcanis/pnp-webpack-plugin), will be native starting from 5+                                                                                                                                                                                          |
-| Flow                            | Incompatible    | Follow [yarnpkg/berry#634](https://github.com/yarnpkg/berry/issues/634)                                                                                                                                                                                                                             |
-| React Native                    | Incompatible    | Follow [react-native-community/cli#27](https://github.com/react-native-community/cli/issues/27)                                                                                                                                                                                                     |
-| VSCode Extension Manager (vsce) | Incompatible    | Use the [vsce-yarn-patch](https://www.npmjs.com/package/vsce-yarn-patch) fork with the `node-modules` plugin enabled. The fork is required until [microsoft/vscode-vsce#379](https://github.com/microsoft/vscode-vsce/pull/379) is merged, as `vsce` currently uses the removed `yarn list` command |
+#### Native support
+
+A lot of very common frontend tools now support Plug'n'Play natively!
+
+| <div style="width:150px">Project name</div> | Note |
+| --- | --- |
+| Babel | Starting from `resolve` 1.9 |
+| Create-React-App | Starting from 2.0+ |
+| ESLint | Some compatibility issues w/ shared configs |
+| Gatsby | Starting from 2.15.0+ |
+| Husky | Starting from 4.0.0-1+ |
+| Jest | Starting from 24.1+ |
+| Next.js | Starting from 9.1.2+ |
+| Prettier | Starting from 1.17+ |
+| Rollup | Starting from `resolve` 1.9+ |
+| TypeScript-ESLint | Starting from 2.12+ |
+| WebStorm | Starting from 2019.3+; See [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
+| TypeScript | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by | Webpack | Native | Starting from 5+ ([plugin](https://github.com/arcanis/pnp-webpack-plugin) available for 4.x) |
+
+#### Support via plugins
+
+| <div style="width:150px">Project name</div> | Note |
+| --- | --- |
+| VSCode-ESLint | Follow [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
+| VSCode | Follow [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
+| Webpack 4.x | Via [`pnp-webpack-plugin`](https://github.com/arcanis/pnp-webpack-plugin) (native starting from 5+) |
+
+#### Incompatible
+
+The following tools unfortunately cannot be used with pure Plug'n'Play install (even under loose mode).
+
+**Important:** Even if a tool is incompatible with Plug'n'Play, you can still enable the [`node-modules` plugin](https://github.com/yarnpkg/berry/tree/master/packages/plugin-node-modules). Just follow the [instructions](/advanced/migration#if-required-enable-the-node-modules-plugin) and you'll be ready to go in a minute 🙂
+
+| <div style="width:150px">Project name</div> | Note |
+| --- | --- |
+| Flow | Follow [yarnpkg/berry#634](https://github.com/yarnpkg/berry/issues/634) |
+| React Native | Follow [react-native-community/cli#27](https://github.com/react-native-community/cli/issues/27) |
+| VSCode Extension Manager (vsce) | Use the [vsce-yarn-patch](https://www.npmjs.com/package/vsce-yarn-patch) fork with the `node-modules` plugin enabled. The fork is required until [microsoft/vscode-vsce#379](https://github.com/microsoft/vscode-vsce/pull/379) is merged, as `vsce` currently uses the removed `yarn list` command |
 
 This list is kept up-to-date based on the latest release we've published starting from the v2. In case you notice something off in your own project please try to upgrade Yarn and the problematic package first, then feel free to file an issue. And maybe a PR? 😊
-
----
-
-**Important:** If a tool is incompatible with PnP, you can still enable the [`node-modules` plugin](https://github.com/yarnpkg/berry/tree/master/packages/plugin-node-modules). Just follow the [instructions](/advanced/migration#if-required-enable-the-node-modules-plugin) and you'll be ready to go in a minute 🙂

--- a/packages/gatsby/src/components/layout.css
+++ b/packages/gatsby/src/components/layout.css
@@ -32,3 +32,13 @@ hr {
   border: 0;
   border-top: 1px solid rgba(0,0,0,0.1);
 }
+
+th {
+  width: 0;
+
+  text-align: left;
+}
+
+th:last-child {
+  width: 100%;
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**

Discussion in #749, and the lack of documentation (overview) of changed CLI commands.

**How did you fix it?**

Add a full comparison table between v1 CLI commands and v2.