### PR TITLE
fix(pnpify): remove leading slash on windows in removeZipPrefix

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -46,7 +46,9 @@ const moduleWrapper = tsserver => {
   }
 
   function removeZipPrefix(str) {
-    return str.replace(/^zip:/, ``);
+    return process.platform === 'win32'
+      ? str.replace(/^zip:\//, ``)
+      : str.replace(/^zip:/, ``);
   }
 };
 

--- a/.yarn/versions/35658422.yml
+++ b/.yarn/versions/35658422.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": prerelease
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -73,7 +73,9 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       }
 
       function removeZipPrefix(str) {
-        return str.replace(/^zip:/, \`\`);
+        return process.platform === 'win32'
+          ? str.replace(/^zip:\\//, \`\`)
+          : str.replace(/^zip:/, \`\`);
       }
     };
   `;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The TypeScript SDK doesn't strip the zip prefix correctly on Windows causing import suggestions to not show where the thing comes from.

Fixes #1533

**How did you fix it?**

Remove the leading slash that was left in on Windows

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
