### PR TITLE
Adds Lexicon Entry for 'Build Scripts'

### DIFF
--- a/packages/gatsby/content/advanced/lexicon.md
+++ b/packages/gatsby/content/advanced/lexicon.md
@@ -10,6 +10,14 @@ title: "Lexicon"
 
 <!-- Note that all entries within this file must be alphabetically sorted -->
 
+### Build Scripts
+
+Refers to tasks executed right after the packages got installed; typically the `postinstall` scripts configured in the [`scripts` field](/configuration/manifest#scripts) from the manifest.
+
+Build scripts should be left to native dependencies, there is virtually no reason for pure JavaScript packages to use them. They have [significant side effects](/advanced/lifecycle-scripts#a-note-about-postinstall) on your users projects, so weight careful whether you really need them.
+
+See also: [Lifecycle Scripts](/advanced/lifecycle-scripts)
+
 ### Dependency
 
 A dependency (listed in the [`dependencies` field](/configuration/manifest#dependencies) of the manifest) describes a relationship between two packages.
@@ -187,9 +195,3 @@ Yarn is a command line tool used to manage programming environments. Written in 
 ### Zero-Install
 
 See also: [Zero-Install](/features/zero-installs)
-
-### Build Scripts
-
-Refers to tasks executed following package installations; either as postinstall scripts or a binding.gyp file
-
-See also: [Lifecycle Scripts](/advanced/lifecycle-scripts)

--- a/packages/gatsby/content/advanced/lexicon.md
+++ b/packages/gatsby/content/advanced/lexicon.md
@@ -187,3 +187,9 @@ Yarn is a command line tool used to manage programming environments. Written in 
 ### Zero-Install
 
 See also: [Zero-Install](/features/zero-installs)
+
+### Build Scripts
+
+Refers to tasks executed following package installations; either as postinstall scripts or a binding.gyp file
+
+See also: [Lifecycle Scripts](/advanced/lifecycle-scripts)


### PR DESCRIPTION
**What's the problem this PR addresses?**
 - The docs make several references to 'build scripts'
 - i'm stupid
...

**How did you fix it?**
Sheer hard work
...
