### PR TITLE
Remove typos from constraints file

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -44,18 +44,14 @@ gen_enforced_dependency(WorkspaceCwd, 'tslib', 'range', 'dependencies') :-
     \+ workspace_has_dependency(WorkspaceCwd, 'tslib', _, _).
 
 % This rule will enforce that all packages must have a "BSD-2-Clause" license field
-gen_enforced_field(WorkspaceCwd, 'license', 'BSD-2-Clause') :-
-  workspace(WorkspacedCwd).
+gen_enforced_field(WorkspaceCwd, 'license', 'BSD-2-Clause').
 
 % This rule will enforce that all packages must have a engines.node field of >=10.19.0
-gen_enforced_field(WorkspaceCwd, 'engines.node', '>=10.19.0') :-
-  workspace(WorkspacedCwd).
+gen_enforced_field(WorkspaceCwd, 'engines.node', '>=10.19.0').
 
 % Required to make the package work with the GitHub Package Registry
-gen_enforced_field(WorkspaceCwd, 'repository.type', 'git') :-
-  workspace(WorkspacedCwd).
-gen_enforced_field(WorkspaceCwd, 'repository.url', 'ssh://git@github.com/yarnpkg/berry.git') :-
-  workspace(WorkspacedCwd).
+gen_enforced_field(WorkspaceCwd, 'repository.type', 'git').
+gen_enforced_field(WorkspaceCwd, 'repository.url', 'ssh://git@github.com/yarnpkg/berry.git').
 
 % This rule will require that the plugins that aren't embed in the CLI list a specific script that'll
 % be called as part of our release process (to rebuild them in the context of our repository)


### PR DESCRIPTION
**What's the problem this PR addresses?**

The constraints.pro file contained typos: `WorkspaceCwd` vs `WorkspacedCwd`

**How did you fix it?**

Remove the `workspace(WorkspacedCwd)` predicate entirely, the `WorkspaceCwd` is already populated with workspace values, so this is a superfluous validation.

The fact that this kind of typo can happen without any warning or error is a strong motivator for #1276.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
