### PR TITLE
Uniformizes the --all flag

### DIFF
--- a/.github/workflows/e2e-pnpify-workflow.yml
+++ b/.github/workflows/e2e-pnpify-workflow.yml
@@ -37,6 +37,6 @@ jobs:
 
         yarn add @yarnpkg/pnpify @angular-devkit/core@next @babel/preset-env @babel/core -D
 
-        yarn unplug @angular/platform-browser @angular/core @angular/common @angular/compiler-cli
+        yarn unplug -AR @angular/platform-browser @angular/core @angular/common @angular/compiler-cli
 
         yarn pnpify ng build --aot

--- a/.yarn/versions/8f408611.yml
+++ b/.yarn/versions/8f408611.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/8f408611.yml
+++ b/.yarn/versions/8f408611.yml
@@ -1,7 +1,7 @@
 releases:
   "@yarnpkg/cli": prerelease
   "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnp": minor
   "@yarnpkg/plugin-workspace-tools": patch
 
 declined:

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/yarn.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/yarn.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_RC_FILENAME}           from '@yarnpkg/core';
+import {DEFAULT_RC_FILENAME, Manifest} from '@yarnpkg/core';
 import {PortablePath, ppath, Filename} from '@yarnpkg/fslib';
 
 import * as fsUtils                    from './fs';
@@ -11,8 +11,9 @@ export async function writeConfiguration(dir: PortablePath, value: {[key: string
   return await fsUtils.writeSyml(ppath.join(dir, filename), value);
 }
 
-export async function readManifest(dir: PortablePath, {filename = Filename.manifest}: {filename?: Filename} = {}) {
-  return await fsUtils.readJson(ppath.join(dir, filename));
+export async function readManifest(dir: PortablePath, {key, filename = Filename.manifest}: {key?: keyof Manifest, filename?: Filename} = {}) {
+  const data = await fsUtils.readJson(ppath.join(dir, filename));
+  return key != null ? data?.[key] : data;
 }
 
 export function getRelativePluginPath(name: string) {

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/one-fixed-dep-2.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/one-fixed-dep-2.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/one-fixed-dep-2.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/one-fixed-dep-2.0.0/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "one-fixed-dep",
+    "version": "2.0.0",
+    "dependencies": {
+        "no-deps": "2.0.0"
+    }
+}

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -8,7 +8,7 @@ export default class LinkCommand extends BaseCommand {
   @Command.String()
   destination!: string;
 
-  @Command.Boolean(`--all`)
+  @Command.Boolean(`-A,--all`)
   all: boolean = false;
 
   @Command.Boolean(`-p,--private`)

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -7,6 +7,7 @@ import {UsageError}                                                             
 
 import {AbstractPnpInstaller}                                                           from './AbstractPnpInstaller';
 import {getPnpPath}                                                                     from './index';
+import * as pnpUtils                                                                    from './pnpUtils';
 
 const FORCED_UNPLUG_PACKAGES = new Set([
   // Some packages do weird stuff and MUST be unplugged. I don't like them.
@@ -193,12 +194,8 @@ export class PnpInstaller extends AbstractPnpInstaller {
     return nodeModules;
   }
 
-  private getUnpluggedPath(locator: Locator) {
-    return ppath.resolve(this.opts.project.configuration.get(`pnpUnpluggedFolder`), structUtils.slugifyLocator(locator));
-  }
-
   private async unplugPackage(locator: Locator, packageFs: FakeFS<PortablePath>) {
-    const unplugPath = this.getUnpluggedPath(locator);
+    const unplugPath = pnpUtils.getUnpluggedPath(locator, {configuration: this.opts.project.configuration});
     this.unpluggedPaths.add(unplugPath);
 
     await xfs.mkdirPromise(unplugPath, {recursive: true});

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -10,8 +10,8 @@ export default class UnplugCommand extends BaseCommand {
   @Command.Rest()
   patterns: Array<string> = [];
 
-  @Command.Boolean(`-A,--all`)
-  all: boolean = false;
+  @Command.Boolean(`-R,--recursive`)
+  recursive: boolean = false;
 
   @Command.Boolean(`--json`)
   json: boolean = false;
@@ -46,10 +46,10 @@ export default class UnplugCommand extends BaseCommand {
       `yarn unplug '@babel/*'`,
     ], [
       `Unplug all instances of lodash referenced by the project`,
-      `yarn unplug lodash -A`,
+      `yarn unplug lodash -R`,
     ], [
       `Unplug all packages (only for testing, not recommended)`,
-      `yarn unplug -A '*'`,
+      `yarn unplug -R '*'`,
     ]],
   });
 
@@ -70,7 +70,7 @@ export default class UnplugCommand extends BaseCommand {
     const {topLevelWorkspace} = project;
 
     let packages: Set<Package>;
-    if (this.all) {
+    if (this.recursive) {
       packages = new Set(project.storedPackages.values());
     } else {
       packages = new Set();
@@ -122,9 +122,7 @@ export default class UnplugCommand extends BaseCommand {
 
           const version = pkg.version ?? `unknown`;
 
-          const dependencyMeta = topLevelWorkspace.manifest.ensureDependencyMeta(
-            structUtils.makeDescriptor(pkg, version)
-          );
+          const dependencyMeta = topLevelWorkspace.manifest.ensureDependencyMeta(structUtils.makeDescriptor(pkg, version));
           dependencyMeta.unplugged = true;
 
           report.reportInfo(MessageName.UNNAMED, `Unplugged ${structUtils.prettyLocator(configuration, pkg)}`);
@@ -143,7 +141,7 @@ export default class UnplugCommand extends BaseCommand {
         }
       }
 
-      const projectOrWorkspaces = this.all
+      const projectOrWorkspaces = this.recursive
         ? `the project`
         : `any workspace`;
 

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -1,11 +1,11 @@
-import {BaseCommand, WorkspaceRequiredError}                                           from '@yarnpkg/cli';
-import {Cache, Configuration, Project, StreamReport, Package, MessageName, FormatType} from '@yarnpkg/core';
-import {structUtils, semverUtils}                                                      from '@yarnpkg/core';
-import {Command, Usage, UsageError}                                                    from 'clipanion';
-import micromatch                                                                      from 'micromatch';
-import semver                                                                          from 'semver';
+import {BaseCommand, WorkspaceRequiredError}                                                                              from '@yarnpkg/cli';
+import {Cache, Configuration, Project, StreamReport, Package, MessageName, FormatType, LocatorHash, Workspace, miscUtils} from '@yarnpkg/core';
+import {structUtils, semverUtils}                                                                                         from '@yarnpkg/core';
+import {Command, Usage, UsageError}                                                                                       from 'clipanion';
+import micromatch                                                                                                         from 'micromatch';
+import semver                                                                                                             from 'semver';
 
-import * as pnpUtils                                                                   from '../pnpUtils';
+import * as pnpUtils                                                                                                      from '../pnpUtils';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UnplugCommand extends BaseCommand {
@@ -72,90 +72,125 @@ export default class UnplugCommand extends BaseCommand {
 
     await project.restoreInstallState();
 
-    const {topLevelWorkspace} = project;
+    const unreferencedPatterns = new Set(this.patterns);
 
-    let packages: Set<Package>;
-    if (this.recursive) {
-      packages = new Set(project.storedPackages.values());
-    } else {
-      packages = new Set();
-      for (const workspace of project.workspaces) {
-        for (const descriptor of workspace.dependencies.values()) {
-          const resolution = project.storedResolutions.get(descriptor.descriptorHash);
+    const matchers = this.patterns.map(pattern => {
+      const patternDescriptor = structUtils.parseDescriptor(pattern);
+      const pseudoDescriptor = patternDescriptor.range !== `unknown`
+        ? patternDescriptor
+        : structUtils.makeDescriptor(patternDescriptor, `*`);
 
-          if (typeof resolution === `undefined`)
-            throw new Error(`Assertion failed: Expected the resolution to have been registered`);
+      if (!semver.validRange(pseudoDescriptor.range))
+        throw new UsageError(`The range of the descriptor patterns must be a valid semver range (${structUtils.prettyDescriptor(configuration, pseudoDescriptor)})`);
 
-          const pkg = project.storedPackages.get(resolution);
+      return (pkg: Package) => {
+        const stringifiedIdent = structUtils.stringifyIdent(pkg);
+        if (!micromatch.isMatch(stringifiedIdent, structUtils.stringifyIdent(pseudoDescriptor)))
+          return false;
 
-          if (typeof pkg === `undefined`)
-            throw new Error(`Assertion failed: Expected the package to have been registered`);
+        if (pkg.version && !semverUtils.satisfiesWithPrereleases(pkg.version, pseudoDescriptor.range))
+          return false;
 
-          packages.add(pkg);
+        unreferencedPatterns.delete(pattern);
+
+        return true;
+      };
+    });
+
+    const getAllMatchingPackages = () => {
+      const selection: Array<Package> = [];
+
+      for (const pkg of project.storedPackages.values())
+        if (!project.tryWorkspaceByLocator(pkg) && !structUtils.isVirtualLocator(pkg) && matchers.some(matcher => matcher(pkg)))
+          selection.push(pkg);
+
+      return selection;
+    };
+
+    const getSelectedPackages = (roots: Array<Workspace>) => {
+      const seen: Set<LocatorHash> = new Set();
+      const selection: Array<Package> = [];
+
+      const traverse = (pkg: Package, depth: number) => {
+        if (seen.has(pkg.locatorHash))
+          return;
+
+        seen.add(pkg.locatorHash);
+
+        if (!project.tryWorkspaceByLocator(pkg) && !structUtils.isVirtualLocator(pkg) && matchers.some(matcher => matcher(pkg)))
+          selection.push(pkg);
+
+        // Don't recurse unless requested
+        if (depth > 0 && !this.recursive)
+          return;
+
+        for (const dependency of pkg.dependencies.values()) {
+          const resolution = project.storedResolutions.get(dependency.descriptorHash);
+          if (!resolution)
+            throw new Error(`Assertion failed: The resolution should have been registered`);
+
+          const nextPkg = project.storedPackages.get(resolution);
+          if (!nextPkg)
+            throw new Error(`Assertion failed: The package should have been registered`);
+
+          traverse(nextPkg, depth + 1);
         }
+      };
+
+      for (const workspace of roots) {
+        const pkg = project.storedPackages.get(workspace.anchoredLocator.locatorHash);
+        if (!pkg)
+          throw new Error(`Assertion failed: The package should have been registered`);
+
+        traverse(pkg, 0);
       }
-    }
+
+      return selection;
+    };
+
+    let selection: Array<Package>;
+
+    // We can shortcut the execution if we want all the dependencies and
+    // transitive dependencies of all the branches: it means we want everything!
+    if (this.all && this.recursive)
+      selection = getAllMatchingPackages();
+    else if (this.all)
+      selection = getSelectedPackages(project.workspaces);
+    else
+      selection = getSelectedPackages([workspace]);
+
+    const projectOrWorkspaces = this.recursive
+      ? `the project`
+      : `any workspace`;
+
+    if (unreferencedPatterns.size > 1)
+      throw new UsageError(`Patterns ${[...unreferencedPatterns].join(`, `)} don't match any packages referenced by ${projectOrWorkspaces}`);
+    if (unreferencedPatterns.size > 0)
+      throw new UsageError(`Pattern ${[...unreferencedPatterns][0]} doesn't match any packages referenced by ${projectOrWorkspaces}`);
+
+    selection = miscUtils.sortMap(selection, pkg => {
+      return structUtils.stringifyLocator(pkg);
+    });
 
     const report = await StreamReport.start({
       configuration,
       stdout: this.context.stdout,
       json: this.json,
     }, async report => {
-      const unreferencedPatterns = [];
+      for (const pkg of selection) {
+        const version = pkg.version ?? `unknown`;
 
-      for (const pattern of this.patterns) {
-        let isReferenced = false;
+        const dependencyMeta = project.topLevelWorkspace.manifest.ensureDependencyMeta(structUtils.makeDescriptor(pkg, version));
+        dependencyMeta.unplugged = true;
 
-        const patternDescriptor = structUtils.parseDescriptor(pattern);
-        const pseudoDescriptor = patternDescriptor.range !== `unknown`
-          ? patternDescriptor
-          : structUtils.makeDescriptor(patternDescriptor, `*`);
-
-        if (!semver.validRange(pseudoDescriptor.range))
-          throw new UsageError(`The range of the descriptor patterns must be a valid semver range (${structUtils.prettyDescriptor(configuration, pseudoDescriptor)})`);
-
-        for (const pkg of packages) {
-          if (structUtils.isVirtualLocator(pkg))
-            continue;
-
-          const stringifiedIdent = structUtils.stringifyIdent(pkg);
-          if (!micromatch.isMatch(stringifiedIdent, structUtils.stringifyIdent(pseudoDescriptor)))
-            continue;
-
-          if (pkg.version && !semverUtils.satisfiesWithPrereleases(pkg.version, pseudoDescriptor.range))
-            continue;
-
-          const version = pkg.version ?? `unknown`;
-
-          const dependencyMeta = topLevelWorkspace.manifest.ensureDependencyMeta(structUtils.makeDescriptor(pkg, version));
-          dependencyMeta.unplugged = true;
-
-          report.reportInfo(MessageName.UNNAMED, `Unplugged ${structUtils.prettyLocator(configuration, pkg)} in ${configuration.format(pnpUtils.getUnpluggedPath(pkg, {configuration}), FormatType.PATH)}`);
-
-          report.reportJson({
-            pattern,
-            locator: structUtils.stringifyLocator(pkg),
-            version,
-          });
-
-          isReferenced = true;
-        }
-
-        if (!isReferenced) {
-          unreferencedPatterns.push(pattern);
-        }
+        report.reportInfo(MessageName.UNNAMED, `Will unpack ${structUtils.prettyLocator(configuration, pkg)} to ${configuration.format(pnpUtils.getUnpluggedPath(pkg, {configuration}), FormatType.PATH)}`);
+        report.reportJson({
+          locator: structUtils.stringifyLocator(pkg),
+          version,
+        });
       }
 
-      const projectOrWorkspaces = this.recursive
-        ? `the project`
-        : `any workspace`;
-
-      if (unreferencedPatterns.length > 1)
-        throw new UsageError(`Patterns ${unreferencedPatterns.join(`, `)} don't match any packages referenced by ${projectOrWorkspaces}`);
-      if (unreferencedPatterns.length > 0)
-        throw new UsageError(`Pattern ${unreferencedPatterns[0]} doesn't match any packages referenced by ${projectOrWorkspaces}`);
-
-      await topLevelWorkspace.persistManifest();
+      await project.topLevelWorkspace.persistManifest();
 
       report.reportSeparator();
 

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -1,11 +1,11 @@
-import {BaseCommand, WorkspaceRequiredError}                               from '@yarnpkg/cli';
-import {Cache, Configuration, Project, StreamReport, Package, MessageName} from '@yarnpkg/core';
-import {structUtils, semverUtils}                                          from '@yarnpkg/core';
-import {Command, Usage, UsageError}                                        from 'clipanion';
-import micromatch                                                          from 'micromatch';
-import semver                                                              from 'semver';
+import {BaseCommand, WorkspaceRequiredError}                                           from '@yarnpkg/cli';
+import {Cache, Configuration, Project, StreamReport, Package, MessageName, FormatType} from '@yarnpkg/core';
+import {structUtils, semverUtils}                                                      from '@yarnpkg/core';
+import {Command, Usage, UsageError}                                                    from 'clipanion';
+import micromatch                                                                      from 'micromatch';
+import semver                                                                          from 'semver';
 
-import * as pnpUtils                                                       from '../pnpUtils';
+import * as pnpUtils                                                                   from '../pnpUtils';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UnplugCommand extends BaseCommand {
@@ -130,7 +130,7 @@ export default class UnplugCommand extends BaseCommand {
           const dependencyMeta = topLevelWorkspace.manifest.ensureDependencyMeta(structUtils.makeDescriptor(pkg, version));
           dependencyMeta.unplugged = true;
 
-          report.reportInfo(MessageName.UNNAMED, `Unplugged ${structUtils.prettyLocator(configuration, pkg)} in ${pnpUtils.getUnpluggedPath(locator, {configuration})}`);
+          report.reportInfo(MessageName.UNNAMED, `Unplugged ${structUtils.prettyLocator(configuration, pkg)} in ${configuration.format(pnpUtils.getUnpluggedPath(pkg, {configuration}), FormatType.PATH)}`);
 
           report.reportJson({
             pattern,

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -6,6 +6,9 @@ import semver                                              from 'semver';
 
 import {PnpLinker}                                         from './PnpLinker';
 import unplug                                              from './commands/unplug';
+import * as pnpUtils                                       from './pnpUtils';
+
+export {pnpUtils};
 
 export const getPnpPath = (project: Project) => {
   let mainFilename;

--- a/packages/plugin-pnp/sources/pnpUtils.ts
+++ b/packages/plugin-pnp/sources/pnpUtils.ts
@@ -1,0 +1,6 @@
+import {Locator, structUtils, Configuration} from '@yarnpkg/core';
+import {ppath}                               from '@yarnpkg/fslib';
+
+export function getUnpluggedPath(locator: Locator, {configuration}: {configuration: Configuration}) {
+  return ppath.resolve(configuration.get(`pnpUnpluggedFolder`), structUtils.slugifyLocator(locator));
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**

Various commands had different styles of `--all` flag.

**How did you fix it?**

This PR normalizes the syntax by using the two following flags:

- `-A,--all` will always target all the workspaces (but not their transitive dependencies)
- `-R,--recursive` will always target all the dependencies (but not all the workspaces)

The `-a` flag for `yarn workspaces foreach` is deprecated, but will only be removed in the next major.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
