### PR TITLE
fix: use scripts-prepend-node-path when running npm

### DIFF
--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -30,7 +30,7 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-
+        echo Remove Me
         yarn init -p
         yarn add -D parcel@nightly lodash
 

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -30,7 +30,7 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        echo Remove Me
+
         yarn init -p
         yarn add -D parcel@nightly lodash
 

--- a/.yarn/versions/38d4ca07.yml
+++ b/.yarn/versions/38d4ca07.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/fslib"
+  - "@yarnpkg/libui"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -193,6 +193,9 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
           // one instead
           delete env.npm_config_user_agent;
 
+          // Include the path for the node binary npm was executed with
+          env.npm_config_scripts_prepend_node_path = `1`;
+
           // Apparently "npm ci" is how you get npm to actually use the lockfile
           const install = await execUtils.pipevp(`npm`, [`ci`], {cwd, env, stdin, stdout, stderr, end: execUtils.EndStrategy.ErrorCode});
           if (install.code !== 0)

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -194,7 +194,7 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
           delete env.npm_config_user_agent;
 
           // Include the path for the node binary npm was executed with
-          env.npm_config_scripts_prepend_node_path = `1`;
+          env.npm_config_scripts_prepend_node_path = `true`;
 
           // Apparently "npm ci" is how you get npm to actually use the lockfile
           const install = await execUtils.pipevp(`npm`, [`ci`], {cwd, env, stdin, stdout, stderr, end: execUtils.EndStrategy.ErrorCode});


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

npm is currently invoked without `scripts-prepend-node-path`, which means that there is a possibility that multiple versions of node are used across npm (see https://github.com/yarnpkg/berry/pull/1399/checks?check_run_id=706416669#step:5:111).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

```ts
env.npm_config_scripts_prepend_node_path = `true`;
```

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
