### PR TITLE
Keeps track of the Algolia element

### DIFF
--- a/packages/gatsby/gatsby-plugin-algolia-docsearch/gatsby-ssr.js
+++ b/packages/gatsby/gatsby-plugin-algolia-docsearch/gatsby-ssr.js
@@ -28,9 +28,13 @@ exports.onRenderBody = ({setHeadComponents, setPostBodyComponents}, {specs = []}
         type: `text/javascript`,
         dangerouslySetInnerHTML: {
           __html: `{
+            let docuSearchElem;
+
             const observer = new MutationObserver((mutations, instance) => {
-              const docuSearchElem = document.querySelector(${JSON.stringify(inputSelector)});
-              if (!docuSearchElem)
+              const previousElem = docuSearchElem;
+
+              docuSearchElem = document.querySelector(${JSON.stringify(inputSelector)});
+              if (!docuSearchElem || docuSearchElem === previousElem)
                 return;
 
               docsearch({
@@ -39,9 +43,6 @@ exports.onRenderBody = ({setHeadComponents, setPostBodyComponents}, {specs = []}
                 inputSelector: ${JSON.stringify(inputSelector)},
                 debug: ${JSON.stringify(debug)}
               });
-
-              // stop observing
-              instance.disconnect();
             });
 
             // start observing


### PR DESCRIPTION
**What's the problem this PR addresses?**

The Algolia context is trashed when moving from a page to another.

**How did you fix it?**

We just keep watching the dom, so that if the node disappears we can restart docsearch.

A better fix would be to use `useEffect`, but that comes with its own problems (DocSearch only accept a selector, so we couldn't just pass it the element reference).
