### PR TITLE
show license in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,6 @@ The following packages are meant to be used by Yarn itself, and probably won't b
 
 - [@yarnpkg/builder](packages/yarnpkg-builder) contains a CLI tool to package berry and its plugins.
 - [@yarnpkg/cli](packages/yarnpkg-cli) is a CLI entry point built on top of [@yarnpkg/core](packages/yarnpkg-core).
+
+## License
+[BSD 2-Clause](https://choosealicense.com/licenses/bsd-2-clause/#)


### PR DESCRIPTION
**What's the problem this PR addresses?**
Show what license you guys use in this repository.
Have a link to redirect them to a site that explains that license easily
this is helpful for newcomers 
...

**How did you fix it?**
link it in the bottom of the readme.md 
...
