### PR TITLE
feat: Allow specifying arbitrary fields to be added to package.json during `yarn init`

### DIFF
--- a/.yarn/versions/a3c71b4a.yml
+++ b/.yarn/versions/a3c71b4a.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-init": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/gatsby/src/pages/configuration/manifest.json
+++ b/packages/gatsby/src/pages/configuration/manifest.json
@@ -1,7 +1,7 @@
 {
   "title": "JSON Schema for Yarn Manifest files",
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
-  "description": "Manifest files (also called `package.json` because of their name) contain everything needed to describe the settings unique to one particular package. Project will contain multiple such manifests if they use the workspace feature, as each workspace is described through its own manifest.",
+  "description": "Manifest files (also called `package.json` because of their name) contain everything needed to describe the settings unique to one particular package. Project will contain multiple such manifests if they use the workspace feature, as each workspace is described through its own manifest. Note that defaults for these fields can be set via the `initFields` settings.",
   "type": "object",
   "properties": {
     "name": {
@@ -28,7 +28,7 @@
       "default": true
     },
     "license": {
-      "description": "An SPDX identifier that indicates under which license is your package distributed. Note that the default license can be set via the `initLicense` settings.",
+      "description": "An SPDX identifier that indicates under which license is your package distributed.",
       "type": "string",
       "default": "MIT"
     },

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -172,22 +172,11 @@
       "type": "boolean",
       "default": false
     },
-    "initLicense": {
-      "description": "License used when creating packages via the `init` command.",
-      "type": "string",
-      "default": "MIT"
-    },
     "initScope": {
       "description": "Scope used when creating packages via the `init` command.",
       "type": "string",
       "pattern": "^(?:([^/]+?))$",
       "default": "yarnpkg"
-    },
-    "initVersion": {
-      "description": "Version used when creating packages via the `init` command.",
-      "type": "string",
-      "pattern": "^(?:(.+))$",
-      "default": "0.0.1"
     },
     "initFields": {
       "description": "Additional fields to set when creating packages via the `init` command.",

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -189,6 +189,19 @@
       "pattern": "^(?:(.+))$",
       "default": "0.0.1"
     },
+    "initFields": {
+      "description": "Additional fields to set when creating packages via the `init` command.",
+      "type": "object",
+      "patternProperties": {
+        "^(.+)$": {
+          "description": "All properties will be added verbatim to the generated package.json",
+          "default": "https://yarnpkg.com"
+        }
+      },
+      "default": {
+        "homepage": {}
+      }
+    },
     "installStatePath": {
       "description": "Path of the file where the install state will be persisted.",
       "type": "string",

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -43,6 +43,7 @@ export default class InitCommand extends BaseCommand {
       - \`initLicense\`
       - \`initScope\`
       - \`initVersion\`
+      - \`initFields\`
     `,
     examples: [[
       `Create a new package in the local directory`,
@@ -127,6 +128,10 @@ export default class InitCommand extends BaseCommand {
       await xfs.mkdirpPromise(this.context.cwd);
 
     const manifest = new Manifest();
+
+    const fields = Object.fromEntries(configuration.get<Map<string, any>>(`initFields`).entries());
+    manifest.load(fields);
+
     manifest.name = structUtils.makeIdent(configuration.get(`initScope`), ppath.basename(this.context.cwd));
     manifest.version = configuration.get(`initVersion`);
     manifest.private = this.private || this.workspace;

--- a/packages/plugin-init/sources/index.ts
+++ b/packages/plugin-init/sources/index.ts
@@ -19,6 +19,14 @@ const plugin: Plugin = {
       type: SettingsType.STRING,
       default: null,
     },
+    initFields: {
+      description: `Additional fields to set when creating packages via the init command`,
+      type: SettingsType.MAP,
+      valueDefinition: {
+        description: ``,
+        type: SettingsType.ANY,
+      },
+    },
   },
   commands: [
     init,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Resolves #1374

Previously `yarn init` allowed setting `author`, `repository` and various other fields. Now it can only set a few basic options like name, workspaces, version etc.

Also, in monorepos it's common to have the same properties in all packages in the repo, and it's a bit awkward to copy and paste those fields when initializing a new package in that repo.

**How did you fix it?**

Added an `initFields` configuration option. All the properties specified will be added to the generated `package.json` - there are no constraints in order to support arbitrary additional keys added by libraries, e.g. `"jest"`, `"babel"`, ...

The implementation is pretty simple - it effectively treats `initFields` as the old package.json and loads it into the Manifest before adding any other properties.

There are a couple of things I'm not sure about

* Fields in `initFields` will always be added at the start of the generated `package.json`, even before `name`. This can be changed by adding a `name: null` key to `initFields`, but it's a bit of a weird workaround
* If `initFields` is defined in the project's `.yarnrc.yml` it will completely replace the definition in `~/.yarnrc.yml`. This is probably deliberate behaviour, but intuitively I expected the definitions to be merged
* It's a bit weird having this alongside `initLicense` and `initVersion`, since those effectively do the same thing for a couple of individual properties

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- See https://yarnpkg.com/advanced/contributing#checking-constraints for more details. -->
<!-- Check with `yarn constraints` and fix with `yarn constraints --fix` -->
- [x] I have checked for unmet constraints.
