### PR TITLE
feat(builder): improve builder output

### DIFF
--- a/.yarn/versions/060585a4.yml
+++ b/.yarn/versions/060585a4.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/builder": prerelease
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-builder/sources/cli.ts
+++ b/packages/yarnpkg-builder/sources/cli.ts
@@ -6,6 +6,7 @@ import BuildBundleCommand from './commands/build/bundle';
 import BuildPluginCommand from './commands/build/plugin';
 import HelpCommand        from './commands/help';
 import NewPluginCommand   from './commands/new/plugin';
+import VersionCommand     from './commands/version';
 
 const cli = new Cli({
   binaryName: `yarn builder`,
@@ -15,6 +16,7 @@ cli.register(NewPluginCommand);
 cli.register(BuildBundleCommand);
 cli.register(BuildPluginCommand);
 cli.register(HelpCommand);
+cli.register(VersionCommand);
 
 cli.runExit(process.argv.slice(2), {
   stdin: process.stdin,

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -1,16 +1,18 @@
-import {getDynamicLibs} from '@yarnpkg/cli';
-import chalk            from 'chalk';
-import cp               from 'child_process';
-import {Command, Usage} from 'clipanion';
-import filesize         from 'filesize';
-import fs               from 'fs';
-import path             from 'path';
-import TerserPlugin     from 'terser-webpack-plugin';
-import {promisify}      from 'util';
-import webpack          from 'webpack';
+import {getDynamicLibs}                                                    from '@yarnpkg/cli';
+import {StreamReport, MessageName, Configuration, structUtils, FormatType} from '@yarnpkg/core';
+import {npath}                                                             from '@yarnpkg/fslib';
+import chalk                                                               from 'chalk';
+import cp                                                                  from 'child_process';
+import {Command, Usage}                                                    from 'clipanion';
+import filesize                                                            from 'filesize';
+import fs                                                                  from 'fs';
+import path                                                                from 'path';
+import TerserPlugin                                                        from 'terser-webpack-plugin';
+import {promisify}                                                         from 'util';
+import webpack                                                             from 'webpack';
 
-import {findPlugins}    from '../../tools/findPlugins';
-import {makeConfig}     from '../../tools/makeConfig';
+import {findPlugins}                                                       from '../../tools/findPlugins';
+import {makeConfig}                                                        from '../../tools/makeConfig';
 
 const execFile = promisify(cp.execFile);
 
@@ -48,6 +50,9 @@ export default class BuildBundleCommand extends Command {
   @Command.Path(`build`, `bundle`)
   async execute() {
     const basedir = process.cwd();
+    const portableBaseDir = npath.toPortablePath(basedir);
+    const configuration = new Configuration(portableBaseDir, portableBaseDir, new Map());
+
     const plugins = findPlugins({basedir, profile: this.profile, plugins: this.plugins.map(plugin => path.resolve(plugin))});
     const modules = [...getDynamicLibs().keys()].concat(plugins);
     const output = `${basedir}/bundles/yarn.js`;
@@ -61,85 +66,109 @@ export default class BuildBundleCommand extends Command {
     if (hash !== null)
       version = version.replace(/-(.*)?$/, `-$1${hash}`);
 
-    const compiler = webpack(makeConfig({
-      context: basedir,
-      entry: `./sources/cli.ts`,
+    let buildErrors: string | null = null;
 
-      bail: true,
+    const report = await StreamReport.start({
+      configuration,
+      includeFooter: false,
+      stdout: this.context.stdout,
+      forgettableNames: new Set([MessageName.UNNAMED]),
+    }, async report => {
+      await report.startTimerPromise(`Building the CLI`, async () => {
+        const progress = StreamReport.progressViaCounter(1);
+        report.reportProgress(progress);
 
-      ...!this.noMinify && {
-        mode: `production`,
-      },
+        const prettyWebpack = structUtils.prettyIdent(configuration, structUtils.makeIdent(null, `webpack`));
 
-      ...!this.noMinify && {
-        optimization: {
-          minimizer: [
-            new TerserPlugin({
-              cache: false,
-              extractComments: false,
+        const compiler = webpack(makeConfig({
+          context: basedir,
+          entry: `./sources/cli.ts`,
+
+          bail: true,
+
+          ...!this.noMinify && {
+            mode: `production`,
+          },
+
+          ...!this.noMinify && {
+            optimization: {
+              minimizer: [
+                new TerserPlugin({
+                  cache: false,
+                  extractComments: false,
+                }),
+              ],
+            },
+          },
+
+          output: {
+            filename: path.basename(output),
+            path: path.dirname(output),
+          },
+
+          resolve: {
+            alias: {
+              [path.resolve(basedir, `./sources/tools/getPluginConfiguration.ts`)]: path.resolve(basedir, `./sources/tools/getPluginConfiguration.val.js`),
+            },
+          },
+
+          module: {
+            rules: [{
+            // This file is particular in that it exposes the bundle
+            // configuration to the bundle itself (primitive introspection).
+              test: /[\\/]getPluginConfiguration\.val\.js$/,
+              use: {
+                loader: require.resolve(`val-loader`),
+                options: {modules, plugins},
+              },
+            }],
+          },
+
+          plugins: [
+            new webpack.BannerPlugin({
+              entryOnly: true,
+              banner: `#!/usr/bin/env node\n/* eslint-disable */`,
+              raw: true,
+            }),
+            new webpack.DefinePlugin({
+              [`YARN_VERSION`]: JSON.stringify(version),
+            }),
+            new webpack.ProgressPlugin((percentage: number, message: string) => {
+              progress.set(percentage);
+
+              if (message) {
+                report.reportInfoOnce(MessageName.UNNAMED, `${prettyWebpack}: ${message}`);
+              }
             }),
           ],
-        },
-      },
+        }));
 
-      output: {
-        filename: path.basename(output),
-        path: path.dirname(output),
-      },
-
-      resolve: {
-        alias: {
-          [path.resolve(basedir, `./sources/tools/getPluginConfiguration.ts`)]: path.resolve(basedir, `./sources/tools/getPluginConfiguration.val.js`),
-        },
-      },
-
-      module: {
-        rules: [{
-          // This file is particular in that it exposes the bundle
-          // configuration to the bundle itself (primitive introspection).
-          test: /[\\/]getPluginConfiguration\.val\.js$/,
-          use: {
-            loader: require.resolve(`val-loader`),
-            options: {modules, plugins},
-          },
-        }],
-      },
-
-      plugins: [
-        new webpack.BannerPlugin({
-          entryOnly: true,
-          banner: `#!/usr/bin/env node\n/* eslint-disable */`,
-          raw: true,
-        }),
-        new webpack.DefinePlugin({
-          [`YARN_VERSION`]: JSON.stringify(version),
-        }),
-      ],
-    }));
-
-    const buildErrors = await new Promise<string | null>((resolve, reject) => {
-      compiler.run((err, stats) => {
-        if (err) {
-          reject(err);
-        } else if (stats.compilation.errors.length > 0) {
-          resolve(stats.toString(`errors-only`));
-        } else {
-          resolve(null);
-        }
+        buildErrors = await new Promise<string | null>((resolve, reject) => {
+          compiler.run((err, stats) => {
+            if (err) {
+              reject(err);
+            } else if (stats.compilation.errors.length > 0) {
+              resolve(stats.toString(`errors-only`));
+            } else {
+              resolve(null);
+            }
+          });
+        });
       });
     });
 
     if (buildErrors) {
-      this.context.stdout.write(`${chalk.red(`✗`)} Failed to build the CLI:\n`);
-      this.context.stdout.write(`${buildErrors}\n`);
-      return 1;
+      report.reportError(MessageName.EXCEPTION, `${chalk.red(`✗`)} Failed to build the CLI:`);
+      report.reportError(MessageName.EXCEPTION, `${buildErrors}`);
     } else {
-      this.context.stdout.write(`${chalk.green(`✓`)} Done building the CLI!\n`);
-      this.context.stdout.write(`${chalk.cyan(`?`)} Bundle path: ${output}\n`);
-      this.context.stdout.write(`${chalk.cyan(`?`)} Bundle size: ${filesize(fs.statSync(output).size)}\n`);
-      for (const plugin of plugins)
-        this.context.stdout.write(`    ${chalk.yellow(`→`)} ${plugin}\n`);
-      return 0;
+      report.reportInfo(null, `${chalk.green(`✓`)} Done building the CLI!`);
+      report.reportInfo(null, `${chalk.cyan(`?`)} Bundle path: ${configuration.format(output, FormatType.PATH)}`);
+      report.reportInfo(null, `${chalk.cyan(`?`)} Bundle size: ${configuration.format(filesize(fs.statSync(output).size), FormatType.NUMBER)}`);
+      for (const plugin of plugins) {
+        report.reportInfo(null, `    ${chalk.yellow(`→`)} ${structUtils.prettyIdent(configuration, structUtils.parseIdent(plugin))}`);
+      }
     }
+
+    return report.exitCode();
   }
 }

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -157,6 +157,8 @@ export default class BuildBundleCommand extends Command {
       });
     });
 
+    report.reportSeparator();
+
     if (buildErrors) {
       report.reportError(MessageName.EXCEPTION, `${chalk.red(`✗`)} Failed to build the CLI:`);
       report.reportError(MessageName.EXCEPTION, `${buildErrors}`);
@@ -164,8 +166,11 @@ export default class BuildBundleCommand extends Command {
       report.reportInfo(null, `${chalk.green(`✓`)} Done building the CLI!`);
       report.reportInfo(null, `${chalk.cyan(`?`)} Bundle path: ${configuration.format(output, FormatType.PATH)}`);
       report.reportInfo(null, `${chalk.cyan(`?`)} Bundle size: ${configuration.format(filesize(fs.statSync(output).size), FormatType.NUMBER)}`);
+
+      report.reportSeparator();
+
       for (const plugin of plugins) {
-        report.reportInfo(null, `    ${chalk.yellow(`→`)} ${structUtils.prettyIdent(configuration, structUtils.parseIdent(plugin))}`);
+        report.reportInfo(null, `${chalk.yellow(`→`)} ${structUtils.prettyIdent(configuration, structUtils.parseIdent(plugin))}`);
       }
     }
 

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -1,14 +1,16 @@
-import chalk                        from 'chalk';
-import {Command, Usage, UsageError} from 'clipanion';
-import filesize                     from 'filesize';
-import fs                           from 'fs';
-import path                         from 'path';
-import {RawSource}                  from 'webpack-sources';
-import webpack                      from 'webpack';
+import {StreamReport, MessageName, Configuration, structUtils, FormatType} from '@yarnpkg/core';
+import {npath}                                                             from '@yarnpkg/fslib';
+import chalk                                                               from 'chalk';
+import {Command, Usage, UsageError}                                        from 'clipanion';
+import filesize                                                            from 'filesize';
+import fs                                                                  from 'fs';
+import path                                                                from 'path';
+import {RawSource}                                                         from 'webpack-sources';
+import webpack                                                             from 'webpack';
 
-import {isDynamicLib}               from '../../tools/isDynamicLib';
-import {makeConfig}                 from '../../tools/makeConfig';
-import {reindent}                   from '../../tools/reindent';
+import {isDynamicLib}                                                      from '../../tools/isDynamicLib';
+import {makeConfig}                                                        from '../../tools/makeConfig';
+import {reindent}                                                          from '../../tools/reindent';
 
 // The name gets normalized so that everyone can override some plugins by
 // their own (@arcanis/yarn-plugin-foo would override @yarnpkg/plugin-foo
@@ -30,79 +32,106 @@ export default class BuildPluginCommand extends Command {
   @Command.Path(`build`, `plugin`)
   async execute() {
     const basedir = process.cwd();
+    const portableBaseDir = npath.toPortablePath(basedir);
+    const configuration = new Configuration(portableBaseDir, portableBaseDir, new Map());
+
     const {name: rawName} = require(`${basedir}/package.json`);
     const name = getNormalizedName(rawName);
+    const prettyName = structUtils.prettyIdent(configuration, structUtils.parseIdent(name));
     const output = `${basedir}/bundles/${name}.js`;
 
-    const compiler = webpack(makeConfig({
-      context: basedir,
-      entry: `.`,
+    let buildErrors: string | null = null;
 
-      output: {
-        filename: path.basename(output),
-        path: path.dirname(output),
-        libraryTarget: `var`,
-        library: `plugin`,
-      },
+    const report = await StreamReport.start({
+      configuration,
+      includeFooter: false,
+      stdout: this.context.stdout,
+      forgettableNames: new Set([MessageName.UNNAMED]),
+    }, async report => {
+      await report.startTimerPromise(`Building ${prettyName}`, async () => {
+        const progress = StreamReport.progressViaCounter(1);
+        report.reportProgress(progress);
 
-      externals: [
-        (context: any, request: string, callback: any) => {
-          if (request !== name && isDynamicLib(request)) {
-            callback(null, `commonjs ${request}`);
-          } else {
-            callback();
-          }
-        },
-      ],
+        const prettyWebpack = structUtils.prettyIdent(configuration, structUtils.makeIdent(null, `webpack`));
 
-      plugins: [
-        // This plugin wraps the generated bundle so that it doesn't actually
-        // get evaluated right now - until after we give it a custom require
-        // function that will be able to fetch the dynamic modules.
-        {apply: (compiler: webpack.Compiler) => {
-          compiler.hooks.compilation.tap(`MyPlugin`, (compilation: webpack.compilation.Compilation) => {
-            compilation.hooks.optimizeChunkAssets.tap(`MyPlugin`, (chunks: Array<webpack.compilation.Chunk>) => {
-              for (const chunk of chunks) {
-                for (const file of chunk.files) {
-                  compilation.assets[file] = new RawSource(reindent(`
-                    /* eslint-disable*/
-                    module.exports = {
-                      name: ${JSON.stringify(name)},
-                      factory: function (require) {
-                        ${reindent(compilation.assets[file].source().replace(/^ +/, ``), 11)}
-                        return plugin;
-                      },
-                    };
-                  `));
-                }
+        const compiler = webpack(makeConfig({
+          context: basedir,
+          entry: `.`,
+
+          output: {
+            filename: path.basename(output),
+            path: path.dirname(output),
+            libraryTarget: `var`,
+            library: `plugin`,
+          },
+
+          externals: [
+            (context: any, request: string, callback: any) => {
+              if (request !== name && isDynamicLib(request)) {
+                callback(null, `commonjs ${request}`);
+              } else {
+                callback();
               }
-            });
-          });
-        }},
-      ],
-    }));
+            },
+          ],
 
-    const buildErrors = await new Promise<string | null>((resolve, reject) => {
-      compiler.run((err, stats) => {
-        if (err) {
-          reject(err);
-        } else if (stats.compilation.errors.length > 0) {
-          resolve(stats.toString(`errors-only`));
-        } else {
-          resolve(null);
-        }
+          plugins: [
+            // This plugin wraps the generated bundle so that it doesn't actually
+            // get evaluated right now - until after we give it a custom require
+            // function that will be able to fetch the dynamic modules.
+            {apply: (compiler: webpack.Compiler) => {
+              compiler.hooks.compilation.tap(`MyPlugin`, (compilation: webpack.compilation.Compilation) => {
+                compilation.hooks.optimizeChunkAssets.tap(`MyPlugin`, (chunks: Array<webpack.compilation.Chunk>) => {
+                  for (const chunk of chunks) {
+                    for (const file of chunk.files) {
+                      compilation.assets[file] = new RawSource(reindent(`
+                        /* eslint-disable*/
+                        module.exports = {
+                          name: ${JSON.stringify(name)},
+                          factory: function (require) {
+                            ${reindent(compilation.assets[file].source().replace(/^ +/, ``), 11)}
+                            return plugin;
+                          },
+                        };
+                      `));
+                    }
+                  }
+                });
+              });
+            }},
+            new webpack.ProgressPlugin((percentage: number, message: string) => {
+              progress.set(percentage);
+
+              if (message) {
+                report.reportInfoOnce(MessageName.UNNAMED, `${prettyWebpack}: ${message}`);
+              }
+            }),
+          ],
+        }));
+
+        buildErrors = await new Promise<string | null>((resolve, reject) => {
+          compiler.run((err, stats) => {
+            if (err) {
+              reject(err);
+            } else if (stats.compilation.errors.length > 0) {
+              resolve(stats.toString(`errors-only`));
+            } else {
+              resolve(null);
+            }
+          });
+        });
       });
     });
 
     if (buildErrors !== null) {
-      this.context.stdout.write(`${chalk.red(`✗`)} Failed to build ${name}:\n`);
-      this.context.stdout.write(`${buildErrors}\n`);
-      return 1;
+      report.reportError(MessageName.EXCEPTION, `${chalk.red(`✗`)} Failed to build ${prettyName}:`);
+      report.reportError(MessageName.EXCEPTION, `${buildErrors}`);
     } else {
-      this.context.stdout.write(`${chalk.green(`✓`)} Done building ${name}!\n`);
-      this.context.stdout.write(`${chalk.cyan(`?`)} Bundle path: ${output}\n`);
-      this.context.stdout.write(`${chalk.cyan(`?`)} Bundle size: ${filesize(fs.statSync(output).size)}\n`);
-      return 0;
+      report.reportInfo(null, `${chalk.green(`✓`)} Done building ${prettyName}!`);
+      report.reportInfo(null, `${chalk.cyan(`?`)} Bundle path: ${configuration.format(output, FormatType.PATH)})}`);
+      report.reportInfo(null, `${chalk.cyan(`?`)} Bundle size: ${configuration.format(filesize(fs.statSync(output).size), FormatType.NUMBER)}`);
     }
+
+    return report.exitCode();
   }
 }

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -123,6 +123,8 @@ export default class BuildPluginCommand extends Command {
       });
     });
 
+    report.reportSeparator();
+
     if (buildErrors !== null) {
       report.reportError(MessageName.EXCEPTION, `${chalk.red(`✗`)} Failed to build ${prettyName}:`);
       report.reportError(MessageName.EXCEPTION, `${buildErrors}`);

--- a/packages/yarnpkg-builder/sources/commands/version.ts
+++ b/packages/yarnpkg-builder/sources/commands/version.ts
@@ -1,0 +1,10 @@
+import {Command} from 'clipanion';
+
+// eslint-disable-next-line arca/no-default-export
+export default class VersionCommand extends Command {
+  @Command.Path(`--version`)
+  @Command.Path(`-v`)
+  async execute() {
+    this.context.stdout.write(`${require(`@yarnpkg/builder/package.json`).version || `<unknown>`}\n`);
+  }
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/builder` wasn't showing any progress while building the bundle / plugins. This was a bit annoying, as it seemed like `yarn set version from sources` took forever to finish.

**How did you fix it?**

I used [`webpack.ProgressPlugin`](https://webpack.js.org/plugins/progress-plugin/) to get Webpack's progress in real-time and convert it to `StreamReport` progress.
Now the progress is shown alongside Webpack's status messages (a maximum of 5 at a time, I had to tweak `StreamReport` to make `forgettableMessages` configurable).
I also tweaked the other messages to make them use `configuration.format` where possible.

This is how the `builder build bundle` output looks now:

![image](https://user-images.githubusercontent.com/32596136/81476477-d0e9a700-921a-11ea-8457-e6e428e7cd7e.png)

This is how the `builder build plugin` output looks now:

![image](https://user-images.githubusercontent.com/32596136/81476412-7ea88600-921a-11ea-8873-ed8f5f38f6ec.png)

Note: Currently the `configuration` is obtained using `new Configuration`, as `Configuration.find(cwd, getPluginConfiguration())` wasn't working properly in development. Not sure what I should do about this.

Another note: I also added a version command to the builder.

What do you think? I'm open to suggestions about tweaking the output to make it look even better. 