### PR TITLE
Fix Parcel E2E test

### DIFF
--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         source scripts/e2e-setup-ci.sh
 
         yarn init -p
-        yarn add -D parcel@nightly lodash
+        yarn add -D parcel@nightly lodash @babel/core
 
         # JavaScript
 

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -83,6 +83,8 @@ jobs:
         rm -rf dist src
 
         # Yaml
+        
+        yarn add js-yaml
 
         echo "import data from './data.yaml';console.log(data.berry.works.with[0]);" | tee index.js
         echo "berry: {works: {with:  [Parcel]}}" | tee data.yaml

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -54,7 +54,7 @@ jobs:
 
         # TypeScript (tsc)
 
-        yarn add -D @parcel/config-default @parcel/validator-typescript @types/lodash
+        yarn add -D @parcel/config-default @parcel/validator-typescript @types/lodash typescript
 
         echo "{\"extends\": \"@parcel/config-default\", \"validators\": {\"*.{ts,tsx}\": [\"@parcel/validator-typescript\"]}}" | tee .parcelrc
 
@@ -94,7 +94,7 @@ jobs:
 
         # MDX
 
-        yarn add react-dom react-select
+        yarn add react react-dom react-select @mdx-js/mdx @mdx-js/react
 
         echo "import page from './page.mdx'; console.log('MDX Built');" | tee index.js
         cat > page.mdx <<EOT

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -69,7 +69,7 @@ jobs:
 
         # Less
 
-        yarn add -D bootstrap-less
+        yarn add -D bootstrap-less less
 
         mkdir src
         echo "import './main.less';" | tee src/index.js


### PR DESCRIPTION
We recently disabled autoinstall for `parcel build`...

This doesn't test autoinstall anymore, but I'm not sure how running `parcel serve`, waiting for the build to finish & stopping Parcel could be achieved via a shell script.