### PR TITLE
Make yarn work inside a workspace with "type": "module"

### DIFF
--- a/.yarn/versions/966dd5b5.yml
+++ b/.yarn/versions/966dd5b5.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -79,7 +79,7 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
   if (bundleVersion === null) {
     await xfs.mktempPromise(async tmpDir => {
-      const temporaryPath = ppath.join(tmpDir, `yarn.js` as Filename);
+      const temporaryPath = ppath.join(tmpDir, `yarn.cjs` as Filename);
       await xfs.writeFilePromise(temporaryPath, bundleBuffer);
 
       const {stdout} = await execUtils.execvp(process.execPath, [npath.fromPortablePath(temporaryPath), `--version`], {

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -95,7 +95,7 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
   }
 
   const releaseFolder = ppath.resolve(projectCwd, `.yarn/releases` as PortablePath);
-  const absolutePath = ppath.resolve(releaseFolder, `yarn-${bundleVersion}.js` as Filename);
+  const absolutePath = ppath.resolve(releaseFolder, `yarn-${bundleVersion}.cjs` as Filename);
 
   const displayPath = ppath.relative(configuration.startingCwd, absolutePath);
   const projectPath = ppath.relative(projectCwd, absolutePath);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn doesn't work inside workspaces with `"type": "module"`. 

Fixes #985 

**How did you fix it?**

Switch the yarn releases from `.js` to `.cjs` file extension. This marks the file as always being CommonJS, regardless of the surrounding workspace's type.

The same change should be done in yarn v1, given that a lot of people will keep using v1 as global yarn for the foreseeable future.

**Future work?**

Right now we store the PnP file as `.pnp.js` for regular workspaces, and as `.pnp.cjs` for workspaces marked `type=module`. There are some downsides to this approach:

- This leads to quite a bit of if-checks in yarn itself (generation fo the pnp file, the NODE_OPTIONS environment variable and pnpify).
- If there are external tools that depend on the `.pnp.js` file, they will need to also check for `.pnp.cjs`.
- This makes switching from one to the other more painful than it needs to be, because you need to run `yarn && yarn pnpify --sdk` and reload your IDE.

Always using `.pnp.cjs` removes these downsides.