### PR TITLE
fix(essentials): set cache-folder as a hidden flag

### DIFF
--- a/.yarn/versions/297c088c.yml
+++ b/.yarn/versions/297c088c.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": prerelease
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -33,7 +33,7 @@ export default class YarnCommand extends BaseCommand {
   @Command.Boolean(`--inline-builds`)
   inlineBuilds?: boolean;
 
-  @Command.String(`--cache-folder`)
+  @Command.String(`--cache-folder`, {hidden: true})
   cacheFolder?: string;
 
   @Command.Boolean(`--silent`, {hidden: true})


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `--cache-folder` flag is deprecated but not set as hidden.

**How did you fix it?**

Set the flag as hidden

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.