### PR TITLE
Fix documentation regarding .yarn/install-state.gz

### DIFF
--- a/packages/gatsby/content/advanced/questions-and-answers.md
+++ b/packages/gatsby/content/advanced/questions-and-answers.md
@@ -64,7 +64,7 @@ If you're not using Zero-Installs:
 
 - `.yarn/versions` is used by the [version plugin](/features/release-workflow) to store the package release definitions. You will want to keep it within your repository.
 
-- `.yarn/install-state.tgz` is an optimization file that you shouldn't have to ever commit. It simply stores the exact state of your project so that the next commands can boot without having to resolve your workspaces again.
+- `.yarn/install-state.gz` is an optimization file that you shouldn't have to ever commit. It simply stores the exact state of your project so that the next commands can boot without having to resolve your workspaces again.
 
 - `yarn.lock` should always be stored within your repository ([even if you develop a library](#should-lockfiles-be-committed-to-the-repository)).
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Minor documentation error:

After running `yarn set version berry` and `yarn install`, the created file is `.yarn/install-state.gz`, not `.tgz`.

Source code confirms this: https://github.com/yarnpkg/berry/pull/998/files#diff-23dd4c2e823c25186f1107e88e962032R201

**How did you fix it?**

Changed `.tgz` to `.gz` in documentation.