### PR TITLE
fix(compat): add ink-select-input extension

### DIFF
--- a/.yarn/versions/bb9021aa.yml
+++ b/.yarn/versions/bb9021aa.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -75,4 +75,10 @@ export const packageExtensions: Array<[string, any]> = [
       [`tiny-warning`]: `^1.0.2`,
     },
   }],
+  // https://github.com/vadimdemedes/ink-select-input/pull/26
+  [`ink-select-input@*`, {
+    peerDependencies: {
+      react: `^16.8.2`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

The gatsby e2e test has been failing for weeks and https://github.com/vadimdemedes/ink-select-input/pull/26 has been open for 17 days now.

**How did you fix it?**

Added `react` as a peer dependency to `ink-select-input` in `plugin-compat`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
