### PR TITLE
fix(dlx): prevent dlx from counting as a project in the telemetry

### DIFF
--- a/.yarn/versions/6f730f82.yml
+++ b/.yarn/versions/6f730f82.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-dlx": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -37,6 +37,9 @@ export default class DlxCommand extends BaseCommand {
 
   @Command.Path(`dlx`)
   async execute() {
+    // Disable telemetry to prevent each `dlx` call from counting as a project
+    Configuration.telemetry = null;
+
     return await xfs.mktempPromise(async baseDir => {
       const tmpDir = ppath.join(baseDir, `dlx-${process.pid}` as Filename);
       await xfs.mkdirPromise(tmpDir);
@@ -56,10 +59,11 @@ export default class DlxCommand extends BaseCommand {
 
         await Configuration.updateConfiguration(tmpDir, (current: any) => {
           if (typeof current.plugins === `undefined`)
-            return {enableGlobalCache: true};
+            return {enableGlobalCache: true, enableTelemetry: false};
 
           return {
             enableGlobalCache: true,
+            enableTelemetry: false,
             plugins: current.plugins.map((plugin: any) => {
               const sourcePath: NativePath = typeof plugin === `string`
                 ? plugin
@@ -78,7 +82,7 @@ export default class DlxCommand extends BaseCommand {
           };
         });
       } else {
-        await xfs.writeFilePromise(targetYarnrc, `enableGlobalCache: true\n`);
+        await xfs.writeFilePromise(targetYarnrc, `enableGlobalCache: true\nenableTelemetry: false\n`);
       }
 
       const pkgs = typeof this.pkg !== `undefined`


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn dlx` currently counts as a project in the telemetry which will inflate that metric a lot.

**How did you fix it?**

Disabled telemetry for everything `dlx` does, `dlx` itself still counts but anything it does and anything the project it creates does isn't counted.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
