### PR TITLE
perf(core): skip await if response has already resolved

### DIFF
--- a/.yarn/versions/8c6a6df8.yml
+++ b/.yarn/versions/8c6a6df8.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"


### PR DESCRIPTION
**What's the problem this PR addresses?**

The resolution step is currently a bit slow and uses a decent amount of memory.

**How did you fix it?**

- Once the GET request finishes, replace the entry in the cache with the response body
- If the entry from the cache is a buffer, skip the await call.

**Results**
Average measurements over three runs with no lockfile
||Total dependencies|Time before* | Time after*| RAM before** | RAM after**|
|--|--|--|--|--|--|
|next@9.4.5-canary.3  | 784 | 1881ms | 811ms|425MB | 196MB|
|react-scripts@3.4.1|1408 |  3633ms | 1325ms |642MB | 237MB|

*Time: `Self Time` of the `get` function measured by the profiler in Chrome DevTools
**RAM: Private bytes as measured by my task manager, after using Chrome DevTools' `Collect garbage` function three times

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
