### PR TITLE
feat(plugin-essentials): add support for glob patterns to yarn remove and yarn up

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -8513,6 +8513,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/plugin-essentials", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-essentials"],
             ["@types/inquirer", "npm:0.0.43"],
             ["@types/lodash", "npm:4.14.136"],
+            ["@types/micromatch", "npm:4.0.1"],
             ["@types/semver", "npm:7.1.0"],
             ["@types/treeify", "npm:1.0.0"],
             ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],
@@ -8523,6 +8524,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["clipanion", "npm:2.4.0"],
             ["inquirer", "npm:6.2.1"],
             ["lodash", "npm:4.17.15"],
+            ["micromatch", "npm:4.0.2"],
             ["semver", "npm:7.1.2"],
             ["treeify", "npm:1.1.0"],
             ["yup", "npm:0.27.0"]
@@ -8539,6 +8541,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
             ["@types/inquirer", "npm:0.0.43"],
             ["@types/lodash", "npm:4.14.136"],
+            ["@types/micromatch", "npm:4.0.1"],
             ["@types/semver", "npm:7.1.0"],
             ["@types/treeify", "npm:1.0.0"],
             ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
@@ -8549,6 +8552,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["clipanion", "npm:2.4.0"],
             ["inquirer", "npm:6.2.1"],
             ["lodash", "npm:4.17.15"],
+            ["micromatch", "npm:4.0.2"],
             ["semver", "npm:7.1.2"],
             ["treeify", "npm:1.1.0"],
             ["yup", "npm:0.27.0"]
@@ -8565,6 +8569,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/plugin-essentials", "workspace:packages/plugin-essentials"],
             ["@types/inquirer", "npm:0.0.43"],
             ["@types/lodash", "npm:4.14.136"],
+            ["@types/micromatch", "npm:4.0.1"],
             ["@types/semver", "npm:7.1.0"],
             ["@types/treeify", "npm:1.0.0"],
             ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
@@ -8575,6 +8580,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["clipanion", "npm:2.4.0"],
             ["inquirer", "npm:6.2.1"],
             ["lodash", "npm:4.17.15"],
+            ["micromatch", "npm:4.0.2"],
             ["semver", "npm:7.1.2"],
             ["treeify", "npm:1.1.0"],
             ["yup", "npm:0.27.0"]

--- a/.yarn/versions/0c32cf56.yml
+++ b/.yarn/versions/0c32cf56.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@types__no-deps-2.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@types__no-deps-2.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@types__no-deps-2.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@types__no-deps-2.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@types/no-deps",
+  "version": "2.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/remove.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/remove.test.js
@@ -1,5 +1,6 @@
 const {
   fs: {readJson, writeJson},
+  yarn: {readManifest},
 } = require(`pkg-tests-core`);
 
 describe(`Commands`, () => {
@@ -139,6 +140,64 @@ describe(`Commands`, () => {
         await expect(readJson(`${path}/packages/workspace-a/package.json`)).resolves.not.toHaveProperty(`dependencies`);
         await expect(readJson(`${path}/packages/workspace-b/package.json`)).resolves.not.toHaveProperty(`dependencies`);
         await expect(readJson(`${path}/packages/workspace-c/package.json`)).resolves.not.toHaveProperty(`dependencies`);
+      }),
+    );
+
+    test(
+      `it should remove all dependencies matching a glob pattern (scope & star)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`@types/iarna__toml`]: `1.0.0`,
+          [`@types/is-number`]: `1.0.0`,
+          [`@types/no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`remove`, `@types/*`);
+
+        await expect(readManifest(path)).resolves.not.toHaveProperty(`dependencies`);
+      }),
+    );
+
+    test(
+      `it should remove all dependencies matching a glob pattern (star)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`dep-loop-entry`]: `1.0.0`,
+          [`dep-loop-exit`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`remove`, `dep-loop-*`);
+
+        await expect(readManifest(path)).resolves.not.toHaveProperty(`dependencies`);
+      }),
+    );
+
+    test(
+      `it should remove all dependencies matching a glob pattern (star-word-star)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`dep-loop-entry`]: `1.0.0`,
+          [`dep-loop-exit`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`remove`, `*loop*`);
+
+        await expect(readManifest(path)).resolves.not.toHaveProperty(`dependencies`);
+      }),
+    );
+
+
+    test(
+      `it should remove all dependencies matching a glob pattern (braces)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`dep-loop-entry`]: `1.0.0`,
+          [`dep-loop-exit`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`remove`, `dep-loop-{entry,exit}`);
+
+        await expect(readManifest(path)).resolves.not.toHaveProperty(`dependencies`);
       }),
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
@@ -1,0 +1,45 @@
+import {yarn} from 'pkg-tests-core';
+
+const {readManifest} = yarn;
+
+describe(`Commands`, () => {
+  describe(`up`, () => {
+    test(
+      `it should upgrade all dependencies matching a glob pattern (scope & star)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`@types/is-number`]: `1.0.0`,
+          [`@types/no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`up`, `@types/*`);
+
+        await expect(readManifest(path)).resolves.toStrictEqual({
+          dependencies: {
+            [`@types/is-number`]: `^2.0.0`,
+            [`@types/no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should upgrade all dependencies matching a glob pattern (scope & star & range)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`@types/is-number`]: `2.0.0`,
+          [`@types/no-deps`]: `2.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`up`, `@types/*@1.0.0`);
+
+        await expect(readManifest(path)).resolves.toStrictEqual({
+          dependencies: {
+            [`@types/is-number`]: `1.0.0`,
+            [`@types/no-deps`]: `1.0.0`,
+          },
+        });
+      }),
+    );
+  });
+});

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -10,6 +10,7 @@
     "clipanion": "^2.4.0",
     "inquirer": "^6.2.0",
     "lodash": "^4.17.15",
+    "micromatch": "^4.0.2",
     "semver": "^7.1.2",
     "treeify": "^1.1.0",
     "yup": "^0.27.0"
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@types/inquirer": "^0.0.43",
     "@types/lodash": "^4.14.136",
+    "@types/micromatch": "^4.0.1",
     "@types/semver": "^7.1.0",
     "@types/treeify": "^1.0.0",
     "@yarnpkg/cli": "workspace:^2.0.0-rc.33",

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -23,7 +23,7 @@ export default class RemoveCommand extends BaseCommand {
 
       If the \`-A,--all\` option is set, the operation will be applied to all workspaces from the current project.
 
-      This command accepts glob patterns as arguments (if supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
+      This command accepts glob patterns as arguments (if valid Idents and supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
     `,
     examples: [[
       `Remove a dependency from the current project`,

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -89,8 +89,8 @@ export default class RemoveCommand extends BaseCommand {
 
         for (const target of targets) {
           const descriptors = workspace.manifest.getForScope(target);
-          const stringifiedIdents = [...descriptors.values()].map(stringifiedIdent => {
-            return structUtils.stringifyIdent(stringifiedIdent);
+          const stringifiedIdents = [...descriptors.values()].map(descriptor => {
+            return structUtils.stringifyIdent(descriptor);
           });
 
           for (const stringifiedIdent of micromatch(stringifiedIdents, structUtils.stringifyIdent(pseudoIdent))) {

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -74,6 +74,10 @@ export default class RemoveCommand extends BaseCommand {
     for (const pattern of this.patterns) {
       let isReferenced = false;
 
+      // This isn't really needed - It's just for consistency:
+      // All patterns are either valid or not for all commands (e.g. remove, up)
+      const pseudoIdent = structUtils.parseIdent(pattern);
+
       for (const workspace of affectedWorkspaces) {
         const peerDependenciesMeta = [...workspace.manifest.peerDependenciesMeta.keys()];
         for (const stringifiedIdent of micromatch(peerDependenciesMeta, pattern)) {
@@ -87,7 +91,7 @@ export default class RemoveCommand extends BaseCommand {
           const descriptors = workspace.manifest.getForScope(target);
           const stringifiedIdents = [...descriptors.values()].map(structUtils.stringifyIdent);
 
-          for (const stringifiedIdent of micromatch(stringifiedIdents, pattern)) {
+          for (const stringifiedIdent of micromatch(stringifiedIdents, structUtils.stringifyIdent(pseudoIdent))) {
             const {identHash} = structUtils.parseIdent(stringifiedIdent);
             const removedDescriptor = descriptors.get(identHash)!;
 

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -89,11 +89,16 @@ export default class RemoveCommand extends BaseCommand {
 
         for (const target of targets) {
           const descriptors = workspace.manifest.getForScope(target);
-          const stringifiedIdents = [...descriptors.values()].map(structUtils.stringifyIdent);
+          const stringifiedIdents = [...descriptors.values()].map(stringifiedIdent => {
+            return structUtils.stringifyIdent(stringifiedIdent);
+          });
 
           for (const stringifiedIdent of micromatch(stringifiedIdents, structUtils.stringifyIdent(pseudoIdent))) {
             const {identHash} = structUtils.parseIdent(stringifiedIdent);
-            const removedDescriptor = descriptors.get(identHash)!;
+
+            const removedDescriptor = descriptors.get(identHash);
+            if (typeof removedDescriptor === `undefined`)
+              throw new Error(`Assertion failed: Expected the descriptor to be registered`);
 
             workspace.manifest[target].delete(identHash);
 

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -32,13 +32,13 @@ export default class RemoveCommand extends BaseCommand {
       `Remove a dependency from all workspaces at once`,
       `$0 remove lodash --all`,
     ], [
-      `Remove all dependencies matching a glob pattern from the current project (star)`,
+      `Remove all dependencies starting with \`eslint-\``,
       `$0 remove 'eslint-*'`,
     ], [
-      `Remove all dependencies matching a glob pattern from the current project (star & scoped)`,
+      `Remove all dependencies with the \`@babel\` scope`,
       `$0 remove '@babel/*'`,
     ], [
-      `Remove all dependencies matching a glob pattern from the current project (braces)`,
+      `Remove all dependencies matching \`react-dom\` or \`react-helmet\``,
       `$0 remove 'react-{dom,helmet}'`,
     ]],
   });

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -40,7 +40,7 @@ export default class UpCommand extends BaseCommand {
 
       This command accepts glob patterns as arguments (if valid Descriptors and supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
 
-      **Note:** The range has to be static, only the package scopes and names can contain glob patterns.
+      **Note:** The ranges have to be static, only the package scopes and names can contain glob patterns.
     `,
     examples: [[
       `Upgrade all instances of lodash to the latest release`,

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -102,11 +102,17 @@ export default class UpCommand extends BaseCommand {
       for (const workspace of project.workspaces) {
         for (const target of [suggestUtils.Target.REGULAR, suggestUtils.Target.DEVELOPMENT]) {
           const descriptors = workspace.manifest.getForScope(target);
-          const stringifiedIdents = [...descriptors.values()].map(structUtils.stringifyIdent);
+          const stringifiedIdents = [...descriptors.values()].map(descriptor => {
+            return structUtils.stringifyIdent(descriptor);
+          });
 
           for (const stringifiedIdent of micromatch(stringifiedIdents, structUtils.stringifyIdent(pseudoDescriptor))) {
             const ident = structUtils.parseIdent(stringifiedIdent);
+
             const existingDescriptor = workspace.manifest[target].get(ident.identHash)!;
+            if (typeof existingDescriptor === `undefined`)
+              throw new Error(`Assertion failed: Expected the descriptor to be registered`);
+
             const request = structUtils.makeDescriptor(ident, pseudoDescriptor.range);
 
             allSuggestionsPromises.push(Promise.resolve().then(async () => {

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -32,11 +32,15 @@ export default class UpCommand extends BaseCommand {
   static usage: Usage = Command.Usage({
     description: `upgrade dependencies across the project`,
     details: `
-      This command upgrades a list of packages to their latest available version across the whole project (regardless of whether they're part of \`dependencies\` or \`devDependencies\` - \`peerDependencies\` won't be affected). This is a project-wide command: all workspaces will be upgraded in the process.
+      This command upgrades the packages matching the list of specified patterns to their latest available version across the whole project (regardless of whether they're part of \`dependencies\` or \`devDependencies\` - \`peerDependencies\` won't be affected). This is a project-wide command: all workspaces will be upgraded in the process.
 
       If \`-i,--interactive\` is set (or if the \`preferInteractive\` settings is toggled on) the command will offer various choices, depending on the detected upgrade paths. Some upgrades require this flag in order to resolve ambiguities.
 
       The, \`-C,--caret\`, \`-E,--exact\` and  \`-T,--tilde\` options have the same meaning as in the \`add\` command (they change the modifier used when the range is missing or a tag, and are ignored when the range is explicitly set).
+
+      This command accepts glob patterns as arguments (if valid Descriptors and supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
+
+      **Note:** The range has to be static, only the package scopes and names can contain glob patterns.
     `,
     examples: [[
       `Upgrade all instances of lodash to the latest release`,
@@ -47,6 +51,15 @@ export default class UpCommand extends BaseCommand {
     ], [
       `Upgrade all instances of lodash to 1.2.3`,
       `$0 up lodash@1.2.3`,
+    ], [
+      `Upgrade all instances of packages with the \`@babel\` scope to the latest release`,
+      `$0 up '@babel/*'`,
+    ], [
+      `Upgrade all instances of packages containing the word \`jest\` to the latest release`,
+      `$0 up '*jest*'`,
+    ], [
+      `Upgrade all instances of packages with the \`@babel\` scope to 7.0.0`,
+      `$0 up '@babel/*@7.0.0'`,
     ]],
   });
 

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -109,7 +109,7 @@ export default class UpCommand extends BaseCommand {
           for (const stringifiedIdent of micromatch(stringifiedIdents, structUtils.stringifyIdent(pseudoDescriptor))) {
             const ident = structUtils.parseIdent(stringifiedIdent);
 
-            const existingDescriptor = workspace.manifest[target].get(ident.identHash)!;
+            const existingDescriptor = workspace.manifest[target].get(ident.identHash);
             if (typeof existingDescriptor === `undefined`)
               throw new Error(`Assertion failed: Expected the descriptor to be registered`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6375,6 +6375,7 @@ __metadata:
   dependencies:
     "@types/inquirer": ^0.0.43
     "@types/lodash": ^4.14.136
+    "@types/micromatch": ^4.0.1
     "@types/semver": ^7.1.0
     "@types/treeify": ^1.0.0
     "@yarnpkg/cli": "workspace:^2.0.0-rc.33"
@@ -6385,6 +6386,7 @@ __metadata:
     clipanion: ^2.4.0
     inquirer: ^6.2.0
     lodash: ^4.17.15
+    micromatch: ^4.0.2
     semver: ^7.1.2
     treeify: ^1.1.0
     yup: ^0.27.0


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn remove` and `yarn up` don't currently support glob patterns, which makes removing / upgrading all dependencies containing a specific scope / word more difficult than it should be.

Closes #1418.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I implemented glob support to both `yarn remove` and `yarn up`, using `micromatch`, the library that we already use for everything glob related.

For `yarn remove`, we get the list of idents for a scope and we iterate over the matches, removing the descriptor corresponding to the matched ident. 

For `yarn up`, we get the list of idents for a scope and we iterate over the matches, setting the existing descriptor to the descriptor corresponding to the matched ident, and the descriptor used in the request to a new descriptor, created from the matched ident and the range of the pattern. For obvious reasons, the range has to be static, so glob patterns can only be used for the ident part of the descriptor.

I haven't added any tests yet, but locally all of the examples I added to the documentation work, so nothing that previously worked should be broken.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
