### PR TITLE
dont let the package-lock.json even generate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Since we have yarn.lock we don't need a package-lock.json

**What's the problem this PR addresses?**
Don't let the packacge-lock.json even be created since we have a yarn.lock
...

**How did you fix it?**
.npmrc file
...
