### PR TITLE
fix(core): ignore node_modules and .git folders for workspaces

### DIFF
--- a/.yarn/versions/8cc061aa.yml
+++ b/.yarn/versions/8cc061aa.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -69,6 +69,7 @@ export class Workspace {
         expandDirectories: false,
         onlyDirectories: true,
         onlyFiles: false,
+        ignore: [`node_modules`, `.git`],
       });
 
       // It seems that the return value of globby isn't in any guaranteed order - not even the directory listing order


### PR DESCRIPTION
**What's the problem this PR addresses?**

When specifying a globstar pattern for workspaces, the `node_modules` folders aren't ignored which causes `duplicate workspace name` errors.

Fixes https://github.com/yarnpkg/berry/issues/1297
Fixes https://github.com/yarnpkg/berry/issues/1191

**How did you fix it?**

Ignore `node_modules` and `.git` folders when searching for workspaces

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
