### PR TITLE
Fixes pattern checksum

### DIFF
--- a/.yarn/versions/d5a0f5d8.yml
+++ b/.yarn/versions/d5a0f5d8.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/immutablePatterns.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/immutablePatterns.test.ts
@@ -122,5 +122,24 @@ describe(`Features`, () => {
         },
       )
     );
+
+    it(`shouldn't fail when a folder didn't change`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        },
+        {
+          nodeLinker: `node-modules`,
+        },
+        async ({path, run, source}) => {
+          await xfs.writeFilePromise(ppath.join(path, Filename.rc), `immutablePatterns: ["**/node_modules"]`);
+
+          await run(`install`);
+          await run(`install`, `--immutable`);
+        },
+      )
+    );
   });
 });

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -688,6 +688,7 @@ export class Configuration {
 
   public packageExtensions: Map<IdentHash, Array<{
     descriptor: Descriptor,
+    changes: Set<string>,
     patch: (pkg: Package) => void,
   }>> = new Map();
 
@@ -1216,6 +1217,16 @@ export class Configuration {
 
       miscUtils.getArrayWithDefault(packageExtensions, descriptor.identHash).push({
         descriptor,
+        changes: new Set([
+          ...[
+            ...extension.dependencies.values(),
+            ...extension.peerDependencies.values(),
+          ].map(descriptor => {
+            return structUtils.stringifyIdent(descriptor);
+          }),
+          ...extension.dependenciesMeta.keys(),
+          ...extension.peerDependenciesMeta.keys(),
+        ]),
         patch: pkg => {
           pkg.dependencies = new Map([...pkg.dependencies, ...extension.dependencies]);
           pkg.peerDependencies = new Map([...pkg.peerDependencies, ...extension.peerDependencies]);

--- a/packages/yarnpkg-core/sources/LightReport.ts
+++ b/packages/yarnpkg-core/sources/LightReport.ts
@@ -1,9 +1,10 @@
-import {Writable}      from 'stream';
+import {Writable}                            from 'stream';
 
-import {Configuration} from './Configuration';
-import {MessageName}   from './MessageName';
-import {Report}        from './Report';
-import {Locator}       from './types';
+import {Configuration}                       from './Configuration';
+import {MessageName}                         from './MessageName';
+import {Report}                              from './Report';
+import {formatNameWithHyperlink, formatName} from './StreamReport';
+import {Locator}                             from './types';
 
 export type LightReportOptions = {
   configuration: Configuration,
@@ -77,7 +78,7 @@ export class LightReport extends Report {
 
   reportError(name: MessageName, text: string) {
     this.errorCount += 1;
-    this.stdout.write(`${this.configuration.format(`➤`, `redBright`)} ${this.formatName(name)}: ${text}\n`);
+    this.stdout.write(`${this.configuration.format(`➤`, `redBright`)} ${this.formatNameWithHyperlink(name)}: ${text}\n`);
   }
 
   reportProgress(progress: AsyncIterable<{progress: number, title?: string}>) {
@@ -109,7 +110,10 @@ export class LightReport extends Report {
     }
   }
 
-  private formatName(name: MessageName) {
-    return `BR${name.toString(10).padStart(4, `0`)}`;
+  private formatNameWithHyperlink(name: MessageName | null) {
+    return formatNameWithHyperlink(name, {
+      configuration: this.configuration,
+      json: false,
+    });
   }
 }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1422,8 +1422,9 @@ export class Project {
     Configuration.telemetry?.reportInstall(nodeLinker);
 
     for (const extensions of this.configuration.packageExtensions.values())
-      for (const {descriptor} of extensions)
-        Configuration.telemetry?.reportPackageExtension(structUtils.stringifyIdent(descriptor));
+      for (const {descriptor, changes} of extensions)
+        for (const change of changes)
+          Configuration.telemetry?.reportPackageExtension(`${structUtils.stringifyIdent(descriptor)}:${change}`);
 
     const validationWarnings: Array<{name: MessageName, text: string}> = [];
     const validationErrors: Array<{name: MessageName, text: string}> = [];


### PR DESCRIPTION
**What's the problem this PR addresses?**

The checksum was returned under the form of the checksum object, not a hash, so it was always comparing different. Additionally, `globby` has a problem with `expandDirectories`: https://github.com/sindresorhus/globby/issues/147

I also fixed the reporting for LightStream, and the telemetry payload for package extensions (so that they include the change that's applied).

**How did you fix it?**

We now get the list of directories matching the pattern, then we manually add those to the pattern list, without using the `expandDirectories` option.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
