### PR TITLE
feat(pnpify): add default sdks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,10 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true,
+    "**/yarn.lock": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "search.exclude": {
     "**/.yarn": true,
-    "**/.pnp.*": true,
-    "**/yarn.lock": true
+    "**/.pnp.*": true
   }
 }

--- a/.yarn/versions/88c6bc4f.yml
+++ b/.yarn/versions/88c6bc4f.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": minor
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
@@ -1,9 +1,9 @@
-import {PortablePath, npath, ppath}                                                               from '@yarnpkg/fslib';
-import {PnpApi}                                                                                   from '@yarnpkg/pnp';
-import mergeWith                                                                                  from 'lodash/mergeWith';
+import {PortablePath, npath, ppath}                                                   from '@yarnpkg/fslib';
+import {PnpApi}                                                                       from '@yarnpkg/pnp';
+import mergeWith                                                                      from 'lodash/mergeWith';
 
-import {Wrapper, GenerateIntegrationWrapper, GenerateDefaultWrapper, IntegrationSdks, DefaultSdk} from '../generateSdk';
-import * as sdkUtils                                                                              from '../sdkUtils';
+import {Wrapper, GenerateIntegrationWrapper, GenerateDefaultWrapper, IntegrationSdks} from '../generateSdk';
+import * as sdkUtils                                                                  from '../sdkUtils';
 
 export const merge = (object: unknown, source: unknown) =>
   mergeWith(object, source, (objValue, srcValue) => {
@@ -21,6 +21,21 @@ export enum VSCodeConfiguration {
 export const addVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCodeConfiguration, patch: any) => {
   const relativeFilePath = `.vscode/${type}` as PortablePath;
   await sdkUtils.addSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch);
+};
+
+export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: PnpApi) => {
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
+    [`search.exclude`]: {
+      [`**/.yarn`]: true,
+      [`**/.pnp.*`]: true,
+    },
+  });
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
+    [`recommendations`]: [
+      `arcanis.vscode-zipfs`,
+    ],
+  });
 };
 
 export const generateEslintWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
@@ -102,25 +117,8 @@ export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = a
   });
 };
 
-export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: PnpApi) => {
-  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`search.exclude`]: {
-      [`**/.yarn`]: true,
-      [`**/.pnp.*`]: true,
-    },
-  });
-
-  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
-    [`recommendations`]: [
-      `arcanis.vscode-zipfs`,
-    ],
-  });
-};
-
-// eslint-disable-next-line arca/no-default-export
-export default generateDefaultWrapper as DefaultSdk;
-
 export const VSCODE_SDKS: IntegrationSdks = [
+  [null, generateDefaultWrapper],
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
   [`typescript-language-server`, null],

--- a/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
@@ -107,7 +107,6 @@ export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: Pnp
     [`search.exclude`]: {
       [`**/.yarn`]: true,
       [`**/.pnp.*`]: true,
-      [`**/yarn.lock`]: true,
     },
   });
 

--- a/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
@@ -1,9 +1,9 @@
-import {PortablePath, npath, ppath}                           from '@yarnpkg/fslib';
-import {PnpApi}                                               from '@yarnpkg/pnp';
-import mergeWith                                              from 'lodash/mergeWith';
+import {PortablePath, npath, ppath}                                                               from '@yarnpkg/fslib';
+import {PnpApi}                                                                                   from '@yarnpkg/pnp';
+import mergeWith                                                                                  from 'lodash/mergeWith';
 
-import {Wrapper, GenerateIntegrationWrapper, IntegrationSdks} from '../generateSdk';
-import * as sdkUtils                                          from '../sdkUtils';
+import {Wrapper, GenerateIntegrationWrapper, GenerateDefaultWrapper, IntegrationSdks, DefaultSdk} from '../generateSdk';
+import * as sdkUtils                                                                              from '../sdkUtils';
 
 export const merge = (object: unknown, source: unknown) =>
   mergeWith(object, source, (objValue, srcValue) => {
@@ -68,12 +68,6 @@ export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpA
     ),
     [`typescript.enablePromptUseWorkspaceTsdk`]: true,
   });
-
-  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
-    [`recommendations`]: [
-      `arcanis.vscode-zipfs`,
-    ],
-  });
 };
 
 export const generateStylelintWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
@@ -107,6 +101,25 @@ export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = a
     ],
   });
 };
+
+export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: PnpApi) => {
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
+    [`search.exclude`]: {
+      [`**/.yarn`]: true,
+      [`**/.pnp.*`]: true,
+      [`**/yarn.lock`]: true,
+    },
+  });
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
+    [`recommendations`]: [
+      `arcanis.vscode-zipfs`,
+    ],
+  });
+};
+
+// eslint-disable-next-line arca/no-default-export
+export default generateDefaultWrapper as DefaultSdk;
 
 export const VSCODE_SDKS: IntegrationSdks = [
   [`eslint`, generateEslintWrapper],


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Yarn's vendor files are currently taken into account by VSCode's file search, which can be very dangerous in combination with search & replace (just ask the person that accidentally replaced all occurences of `--frozen-lockfile` with `--immutable`, which included the ones in Yarn's source code...).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it possible to specify default SDKs (without requiring any specific dependency to be installed). I made it include the `search.exclude` VSCode setting and I also moved the `arcanis.vscode-zipfs` extension recommandation from the TS VSCode SDK to the Default VSCode SDK.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
