### PR TITLE
Upgrade interactive tweaks

### DIFF
--- a/.yarn/versions/8045181c.yml
+++ b/.yarn/versions/8045181c.yml
@@ -1,5 +1,4 @@
 releases:
+  "@yarnpkg/libui": prerelease
   "@yarnpkg/plugin-interactive-tools": prerelease
-
-declined:
-  - "@yarnpkg/libui"
+  "@yarnpkg/plugin-version": prerelease

--- a/.yarn/versions/8045181c.yml
+++ b/.yarn/versions/8045181c.yml
@@ -1,4 +1,6 @@
 releases:
   "@yarnpkg/libui": prerelease
   "@yarnpkg/plugin-interactive-tools": prerelease
-  "@yarnpkg/plugin-version": prerelease
+
+declined:
+  - "@yarnpkg/plugin-version"

--- a/.yarn/versions/8045181c.yml
+++ b/.yarn/versions/8045181c.yml
@@ -1,3 +1,5 @@
-undecided:
-  - "@yarnpkg/plugin-interactive-tools"
+releases:
+  "@yarnpkg/plugin-interactive-tools": prerelease
+
+declined:
   - "@yarnpkg/libui"

--- a/.yarn/versions/8045181c.yml
+++ b/.yarn/versions/8045181c.yml
@@ -1,0 +1,3 @@
+undecided:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/libui"

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -7,7 +7,7 @@ import {renderForm, SubmitInjectedComponent}                                    
 import {suggestUtils}                                                                                                      from '@yarnpkg/plugin-essentials';
 import {Command, Usage}                                                                                                    from 'clipanion';
 import {diffWords}                                                                                                         from 'diff';
-import {Box, Text, Color}                                                                                                  from 'ink';
+import {Box, Color, Text}                                                                                                  from 'ink';
 import React, {useEffect, useState}                                                                                        from 'react';
 import semver                                                                                                              from 'semver';
 
@@ -109,7 +109,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         fetchUpdatedDescriptor(descriptor, descriptor.range, `latest`),
       ]);
 
-      const suggestions: Array<{value: string | null, label: string }> = [{
+      const suggestions: Array<{value: string | null, label: string}> = [{
         value: null,
         label: descriptor.range,
       }];
@@ -128,11 +128,10 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         });
       }
 
-
       return suggestions;
     };
 
-    const Promp = () => {
+    const Prompt = () => {
       return (
         <Box flexDirection="column">
           <Color bold>Info:</Color>
@@ -207,7 +206,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
 
       return <>
         <Box flexDirection={`column`}>
-          <Promp/>
+          <Prompt/>
           <Header/>
           <ScrollableItems radius={10} children={sortedDependencies.map(descriptor => {
             return <UpgradeEntry key={descriptor.descriptorHash} active={false} descriptor={descriptor} />;

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -147,17 +147,18 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           <Box marginLeft={1}>
           - Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
           </Box>
-          <Text bold>
-            <Color greenBright>?</Color> Pick the packages you want to upgrade.
-          </Text>
         </Box>
       );
     };
 
     const Header = () => {
       return (
-        <Box flexDirection="row" marginLeft={4}>
-          <Box width={45}><Color bold underline gray>Name</Color></Box>
+        <Box flexDirection="row">
+          <Box width={49}>
+            <Text bold>
+              <Color greenBright>?</Color> Pick the packages you want to upgrade.
+            </Text>
+          </Box>
           <Box width={15}><Color bold underline gray>Current</Color></Box>
           <Box width={15}><Color bold underline gray>Range/Latest</Color></Box>
         </Box>

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -114,16 +114,19 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         label: descriptor.range,
       }];
 
-      suggestions.push({
-        value: resolution,
-        label: colorizeVersionDiff(descriptor.range, resolution),
-      });
+      if (resolution !== descriptor.range) {
+        suggestions.push({
+          value: resolution,
+          label: colorizeVersionDiff(descriptor.range, resolution),
+        });
+      }
 
-
-      suggestions.push({
-        value: dependency,
-        label: colorizeVersionDiff(descriptor.range, dependency),
-      });
+      if (dependency !== resolution && dependency !== descriptor.range) {
+        suggestions.push({
+          value: dependency,
+          label: colorizeVersionDiff(descriptor.range, dependency),
+        });
+      }
 
 
       return suggestions;
@@ -155,10 +158,9 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     const Header = () => {
       return (
         <Box flexDirection="row" marginLeft={4}>
-          <Box width={30}><Color bold underline gray>Name</Color></Box>
+          <Box width={45}><Color bold underline gray>Package</Color></Box>
           <Box width={15}><Color bold underline gray>Current</Color></Box>
-          <Box width={15}><Color bold underline gray>Range</Color></Box>
-          <Box width={15}><Color bold underline gray>Latest</Color></Box>
+          <Box width={15}><Color bold underline gray>Range/Latest</Color></Box>
         </Box>
       );
     };
@@ -176,7 +178,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       ]);
 
       return <Box>
-        <Box width={30}>
+        <Box width={45} textWrap="wrap">
           <Text bold>
             {structUtils.prettyIdent(configuration, descriptor)}
           </Text>

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -7,7 +7,7 @@ import {renderForm, SubmitInjectedComponent}                                    
 import {suggestUtils}                                                                                                      from '@yarnpkg/plugin-essentials';
 import {Command, Usage}                                                                                                    from 'clipanion';
 import {diffWords}                                                                                                         from 'diff';
-import {Box, Color}                                                                                                        from 'ink';
+import {Box, Text, Color}                                                                                                  from 'ink';
 import React, {useEffect, useState}                                                                                        from 'react';
 import semver                                                                                                              from 'semver';
 
@@ -109,26 +109,58 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         fetchUpdatedDescriptor(descriptor, descriptor.range, `latest`),
       ]);
 
-      const suggestions: Array<{value: string | null, label: string}> = [{
+      const suggestions: Array<{value: string | null, label: string }> = [{
         value: null,
         label: descriptor.range,
       }];
 
-      if (resolution !== descriptor.range) {
-        suggestions.push({
-          value: resolution,
-          label: colorizeVersionDiff(descriptor.range, resolution),
-        });
-      }
+      suggestions.push({
+        value: resolution,
+        label: colorizeVersionDiff(descriptor.range, resolution),
+      });
 
-      if (dependency !== resolution && dependency !== descriptor.range) {
-        suggestions.push({
-          value: dependency,
-          label: colorizeVersionDiff(descriptor.range, dependency),
-        });
-      }
+
+      suggestions.push({
+        value: dependency,
+        label: colorizeVersionDiff(descriptor.range, dependency),
+      });
+
 
       return suggestions;
+    };
+
+    const Promp = () => {
+      return (
+        <Box flexDirection="column">
+          <Color bold>Info:</Color>
+          <Box marginLeft={1}>
+          - Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select packages.
+          </Box>
+          <Box marginLeft={1}>
+          - Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select versions.
+          </Box>
+          <Box marginLeft={1}>
+          - Press <Color bold cyanBright>{`<enter>`}</Color> to install.
+          </Box>
+          <Box marginLeft={1}>
+          - Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
+          </Box>
+          <Text bold>
+            <Color greenBright>?</Color> Pick the packages you want to upgrade.
+          </Text>
+        </Box>
+      );
+    };
+
+    const Header = () => {
+      return (
+        <Box flexDirection="row" marginLeft={4}>
+          <Box width={30}><Color bold underline gray>Name</Color></Box>
+          <Box width={15}><Color bold underline gray>Current</Color></Box>
+          <Box width={15}><Color bold underline gray>Range</Color></Box>
+          <Box width={15}><Color bold underline gray>Latest</Color></Box>
+        </Box>
+      );
     };
 
     const UpgradeEntry = ({active, descriptor}: {active: boolean, descriptor: Descriptor}) => {
@@ -144,8 +176,10 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       ]);
 
       return <Box>
-        <Box width={60}>
-          {structUtils.prettyIdent(configuration, descriptor)}
+        <Box width={30}>
+          <Text bold>
+            {structUtils.prettyIdent(configuration, descriptor)}
+          </Text>
         </Box>
         {suggestions !== null
           ? <ItemOptions active={active} options={suggestions} value={action} onChange={setAction} sizes={[15, 15, 15]} />
@@ -171,9 +205,8 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
 
       return <>
         <Box flexDirection={`column`}>
-          <Box textWrap={`wrap`} marginBottom={1}>
-            The following packages are direct dependencies of your project. Select those you want to upgrade, then press enter. Press ctrl-C to abort at any time:
-          </Box>
+          <Promp/>
+          <Header/>
           <ScrollableItems radius={10} children={sortedDependencies.map(descriptor => {
             return <UpgradeEntry key={descriptor.descriptorHash} active={false} descriptor={descriptor} />;
           })} />

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -133,24 +133,21 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
 
     const Prompt = () => {
       return (
-        <Box flexDirection="column">
-          <Color bold>Info:</Color>
-          <Box flexDirection="row">
-            <Box flexDirection="column">
-              <Box marginLeft={1}>
-                <Text bold>-</Text> Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select packages.
-              </Box>
-              <Box marginLeft={1}>
-                <Text bold>-</Text> Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select versions.
-              </Box>
+        <Box flexDirection="row">
+          <Box flexDirection="column" width={49}>
+            <Box marginLeft={1}>
+             Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select packages.
             </Box>
-            <Box flexDirection="column">
-              <Box marginLeft={1}>
-                <Text bold>-</Text> Press <Color bold cyanBright>{`<enter>`}</Color> to install.
-              </Box>
-              <Box marginLeft={1}>
-                <Text bold>-</Text> Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
-              </Box>
+            <Box marginLeft={1}>
+             Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select versions.
+            </Box>
+          </Box>
+          <Box flexDirection="column">
+            <Box marginLeft={1}>
+             Press <Color bold cyanBright>{`<enter>`}</Color> to install.
+            </Box>
+            <Box marginLeft={1}>
+             Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
             </Box>
           </Box>
         </Box>
@@ -159,7 +156,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
 
     const Header = () => {
       return (
-        <Box flexDirection="row">
+        <Box flexDirection="row" paddingTop={1} paddingBottom={1}>
           <Box width={50}>
             <Text bold>
               <Color greenBright>?</Color> Pick the packages you want to upgrade.

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -185,7 +185,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         </Box>
         {suggestions !== null
           ? <ItemOptions active={active} options={suggestions} value={action} onChange={setAction} sizes={[15, 15, 15]} />
-          : <Box><Color gray>Fetching suggestions...</Color></Box>
+          : <Box marginLeft={2}><Color gray>Fetching suggestions...</Color></Box>
         }
       </Box>;
     };

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -135,17 +135,23 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       return (
         <Box flexDirection="column">
           <Color bold>Info:</Color>
-          <Box marginLeft={1}>
-          - Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select packages.
-          </Box>
-          <Box marginLeft={1}>
-          - Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select versions.
-          </Box>
-          <Box marginLeft={1}>
-          - Press <Color bold cyanBright>{`<enter>`}</Color> to install.
-          </Box>
-          <Box marginLeft={1}>
-          - Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
+          <Box flexDirection="row">
+            <Box flexDirection="column">
+              <Box marginLeft={1}>
+                <Text bold>-</Text> Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select packages.
+              </Box>
+              <Box marginLeft={1}>
+                <Text bold>-</Text> Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select versions.
+              </Box>
+            </Box>
+            <Box flexDirection="column">
+              <Box marginLeft={1}>
+                <Text bold>-</Text> Press <Color bold cyanBright>{`<enter>`}</Color> to install.
+              </Box>
+              <Box marginLeft={1}>
+                <Text bold>-</Text> Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
+              </Box>
+            </Box>
           </Box>
         </Box>
       );
@@ -154,13 +160,13 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     const Header = () => {
       return (
         <Box flexDirection="row">
-          <Box width={49}>
+          <Box width={50}>
             <Text bold>
               <Color greenBright>?</Color> Pick the packages you want to upgrade.
             </Text>
           </Box>
-          <Box width={15}><Color bold underline gray>Current</Color></Box>
-          <Box width={15}><Color bold underline gray>Range/Latest</Color></Box>
+          <Box width={17}><Color bold underline gray>Current</Color></Box>
+          <Box width={17}><Color bold underline gray>Range/Latest</Color></Box>
         </Box>
       );
     };
@@ -184,7 +190,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           </Text>
         </Box>
         {suggestions !== null
-          ? <ItemOptions active={active} options={suggestions} value={action} onChange={setAction} sizes={[15, 15, 15]} />
+          ? <ItemOptions active={active} options={suggestions} value={action} onChange={setAction} sizes={[17, 17, 17]} />
           : <Box marginLeft={2}><Color gray>Fetching suggestions...</Color></Box>
         }
       </Box>;

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -158,7 +158,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     const Header = () => {
       return (
         <Box flexDirection="row" marginLeft={4}>
-          <Box width={45}><Color bold underline gray>Package</Color></Box>
+          <Box width={45}><Color bold underline gray>Name</Color></Box>
           <Box width={15}><Color bold underline gray>Current</Color></Box>
           <Box width={15}><Color bold underline gray>Range/Latest</Color></Box>
         </Box>

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -17,9 +17,9 @@ export const ItemOptions = function <T>({active, options, value, onChange, sizes
   return <>
     {options.map(({label}, index) => {
       if (index === selectedIndex) {
-        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color green>◉</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color green> ◉ </Color> <Text bold>{label}</Text></Box>;
       } else {
-        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color yellow>◯</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color yellow> ◯ </Color> <Text bold>{label}</Text></Box>;
       }
     })}
   </>;

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -17,9 +17,9 @@ export const ItemOptions = function <T>({active, options, value, onChange, sizes
   return <>
     {options.map(({label}, index) => {
       if (index === selectedIndex) {
-        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color greenBright>◉</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color green>◉</Color> <Text bold>{label}</Text></Box>;
       } else {
-        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color yellowBright>◯</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color yellow>◯</Color> <Text bold>{label}</Text></Box>;
       }
     })}
   </>;

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -17,9 +17,9 @@ export const ItemOptions = function <T>({active, options, value, onChange, sizes
   return <>
     {options.map(({label}, index) => {
       if (index === selectedIndex) {
-        return <Box key={label} minWidth={sizes[index] || 0} paddingLeft={2}><Color>◉</Color> <Text bold underline>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color>◉</Color> <Text bold>{label}</Text></Box>;
       } else {
-        return <Box key={label} minWidth={sizes[index] || 0} paddingLeft={2}><Color>◯</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color>◯</Color> <Text bold>{label}</Text></Box>;
       }
     })}
   </>;

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -17,9 +17,9 @@ export const ItemOptions = function <T>({active, options, value, onChange, sizes
   return <>
     {options.map(({label}, index) => {
       if (index === selectedIndex) {
-        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color>◉</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color greenBright>◉</Color> <Text bold>{label}</Text></Box>;
       } else {
-        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color>◯</Color> <Text bold>{label}</Text></Box>;
+        return <Box key={label} width={sizes[index] - 1 || 0} marginLeft={1} textWrap="truncate"><Color yellowBright>◯</Color> <Text bold>{label}</Text></Box>;
       }
     })}
   </>;

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -1,7 +1,7 @@
-import {Box, Color}   from 'ink';
-import React          from 'react';
+import {Box, Color, Text} from 'ink';
+import React              from 'react';
 
-import {useListInput} from '../hooks/useListInput';
+import {useListInput}     from '../hooks/useListInput';
 
 export const ItemOptions = function <T>({active, options, value, onChange, sizes = []}: {active: boolean, options: Array<{value: T, label: string}>, value: T, onChange: (value: T) => void, sizes?: Array<number>}) {
   const values = options.map(({value}) => value);
@@ -17,9 +17,9 @@ export const ItemOptions = function <T>({active, options, value, onChange, sizes
   return <>
     {options.map(({label}, index) => {
       if (index === selectedIndex) {
-        return <Box key={label} minWidth={sizes[index] || 0} paddingLeft={2}><Color green>◼</Color> {label}</Box>;
+        return <Box key={label} minWidth={sizes[index] || 0} paddingLeft={2}><Color>◉</Color> <Text bold underline>{label}</Text></Box>;
       } else {
-        return <Box key={label} minWidth={sizes[index] || 0} paddingLeft={2}><Color yellow>◻</Color> {label}</Box>;
+        return <Box key={label} minWidth={sizes[index] || 0} paddingLeft={2}><Color>◯</Color> <Text bold>{label}</Text></Box>;
       }
     })}
   </>;

--- a/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
+++ b/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
@@ -63,7 +63,7 @@ export const ScrollableItems = ({active = true, children = [], radius = 10, size
     </Box>);
   }
 
-  return <Box flexDirection={`column`} width={`100%`} height={radius * size * 2 + size}>
+  return <Box flexDirection={`column`} width={`100%`}>
     {rendered}
   </Box>;
 };

--- a/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
+++ b/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
@@ -54,8 +54,8 @@ export const ScrollableItems = ({active = true, children = [], radius = 10, size
     const activeItem = active && key === activeKey;
 
     rendered.push(<Box key={key!} height={size}>
-      <Box marginLeft={2} marginRight={2}>
-        {activeItem ? <Color cyan>▶</Color> : ` `}
+      <Box marginLeft={1} marginRight={1}>
+        {activeItem ? <Color cyan bold>></Color> : ` `}
       </Box>
       <Box>
         {React.cloneElement(children[t], {active: activeItem})}


### PR DESCRIPTION
**What's the problem this PR addresses?**

When testing the new version of Yarn (berry) I found out that the interactive tool `upgrade-interactive` has been redone in Ink, but a lot of the "niceness" of the old version was gone. Since I have some experience with Ink, I decided to make it a bit nicer and later maybe add some features if you guys think this is going in the right direction.

**How did you fix it?**

Things I did:
- Added an info section
- Added a prompt
- Added column names
- Tweaked some chars
- Tweaked some colors and font weights
- Tweaked some widths, heights, and spacings

Before:
<img width="1060" alt="Screenshot 2020-05-08 at 11 53 00" src="https://user-images.githubusercontent.com/16746406/81418296-c234be80-914c-11ea-89bd-4689a154dbfc.png">

After:
<img width="634" alt="Screenshot 2020-05-11 at 10 11 12" src="https://user-images.githubusercontent.com/16746406/81538988-d0aef000-936f-11ea-848f-60e149a61c38.png">
