### PR TITLE
[node-modules] Fixes same locator node impersonation after hoisting

### DIFF
--- a/.yarn/versions/a1a51544.yml
+++ b/.yarn/versions/a1a51544.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-a-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-a-1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('dragon-test-7-b');

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-a-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-a-1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "dragon-test-7-a",
+    "version": "1.0.0",
+    "dependencies": {
+      "dragon-test-7-b": "1.0.0",
+      "dragon-test-7-c": "2.0.0"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('dragon-test-7-c');

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "dragon-test-7-b",
+    "version": "1.0.0",
+    "dependencies": {
+      "dragon-test-7-c": "1.0.0"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-2.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-2.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('dragon-test-7-c');

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-2.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-b-2.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "dragon-test-7-b",
+    "version": "2.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./package.json').version;

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "dragon-test-7-c",
+    "version": "1.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-2.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-2.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./package.json').version;

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-2.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-2.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "dragon-test-7-c",
+    "version": "2.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-3.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-3.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./package.json').version;

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-3.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-c-3.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "dragon-test-7-c",
+    "version": "3.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-d-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-d-1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('dragon-test-7-b');

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-d-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/dragon-test-7-d-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "dragon-test-7-d",
+    "version": "1.0.0",
+    "dependencies": {
+      "dragon-test-7-b": "1.0.0"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
@@ -1,4 +1,4 @@
-import {xfs} from '@yarnpkg/fslib';
+import {xfs, npath} from '@yarnpkg/fslib';
 
 const {
   fs: {writeFile, writeJson},
@@ -348,6 +348,51 @@ describe(`Dragon tests`, () => {
 
         await run(`install`);
       },
+    ),
+  );
+
+
+  test(`it should pass the dragon test 7`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        dependencies: {
+          [`dragon-test-7-a`]: `1.0.0`,
+          [`dragon-test-7-d`]: `1.0.0`,
+          [`dragon-test-7-b`]: `2.0.0`,
+          [`dragon-test-7-c`]: `3.0.0`,
+        },
+      },
+      async ({path, run, source}) => {
+        // node-modules linker should support hoisting the same package in different places of the tree in different ways
+        //
+        // . -> A -> B@X -> C@X
+        //        -> C@Y
+        //   -> D -> B@X -> C@X
+        //   -> B@Y
+        //   -> C@Z
+        // should be hoisted to:
+        // . -> A -> B@X -> C@X
+        //        -> C@Y
+        //   -> D -> B@X
+        //        -> C@X
+        //   -> B@Y
+        //   -> C@Z
+        //
+        // Two B@X instances should be hoisted differently in the tree
+        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
+          nodeLinker: "node-modules"
+        `);
+
+        await expect(run(`install`)).resolves.toBeTruthy();
+
+        await expect(source(`require('dragon-test-7-a') + ':' + require('dragon-test-7-d')`)).resolves.toEqual(`1.0.0:1.0.0`);
+
+        // C@X should not be hoisted from . -> A -> B@X
+        await expect(xfs.existsPromise(`${path}/node_modules/dragon-test-7-a/node_modules/dragon-test-7-b/node_modules/dragon-test-7-c`)).resolves.toBeTruthy();
+        // C@X should be hoisted from . -> D -> B@X
+        await expect(xfs.existsPromise(`${path}/node_modules/dragon-test-7-d/node_modules/dragon-test-7-b/node_modules`)).resolves.toBeFalsy();
+      }
     ),
   );
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
@@ -386,6 +386,7 @@ describe(`Dragon tests`, () => {
 
         await expect(run(`install`)).resolves.toBeTruthy();
 
+        // All fixtures export/reexport `dragon-test-7-c` version, we expect that version 1.0.0 will be used by both `dragon-test-7-b` instances
         await expect(source(`require('dragon-test-7-a') + ':' + require('dragon-test-7-d')`)).resolves.toEqual(`1.0.0:1.0.0`);
 
         // C@X should not be hoisted from . -> A -> B@X

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -510,10 +510,10 @@ const shrinkTree = (tree: HoisterWorkTree): HoisterResult => {
     dependencies: new Set(),
   };
 
-  const nodes = new Map<Locator, HoisterResult>([[tree.locator, treeCopy]]);
+  const nodes = new Map<HoisterWorkTree, HoisterResult>([[tree, treeCopy]]);
 
   const addNode = (node: HoisterWorkTree, parentNode: HoisterResult) => {
-    let resultNode = nodes.get(node.locator);
+    let resultNode = nodes.get(node);
     const isSeen = !!resultNode;
 
     if (!resultNode) {
@@ -526,7 +526,7 @@ const shrinkTree = (tree: HoisterWorkTree): HoisterResult => {
     parentNode.dependencies.add(resultNode);
 
     if (!isSeen) {
-      nodes.set(node.locator, resultNode);
+      nodes.set(node, resultNode);
       for (const dep of node.dependencies.values()) {
         if (!node.peerNames.has(dep.name)) {
           addNode(dep, resultNode);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes: #1311 

**How did you fix it?**

After hoisting we are stripping peerDependencies and other misc information needed for hoisting from tree nodes. During this process we maintained a list of processed tree nodes in form of a map `node locator` -> `resulting node with extra info stripped`. This was wrong, because node with the same locator could have been hoisted differently in different parts of the tree. I have changed the map to be `node with extra hoisting info` -> `resulting node with extra info stripped`, this way node impersonation should no longer happen.

