### PR TITLE
docs: add package name into title

### DIFF
--- a/packages/gatsby/src/pages/package.js
+++ b/packages/gatsby/src/pages/package.js
@@ -74,7 +74,7 @@ const PackagePage = ({searchState, onSearchStateChange}) => {
           </Header>
         }
       >
-        <SEO title="Home" keywords={defaultKeywords} />
+        <SEO title={packageName} keywords={defaultKeywords} />
 
         <SearchResults
           onTagClick={tag => setTags([...tags, tag])}


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Currently, all packages have same (default) title so it's hard to navigate among browsers tabs 

https://github.com/yarnpkg/berry/issues/803#issuecomment-629855668

**How did you fix it?**
<!-- A detailed description of your implementation. -->
Prepend page title with a package name

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
