### PR TITLE
Only set BABEL_CACHE_PATH if not present in environment

### DIFF
--- a/scripts/setup-ts-execution.js
+++ b/scripts/setup-ts-execution.js
@@ -1,9 +1,10 @@
 const path = require(`path`);
-const babel = require('@babel/core');
-const os = require('os');
+const babel = require(`@babel/core`);
+const os = require(`os`);
 const root = path.dirname(__dirname);
 
-process.env.BABEL_CACHE_PATH = path.join(os.tmpdir(), 'babel', `.babel.${babel.version}.${babel.getEnv()}.json`);
+if (!process.env.BABEL_CACHE_PATH)
+  process.env.BABEL_CACHE_PATH = path.join(os.tmpdir(), `babel`, `.babel.${babel.version}.${babel.getEnv()}.json`);
 
 require(`@babel/register`)({
   root,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Computers with on access file antivirus scans can suffer greatly from every extra disk access. Allowing developers to set the `BABEL_CACHE_PATH` themselves makes it possible to move the babel cache into a folder that's excluded by the AV scan.

**How did you fix it?**

Only set `BABEL_CACHE_PATH` if it's not present already.

Moving the `BABEL_CACHE_PATH` nearly halves the total run time of `yarn node -p process.versions.pnp` in this repository on my computer, from a mean of 12 seconds to 6-7 seconds.

![image](https://user-images.githubusercontent.com/821510/81852055-b9802600-955a-11ea-8e54-419fec8e5bd9.png)

Fun fact: folders called `Yarn` are excluded in our AV configuration because of the global yarn cache location.
Other ignored folder names include `.git`, so I have colleagues who moved their entire workspace into a folder called `.git`. I wish I was kidding.