### PR TITLE
fix: make yarn up resolve latest for tag

### DIFF
--- a/.yarn/versions/b65d59df.yml
+++ b/.yarn/versions/b65d59df.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -417,8 +417,8 @@ export class Project {
     }
   }
 
-  forgetResolution(descriptor: Descriptor): void
-  forgetResolution(locator: Locator): void
+  forgetResolution(descriptor: Descriptor): void;
+  forgetResolution(locator: Locator): void;
   forgetResolution(dataStructure: Descriptor | Locator): void {
     for (const [descriptorHash, locatorHash] of this.storedResolutions) {
       const doDescriptorHashesMatch = `descriptorHash` in dataStructure

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -417,9 +417,25 @@ export class Project {
     }
   }
 
+  forgetResolution(descriptor: Descriptor): void
+  forgetResolution(locator: Locator): void
+  forgetResolution(dataStructure: Descriptor | Locator): void {
+    for (const [descriptorHash, locatorHash] of this.storedResolutions) {
+      const doDescriptorHashesMatch = `descriptorHash` in dataStructure
+        && dataStructure.descriptorHash === descriptorHash;
+      const doLocatorHashesMatch = `locatorHash` in dataStructure
+        && dataStructure.locatorHash === locatorHash;
+
+      if (doDescriptorHashesMatch || doLocatorHashesMatch) {
+        this.storedDescriptors.delete(descriptorHash);
+        this.storedResolutions.delete(descriptorHash);
+        this.originalPackages.delete(locatorHash);
+      }
+    }
+  }
+
   forgetTransientResolutions() {
     const resolver = this.configuration.makeResolver();
-    const forgottenPackages = new Set();
 
     for (const pkg of this.originalPackages.values()) {
       let shouldPersistResolution: boolean;
@@ -430,15 +446,7 @@ export class Project {
       }
 
       if (!shouldPersistResolution) {
-        this.originalPackages.delete(pkg.locatorHash);
-        forgottenPackages.add(pkg.locatorHash);
-      }
-    }
-
-    for (const [descriptorHash, locatorHash] of this.storedResolutions) {
-      if (forgottenPackages.has(locatorHash)) {
-        this.storedResolutions.delete(descriptorHash);
-        this.storedDescriptors.delete(descriptorHash);
+        this.forgetResolution(pkg);
       }
     }
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn up foo@tag` doesn't re-resolve `tag` if it's already part of the lockfile.

Fixes #1419.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- I added a new `project.forgetResolution` method - accepts both descriptors and locators as arguments.
- I made it so that `yarn up` calls this method if the current descriptor matches the updated descriptor. This "unlocks" the dependency, causing it to be resolved again to the latest satisfying version.

This means that now:
- `yarn up foo@canary` updates `foo` to the latest version resolved for the `canary` tag
- `yarn up foo@3.x` updates `foo` to the latest version resolved for the `3.x` range
- `yarn up foo@github-repo/foo` updates `foo` to the version resolved from the latest commit

Note: I removed the `hasChanged` part of `yarn up`, as we'd have to manually run `resolver.getCandidates` to see if the resolution changes, which would unnecessarily increase the execution time.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
