### PR TITLE
 feat(plugin-essentials): add exec command 

### DIFF
--- a/.yarn/versions/4ab5ebe6.yml
+++ b/.yarn/versions/4ab5ebe6.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/plugin-essentials": prerelease
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-essentials/sources/commands/exec.ts
+++ b/packages/plugin-essentials/sources/commands/exec.ts
@@ -2,7 +2,7 @@ import {BaseCommand}            from '@yarnpkg/cli';
 import {Configuration, Project} from '@yarnpkg/core';
 import {execUtils, scriptUtils} from '@yarnpkg/core';
 import {xfs}                    from '@yarnpkg/fslib';
-import {Command}                from 'clipanion';
+import {Command, Usage}         from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ExecCommand extends BaseCommand {
@@ -11,6 +11,19 @@ export default class ExecCommand extends BaseCommand {
 
   @Command.Proxy()
   args: Array<string> = [];
+
+  static usage: Usage = Command.Usage({
+    description: `execute a shell command`,
+    details: `
+      This command simply executes a shell command.
+
+      It also makes sure to call it in a way that's compatible with the current project (for example, on PnP projects the environment will be setup in such a way that PnP will be correctly injected into the environment).
+    `,
+    examples: [[
+      `Execute a shell command`,
+      `$0 exec echo Hello World`,
+    ]],
+  });
 
   @Command.Path(`exec`)
   async execute() {

--- a/packages/plugin-essentials/sources/commands/exec.ts
+++ b/packages/plugin-essentials/sources/commands/exec.ts
@@ -15,7 +15,7 @@ export default class ExecCommand extends BaseCommand {
   static usage: Usage = Command.Usage({
     description: `execute a shell command`,
     details: `
-      This command simply executes a shell command.
+      This command simply executes a shell binary within the context of the root directory of the active workspace.
 
       It also makes sure to call it in a way that's compatible with the current project (for example, on PnP projects the environment will be setup in such a way that PnP will be correctly injected into the environment).
     `,

--- a/packages/plugin-essentials/sources/commands/exec.ts
+++ b/packages/plugin-essentials/sources/commands/exec.ts
@@ -1,0 +1,32 @@
+import {BaseCommand}            from '@yarnpkg/cli';
+import {Configuration, Project} from '@yarnpkg/core';
+import {execUtils, scriptUtils} from '@yarnpkg/core';
+import {xfs}                    from '@yarnpkg/fslib';
+import {Command}                from 'clipanion';
+
+// eslint-disable-next-line arca/no-default-export
+export default class ExecCommand extends BaseCommand {
+  @Command.String()
+  commandName!: string;
+
+  @Command.Proxy()
+  args: Array<string> = [];
+
+  @Command.Path(`exec`)
+  async execute() {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const {project} = await Project.find(configuration, this.context.cwd);
+
+    return await xfs.mktempPromise(async binFolder => {
+      const {code} = await execUtils.pipevp(this.commandName, this.args, {
+        cwd: this.context.cwd,
+        stdin: this.context.stdin,
+        stdout: this.context.stdout,
+        stderr: this.context.stderr,
+        env: await scriptUtils.makeScriptEnv({project, binFolder}),
+      });
+
+      return code;
+    });
+  }
+}

--- a/packages/plugin-essentials/sources/commands/node.ts
+++ b/packages/plugin-essentials/sources/commands/node.ts
@@ -1,8 +1,5 @@
-import {BaseCommand}            from '@yarnpkg/cli';
-import {Configuration, Project} from '@yarnpkg/core';
-import {execUtils, scriptUtils} from '@yarnpkg/core';
-import {xfs}                    from '@yarnpkg/fslib';
-import {Command, Usage}         from 'clipanion';
+import {BaseCommand}    from '@yarnpkg/cli';
+import {Command, Usage} from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NodeCommand extends BaseCommand {
@@ -24,19 +21,6 @@ export default class NodeCommand extends BaseCommand {
 
   @Command.Path(`node`)
   async execute() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project} = await Project.find(configuration, this.context.cwd);
-
-    return await xfs.mktempPromise(async binFolder => {
-      const {code} = await execUtils.pipevp(`node`, this.args, {
-        cwd: this.context.cwd,
-        stdin: this.context.stdin,
-        stdout: this.context.stdout,
-        stderr: this.context.stderr,
-        env: await scriptUtils.makeScriptEnv({project, binFolder}),
-      });
-
-      return code;
-    });
+    return this.cli.run([`exec`, `node`, ...this.args]);
   }
 }

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -11,6 +11,7 @@ import clipanionEntry                     from './commands/entries/clipanion';
 import helpEntry                          from './commands/entries/help';
 import runEntry                           from './commands/entries/run';
 import versionEntry                       from './commands/entries/version';
+import exec                               from './commands/exec';
 import install                            from './commands/install';
 import link                               from './commands/link';
 import node                               from './commands/node';
@@ -82,6 +83,7 @@ const plugin: Plugin = {
     add,
     bin,
     config,
+    exec,
     install,
     link,
     node,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn doesn't currently have a `yarn exec` command, which makes `yarn workspaces foreach` less powerful than it could be, as it can only run Yarn commands.

**How did you fix it?**

I added a hidden `yarn exec` command, which works exactly like `yarn node` (I even made `yarn node` an alias for `yarn exec node`), but it's generic.

This means that these are now possible:
- `yarn exec ls *.js`
- `yarn workspaces foreach exec ls *.js`