### PR TITLE
Fixes ignore glob pattern for workspaces

### DIFF
--- a/.yarn/versions/30ccfadf.yml
+++ b/.yarn/versions/30ccfadf.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -69,7 +69,7 @@ export class Workspace {
         expandDirectories: false,
         onlyDirectories: true,
         onlyFiles: false,
-        ignore: [`**/node_modules/**`, `**/.git/**`, `**/.yarn/**`],
+        ignore: [`**/node_modules`, `**/.git`, `**/.yarn`],
       });
 
       // It seems that the return value of globby isn't in any guaranteed order - not even the directory listing order

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -69,7 +69,7 @@ export class Workspace {
         expandDirectories: false,
         onlyDirectories: true,
         onlyFiles: false,
-        ignore: [`**/node_modules/**`, `**/.git/**`],
+        ignore: [`**/node_modules/**`, `**/.git/**`, `**/.yarn/**`],
       });
 
       // It seems that the return value of globby isn't in any guaranteed order - not even the directory listing order

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -69,7 +69,7 @@ export class Workspace {
         expandDirectories: false,
         onlyDirectories: true,
         onlyFiles: false,
-        ignore: [`node_modules`, `.git`],
+        ignore: [`**/node_modules/**`, `**/.git/**`],
       });
 
       // It seems that the return value of globby isn't in any guaranteed order - not even the directory listing order


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Fixes: #1191 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have fixed it by fixing the ignore pattern basically `ignore: ['node_modules']` should rather be `ignore: ['**/node_modules/**']` as per:
https://github.com/mrmlnc/fast-glob#how-to-exclude-directory-from-reading

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
