### PR TITLE
 feat(plugin-git): add support for github tarball urls

### DIFF
--- a/.yarn/versions/f239bb28.yml
+++ b/.yarn/versions/f239bb28.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/plugin-git": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
+++ b/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
@@ -32,12 +32,14 @@ exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-
 
 exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#v1.0.0 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.0"`;
 
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate/tarball/b3562c2798507869edb767da869cd7b85487726d 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+
 exports[`gitUtils should properly normalize ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
 
 exports[`gitUtils should properly split GitHubOrg/foo-bar.js 1`] = `
 Object {
   "extra": Object {},
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "head",
     "request": "master",
@@ -48,7 +50,7 @@ Object {
 exports[`gitUtils should properly split GitHubOrg/foo-bar.js#commit:hash 1`] = `
 Object {
   "extra": Object {},
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "commit",
     "request": "hash",
@@ -59,7 +61,7 @@ Object {
 exports[`gitUtils should properly split GitHubOrg/foo-bar.js#commit=hash 1`] = `
 Object {
   "extra": Object {},
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "commit",
     "request": "hash",
@@ -72,7 +74,7 @@ Object {
   "extra": Object {
     "workspace": "foo",
   },
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "commit",
     "request": "hash",
@@ -83,7 +85,7 @@ Object {
 exports[`gitUtils should properly split GitHubOrg/foo-bar.js#hash 1`] = `
 Object {
   "extra": Object {},
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": null,
     "request": "hash",
@@ -94,7 +96,7 @@ Object {
 exports[`gitUtils should properly split GitHubOrg/foo-bar.js#tag=hello 1`] = `
 Object {
   "extra": Object {},
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "tag",
     "request": "hello",
@@ -107,7 +109,7 @@ Object {
   "extra": Object {
     "workspace": "foo",
   },
-  "repo": "GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "head",
     "request": "master",
@@ -118,7 +120,7 @@ Object {
 exports[`gitUtils should properly split GitHubOrg/foo2bar.js 1`] = `
 Object {
   "extra": Object {},
-  "repo": "GitHubOrg/foo2bar.js",
+  "repo": "https://github.com/GitHubOrg/foo2bar.js.git",
   "treeish": Object {
     "protocol": "head",
     "request": "master",
@@ -151,7 +153,7 @@ Object {
 exports[`gitUtils should properly split github:GitHubOrg/foo-bar.js 1`] = `
 Object {
   "extra": Object {},
-  "repo": "github:GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "head",
     "request": "master",
@@ -162,7 +164,7 @@ Object {
 exports[`gitUtils should properly split github:GitHubOrg/foo-bar.js#hash 1`] = `
 Object {
   "extra": Object {},
-  "repo": "github:GitHubOrg/foo-bar.js",
+  "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": null,
     "request": "hash",
@@ -210,6 +212,17 @@ Object {
   "treeish": Object {
     "protocol": null,
     "request": "v1.0.0",
+  },
+}
+`;
+
+exports[`gitUtils should properly split https://github.com/TooTallNate/util-deprecate/tarball/b3562c2798507869edb767da869cd7b85487726d 1`] = `
+Object {
+  "extra": Object {},
+  "repo": "https://github.com/TooTallNate/util-deprecate.git",
+  "treeish": Object {
+    "protocol": null,
+    "request": "b3562c2798507869edb767da869cd7b85487726d",
   },
 }
 `;

--- a/packages/plugin-git/sources/gitUtils.test.js
+++ b/packages/plugin-git/sources/gitUtils.test.js
@@ -15,6 +15,7 @@ const VALID_PATTERNS = [
   `https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0`,
   `https://github.com/TooTallNate/util-deprecate.git#master`,
   `https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d`,
+  `https://github.com/TooTallNate/util-deprecate/tarball/b3562c2798507869edb767da869cd7b85487726d`,
   `git://github.com/TooTallNate/util-deprecate.git#v1.0.1`,
   `git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,
   `ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -17,6 +17,8 @@ const gitPatterns = [
   /^(?:git\+)?https?:[^#]+\/[^#]+\.git(?:#.*)?$/,
   /^git@[^#]+\/[^#]+\.git(?:#.*)?$/,
   /^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z._0-9-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z._0-9-]+?)(?:\.git)?(?:#.*)?$/,
+  // GitHub `/tarball/` URLs
+  /^https:\/\/github\.com\/(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)\/tarball\/(.+)?$/,
 ];
 
 export enum TreeishProtocols {
@@ -45,6 +47,8 @@ export type RepoUrlParts = {
 };
 
 export function splitRepoUrl(url: string): RepoUrlParts {
+  url = normalizeRepoUrl(url);
+
   const hashIndex = url.indexOf(`#`);
   if (hashIndex === -1) {
     return {
@@ -125,6 +129,9 @@ export function normalizeRepoUrl(url: string) {
 
   // We support this as an alias to GitHub repositories
   url = url.replace(/^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
+
+  // We support GitHub `/tarball/` URLs
+  url = url.replace(/^https:\/\/github\.com\/(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)\/tarball\/(.+)?$/, `https://github.com/$1/$2.git#$3`);
 
   return url;
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

GitHub `/tarball/` URLs aren't currently supported.

Fixes #885.

**How did you fix it?**

GitHub tarball URLs are now supported and normalized correctly.

I also added a new pattern to the tests and updated the snapshots.

Note: I also made the URLs that go through `splitRepoUrl` be normalized as it was required for this change.
