### PR TITLE
feat(vscode-zipfs): treat zip archives as folders

### DIFF
--- a/.yarn/versions/e2437f32.yml
+++ b/.yarn/versions/e2437f32.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: minor


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Because Zip archives are considered regular files by the `ZipFSProvider`, they can't be expanded in the built-in file navigation menu at the top.

This also has to be changed for the sidebar `TreeView` I'm currently implementing to work correctly.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it so that all files with the `.zip` extension are treated as folders.

Before:

![image](https://user-images.githubusercontent.com/32596136/86540524-c09a3380-bf0e-11ea-8f91-d0db8333c0bb.png)

After:

![image](https://user-images.githubusercontent.com/32596136/86540542-d90a4e00-bf0e-11ea-9296-8e3df956b1aa.png)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
