### PR TITLE
fix(core): fix empty scripts

### DIFF
--- a/.yarn/versions/9f2b588d.yml
+++ b/.yarn/versions/9f2b588d.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/9f2b588d.yml
+++ b/.yarn/versions/9f2b588d.yml
@@ -1,6 +1,7 @@
 releases:
   "@yarnpkg/cli": prerelease
   "@yarnpkg/core": prerelease
+  "@yarnpkg/eslint-config": minor
 
 declined:
   - "@yarnpkg/plugin-compat"
@@ -27,4 +28,7 @@ declined:
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/fslib"
+  - "@yarnpkg/libui"
   - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -247,6 +247,8 @@ export const startPackageServer = (): Promise<string> => {
 
       response.writeHead(200, {[`Content-Type`]: `application/json`});
       response.end(data);
+
+      return undefined;
     },
 
     async [RequestType.PackageTarball](parsedRequest, request, response) {
@@ -328,6 +330,8 @@ export const startPackageServer = (): Promise<string> => {
 
         return response.end(data);
       });
+
+      return undefined;
     },
     async [RequestType.Repository](parsedRequest, request, response) {
       staticServer(request as any, response as any, finalhandler(request, response));

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-empty-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-empty-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-empty-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-scripted-empty-1.0.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "no-deps-scripted-empty",
+  "version": "1.0.0",
+  "scripts": {
+      "preinstall": "",
+      "install": "",
+      "postinstall": ""
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -283,6 +283,13 @@ describe(`Scripts tests`, () => {
   );
 
   test(
+    `it should correctly run empty install scripts`,
+    makeTemporaryEnv({dependencies: {[`no-deps-scripted-empty`]: `1.0.0`}}, async ({path, run, source}) => {
+      await run(`install`);
+    }),
+  );
+
+  test(
     `it should correctly run scripts when project path has space inside`,
     makeTemporaryEnv({
       private: true,

--- a/packages/eslint-config/rules/best-practices.js
+++ b/packages/eslint-config/rules/best-practices.js
@@ -14,6 +14,8 @@ module.exports = {
 
     'arca/no-default-export': 2,
 
+    'consistent-return': 2,
+
     'dot-notation': 2,
 
     'no-async-promise-executor': 2,

--- a/packages/plugin-compat/sources/index.ts
+++ b/packages/plugin-compat/sources/index.ts
@@ -23,7 +23,7 @@ const plugin: Plugin<CoreHooks & PatchHooks> = {
     getBuiltinPatch: async (project, name) => {
       const TAG = `compat/`;
       if (!name.startsWith(TAG))
-        return;
+        return undefined;
 
       const ident = structUtils.parseIdent(name.slice(TAG.length));
       const patch = PATCHES.get(ident.identHash);

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -100,9 +100,10 @@ export default class YarnCommand extends BaseCommand {
         }
       });
 
-      if (deprecationReport.hasErrors()) {
+      if (deprecationReport.hasErrors())
         return deprecationReport.exitCode();
-      }
+
+      return undefined;
     };
 
     // The ignoreEngines flag isn't implemented at the moment. I'm still

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -120,5 +120,7 @@ export default class RemoveCommand extends BaseCommand {
 
       return report.exitCode();
     }
+
+    return undefined;
   }
 }

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -39,7 +39,7 @@ export default class SetVersionCommand extends BaseCommand {
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     if (configuration.get(`yarnPath`) && this.onlyIfNeeded)
-      return;
+      return undefined;
 
     let bundleUrl: string;
     if (this.version === `latest` || this.version === `berry`)

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -220,5 +220,7 @@ export default class UpCommand extends BaseCommand {
 
       return installReport.exitCode();
     }
+
+    return undefined;
   }
 }

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -80,7 +80,7 @@ class NodeModulesInstaller extends AbstractPnpInstaller {
 
   async finalizeInstallWithPnp(pnpSettings: PnpSettings) {
     if (this.opts.project.configuration.get(`nodeLinker`) !== `node-modules`)
-      return;
+      return undefined;
 
     const defaultFsLayer = new VirtualFS({
       baseFs: new ZipOpenFS({

--- a/packages/plugin-node-modules/sources/PnpLooseLinker.ts
+++ b/packages/plugin-node-modules/sources/PnpLooseLinker.ts
@@ -18,7 +18,7 @@ class PnpLooseInstaller extends PnpInstaller {
 
   async finalizeInstallWithPnp(pnpSettings: PnpSettings) {
     if (this.opts.project.configuration.get(`pnpMode`) !== this.mode)
-      return;
+      return undefined;
 
     const defaultFsLayer = new VirtualFS({
       baseFs: new ZipOpenFS({

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -133,6 +133,9 @@ function shouldAuthenticate(authConfiguration: MapLike, authType: AuthType) {
 
     case AuthType.NO_AUTH:
       return false;
+
+    default:
+      throw new Error(`Unreachable`);
   }
 }
 

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -57,7 +57,7 @@ export default class VersionApplyCommand extends Command<CommandContext> {
 
     const versionFile = await versionUtils.openVersionFile(project);
     if (versionFile === null || versionFile.releaseRoots.size === 0)
-      return;
+      return undefined;
 
     if (versionFile.root === null)
       throw new UsageError(`This command can only be run on Git repositories`);
@@ -261,6 +261,8 @@ export default class VersionApplyCommand extends Command<CommandContext> {
       versionFile.releases.set(workspace, decision);
 
     await versionFile.saveAll();
+
+    return undefined;
   }
 
   async executeStandard() {

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -279,6 +279,8 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           report.reportError(MessageName.UNNAMED, `The command failed for workspaces that are depended upon by other workspaces; can't satisfy the dependency graph`);
         }
       }
+
+      return undefined;
     });
 
     if (finalExitCode !== null) {

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -265,7 +265,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
             return structUtils.prettyLocator(configuration, workspace.anchoredLocator);
           }).join(`, `);
 
-          return report.reportError(MessageName.CYCLIC_DEPENDENCIES, `Dependency cycle detected (${cycle})`);
+          report.reportError(MessageName.CYCLIC_DEPENDENCIES, `Dependency cycle detected (${cycle})`);
         }
 
         const exitCodes: Array<number> = await Promise.all(commandPromises);
@@ -279,8 +279,6 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           report.reportError(MessageName.UNNAMED, `The command failed for workspaces that are depended upon by other workspaces; can't satisfy the dependency graph`);
         }
       }
-
-      return 0;
     });
 
     if (finalExitCode !== null) {

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -266,6 +266,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           }).join(`, `);
 
           report.reportError(MessageName.CYCLIC_DEPENDENCIES, `Dependency cycle detected (${cycle})`);
+          return;
         }
 
         const exitCodes: Array<number> = await Promise.all(commandPromises);

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -107,6 +107,8 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
         stderr: process.stderr,
       });
     }
+
+    return undefined;
   }
 
   return run().catch(error => {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -520,11 +520,12 @@ function getDefaultValue(configuration: Configuration, definition: SettingsDefin
         return null;
 
       if (configuration.projectCwd === null) {
-        if (ppath.isAbsolute(definition.default)) {
+        if (ppath.isAbsolute(definition.default))
           return ppath.normalize(definition.default);
-        } else if (definition.isNullable || definition.default === null) {
+        else if (definition.isNullable || definition.default === null)
           return null;
-        }
+
+        return undefined;
       } else {
         if (Array.isArray(definition.default)) {
           return definition.default.map((entry: string) => ppath.resolve(configuration.projectCwd!, entry as PortablePath));

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1591,6 +1591,8 @@ export class Project {
     Object.assign(this, installState);
 
     this.refreshWorkspaceDependencies();
+
+    return undefined;
   }
 
   async applyLightResolution() {

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -363,7 +363,7 @@ export class StreamReport extends Report {
     const cacheMissDelta = this.cacheMissCount - cacheMissCount;
 
     if (cacheHitDelta === 0 && cacheMissDelta === 0)
-      return;
+      return undefined;
 
     let fetchStatus = ``;
 

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -267,13 +267,13 @@ type ExecutePackageScriptOptions = {
   stderr: Writable,
 };
 
-export async function executePackageScript(locator: Locator, scriptName: string, args: Array<string>, {cwd, project, stdin, stdout, stderr}: ExecutePackageScriptOptions) {
+export async function executePackageScript(locator: Locator, scriptName: string, args: Array<string>, {cwd, project, stdin, stdout, stderr}: ExecutePackageScriptOptions): Promise<number> {
   return await xfs.mktempPromise(async binFolder => {
     const {manifest, env, cwd: realCwd} = await initializePackageEnvironment(locator, {project, binFolder, cwd, lifecycleScript: scriptName});
 
     const script = manifest.scripts.get(scriptName);
     if (typeof script === `undefined`)
-      return;
+      return 1;
 
     const realExecutor = async () => {
       return await execute(script, args, {cwd: realCwd, env, stdin, stdout, stderr});

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -164,9 +164,10 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
           stdout.write(`\n`);
 
           const pack = await execUtils.pipevp(`yarn`, [...workspaceCli, `pack`, `--filename`, npath.fromPortablePath(outputPath)], {cwd, env, stdin, stdout, stderr});
-          if (pack.code !== 0) {
+          if (pack.code !== 0)
             return pack.code;
-          }
+
+          return undefined;
         }],
 
         [PackageManager.Yarn2, async () => {
@@ -179,9 +180,10 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
           // we're already operating within a Yarn 2 context (plus people should
           // really check-in their Yarn versions anyway).
           const pack = await execUtils.pipevp(`yarn`, [...workspaceCli, `pack`, `--install-if-needed`, `--filename`, npath.fromPortablePath(outputPath)], {cwd, env, stdin, stdout, stderr});
-          if (pack.code !== 0) {
+          if (pack.code !== 0)
             return pack.code;
-          }
+
+          return undefined;
         }],
 
         [PackageManager.Npm, async () => {
@@ -213,6 +215,8 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
 
           // Only then can we move the pack to its rightful location
           await xfs.renamePromise(packTarget, outputPath);
+
+          return undefined;
         }],
       ]);
 

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -272,7 +272,7 @@ export async function executePackageScript(locator: Locator, scriptName: string,
     const {manifest, env, cwd: realCwd} = await initializePackageEnvironment(locator, {project, binFolder, cwd, lifecycleScript: scriptName});
 
     const script = manifest.scripts.get(scriptName);
-    if (!script)
+    if (typeof script === `undefined`)
       return;
 
     const realExecutor = async () => {

--- a/packages/yarnpkg-fslib/sources/ZipFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipFS.ts
@@ -310,6 +310,8 @@ export class ZipFS extends BasePortableFakeFS {
       this.baseFs.chmodSync(this.path, previousMod);
 
     this.ready = false;
+
+    return undefined;
   }
 
   discardAndClose() {
@@ -966,6 +968,8 @@ export class ZipFS extends BasePortableFakeFS {
 
     this.hydrateDirectory(resolvedP);
     this.chmodSync(resolvedP, mode);
+
+    return undefined;
   }
 
   async rmdirPromise(p: PortablePath) {

--- a/packages/yarnpkg-libui/sources/hooks/useFocusRequest.ts
+++ b/packages/yarnpkg-libui/sources/hooks/useFocusRequest.ts
@@ -14,7 +14,7 @@ export const useFocusRequest = function ({active, handler}: {active: boolean, ha
 
   useEffect(() => {
     if (!active || typeof handler === `undefined`)
-      return;
+      return undefined;
 
     const cb = (ch: any, key: any) => {
       if (key.name === `tab`) {

--- a/packages/yarnpkg-libui/sources/hooks/useListInput.ts
+++ b/packages/yarnpkg-libui/sources/hooks/useListInput.ts
@@ -6,7 +6,7 @@ export const useListInput = function <T>(value: T, values: Array<T>, {active, mi
 
   useEffect(() => {
     if (!active)
-      return;
+      return undefined;
 
     const cb = (ch: any, key: any) => {
       const index = values.indexOf(value);

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -147,7 +147,7 @@ const getHoistedDependencies = (rootNode: HoisterWorkTree): Map<PackageName, Hoi
  */
 const hoistTo = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath: Set<Locator>, parentAncestorDependencies: Map<PackageName, HoisterWorkTree>, ancestorMap: AncestorMap, options: InternalHoistOptions, seenNodes: Set<HoisterWorkTree> = new Set()) => {
   if (seenNodes.has(rootNode))
-    return 0;
+    return;
   seenNodes.add(rootNode);
 
   const ancestorDependencies = new Map(parentAncestorDependencies);

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -597,6 +597,9 @@ function locateArgsVariableInArgument(arg: Argument): boolean {
     case `argument`: {
       return arg.segments.some(segment => locateArgsVariableInSegment(segment));
     } break;
+
+    default:
+      throw new Error(`Unreacheable`);
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "jsx": "react",
     "lib": ["dom", "es2017", "esnext", "esnext.asynciterable"],
     "module": "commonjs",
+    "noImplicitReturns": true,
     "strict": true,
     "target": "es2017",
     "declaration": true


### PR DESCRIPTION
**What's the problem this PR addresses?**

Empty scripts in `executePackageScript` were failing because the comparision didn't include only `undefined`, but it also included the empty string.

Fixes #1071.

**How did you fix it?**

I changed `if (!script) return;` to `if (typeof script === 'undefined') return;`.

I also added an integration test.
