### PR TITLE
docs: fix scroll restoration for menu

### DIFF
--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -12,7 +12,7 @@ const useScroll = () => {
   }
 
   useLayoutEffect(() => {
-    const id = window.location.pathname.split(`/`)[2];
+    const id = window.location.pathname.split(`/`)[1];
     const initPos = readBrowserStorage(id);
     ref.current.scrollTop = initPos == null ? 0 : parseInt(initPos, 10);
     return () => setBrowserStorage(id, ref.current.scrollTop);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Currently, scroll restoration is broken. Try to jump between pages in CLI section.
https://yarnpkg.com/cli/set/version

**How did you fix it?**
Seems that URLs structure was changed and it broke scroll restoration. Now we use a common part of URL. 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

