### PR TITLE
Fixes event emitter leaks

### DIFF
--- a/.yarn/versions/2edeb9ad.yml
+++ b/.yarn/versions/2edeb9ad.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/shell": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/execUtils.ts
+++ b/packages/yarnpkg-core/sources/execUtils.ts
@@ -18,11 +18,6 @@ export type PipevpOptions = {
   stderr: Writable,
 };
 
-// Rather than attaching one SIGINT handler for each process, we
-// attach a single one and use a refcount to detect once it's no
-// longer needed.
-let sigintRefCount = 0;
-
 function hasFd(stream: null | Readable | Writable) {
   // @ts-ignore: Not sure how to typecheck this field
   return stream !== null && typeof stream.fd === `number`;
@@ -32,6 +27,11 @@ function sigintHandler() {
   // We don't want SIGINT to kill our process; we want it to kill the
   // innermost process, whose end will cause our own to exit.
 }
+
+// Rather than attaching one SIGINT handler for each process, we
+// attach a single one and use a refcount to detect once it's no
+// longer needed.
+let sigintRefCount = 0;
 
 export async function pipevp(fileName: string, args: Array<string>, {cwd, env = process.env, strict = false, stdin = null, stdout, stderr, end = EndStrategy.Always}: PipevpOptions): Promise<{code: number}> {
   const stdio: Array<any> = [`pipe`, `pipe`, `pipe`];

--- a/packages/yarnpkg-shell/sources/pipe.ts
+++ b/packages/yarnpkg-shell/sources/pipe.ts
@@ -22,11 +22,15 @@ export type ProcessImplementation = (
   promise: Promise<number>,
 };
 
-function nextTick() {
-  return new Promise(resolve => {
-    process.nextTick(resolve);
-  });
+function sigintHandler() {
+  // We don't want SIGINT to kill our process; we want it to kill the
+  // innermost process, whose end will cause our own to exit.
 }
+
+// Rather than attaching one SIGINT handler for each process, we
+// attach a single one and use a refcount to detect once it's no
+// longer needed.
+let sigintRefCount = 0;
 
 export function makeProcess(name: string, args: Array<string>, opts: ShellOptions, spawnOpts: any): ProcessImplementation {
   return (stdio: Stdio) => {
@@ -48,12 +52,8 @@ export function makeProcess(name: string, args: Array<string>, opts: ShellOption
       stderr,
     ]});
 
-    const sigintHandler = () => {
-      // We don't want SIGINT to kill our process; we want it to kill the
-      // innermost process, whose end will cause our own to exit.
-    };
-
-    process.on(`SIGINT`, sigintHandler);
+    if (sigintRefCount++ === 0)
+      process.on(`SIGINT`, sigintHandler);
 
     if (stdio[0] instanceof Transform)
       stdio[0].pipe(child.stdin!);
@@ -66,7 +66,8 @@ export function makeProcess(name: string, args: Array<string>, opts: ShellOption
       stdin: child.stdin!,
       promise: new Promise(resolve => {
         child.on(`error`, error => {
-          process.off(`SIGINT`, sigintHandler);
+          if (--sigintRefCount === 0)
+            process.off(`SIGINT`, sigintHandler);
 
           // @ts-ignore
           switch (error.code) {
@@ -86,7 +87,8 @@ export function makeProcess(name: string, args: Array<string>, opts: ShellOption
         });
 
         child.on(`exit`, code => {
-          process.off(`SIGINT`, sigintHandler);
+          if (--sigintRefCount === 0)
+            process.off(`SIGINT`, sigintHandler);
 
           if (code !== null) {
             resolve(code);
@@ -107,7 +109,7 @@ export function makeBuiltin(builtin: (opts: any) => Promise<number>): ProcessImp
 
     return {
       stdin,
-      promise: nextTick().then(() => builtin({
+      promise: Promise.resolve().then(() => builtin({
         stdin,
         stdout: stdio[1],
         stderr: stdio[2],


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell wasn't using a refcount for its ^C interception, causing leak warnings to be emitted.

**How did you fix it?**

We have two places where process are spawned: within the core, and within the shell. Since the shell doesn't depend on the core (that's intended), the logic needs to be duplicated between both.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
