### PR TITLE
Apply negative offset if fuzzy match lies before first guess

### DIFF
--- a/.yarn/versions/1b1c979e.yml
+++ b/.yarn/versions/1b1c979e.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-patch": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/tools/apply.ts
+++ b/packages/plugin-patch/sources/tools/apply.ts
@@ -163,6 +163,7 @@ export async function applyPatch({hunks, path}: FilePatch, {baseFs, dryRun = fal
         location = firstGuess - offset;
         modifications = evaluateHunk(hunk, fileLines, location);
         if (modifications !== null) {
+          offset = -offset;
           break;
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Patches where hunks are systematically applied with a negative fuzzy offset grow the `fixupOffset` which leads to an even bigger offset for the next hunk, and so on and so on. This quickly leads to exponential growth of `offset` and a corresponding exponential growth of the time it takes to apply the next hunk.

Closes #1559

**How did you fix it?**

Let a negative offset shrink the `fixupOffset`



**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
