### PR TITLE
fix(plugin-essentials): make `yarn {add,up}` respect `preferInteractive`

### DIFF
--- a/.yarn/versions/3c2d2550.yml
+++ b/.yarn/versions/3c2d2550.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -86,4 +86,6 @@ packageExtensions:
     dependencies:
       react-fast-compare: "*"
 
+preferInteractive: true
+
 yarnPath: scripts/run-yarn.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (plus any relevant plugin by running `yarn import plugin from sources <name>`).
 
+### CLI
+
 - `yarn add` and `yarn up` will now respect the `preferInteractive` configuration option.
 
 ## 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (plus any relevant plugin by running `yarn import plugin from sources <name>`).
 
+- `yarn add` and `yarn up` will now respect the `preferInteractive` configuration option.
+
 ## 2.1.1
 
 - Fixed hyperlink rendering on iTerm
@@ -48,7 +50,7 @@
 - The new `changesetBaseRef` setting can be used to change the name of the master branch that `yarn version check` will use in its changeset heuristic.
 - The new `httpTimeout` and `httpRetry` settings allow you to configure the behavior of the HTTP(s) requests.
 - The new `preferTruncatedLines` setting allow you to tell Yarn that it's ok if info and warning messages are truncated to fit in a single line (errors will always wrap as much as needed, and piping Yarn's output will toggle off this behaviour altogether).
-- The cache compression level can now be configured through `compressionLevel`. If you don't use Zero-Installs, using a value of `0` may yield speed improvements at little cost. 
+- The cache compression level can now be configured through `compressionLevel`. If you don't use Zero-Installs, using a value of `0` may yield speed improvements at little cost.
 - Plugins are now loaded from the location of the RC file.
 
 ### Protocols

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -39,7 +39,7 @@ export default class AddCommand extends BaseCommand {
   preferDev: boolean = false;
 
   @Command.Boolean(`-i,--interactive`)
-  interactive: boolean = false;
+  interactive: boolean | null = null;
 
   @Command.Boolean(`--cached`)
   cached: boolean = false;
@@ -99,6 +99,8 @@ export default class AddCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
+    const interactive = this.interactive ?? configuration.get<boolean>(`preferInteractive`);
+
     // @ts-ignore
     const prompt = inquirer.createPromptModule({
       input: this.context.stdin as NodeJS.ReadStream,
@@ -108,7 +110,7 @@ export default class AddCommand extends BaseCommand {
     const modifier = suggestUtils.getModifier(this, project);
 
     const strategies = [
-      ...this.interactive ? [
+      ...interactive ? [
         suggestUtils.Strategy.REUSE,
       ] : [],
       suggestUtils.Strategy.PROJECT,
@@ -118,7 +120,7 @@ export default class AddCommand extends BaseCommand {
       suggestUtils.Strategy.LATEST,
     ];
 
-    const maxResults = this.interactive
+    const maxResults = interactive
       ? Infinity
       : 1;
 

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -15,7 +15,7 @@ export default class UpCommand extends BaseCommand {
   patterns: Array<string> = [];
 
   @Command.Boolean(`-i,--interactive`)
-  interactive: boolean = false;
+  interactive: boolean | null = null;
 
   @Command.Boolean(`-v,--verbose`)
   verbose: boolean = false;
@@ -72,6 +72,8 @@ export default class UpCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
+    const interactive = this.interactive ?? configuration.get<boolean>(`preferInteractive`);
+
     // @ts-ignore
     const prompt = inquirer.createPromptModule({
       input: this.context.stdin as NodeJS.ReadStream,
@@ -80,7 +82,7 @@ export default class UpCommand extends BaseCommand {
 
     const modifier = suggestUtils.getModifier(this, project);
 
-    const strategies = this.interactive ? [
+    const strategies = interactive ? [
       suggestUtils.Strategy.KEEP,
       suggestUtils.Strategy.REUSE,
       suggestUtils.Strategy.PROJECT,
@@ -162,7 +164,7 @@ export default class UpCommand extends BaseCommand {
           } else {
             report.reportError(MessageName.CANT_SUGGEST_RESOLUTIONS, `${structUtils.prettyDescriptor(configuration, existing)} can't be resolved to a satisfying range`);
           }
-        } else if (nonNullSuggestions.length > 1 && !this.interactive) {
+        } else if (nonNullSuggestions.length > 1 && !interactive) {
           report.reportError(MessageName.CANT_SUGGEST_RESOLUTIONS, `${structUtils.prettyDescriptor(configuration, existing)} has multiple possible upgrade strategies; use -i to disambiguate manually`);
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn {add,up}` weren't respecting the `preferInteractive` configuration option.

Fixes #1566.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it so that `yarn {add,up}` respects the `preferInteractive` configuration option. I'm not sure if we should also make this change for `yarn version check`, as it's very different from `yarn version check -i`. What do you think?

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
