### PR TITLE
perf: Reduce `yarn add/yarn remove` time by validating cache file checksums only once

### DIFF
--- a/.yarn/versions/27adb827.yml
+++ b/.yarn/versions/27adb827.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -51,6 +51,7 @@ export class ExecFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator),
       loader: () => this.fetchFromDisk(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-file/sources/FileFetcher.ts
+++ b/packages/plugin-file/sources/FileFetcher.ts
@@ -32,6 +32,7 @@ export class FileFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the disk`),
       loader: () => this.fetchFromDisk(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-file/sources/TarballFileFetcher.ts
+++ b/packages/plugin-file/sources/TarballFileFetcher.ts
@@ -27,6 +27,7 @@ export class TarballFileFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the disk`),
       loader: () => this.fetchFromDisk(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-git/sources/GitFetcher.ts
+++ b/packages/plugin-git/sources/GitFetcher.ts
@@ -27,6 +27,7 @@ export class GitFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote repository`),
       loader: () => this.cloneFromRemote(normalizedLocator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-github/sources/GithubFetcher.ts
+++ b/packages/plugin-github/sources/GithubFetcher.ts
@@ -25,6 +25,7 @@ export class GithubFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from GitHub`),
       loader: () => this.fetchFromNetwork(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-http/sources/TarballHttpFetcher.ts
+++ b/packages/plugin-http/sources/TarballHttpFetcher.ts
@@ -26,6 +26,7 @@ export class TarballHttpFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote server`),
       loader: () => this.fetchFromNetwork(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -32,6 +32,7 @@ export class NpmHttpFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote server`),
       loader: () => this.fetchFromNetwork(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-npm/sources/NpmSemverFetcher.ts
+++ b/packages/plugin-npm/sources/NpmSemverFetcher.ts
@@ -34,6 +34,7 @@ export class NpmSemverFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote registry`),
       loader: () => this.fetchFromNetwork(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/plugin-patch/sources/PatchFetcher.ts
+++ b/packages/plugin-patch/sources/PatchFetcher.ts
@@ -25,6 +25,7 @@ export class PatchFetcher implements Fetcher {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the disk`),
       loader: () => this.patchPackage(locator, opts),
+      skipIntegrityCheck: opts.skipIntegrityCheck,
     });
 
     return {

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -134,7 +134,7 @@ export class Cache {
     }
   }
 
-  async fetchPackageFromCache(locator: Locator, expectedChecksum: string | null, {onHit, onMiss, loader, skipIntegrityCheck}: {onHit?: () => void, onMiss?: () => void, loader?: () => Promise<ZipFS>, skipIntegrityCheck: boolean}): Promise<[FakeFS<PortablePath>, () => void, string]> {
+  async fetchPackageFromCache(locator: Locator, expectedChecksum: string | null, {onHit, onMiss, loader, skipIntegrityCheck}: {onHit?: () => void, onMiss?: () => void, loader?: () => Promise<ZipFS>, skipIntegrityCheck?: boolean}): Promise<[FakeFS<PortablePath>, () => void, string]> {
     const mirrorPath = this.getLocatorMirrorPath(locator);
 
     const baseFs = new NodeFS();

--- a/packages/yarnpkg-core/sources/Fetcher.ts
+++ b/packages/yarnpkg-core/sources/Fetcher.ts
@@ -14,6 +14,7 @@ export type FetchOptions = MinimalFetchOptions & {
   cache: Cache,
   checksums: Map<LocatorHash, string>,
   report: Report,
+  skipIntegrityCheck: boolean
 };
 
 export type FetchResult = {

--- a/packages/yarnpkg-core/sources/Fetcher.ts
+++ b/packages/yarnpkg-core/sources/Fetcher.ts
@@ -14,7 +14,7 @@ export type FetchOptions = MinimalFetchOptions & {
   cache: Cache,
   checksums: Map<LocatorHash, string>,
   report: Report,
-  skipIntegrityCheck: boolean
+  skipIntegrityCheck?: boolean
 };
 
 export type FetchResult = {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -541,7 +541,7 @@ export class Project {
 
     const resolveOptions: ResolveOptions = opts.lockfileOnly
       ? {project: this, report: opts.report, resolver}
-      : {project: this, report: opts.report, resolver, fetchOptions: {project: this, cache: opts.cache, checksums: this.storedChecksums, report: opts.report, fetcher}};
+      : {project: this, report: opts.report, resolver, fetchOptions: {project: this, cache: opts.cache, checksums: this.storedChecksums, report: opts.report, fetcher, skipIntegrityCheck: false}};
 
     const allDescriptors = new Map<DescriptorHash, Descriptor>();
     const allPackages = new Map<LocatorHash, Package>();
@@ -938,7 +938,7 @@ export class Project {
 
   async fetchEverything({cache, report, fetcher: userFetcher}: InstallOptions) {
     const fetcher = userFetcher || this.configuration.makeFetcher();
-    const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report};
+    const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report, skipIntegrityCheck: false};
 
     const locatorHashes = miscUtils.sortMap(this.storedResolutions.values(), [(locatorHash: LocatorHash) => {
       const pkg = this.storedPackages.get(locatorHash);
@@ -994,7 +994,7 @@ export class Project {
 
   async linkEverything({cache, report, fetcher: optFetcher}: InstallOptions) {
     const fetcher = optFetcher || this.configuration.makeFetcher();
-    const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report};
+    const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report, skipIntegrityCheck: true};
 
     const linkers = this.configuration.getLinkers();
     const linkerOptions = {project: this, report};

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -541,7 +541,7 @@ export class Project {
 
     const resolveOptions: ResolveOptions = opts.lockfileOnly
       ? {project: this, report: opts.report, resolver}
-      : {project: this, report: opts.report, resolver, fetchOptions: {project: this, cache: opts.cache, checksums: this.storedChecksums, report: opts.report, fetcher, skipIntegrityCheck: false}};
+      : {project: this, report: opts.report, resolver, fetchOptions: {project: this, cache: opts.cache, checksums: this.storedChecksums, report: opts.report, fetcher}};
 
     const allDescriptors = new Map<DescriptorHash, Descriptor>();
     const allPackages = new Map<LocatorHash, Package>();
@@ -938,7 +938,7 @@ export class Project {
 
   async fetchEverything({cache, report, fetcher: userFetcher}: InstallOptions) {
     const fetcher = userFetcher || this.configuration.makeFetcher();
-    const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report, skipIntegrityCheck: false};
+    const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report};
 
     const locatorHashes = miscUtils.sortMap(this.storedResolutions.values(), [(locatorHash: LocatorHash) => {
       const pkg = this.storedPackages.get(locatorHash);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Yarn computes cache file checksums during `Fetch step` and then computes the same cache file checksums during `Link step`.

On a `next.js` project this results in the following timings:
||before|after|
|--|--|--|
|yarn add leftpad| 16.47s | 13.44s|

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have added a `skipIntegrityCheck` option to `Fetcher` that can be used during Link step to not run integrity checks on the same files the second time. 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
