### PR TITLE
fix(plugin-version): Correctly check void releases for all falsy values 

### DIFF
--- a/.yarn/versions/7bfd08a0.yml
+++ b/.yarn/versions/7bfd08a0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": prerelease

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -174,10 +174,11 @@ export async function updateVersionFiles(project: Project) {
     const versionContent = await xfs.readFilePromise(versionPath, `utf8`);
     const versionData = parseSyml(versionContent);
 
-    if (typeof versionData.releases === `undefined`)
+    const releases = versionData?.releases;
+    if (!releases)
       continue;
 
-    for (const locatorStr of Object.keys(versionData.releases || {})) {
+    for (const locatorStr of Object.keys(releases)) {
       const locator = structUtils.parseLocator(locatorStr);
       const workspace = project.tryWorkspaceByLocator(locator);
 


### PR DESCRIPTION
js-yaml implements the YAML spec and it has no undefined type:

- https://github.com/nodeca/js-yaml/issues/356#issuecomment-311614322

I.e.:

```
> require('js-yaml').safeLoad('')
undefined // if the file is empty
> require('js-yaml').safeLoad('releases:\n')
{ releases: null }
```
