### PR TITLE
feat(plugin-workspace-tools): handle SIGINT in workspaces foreach

### DIFF
--- a/.yarn/versions/a26384d1.yml
+++ b/.yarn/versions/a26384d1.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": patch


### PR DESCRIPTION
**What's the problem this PR addresses?**

Hitting `ctrl-c` doesn't stop `yarn workspaces foreach <stuff>`. It kills the currently running processes, but yarn starts the next batch, and the next, and the next etc.

Fixes #1622

**How did you fix it?**

Handle signal code 130, which signals SIGINT, by blocking all future commands from running.

`yarn workspaces foreach` will also exit with the SIGINT exit code, signaling to parent processes, if any, that yarn has exited due to a signal.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
