### PR TITLE
perf(core): wrap LazyFS inside AliasFS to speed up getRealPath calls

### DIFF
--- a/.yarn/versions/ea6c2aeb.yml
+++ b/.yarn/versions/ea6c2aeb.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -1,15 +1,15 @@
-import {FakeFS, LazyFS, NodeFS, ZipFS, PortablePath, Filename} from '@yarnpkg/fslib';
-import {ppath, toFilename, xfs, DEFAULT_COMPRESSION_LEVEL}     from '@yarnpkg/fslib';
-import {getLibzipPromise}                                      from '@yarnpkg/libzip';
-import fs                                                      from 'fs';
+import {FakeFS, LazyFS, NodeFS, ZipFS, PortablePath, Filename, AliasFS} from '@yarnpkg/fslib';
+import {ppath, toFilename, xfs, DEFAULT_COMPRESSION_LEVEL}              from '@yarnpkg/fslib';
+import {getLibzipPromise}                                               from '@yarnpkg/libzip';
+import fs                                                               from 'fs';
 
-import {Configuration}                                         from './Configuration';
-import {MessageName}                                           from './MessageName';
-import {ReportError}                                           from './Report';
-import * as hashUtils                                          from './hashUtils';
-import * as miscUtils                                          from './miscUtils';
-import * as structUtils                                        from './structUtils';
-import {LocatorHash, Locator}                                  from './types';
+import {Configuration}                                                  from './Configuration';
+import {MessageName}                                                    from './MessageName';
+import {ReportError}                                                    from './Report';
+import * as hashUtils                                                   from './hashUtils';
+import * as miscUtils                                                   from './miscUtils';
+import * as structUtils                                                 from './structUtils';
+import {LocatorHash, Locator}                                           from './types';
 
 const CACHE_VERSION = 6;
 
@@ -291,6 +291,9 @@ export class Cache {
     }, message => {
       return `Failed to open the cache entry for ${structUtils.prettyLocator(this.configuration, locator)}: ${message}`;
     }), ppath);
+    // We use an AliasFS to speed up getRealPath calls (e.g. VirtualFetcher.ensureVirtualLink)
+    // (there's no need to create the lazy baseFs instance to gather the already-known cachePath)
+    const aliasFs = new AliasFS(cachePath, {baseFs: lazyFs, pathUtils: ppath});
 
     const releaseFs = () => {
       if (zipFs !== null) {
@@ -298,7 +301,7 @@ export class Cache {
       }
     };
 
-    return [lazyFs, releaseFs, checksum];
+    return [aliasFs, releaseFs, checksum];
   }
 
   private async writeFileWithLock<T>(file: PortablePath | null, generator: () => Promise<T>) {

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -291,6 +291,7 @@ export class Cache {
     }, message => {
       return `Failed to open the cache entry for ${structUtils.prettyLocator(this.configuration, locator)}: ${message}`;
     }), ppath);
+
     // We use an AliasFS to speed up getRealPath calls (e.g. VirtualFetcher.ensureVirtualLink)
     // (there's no need to create the lazy baseFs instance to gather the already-known cachePath)
     const aliasFs = new AliasFS(cachePath, {baseFs: lazyFs, pathUtils: ppath});


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We were creating the `ZipFS` instance inside the `LazyFS` returned by `fetchPackageFromCache` too early inside `VirtualFetcher.ensureVirtualLink`, because we were calling `sourceFetch.packageFs.getRealPath`, which caused the `baseFs` to be created from the `factory` function and querried using `getRealPath`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

This can be optimized by wrapping the `LazyFS` inside an `AliasFS` targetting the `cachePath`, which causes all `getRealPath` calls to return the `cachePath` directly without having to go through the `ZipFS`.

This reduces the execution time of all `VirtualFetcher.ensureVirtualLink` calls from `238.4 ms` to `15.7 ms` (`93.4144%` decrease) - tested inside the Berry repo (with a hot cache - not that it would matter, since `VirtualFetcher` never goes through the cache anyways).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
