### PR TITLE
perf(core): avoid opening zip file with ZipFS just to close it again

### DIFF
--- a/.yarn/versions/4c8d8011.yml
+++ b/.yarn/versions/4c8d8011.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -193,8 +193,9 @@ export class Cache {
     const loadPackageThroughMirror = async () => {
       if (mirrorPath === null || !xfs.existsSync(mirrorPath)) {
         const zipFs = await loader!();
+        const realPath = zipFs.getRealPath();
         zipFs.saveAndClose();
-        return zipFs.getRealPath();
+        return realPath;
       }
 
       const tempDir = await xfs.mktempPromise();

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -191,17 +191,17 @@ export class Cache {
     };
 
     const loadPackageThroughMirror = async () => {
-      if (mirrorPath === null || !xfs.existsSync(mirrorPath))
-        return await loader!();
+      if (mirrorPath === null || !xfs.existsSync(mirrorPath)) {
+        const zipFs = await loader!();
+        zipFs.saveAndClose();
+        return zipFs.getRealPath();
+      }
 
       const tempDir = await xfs.mktempPromise();
       const tempPath = ppath.join(tempDir, this.getVersionFilename(locator));
 
       await xfs.copyFilePromise(mirrorPath, tempPath, fs.constants.COPYFILE_FICLONE);
-
-      return new ZipFS(tempPath, {
-        libzip: await getLibzipPromise(),
-      });
+      return tempPath;
     };
 
     const loadPackage = async () => {
@@ -210,10 +210,7 @@ export class Cache {
       if (this.immutable)
         throw new ReportError(MessageName.IMMUTABLE_CACHE, `Cache entry required but missing for ${structUtils.prettyLocator(this.configuration, locator)}`);
 
-      const zipFs = await loadPackageThroughMirror();
-      const originalPath = zipFs.getRealPath();
-
-      zipFs.saveAndClose();
+      const originalPath = await loadPackageThroughMirror();
 
       await xfs.chmodPromise(originalPath, 0o644);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When loading a package from the mirror(global cache) Yarn opens the zip file using ZipFS just to immediately close it again.

**How did you fix it?**

Modify `loadPackageThroughMirror` to return the path to the zip archive as that is what `loadPackage` is after.

**Result**

Testing on https://github.com/microsoft/TypeScript-Website this reduces the time to fetch from a hot global cache to the local cache by ~4 seconds

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.