### PR TITLE
fix(core): format FormatType.PATH as NativePath

### DIFF
--- a/.yarn/versions/b9fa3f4c.yml
+++ b/.yarn/versions/b9fa3f4c.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1195,6 +1195,9 @@ export class Configuration {
   }
 
   format(text: string, colorRequest: FormatType | string) {
+    if (colorRequest === FormatType.PATH)
+      text = npath.fromPortablePath(text);
+
     if (!this.get(`enableColors`))
       return text;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Install output shows build error log paths as PortablePaths

**How did you fix it?**

Update `format` to convert `PortablePath` to `NativePath` when the type is `FormatType.PATH`