### PR TITLE
add jest to pnpify

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "jest.pathToJest": "yarn run jest"
 }

--- a/.yarn/versions/95847094.yml
+++ b/.yarn/versions/95847094.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -178,18 +178,9 @@ export const generatePrettierWrapper = async (pnpApi: PnpApi, target: PortablePa
 };
 
 export const generateJestWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
-  const wrapper = new Wrapper(`jest` as PortablePath, {pnpApi, target});
-
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`index.js` as PortablePath);
-
+  // since jest already supports pnp we can just modify the run command
   await addVSCodeWorkspaceSettings(pnpApi, {
-    [`jest.pathToJest`]: npath.fromPortablePath(
-      wrapper.getProjectPathTo(
-        `index.js` as PortablePath,
-      ),
-    ),
+    [`jest.pathToJest`]:  `yarn run jest`,
   });
 };
 
@@ -249,7 +240,7 @@ const SDKS: Array<[string, (pnpApi: PnpApi, target: PortablePath) => Promise<voi
   [`typescript-language-server`, generateTypescriptLanguageServerWrapper],
   [`typescript`, generateTypescriptWrapper],
   [`stylelint`, generateStylelintWrapper],
-  [`jest`, generateJestWrapper]
+  [`jest`, generateJestWrapper],
 ];
 
 export const generateSdk = async (pnpApi: PnpApi): Promise<any> => {

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -177,6 +177,22 @@ export const generatePrettierWrapper = async (pnpApi: PnpApi, target: PortablePa
   });
 };
 
+export const generateJestWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`jest` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`index.js` as PortablePath);
+
+  await addVSCodeWorkspaceSettings(pnpApi, {
+    [`jest.pathToJest`]: npath.fromPortablePath(
+      wrapper.getProjectPathTo(
+        `index.js` as PortablePath,
+      ),
+    ),
+  });
+};
+
 export const generateTypescriptLanguageServerWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
@@ -226,12 +242,14 @@ export const generateStylelintWrapper = async (pnpApi: PnpApi, target: PortableP
   });
 };
 
+
 const SDKS: Array<[string, (pnpApi: PnpApi, target: PortablePath) => Promise<void>]> = [
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
   [`typescript-language-server`, generateTypescriptLanguageServerWrapper],
   [`typescript`, generateTypescriptWrapper],
   [`stylelint`, generateStylelintWrapper],
+  [`jest`, generateJestWrapper]
 ];
 
 export const generateSdk = async (pnpApi: PnpApi): Promise<any> => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
Add IDE editor support for [vscode-jest](https://github.com/jest-community/vscode-jest).
...

**How did you fix it?**
Jest already supports pnp but configuration for `vscode-jest` does not automatically configure the `jest.pathToJest`. All this does is modify the command in `.vscode/settings.json` to properly execute `jest tests` under pnp.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
