### PR TITLE
Using proper svelte extension settings now

### DIFF
--- a/.yarn/versions/fb20bd87.yml
+++ b/.yarn/versions/fb20bd87.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
@@ -94,7 +94,7 @@ export const generateStylelintWrapper: GenerateIntegrationWrapper = async (pnpAp
 
 export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`svelte.language-server.runtime`]: npath.fromPortablePath(
+    [`svelte.language-server.ls-path`]: npath.fromPortablePath(
       wrapper.getProjectPathTo(
         `bin/server.js` as PortablePath,
       ),


### PR DESCRIPTION
**What's the problem this PR addresses?**
We were changing `svelte.language-server.runtime` which isn't the correct option to be used. Now it is changing `svelte.language-server.ls-path` which should be added by this [PR](https://github.com/sveltejs/language-tools/pull/202)

**How did you fix it?**
Changed the string

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
