### PR TITLE
Makes `yarn config get` return native paths

### DIFF
--- a/.yarn/versions/df0edab2.yml
+++ b/.yarn/versions/df0edab2.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/core": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/df0edab2.yml
+++ b/.yarn/versions/df0edab2.yml
@@ -27,4 +27,5 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/cli"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"
   - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
@@ -1,4 +1,4 @@
-import {xfs} from '@yarnpkg/fslib';
+import {npath, xfs} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
   describe(`config get`, () => {
@@ -30,6 +30,14 @@ describe(`Commands`, () => {
         await expect(run(`config`, `get`, `npmAuthToken`, `--no-redacted`)).resolves.toMatchObject({
           stdout: `foobar\n`,
         });
+      }),
+    );
+
+    test(
+      `it should print native paths`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const value = await run(`config`, `get`, `cacheFolder`, `--no-redacted`);
+        expect(value).toEqual(npath.fromPortablePath(value));
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/get.test.js
@@ -36,7 +36,9 @@ describe(`Commands`, () => {
     test(
       `it should print native paths`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        const value = await run(`config`, `get`, `cacheFolder`, `--no-redacted`);
+        const {stdout} = await run(`config`, `get`, `cacheFolder`, `--no-redacted`);
+        const value = stdout.trim();
+
         expect(value).toEqual(npath.fromPortablePath(value));
       }),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/projectDetection.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/projectDetection.test.js
@@ -1,3 +1,5 @@
+import {npath} from '@yarnpkg/fslib';
+
 const {
   fs: {mkdirp, writeFile},
   misc: {parseJsonStream},
@@ -15,7 +17,7 @@ describe(`Features`, () => {
             `key`,
           )).toMatchObject({
             [`cacheFolder`]: {
-              effective: `${path}/.yarn/cache`,
+              effective: npath.fromPortablePath(`${path}/.yarn/cache`),
             },
           });
         },
@@ -36,7 +38,7 @@ describe(`Features`, () => {
             `key`,
           )).toMatchObject({
             [`cacheFolder`]: {
-              effective: `${path}/.yarn/cache`,
+              effective: npath.fromPortablePath(`${path}/.yarn/cache`),
             },
           });
         },
@@ -58,7 +60,7 @@ describe(`Features`, () => {
             `key`,
           )).toMatchObject({
             [`cacheFolder`]: {
-              effective: `${path}/subfolder/.yarn/cache`,
+              effective: npath.fromPortablePath(`${path}/subfolder/.yarn/cache`),
             },
           });
         },

--- a/packages/plugin-essentials/sources/commands/config.ts
+++ b/packages/plugin-essentials/sources/commands/config.ts
@@ -100,11 +100,11 @@ export default class ConfigCommand extends BaseCommand {
           }, 0);
 
           for (const [key, description] of keysAndDescriptions) {
-            report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${description.padEnd(maxDescriptionLength, ` `)}   ${inspect(configuration.getRedacted(key), inspectConfig)}`);
+            report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${description.padEnd(maxDescriptionLength, ` `)}   ${inspect(configuration.getSpecial(key, {hideSecrets: true, getNativePaths: true}), inspectConfig)}`);
           }
         } else {
           for (const key of keys) {
-            report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${inspect(configuration.getRedacted(key), inspectConfig)}`);
+            report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${inspect(configuration.getSpecial(key, {hideSecrets: true, getNativePaths: true}), inspectConfig)}`);
           }
         }
       }

--- a/packages/plugin-essentials/sources/commands/config.ts
+++ b/packages/plugin-essentials/sources/commands/config.ts
@@ -58,7 +58,11 @@ export default class ConfigCommand extends BaseCommand {
         for (const key of keys) {
           const data = configuration.settings.get(key);
 
-          const effective = configuration.getRedacted(key);
+          const effective = configuration.getSpecial(key, {
+            hideSecrets: true,
+            getNativePaths: true,
+          });
+
           const source = configuration.sources.get(key);
 
           if (this.verbose) {

--- a/packages/plugin-essentials/sources/commands/config/get.ts
+++ b/packages/plugin-essentials/sources/commands/config/get.ts
@@ -1,8 +1,8 @@
-import {BaseCommand}                 from '@yarnpkg/cli';
-import {Configuration, StreamReport} from '@yarnpkg/core';
-import {Command, Usage, UsageError}  from 'clipanion';
-import getPath                       from 'lodash/get';
-import {inspect}                     from 'util';
+import {BaseCommand}                                                   from '@yarnpkg/cli';
+import {Configuration, StreamReport, SettingsDefinition, SettingsType} from '@yarnpkg/core';
+import {Command, Usage, UsageError}                                    from 'clipanion';
+import getPath                                                         from 'lodash/get';
+import {inspect}                                                       from 'util';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ConfigSetCommand extends BaseCommand {
@@ -51,9 +51,10 @@ export default class ConfigSetCommand extends BaseCommand {
     if (typeof setting === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${name}"`);
 
-    const value = this.unsafe
-      ? configuration.get(name)
-      : configuration.getRedacted(name);
+    const value = configuration.getSpecial(name, {
+      hideSecrets: !this.unsafe,
+      getNativePaths: true,
+    });
 
     const asObject = convertMapsToObjects(value);
     const requestedObject = path

--- a/packages/plugin-essentials/sources/commands/config/get.ts
+++ b/packages/plugin-essentials/sources/commands/config/get.ts
@@ -1,8 +1,8 @@
-import {BaseCommand}                                                   from '@yarnpkg/cli';
-import {Configuration, StreamReport, SettingsDefinition, SettingsType} from '@yarnpkg/core';
-import {Command, Usage, UsageError}                                    from 'clipanion';
-import getPath                                                         from 'lodash/get';
-import {inspect}                                                       from 'util';
+import {BaseCommand}                 from '@yarnpkg/cli';
+import {Configuration, StreamReport} from '@yarnpkg/core';
+import {Command, Usage, UsageError}  from 'clipanion';
+import getPath                       from 'lodash/get';
+import {inspect}                     from 'util';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ConfigSetCommand extends BaseCommand {
@@ -51,12 +51,12 @@ export default class ConfigSetCommand extends BaseCommand {
     if (typeof setting === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${name}"`);
 
-    const value = configuration.getSpecial(name, {
+    const displayedValue = configuration.getSpecial(name, {
       hideSecrets: !this.unsafe,
       getNativePaths: true,
     });
 
-    const asObject = convertMapsToObjects(value);
+    const asObject = convertMapsToObjects(displayedValue);
     const requestedObject = path
       ? getPath(asObject, path)
       : asObject;

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -74,12 +74,12 @@ export default class ConfigSetCommand extends BaseCommand {
     });
 
     const updatedConfiguration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const redactedValue = updatedConfiguration.getSpecial(name, {
+    const displayedValue = updatedConfiguration.getSpecial(name, {
       hideSecrets: true,
       getNativePaths: true,
     });
 
-    const asObject = convertMapsToObjects(redactedValue);
+    const asObject = convertMapsToObjects(displayedValue);
     const requestedObject = path
       ? getPath(asObject, path)
       : asObject;

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -74,7 +74,10 @@ export default class ConfigSetCommand extends BaseCommand {
     });
 
     const updatedConfiguration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const redactedValue = updatedConfiguration.getRedacted(name);
+    const redactedValue = updatedConfiguration.getSpecial(name, {
+      hideSecrets: true,
+      getNativePaths: true,
+    });
 
     const asObject = convertMapsToObjects(redactedValue);
     const requestedObject = path

--- a/packages/plugin-exec/sources/execUtils.ts
+++ b/packages/plugin-exec/sources/execUtils.ts
@@ -1,5 +1,5 @@
 import {structUtils, FetchOptions, Ident, Locator} from '@yarnpkg/core';
-import {ppath, NodeFS, PortablePath, npath, CwdFS} from '@yarnpkg/fslib';
+import {ppath, PortablePath, npath, CwdFS}         from '@yarnpkg/fslib';
 
 
 export function parseSpec(spec: string) {

--- a/packages/plugin-file/sources/FileFetcher.ts
+++ b/packages/plugin-file/sources/FileFetcher.ts
@@ -1,7 +1,7 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
 import {miscUtils, structUtils, tgzUtils}           from '@yarnpkg/core';
-import {NodeFS, PortablePath, ppath, CwdFS}         from '@yarnpkg/fslib';
+import {PortablePath, ppath, CwdFS}                 from '@yarnpkg/fslib';
 
 import {PROTOCOL}                                   from './constants';
 

--- a/packages/plugin-file/sources/TarballFileFetcher.ts
+++ b/packages/plugin-file/sources/TarballFileFetcher.ts
@@ -1,7 +1,7 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
 import {miscUtils, structUtils, tgzUtils}           from '@yarnpkg/core';
-import {NodeFS, PortablePath, ppath, CwdFS}         from '@yarnpkg/fslib';
+import {PortablePath, ppath, CwdFS}                 from '@yarnpkg/fslib';
 
 import {TARBALL_REGEXP, PROTOCOL}                   from './constants';
 

--- a/packages/plugin-link/sources/LinkFetcher.ts
+++ b/packages/plugin-link/sources/LinkFetcher.ts
@@ -1,7 +1,7 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
 import {structUtils}                                from '@yarnpkg/core';
-import {CwdFS, JailFS, NodeFS, ppath, PortablePath} from '@yarnpkg/fslib';
+import {CwdFS, JailFS, ppath, PortablePath}         from '@yarnpkg/fslib';
 
 import {LINK_PROTOCOL}                              from './constants';
 

--- a/packages/plugin-link/sources/RawLinkFetcher.ts
+++ b/packages/plugin-link/sources/RawLinkFetcher.ts
@@ -1,7 +1,7 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
 import {structUtils}                                from '@yarnpkg/core';
-import {CwdFS, JailFS, NodeFS, ppath, PortablePath} from '@yarnpkg/fslib';
+import {CwdFS, JailFS, ppath, PortablePath}         from '@yarnpkg/fslib';
 
 import {RAW_LINK_PROTOCOL}                          from './constants';
 

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -1,6 +1,6 @@
 import {Cache, structUtils, Locator, Descriptor, Ident, Project, ThrowReport, miscUtils, FetchOptions, Package, execUtils} from '@yarnpkg/core';
 
-import {npath, PortablePath, xfs, ppath, Filename, NodeFS, NativePath, CwdFS}                                              from '@yarnpkg/fslib';
+import {npath, PortablePath, xfs, ppath, Filename, NativePath, CwdFS}                                                      from '@yarnpkg/fslib';
 
 import {Hooks as PatchHooks}                                                                                               from './index';
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1080,14 +1080,17 @@ export class Configuration {
     return this.values.get(key) as T;
   }
 
-  getSpecial<T = any>(key: string, transforms: SettingTransforms) {
+  getSpecial<T = any>(key: string, {hideSecrets = false, getNativePaths = false}: Partial<SettingTransforms>) {
     const rawValue = this.get(key);
     const definition = this.settings.get(key);
 
     if (typeof definition === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${key}"`);
 
-    return transformConfiguration(rawValue, definition, transforms) as T;
+    return transformConfiguration(rawValue, definition, {
+      hideSecrets,
+      getNativePaths,
+    }) as T;
   }
 
   getSubprocessStreams(logFile: PortablePath, {header, prefix, report}: {header?: string, prefix: string, report: Report}) {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -553,15 +553,22 @@ function getDefaultValue(configuration: Configuration, definition: SettingsDefin
   }
 }
 
-function hideSecrets(rawValue: unknown, definition: SettingsDefinitionNoDefault) {
-  if (definition.type === SettingsType.SECRET && typeof rawValue === `string`)
+type SettingTransforms = {
+  hideSecrets: boolean;
+  getNativePaths: boolean;
+};
+
+function transformConfiguration(rawValue: unknown, definition: SettingsDefinitionNoDefault, transforms: SettingTransforms) {
+  if (definition.type === SettingsType.SECRET && typeof rawValue === `string` && transforms.hideSecrets)
     return SECRET;
+  if (definition.type === SettingsType.ABSOLUTE_PATH && typeof rawValue === `string` && transforms.getNativePaths)
+    return npath.fromPortablePath(rawValue);
 
   if (definition.isArray && Array.isArray(rawValue)) {
     const newValue: Array<unknown> = [];
 
     for (const value of rawValue)
-      newValue.push(hideSecrets(value, definition));
+      newValue.push(transformConfiguration(value, definition, transforms));
 
     return newValue;
   }
@@ -570,7 +577,7 @@ function hideSecrets(rawValue: unknown, definition: SettingsDefinitionNoDefault)
     const newValue: Map<string, unknown> = new Map();
 
     for (const [key, value] of rawValue.entries())
-      newValue.set(key, hideSecrets(value, definition.valueDefinition));
+      newValue.set(key, transformConfiguration(value, definition.valueDefinition, transforms));
 
     return newValue;
   }
@@ -580,7 +587,7 @@ function hideSecrets(rawValue: unknown, definition: SettingsDefinitionNoDefault)
 
     for (const [key, value] of rawValue.entries()) {
       const propertyDefinition = definition.properties[key];
-      newValue.set(key, hideSecrets(value, propertyDefinition));
+      newValue.set(key, transformConfiguration(value, propertyDefinition, transforms));
     }
 
     return newValue;
@@ -1073,14 +1080,14 @@ export class Configuration {
     return this.values.get(key) as T;
   }
 
-  getRedacted<T = any>(key: string) {
+  getSpecial<T = any>(key: string, transforms: SettingTransforms) {
     const rawValue = this.get(key);
     const definition = this.settings.get(key);
 
     if (typeof definition === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${key}"`);
 
-    return hideSecrets(rawValue, definition) as T;
+    return transformConfiguration(rawValue, definition, transforms) as T;
   }
 
   getSubprocessStreams(logFile: PortablePath, {header, prefix, report}: {header?: string, prefix: string, report: Report}) {

--- a/packages/yarnpkg-core/tests/Configuration.test.ts
+++ b/packages/yarnpkg-core/tests/Configuration.test.ts
@@ -26,8 +26,13 @@ describe(`Configuration`, () => {
         plugins: new Set([`@yarnpkg/plugin-npm`]),
       });
 
-      const firstToken = configuration.getRedacted(`npmAuthToken`);
-      const secondToken = configuration.getRedacted(`npmScopes`).get(`myScope`).get(`npmAuthToken`);
+      const firstToken = configuration.getSpecial(`npmAuthToken`, {
+        hideSecrets: true,
+      });
+
+      const secondToken = configuration.getSpecial(`npmScopes`, {
+        hideSecrets: true,
+      }).get(`myScope`).get(`npmAuthToken`);
 
       expect(firstToken).toEqual(SECRET);
       expect(secondToken).toEqual(SECRET);

--- a/packages/yarnpkg-pnp/sources/loader/applyPatch.ts
+++ b/packages/yarnpkg-pnp/sources/loader/applyPatch.ts
@@ -1,12 +1,12 @@
-import {FakeFS, PosixFS, npath, ppath, patchFs, PortablePath, Filename, NativePath} from '@yarnpkg/fslib';
-import fs                                                                           from 'fs';
-import {Module}                                                                     from 'module';
-import {URL, fileURLToPath}                                                         from 'url';
+import {FakeFS, PosixFS, npath, patchFs, PortablePath, Filename, NativePath} from '@yarnpkg/fslib';
+import fs                                                                    from 'fs';
+import {Module}                                                              from 'module';
+import {URL, fileURLToPath}                                                  from 'url';
 
-import {PnpApi}                                                                     from '../types';
+import {PnpApi}                                                              from '../types';
 
-import {ErrorCode, makeError, getIssuerModule}                                      from './internalTools';
-import {Manager}                                                                    from './makeManager';
+import {ErrorCode, makeError, getIssuerModule}                               from './internalTools';
+import {Manager}                                                             from './makeManager';
 
 export type ApplyPatchOptions = {
   fakeFs: FakeFS<PortablePath>,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn config get` currently returns a portable path, which makes it difficult to work with when used in shellscripts.

**How did you fix it?**

I've leveraged the work @paul-soporan did on the secret support to turn it into an all-purpose settings transform function (and renamed `getRedacted` into `getSpecial` to highlight that the function supports more transforms).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
