### PR TITLE
docs(gatsby): Fix typo in compatibility table

### DIFF
--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -91,7 +91,8 @@ A lot of very common frontend tools now support Plug'n'Play natively!
 | Rollup | Starting from `resolve` 1.9+ |
 | TypeScript-ESLint | Starting from 2.12+ |
 | WebStorm | Starting from 2019.3+; See [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
-| TypeScript | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by | Webpack | Native | Starting from 5+ ([plugin](https://github.com/arcanis/pnp-webpack-plugin) available for 4.x) |
+| TypeScript | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by default)
+| Webpack | Native | Starting from 5+ ([plugin](https://github.com/arcanis/pnp-webpack-plugin) available for 4.x) |
 
 #### Support via plugins
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

<img width="928" alt="Screen Shot 2020-05-18 at 15 32 09" src="https://user-images.githubusercontent.com/4290500/82252365-e21e6c00-991c-11ea-8397-33cbc9970bd1.png">

The format is broken in #1294. this commit fixes it.

**How did you fix it?**

Append `default )\n` to the broken line.