### PR TITLE
fix: normalize pwd environment variable behaviour

### DIFF
--- a/.yarn/versions/d5806516.yml
+++ b/.yarn/versions/d5806516.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/shell": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/execUtils.ts
+++ b/packages/yarnpkg-core/sources/execUtils.ts
@@ -51,7 +51,10 @@ export async function pipevp(fileName: string, args: Array<string>, {cwd, env = 
 
   const child = crossSpawn(fileName, args, {
     cwd: npath.fromPortablePath(cwd),
-    env,
+    env: {
+      ...env,
+      PWD: npath.fromPortablePath(cwd),
+    },
     stdio,
   });
 
@@ -119,7 +122,10 @@ export async function execvp(fileName: string, args: Array<string>, {cwd, env = 
 
   const subprocess = crossSpawn(fileName, args, {
     cwd: npath.fromPortablePath(cwd),
-    env,
+    env: {
+      ...env,
+      PWD: npath.fromPortablePath(cwd),
+    },
     stdio,
   });
 

--- a/packages/yarnpkg-core/sources/execUtils.ts
+++ b/packages/yarnpkg-core/sources/execUtils.ts
@@ -120,12 +120,14 @@ export async function execvp(fileName: string, args: Array<string>, {cwd, env = 
   const stdoutChunks: Array<Buffer> = [];
   const stderrChunks: Array<Buffer> = [];
 
+  const nativeCwd = npath.fromPortablePath(cwd);
+
+  if (typeof env.PWD !== `undefined`)
+    env = {...env, PWD: nativeCwd};
+
   const subprocess = crossSpawn(fileName, args, {
-    cwd: npath.fromPortablePath(cwd),
-    env: {
-      ...env,
-      PWD: npath.fromPortablePath(cwd),
-    },
+    cwd: nativeCwd,
+    env,
     stdio,
   });
 

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -388,14 +388,17 @@ function makeCommandAction(args: Array<string>, opts: ShellOptions, state: Shell
   if (!opts.builtins.has(args[0]))
     args = [`command`, ...args];
 
+  const nativeCwd = npath.fromPortablePath(state.cwd);
+
+  let env = state.environment;
+  if (typeof env.PWD !== `undefined`)
+    env = {...env, PWD: nativeCwd};
+
   const [name, ...rest] = args;
   if (name === `command`) {
     return makeProcess(rest[0], rest.slice(1), opts, {
-      cwd: npath.fromPortablePath(state.cwd),
-      env: {
-        ...state.environment,
-        PWD: npath.fromPortablePath(state.cwd),
-      },
+      cwd: nativeCwd,
+      env,
     });
   }
 

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -392,7 +392,10 @@ function makeCommandAction(args: Array<string>, opts: ShellOptions, state: Shell
   if (name === `command`) {
     return makeProcess(rest[0], rest.slice(1), opts, {
       cwd: npath.fromPortablePath(state.cwd),
-      env: state.environment,
+      env: {
+        ...state.environment,
+        PWD: npath.fromPortablePath(state.cwd),
+      },
     });
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some terminals set the `PWD` environment variable, some don't. On windows the value of the variable is different depending on where the command was run. Running `node -p process.env.PWD` directly in Git Bash returns `/c/berry`, while running it from Git Bash as an integrated terminal in VSCode returns `C:/berry`. Running `yarn node -p process.env.PWD` returns `/c/berry` in both scenarios. It would be nice to have some consistency here.

**How did you fix it?**

Set the `PWD` environment variable whenever a process is spawned

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have checked for unmet constraints.