### PR TITLE
Fixes global overrides when used with -e

### DIFF
--- a/.yarn/versions/4db76971.yml
+++ b/.yarn/versions/4db76971.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-exec": prerelease


### PR DESCRIPTION
**What's the problem this PR addresses?**

Installing an `exec:` package that depends on something calling `node -e` in their postinstalls (such as corejs) doesn't work. This is because the global accessors aren't configurable, so when Node tries to set its own it fails.

**How did you fix it?**

- The bootstrap is now done using `--require` instead of `NODE_OPTIONS` so that it doesn't affect nested Node contexts.

- The accessors are now configurable to allow for the user to rebind them if needed.