### PR TITLE
feature(core): replace tar with tar-stream

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -6960,7 +6960,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/micromatch", "npm:4.0.1"],
             ["@types/node", "npm:13.7.0"],
             ["@types/semver", "npm:7.1.0"],
-            ["@types/tar", "npm:4.0.0"],
+            ["@types/tar-stream", "npm:1.6.0"],
             ["@types/tunnel", "npm:0.0.0"],
             ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
@@ -6989,7 +6989,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["pretty-bytes", "npm:5.1.0"],
             ["semver", "npm:7.3.2"],
             ["stream-to-promise", "npm:2.2.0"],
-            ["tar", "npm:4.4.13"],
+            ["tar-stream", "npm:2.0.1"],
             ["tslib", "npm:1.13.0"],
             ["tunnel", "npm:0.0.6"]
           ],

--- a/.yarn/versions/ca56081b.yml
+++ b/.yarn/versions/ca56081b.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-file": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+  "@yarnpkg/plugin-http": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -29,7 +29,7 @@
     "pretty-bytes": "^5.1.0",
     "semver": "^7.1.2",
     "stream-to-promise": "^2.2.0",
-    "tar": "^4.4.6",
+    "tar-stream": "^2.0.1",
     "tslib": "^1.13.0",
     "tunnel": "^0.0.6"
   },
@@ -41,7 +41,7 @@
     "@types/micromatch": "^4.0.1",
     "@types/node": "^13.7.0",
     "@types/semver": "^7.1.0",
-    "@types/tar": "^4.0.0",
+    "@types/tar-stream": "1.6.0",
     "@types/tunnel": "^0.0.0",
     "@yarnpkg/cli": "workspace:^2.1.1",
     "@yarnpkg/plugin-link": "workspace:^2.1.0",

--- a/packages/yarnpkg-core/sources/tgzUtils.ts
+++ b/packages/yarnpkg-core/sources/tgzUtils.ts
@@ -100,7 +100,6 @@ export async function extractArchiveTo<T extends FakeFS<PortablePath>>(tgz: Buff
 
         stream.on(`data`, (chunk: Buffer) => chunks.push(chunk));
         stream.on(`end`, () => {
-          targetFs.createWriteStream(mappedPath);
           targetFs.writeFileSync(mappedPath, Buffer.concat(chunks));
           targetFs.chmodSync(mappedPath, mode);
           targetFs.utimesSync(mappedPath, defaultTime, defaultTime);

--- a/packages/yarnpkg-core/sources/tgzUtils.ts
+++ b/packages/yarnpkg-core/sources/tgzUtils.ts
@@ -1,12 +1,16 @@
 import {Filename, FakeFS, PortablePath, ZipCompression, ZipFS, NodeFS, ppath, xfs, npath} from '@yarnpkg/fslib';
 import {getLibzipPromise}                                                                 from '@yarnpkg/libzip';
-import {Parse}                                                                            from 'tar';
+import tar                                                                                from 'tar-stream';
+import {promisify}                                                                        from 'util';
+import zlib                                                                               from 'zlib';
 
 interface MakeArchiveFromDirectoryOptions {
   baseFs?: FakeFS<PortablePath>,
   prefixPath?: PortablePath | null,
   compressionLevel?: ZipCompression,
 }
+
+const gunzip = promisify(zlib.gunzip);
 
 export async function makeArchiveFromDirectory(source: PortablePath, {baseFs = new NodeFS(), prefixPath = PortablePath.root, compressionLevel}: MakeArchiveFromDirectoryOptions = {}): Promise<ZipFS> {
   const tmpFolder = await xfs.mktempPromise();
@@ -38,15 +42,14 @@ export async function extractArchiveTo<T extends FakeFS<PortablePath>>(tgz: Buff
   // 1980-01-01, like Fedora
   const defaultTime = 315532800;
 
-  // @ts-ignore: Typescript doesn't want me to use new
-  const parser = new Parse();
+  const parser = tar.extract() as tar.Extract;
 
-  function ignore(entry: any) {
+  function ignore(entry: tar.Headers) {
     // Disallow absolute paths; might be malicious (ex: /etc/passwd)
-    if (entry[0] === `/`)
+    if (entry.name[0] === `/`)
       return true;
 
-    const parts = entry.path.split(/\//g);
+    const parts = entry.name.split(/\//g);
 
     // We also ignore paths that could lead to escaping outside the archive
     if (parts.some((part: string) => part === `..`))
@@ -58,71 +61,79 @@ export async function extractArchiveTo<T extends FakeFS<PortablePath>>(tgz: Buff
     return false;
   }
 
-  parser.on(`entry`, (entry: any) => {
-    if (ignore(entry)) {
-      entry.resume();
+  parser.on(`entry`, (header, stream, next) => {
+    if (ignore(header)) {
+      next();
       return;
     }
 
-    const parts = ppath.normalize(npath.toPortablePath(entry.path)).replace(/\/$/, ``).split(/\//g);
+    const parts = ppath.normalize(npath.toPortablePath(header.name)).replace(/\/$/, ``).split(/\//g);
     if (parts.length <= stripComponents) {
-      entry.resume();
+      stream.resume();
+      next();
       return;
     }
 
     const slicePath = parts.slice(stripComponents).join(`/`) as PortablePath;
     const mappedPath = ppath.join(prefixPath, slicePath);
 
-    const chunks: Array<Buffer> = [];
-
     let mode = 0o644;
 
     // If a single executable bit is set, normalize so that all are
-    if (entry.type === `Directory` || (entry.mode & 0o111) !== 0)
+    if (header.type === `directory` || ((header.mode ?? 0) & 0o111) !== 0)
       mode |= 0o111;
 
-    entry.on(`data`, (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
+    switch (header.type) {
+      case `directory`: {
+        targetFs.mkdirpSync(ppath.dirname(mappedPath), {chmod: 0o755, utimes: [defaultTime, defaultTime]});
 
-    entry.on(`end`, () => {
-      switch (entry.type) {
-        case `Directory`: {
-          targetFs.mkdirpSync(ppath.dirname(mappedPath), {chmod: 0o755, utimes: [defaultTime, defaultTime]});
+        targetFs.mkdirSync(mappedPath);
+        targetFs.chmodSync(mappedPath, mode);
+        targetFs.utimesSync(mappedPath, defaultTime, defaultTime);
+        next();
+      } break;
 
-          targetFs.mkdirSync(mappedPath);
-          targetFs.chmodSync(mappedPath, mode);
-          targetFs.utimesSync(mappedPath, defaultTime, defaultTime);
-        } break;
+      case `file`: {
+        targetFs.mkdirpSync(ppath.dirname(mappedPath), {chmod: 0o755, utimes: [defaultTime, defaultTime]});
 
-        case `OldFile`:
-        case `File`: {
-          targetFs.mkdirpSync(ppath.dirname(mappedPath), {chmod: 0o755, utimes: [defaultTime, defaultTime]});
+        const chunks: Array<Buffer> = [];
 
+        stream.on(`data`, (chunk: Buffer) => chunks.push(chunk));
+        stream.on(`end`, () => {
+          targetFs.createWriteStream(mappedPath);
           targetFs.writeFileSync(mappedPath, Buffer.concat(chunks));
           targetFs.chmodSync(mappedPath, mode);
           targetFs.utimesSync(mappedPath, defaultTime, defaultTime);
-        } break;
+          next();
+        });
+      } break;
 
-        case `SymbolicLink`: {
-          targetFs.mkdirpSync(ppath.dirname(mappedPath), {chmod: 0o755, utimes: [defaultTime, defaultTime]});
+      case `symlink`: {
+        targetFs.mkdirpSync(ppath.dirname(mappedPath), {chmod: 0o755, utimes: [defaultTime, defaultTime]});
 
-          targetFs.symlinkSync(entry.linkpath, mappedPath);
-          targetFs.lutimesSync?.(mappedPath, defaultTime, defaultTime);
-        } break;
+        targetFs.symlinkSync(header.linkname as PortablePath, mappedPath);
+        targetFs.lutimesSync?.(mappedPath, defaultTime, defaultTime);
+        next();
+      } break;
+
+      default: {
+        stream.resume();
+        next();
       }
-    });
+    }
   });
+
+  const gunzipped = await gunzip(tgz);
 
   return await new Promise<T>((resolve, reject) =>  {
     parser.on(`error`, (error: Error) => {
       reject(error);
     });
 
-    parser.on(`close`, () => {
+    parser.on(`finish`, () => {
       resolve(targetFs);
     });
 
-    parser.end(tgz);
+    parser.end(gunzipped);
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5372,7 +5372,7 @@ __metadata:
     "@types/micromatch": ^4.0.1
     "@types/node": ^13.7.0
     "@types/semver": ^7.1.0
-    "@types/tar": ^4.0.0
+    "@types/tar-stream": 1.6.0
     "@types/tunnel": ^0.0.0
     "@yarnpkg/cli": "workspace:^2.1.1"
     "@yarnpkg/fslib": "workspace:^2.1.0"
@@ -5401,7 +5401,7 @@ __metadata:
     pretty-bytes: ^5.1.0
     semver: ^7.1.2
     stream-to-promise: ^2.2.0
-    tar: ^4.4.6
+    tar-stream: ^2.0.1
     tslib: ^1.13.0
     tunnel: ^0.0.6
   languageName: unknown


### PR DESCRIPTION
**What's the problem this PR addresses?**

The yarn bundle contains both `tar` (in `@yarnpkg/core`) and `tar-stream` (in `@yarnpkg/plugin-pack`), which both do the same thing.

**How did you fix it?**

Replace `tar` with `tar-stream`. This decreases the yarn bundle size by 66150 bytes (about 3.6%).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
