### PR TITLE
fix(workspace-tools): focus command should persist install state

### DIFF
--- a/.yarn/versions/8c154503.yml
+++ b/.yarn/versions/8c154503.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": prerelease

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -91,6 +91,8 @@ export default class WorkspacesFocus extends BaseCommand {
       includeLogs: true,
     }, async (report: StreamReport) => {
       await project.install({cache, report, persistProject: false});
+      // Virtual package references may have changed so persist just the install state.
+      await project.persistInstallStateFile();
     });
 
     return report.exitCode();


### PR DESCRIPTION
fixes #1364

**What's the problem this PR addresses?**

`workspaces focus` can produce different virtual package references from a full `yarn install`. Before this commit after running `focus` those dependencies became unreachable because the install state on disk didn't match the new references.

See https://github.com/dannycoates/yarnbug to reproduce the bug.

**How did you fix it?**

By adding `persistInstallStateFile()` the install state saves the new references without affecting the other project files.
