### PR TITLE
perf(init): import used lodash method only

### DIFF
--- a/.yarn/versions/2bc54b30.yml
+++ b/.yarn/versions/2bc54b30.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-init": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -3,7 +3,7 @@ import {Configuration, Manifest, Project}    from '@yarnpkg/core';
 import {execUtils, scriptUtils, structUtils} from '@yarnpkg/core';
 import {xfs, ppath, Filename}                from '@yarnpkg/fslib';
 import {Command, Usage, UsageError}          from 'clipanion';
-import {merge}                               from 'lodash';
+import merge                                 from 'lodash/merge';
 import {inspect}                             from 'util';
 
 // eslint-disable-next-line arca/no-default-export


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `init` plugin requires the entire lodash library for one function

**How did you fix it?**

Only import the used function, takes the cli from 2.35MB back down to 2.28MB

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
