### PR TITLE
Improves init

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -8669,10 +8669,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-init-virtual-bb60ce87e8/1/packages/plugin-init/",
           "packageDependencies": [
             ["@yarnpkg/plugin-init", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-init"],
+            ["@types/lodash", "npm:4.14.136"],
             ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.4.1"],
+            ["lodash", "npm:4.17.15"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -8685,10 +8687,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-init-virtual-39bcb727de/1/packages/plugin-init/",
           "packageDependencies": [
             ["@yarnpkg/plugin-init", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-init"],
+            ["@types/lodash", "npm:4.14.136"],
             ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.4.1"],
+            ["lodash", "npm:4.17.15"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -8701,10 +8705,12 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/plugin-init/",
           "packageDependencies": [
             ["@yarnpkg/plugin-init", "workspace:packages/plugin-init"],
+            ["@types/lodash", "npm:4.14.136"],
             ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["clipanion", "npm:2.4.1"],
+            ["lodash", "npm:4.17.15"],
             ["tslib", "npm:1.13.0"]
           ],
           "linkType": "SOFT",

--- a/.yarn/versions/91b6d6ad.yml
+++ b/.yarn/versions/91b6d6ad.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-init": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.22",
     "clipanion": "^2.4.1",
+    "lodash": "^4.17.15",
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
@@ -13,6 +14,7 @@
     "@yarnpkg/core": "^2.0.0-rc.30"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.136",
     "@yarnpkg/cli": "workspace:^2.0.0-rc.36",
     "@yarnpkg/core": "workspace:^2.0.0-rc.30"
   },

--- a/packages/plugin-init/sources/index.ts
+++ b/packages/plugin-init/sources/index.ts
@@ -27,6 +27,14 @@ const plugin: Plugin = {
         type: SettingsType.ANY,
       },
     },
+    initEditorConfig: {
+      description: `Extra rules to define in the generator editorconfig`,
+      type: SettingsType.MAP,
+      valueDefinition: {
+        description: ``,
+        type: SettingsType.ANY,
+      },
+    },
   },
   commands: [
     init,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6407,10 +6407,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-init@workspace:packages/plugin-init"
   dependencies:
+    "@types/lodash": ^4.14.136
     "@yarnpkg/cli": "workspace:^2.0.0-rc.36"
     "@yarnpkg/core": "workspace:^2.0.0-rc.30"
     "@yarnpkg/fslib": "workspace:^2.0.0-rc.22"
     clipanion: ^2.4.1
+    lodash: ^4.17.15
     tslib: ^1.13.0
   peerDependencies:
     "@yarnpkg/cli": ^2.0.0-rc.36


### PR DESCRIPTION
**What's the problem this PR addresses?**

I created a new project yesterday and I still had to spend 5+ minutes copying files from another repository. We should do better, especially since some of those settings (like the gitignore) are required because of Yarn itself.

**How did you fix it?**

Running `yarn init` will now generate more files than usual. It will also:

- initialize the folder as a git repository, because in practice that's always what we want
- add a gitignore + gitattributes file
- add an editorconfig with the configuration that we use for the `.json` / `.yml` files that we generate (also `.js` as a bonus, but that can be easily overridden in the configuration)

If I had this PR yesterday, I'd still have had to:

- Copy the tsconfig
- Copy the rollup config
- Set the main + publishConfig
- Update the gitignore to add my build folder
- Add a npmignore to ignore the sources

I think those should be solved later (by adding a templating system), but we can think about it later.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
