### PR TITLE
 feat(version-check-interactive): display keybindings 

### DIFF
--- a/.yarn/versions/59b13d62.yml
+++ b/.yarn/versions/59b13d62.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": prerelease

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -62,6 +62,32 @@ export default class VersionApplyCommand extends Command<CommandContext> {
     if (versionFile.root === null)
       throw new UsageError(`This command can only be run on Git repositories`);
 
+    const Prompt = () => {
+      return (
+        <Box flexDirection="row" paddingBottom={1}>
+          <Box flexDirection="column" width={100}>
+            <Box marginLeft={1}>
+               Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select workspaces.
+            </Box>
+            <Box marginLeft={1}>
+               Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select release strategies.
+            </Box>
+            <Box marginLeft={1}>
+               Press <Color bold cyanBright>{`<tab>`}</Color> to move the focus to the other group of workspaces.
+            </Box>
+          </Box>
+          <Box flexDirection="column">
+            <Box marginLeft={1}>
+               Press <Color bold cyanBright>{`<enter>`}</Color> to save.
+            </Box>
+            <Box marginLeft={1}>
+               Press <Color bold cyanBright>{`<ctrl+c>`}</Color> to abort.
+            </Box>
+          </Box>
+        </Box>
+      );
+    };
+
     const Undecided = ({workspace, active, decision, setDecision}: {workspace: Workspace, active?: boolean, decision: versionUtils.Decision, setDecision: (decision: versionUtils.Decision) => void}) => {
       const currentVersion = workspace.manifest.version;
       if (currentVersion === null)
@@ -210,6 +236,7 @@ export default class VersionApplyCommand extends Command<CommandContext> {
       }, [focus, setFocus]);
 
       return <Box width={80} flexDirection={`column`}>
+        <Prompt />
         <Box textWrap={`wrap`}>
           The following files have been modified in your local checkout.
         </Box>

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -73,7 +73,7 @@ export default class VersionApplyCommand extends Command<CommandContext> {
                Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select release strategies.
             </Box>
             <Box marginLeft={1}>
-               Press <Color bold cyanBright>{`<tab>`}</Color> to move the focus to the other group of workspaces.
+               Press <Color bold cyanBright>{`<tab>`}</Color> to move the focus between the workspace groups.
             </Box>
           </Box>
           <Box flexDirection="column">

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -65,15 +65,12 @@ export default class VersionApplyCommand extends Command<CommandContext> {
     const Prompt = () => {
       return (
         <Box flexDirection="row" paddingBottom={1}>
-          <Box flexDirection="column" width={100}>
-            <Box marginLeft={1}>
+          <Box flexDirection="column" width={60}>
+            <Box>
                Press <Color bold cyanBright>{`<up>`}</Color>/<Color bold cyanBright>{`<down>`}</Color> to select workspaces.
             </Box>
-            <Box marginLeft={1}>
+            <Box>
                Press <Color bold cyanBright>{`<left>`}</Color>/<Color bold cyanBright>{`<right>`}</Color> to select release strategies.
-            </Box>
-            <Box marginLeft={1}>
-               Press <Color bold cyanBright>{`<tab>`}</Color> to move the focus between the workspace groups.
             </Box>
           </Box>
           <Box flexDirection="column">
@@ -263,6 +260,9 @@ export default class VersionApplyCommand extends Command<CommandContext> {
         {dependentWorkspaces.size > 0 && <>
           <Box marginTop={1} textWrap={`wrap`}>
             The following workspaces depend on other workspaces that have been marked for release, and thus may need to be released as well:
+          </Box>
+          <Box>
+            (Press <Color bold cyanBright>{`<tab>`}</Color> to move the focus between the workspace groups.)
           </Box>
           {dependentWorkspaces.size > 5 ? <Box marginTop={1}>
             <Stats workspaces={dependentWorkspaces} releases={releases} />


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The keybindings for the `yarn version check -i` command aren't currently shown anywhere and "tab to move focus" isn't always intuitive (see https://github.com/yarnpkg/berry/pull/1387#issuecomment-632163204).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it so that the keybindings are now displayed, just like for the `yarn upgrade-interactive` command. Feel free to tweak the alignment / whatever else you feel needs improvements.

![image](https://user-images.githubusercontent.com/32596136/82909976-ae71c080-9f72-11ea-9a41-a4c1d3f85fcb.png)


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
