### PR TITLE
fix(pnp): fix pnpEnableInlining

### DIFF
--- a/.yarn/versions/97d8f96d.yml
+++ b/.yarn/versions/97d8f96d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pnp": prerelease
+  "@yarnpkg/pnp": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1500,4 +1500,39 @@ describe(`Plug'n'Play`, () => {
       ], {encoding: `utf-8`});
     }),
   );
+
+  test(
+    `it should work with pnpEnableInlining set to false`,
+    makeTemporaryEnv({}, {
+      pnpEnableInlining: false,
+    }, async ({path, run, source}) => {
+      await run(`add`, `no-deps`);
+
+      expect(xfs.existsSync(`${path}/.pnp.data.json`)).toBeTruthy();
+
+      await writeFile(`${path}/file.js`, `
+        console.log(require.resolve('no-deps'));
+      `);
+
+      await expect(run(`node`, `file.js`)).resolves.toBeTruthy();
+    }),
+  );
+
+  test(
+    `it should work with pnpEnableInlining set to false and with a custom pnpDataPath`,
+    makeTemporaryEnv({}, {
+      pnpEnableInlining: false,
+      pnpDataPath: `./.pnp.meta.json`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `no-deps`);
+
+      expect(xfs.existsSync(`${path}/.pnp.meta.json`)).toBeTruthy();
+
+      await writeFile(`${path}/file.js`, `
+        console.log(require.resolve('no-deps'));
+      `);
+
+      await expect(run(`node`, `file.js`)).resolves.toBeTruthy();
+    }),
+  );
 });

--- a/packages/yarnpkg-pnp/sources/generatePnpScript.ts
+++ b/packages/yarnpkg-pnp/sources/generatePnpScript.ts
@@ -37,6 +37,7 @@ function generateInlinedSetup(data: SerializedState) {
 
 function generateSplitSetup(dataLocation: string) {
   return [
+    `var path = require('path');\n`,
     `var dataLocation = path.resolve(__dirname, ${JSON.stringify(dataLocation)});\n`,
     `return hydrateRuntimeState(require(dataLocation), {basePath: basePath || path.dirname(dataLocation)});\n`,
   ].join(``);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`path` was used before being required, which caused `pnpEnableInlining` to completely break.

Closes #1073.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

We now require `path` before using it. ¯\\_(ツ)_/¯

I also added tests.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
