### PR TITLE
 fix(plugin-github): parse new style github urls 

### DIFF
--- a/.yarn/versions/d8dd0ce4.yml
+++ b/.yarn/versions/d8dd0ce4.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/plugin-github": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-fixtures/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/index.js
@@ -1,3 +1,3 @@
-const {npath} = require('@yarnpkg/fslib');
+const {npath} = require(`@yarnpkg/fslib`);
 
 module.exports = npath.toPortablePath(__dirname);

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -35,7 +35,12 @@ export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
 
   let [, auth, username, reponame, treeish = `master`] = match;
 
-  treeish = treeish.replace(/[^:]*:/, ``);
+  // Replace Treeish Protocol
+  treeish = treeish
+    // New-style: "commit=abcdef" (without the extras)
+    .replace(/[^=]*=/, ``)
+    // Old-style: "commit:abcdef"
+    .replace(/[^:]*:/, ``);
 
   return {auth, username, reponame, treeish};
 }

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -1,3 +1,5 @@
+import querystring from 'querystring';
+
 type ParsedGithubUrl = {
   auth?: string;
   username: string;
@@ -33,16 +35,13 @@ export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
   if (!match)
     throw new Error(invalidGithubUrlMessage(urlStr));
 
-  let [, auth, username, reponame, treeish = `master`] = match;
+  const [, auth, username, reponame, treeish] = match;
 
-  // Replace Treeish Protocol
-  treeish = treeish
-    // New-style: "commit=abcdef" (without the extras)
-    .replace(/[^=]*=/, ``)
-    // Old-style: "commit:abcdef"
-    .replace(/[^:]*:/, ``);
+  // The URLs have already been normalized by `gitUtils.resolveUrl`,
+  // so it's certain that the `commit` querystring parameter exists
+  const {commit} = querystring.parse(treeish);
 
-  return {auth, username, reponame, treeish};
+  return {auth, username, reponame, treeish: commit as string};
 }
 
 export function invalidGithubUrlMessage(url: string): string {

--- a/packages/plugin-github/sources/githubUtils.ts
+++ b/packages/plugin-github/sources/githubUtils.ts
@@ -35,13 +35,21 @@ export function parseGithubUrl(urlStr: string): ParsedGithubUrl {
   if (!match)
     throw new Error(invalidGithubUrlMessage(urlStr));
 
-  const [, auth, username, reponame, treeish] = match;
+  let [, auth, username, reponame, treeish = `master`] = match;
 
-  // The URLs have already been normalized by `gitUtils.resolveUrl`,
-  // so it's certain that the `commit` querystring parameter exists
-  const {commit} = querystring.parse(treeish);
+  const {commit} = querystring.parse(treeish) as {commit?: string};
 
-  return {auth, username, reponame, treeish: commit as string};
+  treeish =
+    // New style:
+    // The URLs have already been normalized by `gitUtils.resolveUrl`,
+    // so it's certain in the context of the `GithubFetcher`
+    // that the `commit` querystring parameter exists
+    commit
+    // Old style:
+    // Shouldn't ever be needed by the GithubFetcher
+    || treeish.replace(/[^:]*:/, ``);
+
+  return {auth, username, reponame, treeish};
 }
 
 export function invalidGithubUrlMessage(url: string): string {

--- a/packages/plugin-github/tests/githubUtils.test.ts
+++ b/packages/plugin-github/tests/githubUtils.test.ts
@@ -21,6 +21,12 @@ const validScenarios = [{
 }, {
   url: `https://github.com/owner/repo.git#abcdef`,
   auth: undefined, username: `owner`, reponame: `repo`, treeish: `abcdef`,
+}, {
+  url: `https://github.com/owner/repo.git#commit=abcdef`,
+  auth: undefined, username: `owner`, reponame: `repo`, treeish: `abcdef`,
+}, {
+  url: `https://github.com/owner/repo.git#commit=abcdef&workspace=foobar`,
+  auth: undefined, username: `owner`, reponame: `repo`, treeish: `abcdef`,
 }];
 
 const invalidScenarios = [{


### PR DESCRIPTION
(Unrelated: I'm still using my fork because I have to clean up a few branches before I change `origin`.)

**What's the problem this PR addresses?**

New style GitHub urls weren't parsed correctly.

Fixes #1317.

**How did you fix it?**

Now the `protocol=` part of `protocol=abcdef` (the "treeish" part of the url) is discarded correctly.
