### PR TITLE
chore: don't bundle esprima

### DIFF
--- a/.yarn/versions/765b9eaf.yml
+++ b/.yarn/versions/765b9eaf.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": prerelease
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -150,6 +150,15 @@ export default class BuildBundleCommand extends Command {
           },
 
           plugins: [
+            // esprima is only needed for parsing !!js/function, which isn't part of the FAILSAFE_SCHEMA.
+            // Unfortunately, js-yaml declares it as a hard dependency and requires the entire module,
+            // which causes webpack to add 0.13 MB of unused code to the bundle.
+            // Fortunately, js-yaml wraps the require call inside a try / catch block, so we can just ignore it.
+            // Reference: https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/type/js/function.js#L15
+            new webpack.IgnorePlugin({
+              resourceRegExp: /^esprima$/,
+              contextRegExp: /js-yaml/,
+            }),
             new webpack.BannerPlugin({
               entryOnly: true,
               banner: `#!/usr/bin/env node\n/* eslint-disable */`,

--- a/packages/yarnpkg-builder/sources/tools/makeConfig.ts
+++ b/packages/yarnpkg-builder/sources/tools/makeConfig.ts
@@ -83,15 +83,6 @@ export const makeConfig = (config: webpack.Configuration): webpack.Configuration
       resourceRegExp: /^encoding$/,
       contextRegExp: /node-fetch/,
     }),
-    // esprima is only needed for parsing !!js/function, which isn't part of the FAILSAFE_SCHEMA.
-    // Unfortunately, js-yaml declares it as a hard dependency and requires the entire module,
-    // which causes webpack to add 0.13 MB of unused code to the bundle.
-    // Fortunately, js-yaml wraps the require call inside a try / catch block, so we can just ignore it.
-    // Reference: https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/type/js/function.js#L15
-    new webpack.IgnorePlugin({
-      resourceRegExp: /^esprima$/,
-      contextRegExp: /js-yaml/,
-    }),
     new webpack.DefinePlugin({[`IS_WEBPACK`]: `true`}),
     new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
     new ForkTsCheckerWebpackPlugin({

--- a/packages/yarnpkg-builder/sources/tools/makeConfig.ts
+++ b/packages/yarnpkg-builder/sources/tools/makeConfig.ts
@@ -83,6 +83,15 @@ export const makeConfig = (config: webpack.Configuration): webpack.Configuration
       resourceRegExp: /^encoding$/,
       contextRegExp: /node-fetch/,
     }),
+    // esprima is only needed for parsing !!js/function, which isn't part of the FAILSAFE_SCHEMA.
+    // Unfortunately, js-yaml declares it as a hard dependency and requires the entire module,
+    // which causes webpack to add 0.13 MB of unused code to the bundle.
+    // Fortunately, js-yaml wraps the require call inside a try / catch block, so we can just ignore it.
+    // Reference: https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/type/js/function.js#L15
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^esprima$/,
+      contextRegExp: /js-yaml/,
+    }),
     new webpack.DefinePlugin({[`IS_WEBPACK`]: `true`}),
     new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
     new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`esprima` is only needed for parsing `!!js/function`, which isn't part of the `FAILSAFE_SCHEMA`.
Unfortunately, `js-yaml` declares it as a hard dependency and requires the entire module, which causes `webpack` to add `0.13 MB` of unused code to the bundle.
Fortunately, `js-yaml` wraps the require call inside a `try / catch` block, so we can just ignore it.
Reference: https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/type/js/function.js#L15

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've used `webpack.IgnorePlugin` to ignore `esprima`. This decreases the bundle size from `1.89 MB` to `1.76 MB` (`6.87831%` decrease).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
