### PR TITLE
chore(plugin-exec): Fix docs for tar usage that works for GNU & BSD

### DIFF
--- a/.yarn/versions/a0de8eea.yml
+++ b/.yarn/versions/a0de8eea.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-exec"

--- a/packages/plugin-exec/README.md
+++ b/packages/plugin-exec/README.md
@@ -97,5 +97,5 @@ child_process.execFileSync(`yarn`, [`install`], {cwd: pathToRepo});
 child_process.execFileSync(`yarn`, [`pack`, `--out`, pathToArchive], {cwd: pathToSubpackage});
 
 // Send the package content into the build directory
-child_process.execFileSync(`tar`, [`xfz`, `--strip-components=1`, pathToArchive, `-C`, execEnv.buildDir]);
+child_process.execFileSync(`tar`, [`-x`, `-z`, `--strip-components=1`, `-f`, pathToArchive, `-C`, execEnv.buildDir]);
 ```


### PR DESCRIPTION
This PR updates the `plugin-exec` documentation for the monorepo package build example with a package extraction that works for both GNU- and BSD-based OS's.