### PR TITLE
Fixes main files not being packed

### DIFF
--- a/.yarn/versions/0f1c494c.yml
+++ b/.yarn/versions/0f1c494c.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (plus any relevant plugin by running `yarn import plugin from sources <name>`).
 
+### Bugfixes
+
+- `yarn pack` will properly include main/module/bin files, even when not explicitly referenced through the `files` field.
+
 ## 2.1.1
 
 - Fixed hyperlink rendering on iTerm
@@ -48,7 +52,7 @@
 - The new `changesetBaseRef` setting can be used to change the name of the master branch that `yarn version check` will use in its changeset heuristic.
 - The new `httpTimeout` and `httpRetry` settings allow you to configure the behavior of the HTTP(s) requests.
 - The new `preferTruncatedLines` setting allow you to tell Yarn that it's ok if info and warning messages are truncated to fit in a single line (errors will always wrap as much as needed, and piping Yarn's output will toggle off this behaviour altogether).
-- The cache compression level can now be configured through `compressionLevel`. If you don't use Zero-Installs, using a value of `0` may yield speed improvements at little cost. 
+- The cache compression level can now be configured through `compressionLevel`. If you don't use Zero-Installs, using a value of `0` may yield speed improvements at little cost.
 - Plugins are now loaded from the location of the RC file.
 
 ### Protocols

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -72,12 +72,16 @@ describe(`Commands`, () => {
     test(
       `it should always include the main file, even with a "files" field`,
       makeTemporaryEnv({
-        main: `ok.js`,
+        main: `ok1.js`,
+        module: `ok2.js`,
+        browser: `ok3.js`,
         files: [
           `/bad`,
         ],
       }, async ({path, run, source}) => {
-        await fsUtils.writeFile(`${path}/ok.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ok1.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ok2.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ok3.js`, `module.exports = 42;\n`);
         await fsUtils.writeFile(`${path}/ko.js`, `module.exports = 42;\n`);
 
         await run(`install`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -11,7 +11,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).toMatch(/index\.js/);
+        expect(stdout).toMatch(/index\.js/);
       }),
     );
 
@@ -23,7 +23,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/\.yarn\//);
+        expect(stdout).not.toMatch(/\.yarn\//);
       }),
     );
 
@@ -43,10 +43,10 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).toMatch(/lib\/a\.js/);
-        await expect(stdout).toMatch(/lib\/b\.js/);
-        await expect(stdout).not.toMatch(/src\/a\.ts/);
-        await expect(stdout).toMatch(/src\/b\.ts/);
+        expect(stdout).toMatch(/lib\/a\.js/);
+        expect(stdout).toMatch(/lib\/b\.js/);
+        expect(stdout).not.toMatch(/src\/a\.ts/);
+        expect(stdout).toMatch(/src\/b\.ts/);
       }),
     );
 
@@ -63,9 +63,49 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).toMatch(/lib\/a\.js/);
-        await expect(stdout).toMatch(/lib\/b\.js/);
-        await expect(stdout).toMatch(/package\.json/);
+        expect(stdout).toMatch(/lib\/a\.js/);
+        expect(stdout).toMatch(/lib\/b\.js/);
+        expect(stdout).toMatch(/package\.json/);
+      }),
+    );
+
+    test(
+      `it should always include the main file, even with a "files" field`,
+      makeTemporaryEnv({
+        main: `ok.js`,
+        files: [
+          `/bad`,
+        ],
+      }, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/ok.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ko.js`, `module.exports = 42;\n`);
+
+        await run(`install`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        expect(stdout).toMatch(/ok\.js/);
+        expect(stdout).not.toMatch(/ko\.js/);
+      }),
+    );
+
+    test(
+      `it should always include the binary files, even with a "files" field`,
+      makeTemporaryEnv({
+        bin: {
+          ok: `ok.js`,
+        },
+        files: [
+          `/bad`,
+        ],
+      }, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/ok.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ko.js`, `module.exports = 42;\n`);
+
+        await run(`install`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        expect(stdout).toMatch(/ok\.js/);
+        expect(stdout).not.toMatch(/ko\.js/);
       }),
     );
 
@@ -83,8 +123,8 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).toMatch(/lib\/a\.js/);
-        await expect(stdout).not.toMatch(/lib\/b\.js/);
+        expect(stdout).toMatch(/lib\/a\.js/);
+        expect(stdout).not.toMatch(/lib\/b\.js/);
       }),
     );
 
@@ -101,8 +141,8 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).toMatch(/lib\/a\.js/);
-        await expect(stdout).toMatch(/lib\/b\.js/);
+        expect(stdout).toMatch(/lib\/a\.js/);
+        expect(stdout).toMatch(/lib\/b\.js/);
       }),
     );
 
@@ -114,7 +154,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/\.gitignore/);
+        expect(stdout).not.toMatch(/\.gitignore/);
       }),
     );
 
@@ -126,7 +166,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/\.npmignore/);
+        expect(stdout).not.toMatch(/\.npmignore/);
       }),
     );
 
@@ -144,7 +184,7 @@ describe(`Commands`, () => {
         await fsUtils.writeFile(`${path}/lib/foo.js`, ``);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).toMatch(/lib\/foo\.js/);
+        expect(stdout).toMatch(/lib\/foo\.js/);
       }),
     );
 
@@ -154,7 +194,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/\.yarn\/cache/);
+        expect(stdout).not.toMatch(/\.yarn\/cache/);
       }),
     );
 
@@ -164,7 +204,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/yarn\.lock/);
+        expect(stdout).not.toMatch(/yarn\.lock/);
       }),
     );
 
@@ -177,7 +217,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/index\.js/);
+        expect(stdout).not.toMatch(/index\.js/);
       }),
     );
 
@@ -190,7 +230,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/index\.js/);
+        expect(stdout).not.toMatch(/index\.js/);
       }),
     );
 
@@ -204,7 +244,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/__tests__/);
+        expect(stdout).not.toMatch(/__tests__/);
       }),
     );
 
@@ -219,8 +259,8 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/a\.js/);
-        await expect(stdout).toMatch(/b\.js/);
+        expect(stdout).not.toMatch(/a\.js/);
+        expect(stdout).toMatch(/b\.js/);
       }),
     );
 
@@ -307,9 +347,9 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/lib\/README/);
-        await expect(stdout).toMatch(/README\.md/);
-        await expect(stdout).toMatch(/package\.json/);
+        expect(stdout).not.toMatch(/lib\/README/);
+        expect(stdout).toMatch(/README\.md/);
+        expect(stdout).toMatch(/package\.json/);
       }),
     );
 
@@ -326,9 +366,9 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        await expect(stdout).not.toMatch(/lib\/changelog/);
-        await expect(stdout).toMatch(/CHANGELOG\.md/);
-        await expect(stdout).toMatch(/package\.json/);
+        expect(stdout).not.toMatch(/lib\/changelog/);
+        expect(stdout).toMatch(/CHANGELOG\.md/);
+        expect(stdout).toMatch(/package\.json/);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -87,7 +87,9 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`pack`, `--dry-run`);
-        expect(stdout).toMatch(/ok\.js/);
+        expect(stdout).toMatch(/ok1\.js/);
+        expect(stdout).toMatch(/ok2\.js/);
+        expect(stdout).toMatch(/ok3\.js/);
         expect(stdout).not.toMatch(/ko\.js/);
       }),
     );

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -27,6 +27,9 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
     if (rawManifest.publishConfig.module)
       rawManifest.module = rawManifest.publishConfig.module;
 
+    if (rawManifest.publishConfig.browser)
+      rawManifest.browser = rawManifest.publishConfig.browser;
+
     if (rawManifest.publishConfig.bin) {
       rawManifest.bin = rawManifest.publishConfig.bin;
     }

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -207,12 +207,15 @@ export async function genPackList(workspace: Workspace) {
 
   const main = workspace.manifest.publishConfig?.main ?? workspace.manifest.main;
   const module = workspace.manifest.publishConfig?.module ?? workspace.manifest.module;
+  const browser = workspace.manifest.publishConfig?.browser ?? workspace.manifest.browser;
   const bins = workspace.manifest.publishConfig?.bin ?? workspace.manifest.bin;
 
   if (main != null)
     ignoreList.accept.push(ppath.resolve(PortablePath.root, main));
   if (module != null)
     ignoreList.accept.push(ppath.resolve(PortablePath.root, module));
+  if (browser != null)
+    ignoreList.accept.push(ppath.resolve(PortablePath.root, browser));
   for (const path of bins.values())
     ignoreList.accept.push(ppath.resolve(PortablePath.root, path));
 

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -205,15 +205,16 @@ export async function genPackList(workspace: Workspace) {
     reject: [],
   };
 
-  if (workspace.manifest.publishConfig && workspace.manifest.publishConfig.main)
-    ignoreList.accept.push(ppath.resolve(PortablePath.root, workspace.manifest.publishConfig.main));
-  else if (workspace.manifest.main)
-    ignoreList.accept.push(ppath.resolve(PortablePath.root, workspace.manifest.main));
+  const main = workspace.manifest.publishConfig?.main ?? workspace.manifest.main;
+  const module = workspace.manifest.publishConfig?.module ?? workspace.manifest.module;
+  const bins = workspace.manifest.publishConfig?.bin ?? workspace.manifest.bin;
 
-  if (workspace.manifest.publishConfig && workspace.manifest.publishConfig.module)
-    ignoreList.accept.push(ppath.resolve(PortablePath.root, workspace.manifest.publishConfig.module));
-  else if (workspace.manifest.module)
-    ignoreList.accept.push(ppath.resolve(PortablePath.root, workspace.manifest.module));
+  if (main != null)
+    ignoreList.accept.push(ppath.resolve(PortablePath.root, main));
+  if (module != null)
+    ignoreList.accept.push(ppath.resolve(PortablePath.root, module));
+  for (const path of bins.values())
+    ignoreList.accept.push(ppath.resolve(PortablePath.root, path));
 
   const hasExplicitFileList = workspace.manifest.files !== null;
   if (hasExplicitFileList) {

--- a/packages/yarnpkg-core/sources/CorePlugin.ts
+++ b/packages/yarnpkg-core/sources/CorePlugin.ts
@@ -54,8 +54,10 @@ export const CorePlugin: Plugin = {
     }) => {
       // Validate manifest
       const {manifest} = workspace;
+
       if (manifest.resolutions.length && workspace.cwd !== workspace.project.cwd)
         manifest.errors.push(new Error(`Resolutions field will be ignored`));
+
       for (const manifestError of manifest.errors) {
         report.reportWarning(MessageName.INVALID_MANIFEST, manifestError.message);
       }

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -197,6 +197,12 @@ export class Manifest {
     if (typeof data.languageName === `string`)
       this.languageName = data.languageName;
 
+    if (typeof data.main === `string`)
+      this.main = data.main;
+
+    if (typeof data.module === `string`)
+      this.module = data.module;
+
     if (typeof data.bin === `string`) {
       if (this.name !== null) {
         this.bin = new Map([[this.name.name, data.bin]]);

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -28,6 +28,7 @@ export interface PublishConfig {
   access?: string;
   main?: PortablePath;
   module?: PortablePath;
+  browser?: PortablePath;
   bin?: Map<string, PortablePath>;
   registry?: string;
 }
@@ -47,6 +48,7 @@ export class Manifest {
 
   public main: PortablePath | null = null;
   public module: PortablePath | null = null;
+  public browser: PortablePath | null = null;
 
   public languageName: string | null = null;
 
@@ -202,6 +204,9 @@ export class Manifest {
 
     if (typeof data.module === `string`)
       this.module = data.module;
+
+    if (typeof data.browser === `string`)
+      this.browser = data.browser;
 
     if (typeof data.bin === `string`) {
       if (this.name !== null) {
@@ -374,11 +379,14 @@ export class Manifest {
       if (typeof data.publishConfig.main === `string`)
         this.publishConfig.main = data.publishConfig.main;
 
-      if (typeof data.publishConfig.registry === `string`)
-        this.publishConfig.registry = data.publishConfig.registry;
-
       if (typeof data.publishConfig.module === `string`)
         this.publishConfig.module = data.publishConfig.module;
+
+      if (typeof data.publishConfig.browser === `string`)
+        this.publishConfig.browser = data.publishConfig.browser;
+
+      if (typeof data.publishConfig.registry === `string`)
+        this.publishConfig.registry = data.publishConfig.registry;
 
       if (typeof data.publishConfig.bin === `string`) {
         if (this.name !== null) {
@@ -613,6 +621,21 @@ export class Manifest {
       data.languageName = this.languageName;
     else
       delete data.languageName;
+
+    if (this.main !== null)
+      data.main = this.main;
+    else
+      delete data.main;
+
+    if (this.module !== null)
+      data.module = this.module;
+    else
+      delete data.module;
+
+    if (this.browser !== null)
+      data.browser = this.browser;
+    else
+      delete data.browser;
 
     if (this.bin.size === 1 && this.name !== null && this.bin.has(this.name.name)) {
       data.bin = this.bin.get(this.name.name)!;


### PR DESCRIPTION
**What's the problem this PR addresses?**
There were two different problems:

- First, the `main` and `module` fields weren't properly hydrated when reading the manifest files. This caused `yarn pack` to simply not see them, and thus not include them in the generated archive unless they were properly listed in the `files` field.

- Second, the `bin` field was completely omitted from the logic that ensures that `main`, `module`, and `bin` are all part of the generated archive. So again, it had to be explicitly listed.

**How did you fix it?**

The `main` and `module` field are now properly hydrated, and `bin` is now accounted for in `genPackList`. Also added a test to prevent regressions.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
