### PR TITLE
chore(plugin-compat): add babel-plugin-typescript-to-proptypes to ext…

### DIFF
--- a/.yarn/versions/f41b4b75.yml
+++ b/.yarn/versions/f41b4b75.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-compat": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -75,4 +75,10 @@ export const packageExtensions: Array<[string, any]> = [
       [`tiny-warning`]: `^1.0.2`,
     },
   }],
+  // https://github.com/milesj/babel-plugin-typescript-to-proptypes/pull/38
+  [`babel-plugin-typescript-to-proptypes@*`, {
+    dependencies: {
+      [`@babel/types`]: `^7.10.3`,
+    },
+  }],
 ];


### PR DESCRIPTION
…ensions

**What's the problem this PR addresses?**
Adding an item to the extensions file as described here: https://next.yarnpkg.com/advanced/migration#a-package-is-trying-to-access-another-package-

See: https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/37
...

**How did you fix it?**
Adding @babel/types to the relevant package's dependencies.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
