### PR TITLE
fix(npm-cli): save login under specified scope

### DIFF
--- a/.yarn/versions/756df4ca.yml
+++ b/.yarn/versions/756df4ca.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/login.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/login.test.js.snap
@@ -21,7 +21,6 @@ exports[`Commands npm login it should login a user with OTP to a specific scope 
 "npmScopes:
   testScope:
     npmAuthToken: 686159dc-64b3-413e-a244-2de2b8d1c36f
-    npmPublishRegistry: \\"http://yarn.test.registry\\"
     npmRegistryServer: \\"http://yarn.test.registry\\"
 "
 `;
@@ -57,7 +56,6 @@ exports[`Commands npm login it should login a user with no OTP setup to a specif
 "npmScopes:
   testScope:
     npmAuthToken: 316158de-64b3-413e-a244-2de2b8d1c80f
-    npmPublishRegistry: \\"http://yarn.test.registry\\"
     npmRegistryServer: \\"http://yarn.test.registry\\"
 "
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/login.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/login.test.js.snap
@@ -18,12 +18,10 @@ Object {
 `;
 
 exports[`Commands npm login it should login a user with OTP to a specific scope 1`] = `
-"npmRegistries:
-  \\"http://yarn.test.registry\\":
-    npmAuthToken: 686159dc-64b3-413e-a244-2de2b8d1c36f
-
-npmScopes:
+"npmScopes:
   testScope:
+    npmAuthToken: 686159dc-64b3-413e-a244-2de2b8d1c36f
+    npmPublishRegistry: \\"http://yarn.test.registry\\"
     npmRegistryServer: \\"http://yarn.test.registry\\"
 "
 `;
@@ -56,12 +54,10 @@ Object {
 `;
 
 exports[`Commands npm login it should login a user with no OTP setup to a specific scope 1`] = `
-"npmRegistries:
-  \\"http://yarn.test.registry\\":
-    npmAuthToken: 316158de-64b3-413e-a244-2de2b8d1c80f
-
-npmScopes:
+"npmScopes:
   testScope:
+    npmAuthToken: 316158de-64b3-413e-a244-2de2b8d1c80f
+    npmPublishRegistry: \\"http://yarn.test.registry\\"
     npmRegistryServer: \\"http://yarn.test.registry\\"
 "
 `;

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -95,8 +95,6 @@ async function setAuthToken(registry: string, npmAuthToken: string, {configurati
         ...scopes,
         [scope]: {
           ...scopes[scope],
-          npmRegistryServer: registry,
-          npmPublishRegistry: registry,
           npmAuthToken,
         },
       }),

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -67,7 +67,7 @@ export default class NpmLoginCommand extends BaseCommand {
         authType: npmHttpUtils.AuthType.NO_AUTH,
       }) as any;
 
-      await setAuthToken(registry, response.token, {configuration});
+      await setAuthToken(registry, response.token, {configuration, scope: this.scope});
       return report.reportInfo(MessageName.UNNAMED, `Successfully logged in`);
     });
 
@@ -88,7 +88,21 @@ export async function getRegistry({scope, publish, configuration, cwd}: {scope?:
   return npmConfigUtils.getDefaultRegistry({configuration});
 }
 
-async function setAuthToken(registry: string, npmAuthToken: string, {configuration}: {configuration: Configuration}) {
+async function setAuthToken(registry: string, npmAuthToken: string, {configuration, scope}: {configuration: Configuration, scope?: string}) {
+  if (scope) {
+    return await Configuration.updateHomeConfiguration({
+      npmScopes: (scopes: {[key: string]: any} = {}) => ({
+        ...scopes,
+        [scope]: {
+          ...scopes[scope],
+          npmRegistryServer: registry,
+          npmPublishRegistry: registry,
+          npmAuthToken,
+        },
+      }),
+    });
+  }
+
   return await Configuration.updateHomeConfiguration({
     npmRegistries: (registries: {[key: string]: any} = {}) => ({
       ...registries,


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn npm login --scope` doesn't save the login token under the specified scope, instead overwriting the existing login.

**How did you fix it?**

When `--scope` is specified save the login under the `npmScopes` config

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [ ] I have verified that all automated PR checks pass.