### PR TITLE
fix(plugin-essentials): don't show prompt if suggestions are identical

### DIFF
--- a/.yarn/versions/604dd281.yml
+++ b/.yarn/versions/604dd281.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -185,8 +185,15 @@ export default class AddCommand extends BaseCommand {
         return suggestion.descriptor !== null;
       });
 
-      if (nonNullSuggestions.length === 1) {
-        selected = nonNullSuggestions[0].descriptor;
+      const firstSuggestedDescriptor = nonNullSuggestions[0].descriptor;
+
+      if (
+        nonNullSuggestions.length === 1
+        || nonNullSuggestions.every(
+          ({descriptor}) => structUtils.areDescriptorsEqual(descriptor, firstSuggestedDescriptor)
+        )
+      ) {
+        selected = firstSuggestedDescriptor;
       } else {
         askedQuestions = true;
         ({answer: selected} = await prompt({

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -186,13 +186,9 @@ export default class AddCommand extends BaseCommand {
       });
 
       const firstSuggestedDescriptor = nonNullSuggestions[0].descriptor;
+      const areAllTheSame = nonNullSuggestions.every(suggestion => structUtils.areDescriptorsEqual(suggestion.descriptor, firstSuggestedDescriptor));
 
-      if (
-        nonNullSuggestions.length === 1
-        || nonNullSuggestions.every(
-          ({descriptor}) => structUtils.areDescriptorsEqual(descriptor, firstSuggestedDescriptor)
-        )
-      ) {
+      if (nonNullSuggestions.length === 1 || areAllTheSame) {
         selected = firstSuggestedDescriptor;
       } else {
         askedQuestions = true;

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -188,8 +188,15 @@ export default class UpCommand extends BaseCommand {
         return suggestion.descriptor !== null;
       });
 
-      if (nonNullSuggestions.length === 1) {
-        selected = nonNullSuggestions[0].descriptor;
+      const firstSuggestedDescriptor = nonNullSuggestions[0].descriptor;
+
+      if (
+        nonNullSuggestions.length === 1
+        || nonNullSuggestions.every(
+          ({descriptor}) => structUtils.areDescriptorsEqual(descriptor, firstSuggestedDescriptor)
+        )
+      ) {
+        selected = firstSuggestedDescriptor;
       } else {
         askedQuestions = true;
         ({answer: selected} = await prompt({

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -189,13 +189,9 @@ export default class UpCommand extends BaseCommand {
       });
 
       const firstSuggestedDescriptor = nonNullSuggestions[0].descriptor;
+      const areAllTheSame = nonNullSuggestions.every(suggestion => structUtils.areDescriptorsEqual(suggestion.descriptor, firstSuggestedDescriptor));
 
-      if (
-        nonNullSuggestions.length === 1
-        || nonNullSuggestions.every(
-          ({descriptor}) => structUtils.areDescriptorsEqual(descriptor, firstSuggestedDescriptor)
-        )
-      ) {
+      if (nonNullSuggestions.length === 1 || areAllTheSame) {
         selected = firstSuggestedDescriptor;
       } else {
         askedQuestions = true;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn {add,up} foo -i` always prompts the user if `foo` already exists inside another workspace, even if it has the same range as the latest resolved from the registry.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it so that the prompt is skipped if all (non-null) suggested descriptors returned by `suggestUtils` are identical.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
