### PR TITLE
chore(plugin-exec): Document normalization of access/modification time

### DIFF
--- a/.yarn/versions/1b7449db.yml
+++ b/.yarn/versions/1b7449db.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-exec"

--- a/packages/plugin-exec/README.md
+++ b/packages/plugin-exec/README.md
@@ -98,4 +98,11 @@ child_process.execFileSync(`yarn`, [`pack`, `--out`, pathToArchive], {cwd: pathT
 
 // Send the package content into the build directory
 child_process.execFileSync(`tar`, [`-x`, `-z`, `--strip-components=1`, `-f`, pathToArchive, `-C`, execEnv.buildDir]);
+
+// Normalize emitted directories and files to 1980-01-01 access/modification time for a consistent checksum
+const defaultTime = 315532800;
+const files = child_process.execFileSync('find', [execEnv.buildDir]).toString().trim().split('\n');
+for (const file of files) {
+  fs.utimesSync(file, defaultTime, defaultTime);
+}
 ```


### PR DESCRIPTION
Extend the monorepo example with an access-/modification time normalization
step.

`yarn pack` does not pack directories, and archive extraction with `tar` will
then create new directories timestamped at extraction time. This produces a
different checksum every time the script is run.

Normalizing those timestamps will produce consistent checksums on following runs
if the actual file contents remain unchanged.

---

Given the restricted environment, I think, `find` is the most verbose and shortest way of listing files recursively. The Node.js file system module is rather limited in that regard.