### PR TITLE
Fix Google Cloud Functions (GCF) deployment

### DIFF
--- a/.yarn/versions/6c7ed101.yml
+++ b/.yarn/versions/6c7ed101.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -160,9 +160,12 @@ export default class YarnCommand extends BaseCommand {
       }
     }
 
-    // We want to prevent people from using --production with install command
+    // Since the production flag would yield a different lockfile than the
+    // regular installs, it's not part of the regular `install` command anymore.
+    // Instead, we expect users to use it with `yarn workspaces focus` (which can
+    // be used even outside of monorepos).
     if (typeof this.production !== `undefined`) {
-      const exitCode = await reportDeprecation(`The --production option is deprecated; you can only use it with focus command`, {
+      const exitCode = await reportDeprecation(`The --production option is deprecated on 'install'; use 'yarn workspaces focus' instead`, {
         error: true,
       });
 
@@ -171,7 +174,8 @@ export default class YarnCommand extends BaseCommand {
       }
     }
 
-    // We want to prevent people from using --non-interactive
+    // Yarn 2 isn't interactive during installs anyway, so there's no real point
+    // to this flag at the moment.
     if (typeof this.nonInteractive !== `undefined`) {
       const exitCode = await reportDeprecation(`The --non-interactive option is deprecated`, {
         error: !isGCF,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Deploying a Node.js package with Yarn v2 (via `.yarnrc.yml`) to Google Cloud Function (GCF) fails with the following error:

```
ERROR: (gcloud.functions.deploy) OperationError: code=3, message=Build failed: Build error details not available.
```

Fixes https://github.com/yarnpkg/berry/issues/1646

**How did you fix it?**

Do not exit with an error when running `yarn install --non-interactive --frozen-lockfile` in GCF environment.

**Checklist**

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
