### PR TITLE
Implements `executableFiles`

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -24566,6 +24566,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["pkg-tests-specs", "workspace:packages/acceptance-tests/pkg-tests-specs"],
             ["@types/lodash", "npm:4.14.136"],
+            ["@types/tar", "npm:4.0.0"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/monorepo", "workspace:."],
@@ -24573,7 +24574,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["fs-extra", "npm:7.0.1"],
             ["lodash", "npm:4.17.15"],
             ["pkg-tests-core", "workspace:packages/acceptance-tests/pkg-tests-core"],
-            ["semver", "npm:7.3.2"]
+            ["semver", "npm:7.3.2"],
+            ["tar", "npm:4.4.13"]
           ],
           "linkType": "SOFT",
         }]

--- a/.yarn/versions/b895eba7.yml
+++ b/.yarn/versions/b895eba7.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-pack": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (plus any relevant plugin by running `yarn import plugin from sources <name>`).
 
+### Ecosystem
+
+- Packages can now use the `publishConfig.executableFiles` field in their manifests to indicate which files should keep the executable flag once packed in the archive. This is important as for portability reasons Yarn strips the executable flag from all files during packing (otherwise `yarn pack` would yield different outputs when run on Posix vs Windows). Files listed in the `bin` field are assumed executable by default, so you don't need to explicitly list them in `executableFiles`.
+
 ### Bugfixes
 
 - `yarn pack` will properly include main/module/bin files, even when not explicitly referenced through the `files` field.

--- a/packages/acceptance-tests/pkg-tests-specs/package.json
+++ b/packages/acceptance-tests/pkg-tests-specs/package.json
@@ -11,14 +11,16 @@
         "fs-extra": "^7.0.1",
         "lodash": "^4.17.15",
         "pkg-tests-core": "workspace:0.0.0",
-        "semver": "^7.1.2"
+        "semver": "^7.1.2",
+        "tar": "^4.4.6"
     },
     "repository": {
         "type": "git",
         "url": "ssh://git@github.com/yarnpkg/berry.git"
     },
     "devDependencies": {
-        "@types/lodash": "^4.14.136"
+        "@types/lodash": "^4.14.136",
+        "@types/tar": "^4.0.0"
     },
     "engines": {
         "node": ">=10.19.0"

--- a/packages/gatsby/src/pages/configuration/manifest.json
+++ b/packages/gatsby/src/pages/configuration/manifest.json
@@ -302,6 +302,14 @@
           "default": "./build/browser.js",
           "$comment": "{ \"anchor\": \"publishConfig.browser\" }"
         },
+        "executableFiles": {
+          "description": "By default, for portability reasons, no files except those listed in the bin field will be marked as executable in the resulting package archive. The executableFiles field lets you declare additional fields that must have the executable flag (+x) set even if they aren't directly accessible through the bin field.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri-reference"
+          }
+        },
         "main": {
           "$ref": "#/properties/main",
           "$comment": "{ \"anchor\": \"publishConfig.main\", \"overrides\": { \"description\": \"Same principle as the `publishConfig.bin` property; this value will be used instead of the top-level `main` field when generating the workspace tarball.\", \"default\": \"./build/index.js\" } }"

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -86,14 +86,18 @@ export async function genPackStream(workspace: Workspace, files?: Array<Portable
   if (typeof files === `undefined`)
     files = await genPackList(workspace);
 
-  const executableFiles = workspace.manifest.publishConfig?.executableFiles ?? new Set();
+  const executableFiles = new Set<PortablePath>();
+  for (const value of workspace.manifest.publishConfig?.executableFiles ?? new Set())
+    executableFiles.add(ppath.normalize(value));
   for (const value of workspace.manifest.bin.values())
-    executableFiles.add(value);
+    executableFiles.add(ppath.normalize(value));
 
   const pack = tar.pack();
 
   process.nextTick(async () => {
-    for (const file of files!) {
+    for (const fileRequest of files!) {
+      const file = ppath.normalize(fileRequest);
+
       const source = ppath.resolve(workspace.cwd, file);
       const dest = ppath.join(`package` as PortablePath, file);
 

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -11,9 +11,7 @@ import * as miscUtils                                          from './miscUtils
 import * as structUtils                                        from './structUtils';
 import {LocatorHash, Locator}                                  from './types';
 
-// Each time we'll bump this number the cache hashes will change, which will
-// cause all files to be fetched again. Use with caution.
-const CACHE_VERSION = 5;
+const CACHE_VERSION = 6;
 
 export type FetchFromCacheOptions = {
   checksums: Map<LocatorHash, Locator>,

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -1,11 +1,11 @@
-import {FakeFS, Filename, NodeFS, PortablePath, ppath, toFilename} from '@yarnpkg/fslib';
-import {Resolution, parseResolution, stringifyResolution}          from '@yarnpkg/parsers';
-import semver                                                      from 'semver';
+import {FakeFS, Filename, NodeFS, PortablePath, npath, ppath, toFilename} from '@yarnpkg/fslib';
+import {Resolution, parseResolution, stringifyResolution}                 from '@yarnpkg/parsers';
+import semver                                                             from 'semver';
 
-import * as miscUtils                                              from './miscUtils';
-import * as structUtils                                            from './structUtils';
-import {IdentHash}                                                 from './types';
-import {Ident, Descriptor}                                         from './types';
+import * as miscUtils                                                     from './miscUtils';
+import * as structUtils                                                   from './structUtils';
+import {Ident, Descriptor}                                                from './types';
+import {IdentHash}                                                        from './types';
 
 export type AllDependencies = 'dependencies' | 'devDependencies' | 'peerDependencies';
 export type HardDependencies = 'dependencies' | 'devDependencies';
@@ -31,6 +31,7 @@ export interface PublishConfig {
   browser?: PortablePath;
   bin?: Map<string, PortablePath>;
   registry?: string;
+  executableFiles?: Set<PortablePath>;
 }
 
 export class Manifest {
@@ -404,6 +405,19 @@ export class Manifest {
           }
 
           this.publishConfig.bin.set(key, value as PortablePath);
+        }
+      }
+
+      if (Array.isArray(data.publishConfig.executableFiles)) {
+        this.publishConfig.executableFiles = new Set();
+
+        for (const value of data.publishConfig.executableFiles) {
+          if (typeof value !== `string`) {
+            errors.push(new Error(`Invalid executable file definition`));
+            continue;
+          }
+
+          this.publishConfig.executableFiles.add(npath.toPortablePath(value));
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,7 +3,7 @@
 
 __metadata:
   version: 4
-  cacheKey: 5
+  cacheKey: 6
 
 "@algolia/cache-browser-local-storage@npm:4.2.0":
   version: 4.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -20790,6 +20790,7 @@ fsevents@^1.2.7:
   resolution: "pkg-tests-specs@workspace:packages/acceptance-tests/pkg-tests-specs"
   dependencies:
     "@types/lodash": ^4.14.136
+    "@types/tar": ^4.0.0
     "@yarnpkg/core": "workspace:^2.1.1"
     "@yarnpkg/fslib": "workspace:^2.1.0"
     "@yarnpkg/monorepo": "workspace:0.0.0"
@@ -20798,6 +20799,7 @@ fsevents@^1.2.7:
     lodash: ^4.17.15
     pkg-tests-core: "workspace:0.0.0"
     semver: ^7.1.2
+    tar: ^4.4.6
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Yarn currently always ignore the +x flag when packing projects. This breaks projects that depend on internal executable binaries that aren't listed in the `bin` field (it's pretty rare, but there are valid use cases).

**How did you fix it?**
A new `publishConfig.executableFiles` field will let users define the paths that Yarn need to keep executable during packing.

Alternatives and why we didn't do it:

- We could have used the +x flag from the filesystem, but it means that archives packed on Windows would have had different checksum than the ones compiled on Posix. Since we want to make the "install from a git repository" workflow (which requires packing) as painless as possible, this isn't possible.

- We could have always set the +x flag on all files, but we felt it would be confusing to our users. In the worst case it could have had security aspects, although I'm not sure which ones ... but I find likely that someone smarter could find a door.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
