### PR TITLE
[node_modules] Performs hoisting to each root node in one pass only

### DIFF
--- a/.yarn/versions/1105671a.yml
+++ b/.yarn/versions/1105671a.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-node-modules": prerelease
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -290,6 +290,23 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
 
       const leafNode = makeLeafNode(locator, references.slice(1));
       if (!dep.name.endsWith(`$wsroot$`)) {
+        const prevNode = tree.get(nodeModulesLocation);
+        if (prevNode) {
+          if (prevNode.dirList) {
+            throw new Error(`Assertion failed: ${nodeModulesLocation} cannot merge dir node with leaf node`);
+          } else {
+            const locator1 = structUtils.parseLocator(prevNode.locator);
+            const locator2 = structUtils.parseLocator(leafNode.locator);
+
+            if (prevNode.linkType !== leafNode.linkType)
+              throw new Error(`Assertion failed: ${nodeModulesLocation} cannot merge nodes with different link types`);
+            else if (locator1.identHash !== locator2.identHash)
+              throw new Error(`Assertion failed: ${nodeModulesLocation} cannot merge nodes with different idents ${structUtils.stringifyLocator(locator1)} and ${structUtils.stringifyLocator(locator2)}`);
+
+            leafNode.aliases = [...leafNode.aliases, ...prevNode.aliases, structUtils.parseLocator(prevNode.locator).reference];
+          }
+        }
+
         tree.set(nodeModulesLocation, leafNode);
 
         const segments = nodeModulesLocation.split(`/`);

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -149,20 +149,6 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
 };
 
 /**
- * Decouples graph path all the way from decoupled graph node (tree node) up to the node in concern.
- *
- * @param nodePath graph path that starts from decoupled graph node up to the node in concern
- * @returns decoupled node, the last one in `nodePath`
- */
-const decoupleGraphPath = (nodePath: Array<HoisterWorkTree>): HoisterWorkTree => {
-  let parentNode = nodePath[0];
-  for (const node of nodePath.slice(1))
-    parentNode = decoupleGraphNode(parentNode, parentNode.dependencies.get(node.name)!);
-
-  return parentNode;
-};
-
-/**
  * Builds a map of most popular packages that might be hoisted to the root node.
  *
  * The values in the map are idents sorted by popularity from most popular to less popular.
@@ -242,15 +228,14 @@ const hoistTo = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath:
 
   let wasStateChanged;
   do {
-    wasStateChanged = hoistGraph(tree, rootNode, rootNodePath, hoistedDependencies, hoistIdents, options);
-    if (!wasStateChanged) {
-      for (const [name, idents] of hoistIdentMap) {
-        if (idents.length > 1 && !rootNode.dependencies.has(name)) {
-          hoistIdents.delete(idents[0]);
-          idents.shift();
-          hoistIdents.add(idents[0]);
-          wasStateChanged = true;
-        }
+    hoistGraph(tree, rootNode, rootNodePath, hoistedDependencies, hoistIdents, options);
+    wasStateChanged = false;
+    for (const [name, idents] of hoistIdentMap) {
+      if (idents.length > 1 && !rootNode.dependencies.has(name)) {
+        hoistIdents.delete(idents[0]);
+        idents.shift();
+        hoistIdents.add(idents[0]);
+        wasStateChanged = true;
       }
     }
   } while (wasStateChanged);
@@ -309,12 +294,10 @@ const getSortedReglarDependencies = (node: HoisterWorkTree): Set<HoisterWorkTree
  * @param hoistedDependencies map of dependencies that were hoisted to parent nodes
  * @param hoistIdents idents that should be attempted to be hoisted to the root node
  */
-const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath: Set<Locator>, hoistedDependencies: Map<PackageName, HoisterWorkTree>, hoistIdents: Set<Ident>, options: InternalHoistOptions): boolean => {
-  let wasGraphChanged = false;
-
+const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath: Set<Locator>, hoistedDependencies: Map<PackageName, HoisterWorkTree>, hoistIdents: Set<Ident>, options: InternalHoistOptions) => {
   const seenNodes = new Set<HoisterWorkTree>();
 
-  const hoistNode = (nodePath: Array<HoisterWorkTree>, locatorPath: Array<Locator>, node: HoisterWorkTree) => {
+  const hoistNode = (nodePath: Array<HoisterWorkTree>, locatorPath: Array<Locator>, node: HoisterWorkTree, newNodes: Set<HoisterWorkTree>) => {
     if (seenNodes.has(node))
       return;
 
@@ -330,13 +313,13 @@ const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePa
       for (let idx = nodePath.length - 1; idx >= 1; idx--) {
         const parent = nodePath[idx];
         for (const name of checkList) {
-          if (parent.peerNames.has(name))
+          if (parent.peerNames.has(name) && parent.originalDependencies.has(name))
             continue;
 
           const parentDepNode = parent.dependencies.get(name);
           if (parentDepNode) {
             if (options.debugLevel >= 2)
-              reason = `- peer dependency ${prettyPrintLocator(parentDepNode.locator)} from parent ${prettyPrintLocator(parent.locator)} was not hoisted to ${reasonRoot}`;
+              reason = `- peer dependency ${prettyPrintLocator(parentDepNode.locator)} from parent ${prettyPrintLocator(parent.locator)} was not hoisted to ${reasonRoot}, node path: ${nodePath.concat([node]).map(x => prettyPrintLocator(x.locator))}`;
             arePeerDepsSatisfied = false;
             break;
           }
@@ -372,17 +355,17 @@ const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePa
     }
 
     if (isHoistable) {
-      const parentNode = decoupleGraphPath(nodePath);
+      const parentNode = nodePath[nodePath.length - 1];
       parentNode.dependencies.delete(node.name);
       parentNode.hoistedDependencies.set(node.name, node);
       parentNode.reasons.delete(node.name);
-      wasGraphChanged = true;
       const hoistedNode = rootNode.dependencies.get(node.name);
       // Add hoisted node to root node, in case it is not already there
       if (!hoistedNode) {
         // Avoid adding other version of root node to itself
         if (rootNode.ident !== node.ident) {
           rootNode.dependencies.set(node.name, node);
+          newNodes.add(node);
         }
       } else {
         for (const reference of node.references) {
@@ -404,30 +387,36 @@ const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePa
     }
 
     if (!isHoistable && locatorPath.indexOf(node.locator) < 0) {
-      seenNodes.add(node);
+      const decoupledNode = decoupleGraphNode(nodePath[nodePath.length - 1], node);
+      seenNodes.add(decoupledNode);
 
       for (const dep of getSortedReglarDependencies(node))
-        hoistNode([...nodePath, node], [...locatorPath, node.locator], dep);
+        hoistNode([...nodePath, decoupledNode], [...locatorPath, node.locator], dep, newNodes);
 
-      seenNodes.delete(node);
+      seenNodes.delete(decoupledNode);
     }
   };
 
-  for (const dep of rootNode.dependencies.values()) {
-    if (rootNode.peerNames.has(dep.name) || dep.locator === rootNode.locator)
-      continue;
-    seenNodes.add(dep);
+  let newNodes;
+  let nextNewNodes = new Set(rootNode.dependencies.values());
+  do {
+    newNodes = nextNewNodes;
+    nextNewNodes = new Set();
+    for (const dep of newNodes) {
+      if (rootNode.peerNames.has(dep.name) || dep.locator === rootNode.locator)
+        continue;
+      const decoupledDep = decoupleGraphNode(rootNode, dep);
+      seenNodes.add(decoupledDep);
 
-    for (const subDep of getSortedReglarDependencies(dep)) {
-      if (subDep.locator !== dep.locator) {
-        hoistNode([rootNode, dep], [rootNode.locator, dep.locator], subDep);
+      for (const subDep of getSortedReglarDependencies(dep)) {
+        if (subDep.locator !== dep.locator) {
+          hoistNode([rootNode, decoupledDep], [rootNode.locator, dep.locator], subDep, nextNewNodes);
+        }
       }
+
+      seenNodes.delete(decoupledDep);
     }
-
-    seenNodes.delete(dep);
-  }
-
-  return wasGraphChanged;
+  } while (nextNewNodes.size > 0);
 };
 
 const selfCheck = (tree: HoisterWorkTree): string => {

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -242,10 +242,9 @@ const hoistTo = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath:
 
   for (const dependency of rootNode.dependencies.values()) {
     if (!rootNode.peerNames.has(dependency.name) && !rootNodePath.has(dependency.locator)) {
-      const clone = decoupleGraphNode(rootNode, dependency);
-      rootNodePath.add(clone.locator);
-      hoistTo(tree, clone, rootNodePath, options);
-      rootNodePath.delete(clone.locator);
+      rootNodePath.add(dependency.locator);
+      hoistTo(tree, dependency, rootNodePath, options);
+      rootNodePath.delete(dependency.locator);
     }
   }
 };

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -319,7 +319,7 @@ const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePa
           const parentDepNode = parent.dependencies.get(name);
           if (parentDepNode) {
             if (options.debugLevel >= 2)
-              reason = `- peer dependency ${prettyPrintLocator(parentDepNode.locator)} from parent ${prettyPrintLocator(parent.locator)} was not hoisted to ${reasonRoot}, node path: ${nodePath.concat([node]).map(x => prettyPrintLocator(x.locator))}`;
+              reason = `- peer dependency ${prettyPrintLocator(parentDepNode.locator)} from parent ${prettyPrintLocator(parent.locator)} was not hoisted to ${reasonRoot}`;
             arePeerDepsSatisfied = false;
             break;
           }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR further speeds up hoisting process, by doing hoisting to each root node exactly in one pass, without need for multiple passes.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

We are decoupling graph nodes to convert them into tree nodes as we go and use these new nodes to check the peer dependency promises are satisfied, this is possible now, because we hoist as we go. Previously we hoisted as we go, but used original nodes and hence our peer deps were always not satisfied which lead to the need for multiple iterattions.

The speedup varies, but I've seen 2x speedup on big projects.

The PR also fixes the case when workspace dependency locators were not merged together and some of them were lost because of this in `buildNodeModulesTree`. Now they are merged together and also a bunch of assertions added to determine if we try to merge nodes that can't be merged.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
