### PR TITLE
Add GH Actions workflow for Storybook

### DIFF
--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -1,0 +1,37 @@
+#
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/workflows/e2e-storybook-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Storybook'
+jobs:
+  chore:
+    name: 'Validating Storybook (with a React app)'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: 'Use Node.js 10.x'
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.x
+
+    - name: 'Build the standard bundle'
+      run: |
+        node ./scripts/run-yarn.js build:cli
+
+    - name: 'Running the integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        yarn dlx create-react-app my-cra && cd my-cra
+        yarn dlx -p @storybook/cli sb init --yes
+        yarn build-storybook
+

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ On top of our classic integration tests, we also run Yarn every day against the 
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Parcel/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-parcel-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Prettier/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-prettier-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Rollup/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-rollup-workflow.yml)<br/>
+[![](https://github.com/yarnpkg/berry/workflows/E2E%20Storybook/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-storybook-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20TypeScript/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-typescript-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Webpack/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-webpack-workflow.yml)<br/>
 </td></tr>

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -99,9 +99,10 @@ A lot of very common frontend tools now support Plug'n'Play natively!
 | Parcel | Starting from 2.0.0-nightly.212+ |
 | Prettier | Starting from 1.17+ |
 | Rollup | Starting from `resolve` 1.9+ |
+| Storybook | Starting from 6.0+ |
+| TypeScript | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by default)
 | TypeScript-ESLint | Starting from 2.12+ |
 | WebStorm | Starting from 2019.3+; See [Editor SDKs](https://yarnpkg.com/advanced/editor-sdks) |
-| TypeScript | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by default)
 | Webpack | Native | Starting from 5+ ([plugin](https://github.com/arcanis/pnp-webpack-plugin) available for 4.x) |
 
 #### Support via plugins


### PR DESCRIPTION
**Description**

[Storybook](https://github.com/storybookjs/storybook) is a massively used tool in the frontend dev community and wasn't compatible with Berry (PnP mode) for now.  

As of Storybook 6.0, Berry will be supported out of the box for some frameworks (for instance React). 6.0 release will be out soon, in the next few weeks, so I created an e2e test workflow for it. I also added a badge for this workflow in `Current status > Tooling` section of the README.

Closes https://github.com/yarnpkg/berry/issues/592.

--

**Checklist**

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have verified that all automated PR checks pass.
