### PR TITLE
fix(plugin-git): add support for `git+https?` without `.git` ending

### DIFF
--- a/.yarn/versions/634da13b.yml
+++ b/.yarn/versions/634da13b.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-git": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
+++ b/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
@@ -16,6 +16,10 @@ exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#workspace=foo 1
 
 exports[`gitUtils should properly normalize GitHubOrg/foo2bar.js 1`] = `"https://github.com/GitHubOrg/foo2bar.js.git"`;
 
+exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate#v1.0.1 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
 exports[`gitUtils should properly normalize git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
 
 exports[`gitUtils should properly normalize git://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
@@ -124,6 +128,28 @@ Object {
   "treeish": Object {
     "protocol": "head",
     "request": "master",
+  },
+}
+`;
+
+exports[`gitUtils should properly split git+https://github.com/TooTallNate/util-deprecate#v1.0.1 1`] = `
+Object {
+  "extra": Object {},
+  "repo": "https://github.com/TooTallNate/util-deprecate.git",
+  "treeish": Object {
+    "protocol": null,
+    "request": "v1.0.1",
+  },
+}
+`;
+
+exports[`gitUtils should properly split git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `
+Object {
+  "extra": Object {},
+  "repo": "https://github.com/TooTallNate/util-deprecate.git",
+  "treeish": Object {
+    "protocol": null,
+    "request": "v1.0.1",
   },
 }
 `;

--- a/packages/plugin-git/sources/gitUtils.test.js
+++ b/packages/plugin-git/sources/gitUtils.test.js
@@ -19,6 +19,8 @@ const VALID_PATTERNS = [
   `git://github.com/TooTallNate/util-deprecate.git#v1.0.1`,
   `git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,
   `ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,
+  `git+https://github.com/TooTallNate/util-deprecate#v1.0.1`,
+  `git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1`,
 ];
 
 const INVALID_PATTERNS = [

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -14,8 +14,14 @@ function makeGitEnvironment() {
 const gitPatterns = [
   /^ssh:/,
   /^git(?:\+ssh)?:/,
-  /^(?:git\+)?https?:[^#]+\/[^#]+\.git(?:#.*)?$/,
+
+  // `git+` is optional, `.git` is required
+  /^(?:git\+)?https?:[^#]+\/[^#]+(?:\.git)(?:#.*)?$/,
+  // `git+` is required, `.git` is optional
+  /^(?:git\+)https?:[^#]+\/[^#]+(?:\.git)?(?:#.*)?$/,
+
   /^git@[^#]+\/[^#]+\.git(?:#.*)?$/,
+
   /^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z._0-9-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z._0-9-]+?)(?:\.git)?(?:#.*)?$/,
   // GitHub `/tarball/` URLs
   /^https:\/\/github\.com\/(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)\/tarball\/(.+)?$/,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We currently support the "`git+https?` is optional, `.git` is required" case, but not the "`git+https?` is required, `.git` is optional" case.

Fixes #1447.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I split the pattern into 2 patterns, one for each case.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
