### PR TITLE
fix(yarnpkg-libui): Fixed linting error

### DIFF
--- a/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
+++ b/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
@@ -55,7 +55,7 @@ export const ScrollableItems = ({active = true, children = [], radius = 10, size
 
     rendered.push(<Box key={key!} height={size}>
       <Box marginLeft={1} marginRight={1}>
-        {activeItem ? <Color cyan bold>></Color> : ` `}
+        {activeItem ? <Color cyan bold>{`>`}</Color> : ` `}
       </Box>
       <Box>
         {React.cloneElement(children[t], {active: activeItem})}


### PR DESCRIPTION
**What's the problem this PR addresses?**

I was building one of my Yarn 2 plugins (that exists as a branch of a fork of this), 

```
[tsl] ERROR in /berry/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx(58,40)
      TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
```

Caused by a small regression with https://github.com/yarnpkg/berry/pull/1323

```jsx
<Color cyan>▶</Color>
```
to
```jsx
<Color cyan bold>></Color> 
```
throws the linter.


**How did you fix it?**

Just replaced it with a `{'>'}`
