### PR TITLE
Use socket timeout instead of got timeout

### DIFF
--- a/.yarn/versions/197dc69d.yml
+++ b/.yarn/versions/197dc69d.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugfixes
 
+- Requests will not timeout when response takes more than `httpTimeout` to download and will rely on [`socket.setTimeout`](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback) instead.
 - `yarn pack` will properly include main/module/bin files, even when not explicitly referenced through the `files` field.
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugfixes
 
-- Requests will not timeout when response takes more than `httpTimeout` to download and will rely on [`socket.setTimeout`](https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback) instead.
+- Requests won't timeout anymore as long as the server is still sending data.
 - `yarn pack` will properly include main/module/bin files, even when not explicitly referenced through the `files` field.
 
 ### CLI

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -80,12 +80,14 @@ export async function request(target: string, body: Body, {configuration, header
     }
   }
 
-  const timeout = configuration.get(`httpTimeout`);
+  const socketTimeout = configuration.get(`httpTimeout`);
   const retry = configuration.get(`httpRetry`);
 
   //@ts-ignore
   const gotClient = got.extend({
-    timeout,
+    timeout: {
+      socket: socketTimeout,
+    },
     retry,
     ...gotOptions,
   });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When installing big packages like [`hermes-engine@0.4.1`](https://packagephobia.com/result?p=hermes-engine@0.4.1) on slow internet connection, yarn would timeout even if package was slowly downloading.

Fixes https://github.com/facebook/jest/issues/10267

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I used the `timeout.socket` option from [got](https://github.com/sindresorhus/got#timeout) to only timeout if the socket does not receive data for more than `httpTimeout`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
