### PR TITLE
Improves copy performances

### DIFF
--- a/.yarn/versions/2a7ebc69.yml
+++ b/.yarn/versions/2a7ebc69.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/fslib": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/algorithms/copyPromise.ts
+++ b/packages/yarnpkg-fslib/sources/algorithms/copyPromise.ts
@@ -22,45 +22,45 @@ export async function copyPromise<P1 extends Path, P2 extends Path>(destinationF
   const normalizedDestination = destinationFs.pathUtils.normalize(destination);
   const normalizedSource = sourceFs.pathUtils.normalize(source);
 
-  const operations: Operations = [];
-  const lutimes: LUTimes<P1> = [];
+  const prelayout: Operations = [];
+  const postlayout: Operations = [];
 
   await destinationFs.mkdirpPromise(destination);
-
-  await copyImpl(operations, lutimes, destinationFs, normalizedDestination, sourceFs, normalizedSource, opts);
-
-  for (const operation of operations)
-    await operation();
 
   const updateTime = typeof destinationFs.lutimesPromise === `function`
     ? destinationFs.lutimesPromise.bind(destinationFs)
     : destinationFs.utimesPromise.bind(destinationFs);
 
-  for (const [p, atime, mtime] of lutimes) {
-    await updateTime!(p, atime, mtime);
-  }
+  await copyImpl(prelayout, postlayout, updateTime, destinationFs, normalizedDestination, sourceFs, normalizedSource, opts);
+
+  for (const operation of prelayout)
+    await operation();
+
+  await Promise.all(postlayout.map(operation => {
+    return operation();
+  }));
 }
 
-async function copyImpl<P1 extends Path, P2 extends Path>(operations: Operations, lutimes: LUTimes<P1>, destinationFs: FakeFS<P1>, destination: P1, sourceFs: FakeFS<P2>, source: P2, opts: CopyOptions) {
+async function copyImpl<P1 extends Path, P2 extends Path>(prelayout: Operations, postlayout: Operations, updateTime: typeof FakeFS.prototype.utimesPromise, destinationFs: FakeFS<P1>, destination: P1, sourceFs: FakeFS<P2>, source: P2, opts: CopyOptions) {
   const destinationStat = await maybeLStat(destinationFs, destination);
   const sourceStat = await sourceFs.lstatPromise(source);
 
   if (opts.stableTime)
-    lutimes.push([destination, defaultTime, defaultTime]);
+    postlayout.push(() => updateTime(destination, defaultTime, defaultTime));
   else
-    lutimes.push([destination, sourceStat.atime, sourceStat.mtime]);
+    postlayout.push(() => updateTime(destination, sourceStat.atime, sourceStat.mtime));
 
   switch (true) {
     case sourceStat.isDirectory(): {
-      await copyFolder(operations, lutimes, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+      await copyFolder(prelayout, postlayout, updateTime, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
     } break;
 
     case sourceStat.isFile(): {
-      await copyFile(operations, lutimes, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+      await copyFile(prelayout, postlayout, updateTime, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
     } break;
 
     case sourceStat.isSymbolicLink(): {
-      await copySymlink(operations, lutimes, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+      await copySymlink(prelayout, postlayout, updateTime, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
     } break;
 
     default: {
@@ -68,7 +68,9 @@ async function copyImpl<P1 extends Path, P2 extends Path>(operations: Operations
     } break;
   }
 
-  operations.push(async () => destinationFs.chmodPromise(destination, sourceStat.mode & 0o777));
+  postlayout.push(() => {
+    return destinationFs.chmodPromise(destination, sourceStat.mode & 0o777);
+  });
 }
 
 async function maybeLStat<P extends Path>(baseFs: FakeFS<P>, p: P) {
@@ -79,10 +81,10 @@ async function maybeLStat<P extends Path>(baseFs: FakeFS<P>, p: P) {
   }
 }
 
-async function copyFolder<P1 extends Path, P2 extends Path>(operations: Operations, lutimes: LUTimes<P1>, destinationFs: FakeFS<P1>, destination: P1, destinationStat: Stats | null, sourceFs: FakeFS<P2>, source: P2, sourceStat: Stats, opts: CopyOptions) {
+async function copyFolder<P1 extends Path, P2 extends Path>(prelayout: Operations, postlayout: Operations, updateTime: typeof FakeFS.prototype.utimesPromise, destinationFs: FakeFS<P1>, destination: P1, destinationStat: Stats | null, sourceFs: FakeFS<P2>, source: P2, sourceStat: Stats, opts: CopyOptions) {
   if (destinationStat !== null && !destinationStat.isDirectory()) {
     if (opts.overwrite) {
-      operations.push(async () => destinationFs.removePromise(destination));
+      prelayout.push(async () => destinationFs.removePromise(destination));
       destinationStat = null;
     } else {
       return;
@@ -90,25 +92,25 @@ async function copyFolder<P1 extends Path, P2 extends Path>(operations: Operatio
   }
 
   if (destinationStat === null)
-    operations.push(async () => destinationFs.mkdirPromise(destination, {mode: sourceStat.mode}));
+    prelayout.push(async () => destinationFs.mkdirPromise(destination, {mode: sourceStat.mode}));
 
   const entries = await sourceFs.readdirPromise(source);
 
   if (opts.stableSort) {
     for (const entry of entries.sort()) {
-      await copyImpl(operations, lutimes, destinationFs, destinationFs.pathUtils.join(destination, entry), sourceFs, sourceFs.pathUtils.join(source, entry), opts);
+      await copyImpl(prelayout, postlayout, updateTime, destinationFs, destinationFs.pathUtils.join(destination, entry), sourceFs, sourceFs.pathUtils.join(source, entry), opts);
     }
   } else {
     await Promise.all(entries.map(async entry => {
-      await copyImpl(operations, lutimes, destinationFs, destinationFs.pathUtils.join(destination, entry), sourceFs, sourceFs.pathUtils.join(source, entry), opts);
+      await copyImpl(prelayout, postlayout, updateTime, destinationFs, destinationFs.pathUtils.join(destination, entry), sourceFs, sourceFs.pathUtils.join(source, entry), opts);
     }));
   }
 }
 
-async function copyFile<P1 extends Path, P2 extends Path>(operations: Operations, lutimes: LUTimes<P1>, destinationFs: FakeFS<P1>, destination: P1, destinationStat: Stats | null, sourceFs: FakeFS<P2>, source: P2, sourceStat: Stats, opts: CopyOptions) {
+async function copyFile<P1 extends Path, P2 extends Path>(prelayout: Operations, postlayout: Operations, updateTime: typeof FakeFS.prototype.utimesPromise, destinationFs: FakeFS<P1>, destination: P1, destinationStat: Stats | null, sourceFs: FakeFS<P2>, source: P2, sourceStat: Stats, opts: CopyOptions) {
   if (destinationStat !== null) {
     if (opts.overwrite) {
-      operations.push(async () => destinationFs.removePromise(destination));
+      prelayout.push(async () => destinationFs.removePromise(destination));
       destinationStat = null;
     } else {
       return;
@@ -116,16 +118,16 @@ async function copyFile<P1 extends Path, P2 extends Path>(operations: Operations
   }
 
   if (destinationFs as any === sourceFs as any) {
-    operations.push(async () => destinationFs.copyFilePromise(source as any as P1, destination, fs.constants.COPYFILE_FICLONE));
+    prelayout.push(async () => destinationFs.copyFilePromise(source as any as P1, destination, fs.constants.COPYFILE_FICLONE));
   } else {
-    operations.push(async () => destinationFs.writeFilePromise(destination, await sourceFs.readFilePromise(source)));
+    prelayout.push(async () => destinationFs.writeFilePromise(destination, await sourceFs.readFilePromise(source)));
   }
 }
 
-async function copySymlink<P1 extends Path, P2 extends Path>(operations: Operations, lutimes: LUTimes<P1>, destinationFs: FakeFS<P1>, destination: P1, destinationStat: Stats | null, sourceFs: FakeFS<P2>, source: P2, sourceStat: Stats, opts: CopyOptions) {
+async function copySymlink<P1 extends Path, P2 extends Path>(prelayout: Operations, postlayout: Operations, updateTime: typeof FakeFS.prototype.utimesPromise, destinationFs: FakeFS<P1>, destination: P1, destinationStat: Stats | null, sourceFs: FakeFS<P2>, source: P2, sourceStat: Stats, opts: CopyOptions) {
   if (destinationStat !== null) {
     if (opts.overwrite) {
-      operations.push(async () => destinationFs.removePromise(destination));
+      prelayout.push(async () => destinationFs.removePromise(destination));
       destinationStat = null;
     } else {
       return;
@@ -133,5 +135,5 @@ async function copySymlink<P1 extends Path, P2 extends Path>(operations: Operati
   }
 
   const target = await sourceFs.readlinkPromise(source);
-  operations.push(async () => destinationFs.symlinkPromise(convertPath(destinationFs.pathUtils, target), destination));
+  prelayout.push(async () => destinationFs.symlinkPromise(convertPath(destinationFs.pathUtils, target), destination));
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**
We were calling `chmod` on symlinks before the symlink target had been created. This caused issues since the chmod was then applied to a non-existing file, and failed.

**How did you fix it?**
Tbh it's not perfect; we should instead call `lchmod`, but this function doesn't seem supported elsewhere than OSX, so I need to make a bit of research of figure out what's the best course of action.

I also refactored a bit copy so that more things can happen in parallel: the `prelayout` pass is sequential and is meant to prepare the filesystem hierarchy, while the `postlayout` pass tweaks the filesystem attributes of the layout and thus can be executed in parallel.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
