### PR TITLE
[pnpify] Persist virtual node_modules dir to disk on file write

### DIFF
--- a/.yarn/versions/0cef90fb.yml
+++ b/.yarn/versions/0cef90fb.yml
@@ -1,0 +1,2 @@
+undecided:
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/0cef90fb.yml
+++ b/.yarn/versions/0cef90fb.yml
@@ -1,2 +1,9 @@
-undecided:
-  - "@yarnpkg/pnpify"
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Angular over PnPify test is failing now because Angular tries to create a file inside root node_modules dir. Because this dir is virtual in the case of pnpify this attempt fails

**How did you fix it?**

We are checking if `fs.open` has write flags and the parent directory is a virtual directory, and if both are true we persist parent directory to disk.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- See https://yarnpkg.com/advanced/contributing#checking-constraints for more details. -->
<!-- Check with `yarn constraints` and fix with `yarn constraints --fix` -->
- [x] I have checked for unmet constraints.
