### PR TITLE
Rewrite PortablePath/NativePath/FileName types

### DIFF
--- a/.yarn/versions/6b685d16.yml
+++ b/.yarn/versions/6b685d16.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/fslib": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -1,14 +1,20 @@
 import path from 'path';
 
-export type PortablePath = string & { _portable_path: true };
-export type NativePath = string & { _portable_path?: false };
+enum PathType {
+  File,
+  Portable,
+  Native,
+}
+
+export type PortablePath = string & { _path_type: PathType.File | PathType.Portable };
+export type NativePath = string & { _path_type?: PathType.File | PathType.Native };
 
 export const PortablePath = {
   root: `/` as PortablePath,
   dot: `.` as PortablePath,
 };
 
-export type Filename = (PortablePath & NativePath) & { _filename: false };
+export type Filename = string & { _path_type: PathType.File };
 export type Path = PortablePath | NativePath;
 
 export const Filename = {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/fslib` doesn't work in typescript 3.9

**How did you fix it?**

Rework the types
