### PR TITLE
fix(vscode-zipfs): support read after write

### DIFF
--- a/.yarn/versions/49e87d67.yml
+++ b/.yarn/versions/49e87d67.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: patch

--- a/packages/vscode-zipfs/sources/ZipFSProvider.ts
+++ b/packages/vscode-zipfs/sources/ZipFSProvider.ts
@@ -7,8 +7,8 @@ export class ZipFSProvider implements vscode.FileSystemProvider {
     new VirtualFS({
       baseFs: new ZipOpenFS({
         libzip: getLibzipSync(),
-        maxOpenFiles: 80,
-        useCache: true,
+        // The cache is disabled because we need to support read after write (ZIP_ER_CHANGED)
+        useCache: false,
       }),
     })
   );


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The `vscode-zipfs` `ZipFSProvider` didn't support read after write, which caused VSCode to not be able to save any changes inside zip archives.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I disabled the cache (`useCache: false`), which causes `ZipOpenFS` to create a fresh `ZipFS` instance on every FS operation, which prevents `ZIP_ER_CHANGED`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
