### PR TITLE
fix(doctor): fix resolve errors with resolvers that need fetchers

### DIFF
--- a/.yarn/versions/021b6d44.yml
+++ b/.yarn/versions/021b6d44.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": prerelease

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-import {getPluginConfiguration}                                                                                                                                              from '@yarnpkg/cli';
-import {Cache, Configuration, Project, Report, Workspace, structUtils, ProjectLookup, Manifest, Descriptor, HardDependencies, ThrowReport, StreamReport, MessageName, Ident} from '@yarnpkg/core';
-import {PortablePath, npath, ppath, xfs}                                                                                                                                     from '@yarnpkg/fslib';
-import {Cli, Command}                                                                                                                                                        from 'clipanion';
-import globby                                                                                                                                                                from 'globby';
-import micromatch                                                                                                                                                            from 'micromatch';
-import {Module}                                                                                                                                                              from 'module';
-import * as ts                                                                                                                                                               from 'typescript';
+import {getPluginConfiguration}                                                                                                                                                                            from '@yarnpkg/cli';
+import {Cache, Configuration, Project, Report, Workspace, structUtils, ProjectLookup, Manifest, Descriptor, HardDependencies, ThrowReport, StreamReport, MessageName, Ident, ResolveOptions, FetchOptions} from '@yarnpkg/core';
+import {PortablePath, npath, ppath, xfs}                                                                                                                                                                   from '@yarnpkg/fslib';
+import {Cli, Command}                                                                                                                                                                                      from 'clipanion';
+import globby                                                                                                                                                                                              from 'globby';
+import micromatch                                                                                                                                                                                          from 'micromatch';
+import {Module}                                                                                                                                                                                            from 'module';
+import * as ts                                                                                                                                                                                             from 'typescript';
 
-import * as ast                                                                                                                                                              from './ast';
+import * as ast                                                                                                                                                                                            from './ast';
 
 const BUILTINS = new Set([...Module.builtinModules || [], `pnpapi`]);
 
@@ -242,8 +242,8 @@ async function makeResolveFn(project: Project) {
   const checksums = project.storedChecksums;
   const yarnReport = new ThrowReport();
 
-  const fetchOptions = {project, fetcher, cache, checksums, report: yarnReport};
-  const resolveOptions = {...fetchOptions, resolver};
+  const fetchOptions: FetchOptions = {project, fetcher, cache, checksums, report: yarnReport, skipIntegrityCheck: true};
+  const resolveOptions: ResolveOptions = {...fetchOptions, resolver, fetchOptions};
 
   return async (descriptor: Descriptor) => {
     const candidates = await resolver.getCandidates(descriptor, new Map(), resolveOptions);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`@yarnpkg/doctor` can't resolve dependencies that require a fetcher to be configured.

Fixes #778.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it so that the `fetchOptions` are passed to the resolver.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
