### PR TITLE
Replace emojis with Unicode characters

### DIFF
--- a/.yarn/versions/39204e65.yml
+++ b/.yarn/versions/39204e65.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-version"

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -91,9 +91,9 @@ export default class VersionApplyCommand extends Command<CommandContext> {
         <Box>
           {strategies.map(strategy => {
             if (strategy === decision) {
-              return <Box key={strategy} paddingLeft={2}><Color green>◼</Color> {strategy}</Box>;
+              return <Box key={strategy} paddingLeft={2}><Color green>◉ </Color> {strategy} </Box>;
             } else {
-              return <Box key={strategy} paddingLeft={2}><Color yellow>◻</Color> {strategy}</Box>;
+              return <Box key={strategy} paddingLeft={2}><Color yellow>◯ </Color> {strategy} </Box>;
             }
           })}
         </Box>

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -91,9 +91,9 @@ export default class VersionApplyCommand extends Command<CommandContext> {
         <Box>
           {strategies.map(strategy => {
             if (strategy === decision) {
-              return <Box key={strategy} paddingLeft={2}><Color green>◉ </Color> {strategy} </Box>;
+              return <Box key={strategy} paddingLeft={2}><Color green>◉</Color> {strategy}</Box>;
             } else {
-              return <Box key={strategy} paddingLeft={2}><Color yellow>◯ </Color> {strategy} </Box>;
+              return <Box key={strategy} paddingLeft={2}><Color yellow>◯</Color> {strategy}</Box>;
             }
           })}
         </Box>


### PR DESCRIPTION
**What's the problem this PR addresses?**

There were some emojis used in the `version check -i` command that were causing problems for some users.

**How did you fix it?**

I replaced them with Unicode characters for it to be consistent with the `upgrade-interactive` command.

Before:
<img width="651" alt="Screenshot 2020-05-17 at 15 01 31" src="https://user-images.githubusercontent.com/16746406/82147338-55f24300-984f-11ea-9e58-9a7f456a5fc7.png">

After:
<img width="649" alt="Screenshot 2020-05-17 at 15 00 21" src="https://user-images.githubusercontent.com/16746406/82147342-5b4f8d80-984f-11ea-96e5-db82b0117692.png">