### PR TITLE
feat(workspace-tools): add --all flag to the focus command

### DIFF
--- a/.yarn/versions/b28d8e82.yml
+++ b/.yarn/versions/b28d8e82.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": patch

--- a/packages/gatsby/content/advanced/migration.md
+++ b/packages/gatsby/content/advanced/migration.md
@@ -158,6 +158,7 @@ This will cause Yarn to install the project just like Yarn 1 used to, by copying
 | `yarn outdated` | `yarn upgrade-interactive` | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749) |
 | `yarn publish`  | `yarn npm publish`         ||
 | `yarn upgrade`  | `yarn up`                  | Will now upgrade packages across all workspaces |
+| `yarn install --production` | `yarn workspaces focus --all --production` | Requires the `workspace-tools` plugin
 
 ### Deprecated
 

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -2,6 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}                              from '
 import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
 import {structUtils}                                                      from '@yarnpkg/core';
 import {Command, Usage}                                                   from 'clipanion';
+import * as yup                                                           from 'yup';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
@@ -31,6 +32,15 @@ export default class WorkspacesFocus extends BaseCommand {
 
       If the \`--json\` flag is set the output will follow a JSON-stream output also known as NDJSON (https://github.com/ndjson/ndjson-spec).
     `,
+  });
+
+  static schema = yup.object().shape({
+    all: yup.bool(),
+    workspaces: yup.array().when(`all`, {
+      is: true,
+      then: yup.array().max(0, `Cannot specify workspaces when using the --all flag`),
+      otherwise: yup.array(),
+    }),
   });
 
   @Command.Path(`workspaces`, `focus`)

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -14,6 +14,9 @@ export default class WorkspacesFocus extends BaseCommand {
   @Command.Boolean(`--production`)
   production: boolean = false;
 
+  @Command.Boolean(`--all`)
+  all: boolean = false;
+
   static usage: Usage = Command.Usage({
     category: `Workspace-related commands`,
     description: `install a single workspace and its dependencies`,
@@ -21,6 +24,8 @@ export default class WorkspacesFocus extends BaseCommand {
       This command will run an install as if the specified workspaces (and all other workspaces they depend on) were the only ones in the project. If no workspaces are explicitly listed, the active one will be assumed.
 
       Note that this command is only very moderately useful when using zero-installs, since the cache will contain all the packages anyway - meaning that the only difference between a full install and a focused install would just be a few extra lines in the \`.pnp.js\` file, at the cost of introducing an extra complexity.
+
+      If the \`--all\` flag is set, the entire project will be installed. Combine with \`--production\` to replicate the old \`yarn install --production\`.
 
       If the \`--production\` flag is set, only regular dependencies will be installed, and dev dependencies will be omitted.
 
@@ -35,7 +40,9 @@ export default class WorkspacesFocus extends BaseCommand {
     const cache = await Cache.find(configuration);
 
     let requiredWorkspaces: Set<Workspace>;
-    if (this.workspaces.length === 0) {
+    if (this.all) {
+      requiredWorkspaces = new Set(project.workspaces);
+    } else if (this.workspaces.length === 0) {
       if (!workspace)
         throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -14,7 +14,7 @@ export default class WorkspacesFocus extends BaseCommand {
   @Command.Boolean(`--production`)
   production: boolean = false;
 
-  @Command.Boolean(`--all`)
+  @Command.Boolean(`-A,--all`)
   all: boolean = false;
 
   static usage: Usage = Command.Usage({
@@ -25,7 +25,7 @@ export default class WorkspacesFocus extends BaseCommand {
 
       Note that this command is only very moderately useful when using zero-installs, since the cache will contain all the packages anyway - meaning that the only difference between a full install and a focused install would just be a few extra lines in the \`.pnp.js\` file, at the cost of introducing an extra complexity.
 
-      If the \`--all\` flag is set, the entire project will be installed. Combine with \`--production\` to replicate the old \`yarn install --production\`.
+      If the \`-A,--all\` flag is set, the entire project will be installed. Combine with \`--production\` to replicate the old \`yarn install --production\`.
 
       If the \`--production\` flag is set, only regular dependencies will be installed, and dev dependencies will be omitted.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

There is currently no way to replicate the behaviour of `yarn install --production` from V1, `yarn workspaces focus --production` gets close but requires that the root depend on all workspaces to truly replicate the behaviour

**How did you fix it?**

Added a `--all` flag to the focus command (`yarn workspaces focus`) to allow `yarn workspaces focus --all --production`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
