### PR TITLE
fix(core): avoid leaking xfs temp folders when running build scripts

### DIFF
--- a/.yarn/versions/997be237.yml
+++ b/.yarn/versions/997be237.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1331,6 +1331,9 @@ export class Project {
                   exitCode = 1;
                 }
 
+                stdout.end();
+                stderr.end();
+
                 if (exitCode === 0) {
                   nextBState.set(pkg.locatorHash, buildHash);
                   return true;


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn is leaking `xfs` temp folders created when running build scripts. Running `yarn rebuild` on master (526947260dae29475ff69561c2cdb45024bbed04) leaves 6 empty `xfs` temp folders.

**How did you fix it?**

Explicitly close the stream created by `getSubprocessStreams`[1] after we're done with it so it doesn't prevent `removePromise`[2] from deleting the folder.

1: https://github.com/yarnpkg/berry/blob/526947260dae29475ff69561c2cdb45024bbed04/packages/yarnpkg-core/sources/Configuration.ts#L1005
2: https://github.com/yarnpkg/berry/blob/5f0439a087b8463d97fb70c96dc6f983a91be512/packages/yarnpkg-fslib/sources/FakeFS.ts#L179-L191