### PR TITLE
Refactors login/logout

### DIFF
--- a/.yarn/versions/e5035e39.yml
+++ b/.yarn/versions/e5035e39.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+  "@yarnpkg/parsers": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/yarn.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/yarn.ts
@@ -16,6 +16,6 @@ export async function readManifest(dir: PortablePath, {key, filename = Filename.
   return key != null ? data?.[key] : data;
 }
 
-export function getRelativePluginPath(name: string) {
-  return `.yarn/plugins/${name}.cjs` as PortablePath;
+export function getPluginPath(dir: PortablePath, name: string) {
+  return ppath.join(dir, `.yarn/plugins/${name}.cjs` as PortablePath);
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/logout.test.ts.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/logout.test.ts.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Commands npm logout should logout a user from all registries when the -A,--all flag is used 1`] = `
+exports[`Commands npm logout should logout a user from all registries and all scopes when the -A,--all flag is used 1`] = `
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out of all registries
+  "stdout": "➤ YN0000: Successfully logged out from everything
+➤ YN0000: Successfully logged out from the registry
 ➤ YN0000: Done
 ",
 }
@@ -14,7 +15,7 @@ exports[`Commands npm logout should logout a user from the default registry when
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out of http://yarn.test.registry
+  "stdout": "➤ YN0000: Successfully logged out from the registry
 ➤ YN0000: Done
 ",
 }
@@ -24,17 +25,7 @@ exports[`Commands npm logout should logout a user from the publish registry when
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out of https://npm.pkg.github.com
-➤ YN0000: Done
-",
-}
-`;
-
-exports[`Commands npm logout should logout a user from the scope publish registry when the -s,--scope and --publish flags are used 1`] = `
-Object {
-  "code": 0,
-  "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out of https://fourth.yarn.test.registry
+  "stdout": "➤ YN0000: Successfully logged out from the registry
 ➤ YN0000: Done
 ",
 }
@@ -44,7 +35,7 @@ exports[`Commands npm logout should logout a user from the scope registry when t
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out of https://third.yarn.test.registry
+  "stdout": "➤ YN0000: Successfully logged out from the scope
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/logout.test.ts.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/logout.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: Successfully logged out from everything
-➤ YN0000: Successfully logged out from the registry
+➤ YN0000: Successfully logged out from http://yarn.test.registry
 ➤ YN0000: Done
 ",
 }
@@ -15,7 +15,7 @@ exports[`Commands npm logout should logout a user from the default registry when
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out from the registry
+  "stdout": "➤ YN0000: Successfully logged out from http://yarn.test.registry
 ➤ YN0000: Done
 ",
 }
@@ -25,7 +25,7 @@ exports[`Commands npm logout should logout a user from the publish registry when
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out from the registry
+  "stdout": "➤ YN0000: Successfully logged out from https://npm.pkg.github.com
 ➤ YN0000: Done
 ",
 }
@@ -35,7 +35,7 @@ exports[`Commands npm logout should logout a user from the scope registry when t
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: Successfully logged out from the scope
+  "stdout": "➤ YN0000: Successfully logged out from first
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/logout.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/logout.test.ts
@@ -1,5 +1,5 @@
 import {Filename, xfs} from '@yarnpkg/fslib';
-import {fs, yarn}      from 'pkg-tests-core';
+import {yarn}          from 'pkg-tests-core';
 
 const SPEC_RC_FILENAME = `.spec-yarnrc` as Filename;
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/logout.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/logout.test.ts
@@ -1,18 +1,21 @@
-import {Filename} from '@yarnpkg/fslib';
-import {fs, yarn} from 'pkg-tests-core';
-
-const {createTemporaryFolder} = fs;
-const {writeConfiguration, readConfiguration} = yarn;
+import {Filename, xfs} from '@yarnpkg/fslib';
+import {fs, yarn}      from 'pkg-tests-core';
 
 const SPEC_RC_FILENAME = `.spec-yarnrc` as Filename;
+
+const FAKE_FIRST_SCOPE = `first`;
+const FAKE_SECOND_SCOPE = `second`;
+const FAKE_THIRD_SCOPE = `third`;
 
 const FAKE_REGISTRY_URL = `http://yarn.test.registry`;
 const FAKE_PUBLISH_REGISTRY_URL = `https://npm.pkg.github.com`;
 const FAKE_THIRD_REGISTRY_URL = `https://third.yarn.test.registry`;
-const FAKE_FOURTH_REGISTRY_URL = `https://fourth.yarn.test.registry`;
+
+const CLASSIC_SCOPE_SETTINGS = {
+  npmAlwaysAuth: `true`,
+};
 
 const FAKE_REGISTRY_CREDENTIALS = {
-  npmAlwaysAuth: `true`,
   npmAuthIdent: `username:password`,
   npmAuthToken: `ffffffff-ffff-ffff-ffff-ffffffffffff`,
 };
@@ -25,14 +28,20 @@ describe(`Commands`, () => {
         npmRegistryServer: FAKE_REGISTRY_URL,
         npmPublishRegistry: FAKE_PUBLISH_REGISTRY_URL,
       }, async ({path, run, source}) => {
-        const homePath = await createTemporaryFolder();
-        await writeConfiguration(homePath, {
+        const homePath = await xfs.mktempPromise();
+
+        await yarn.writeConfiguration(homePath, {
           npmRegistries: {
             [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
           },
-        }, {filename: SPEC_RC_FILENAME});
+          npmScopes: {
+            [FAKE_FIRST_SCOPE]: FAKE_REGISTRY_CREDENTIALS,
+          },
+        }, {
+          filename: SPEC_RC_FILENAME,
+        });
 
         let code: number;
         let stdout: string;
@@ -51,30 +60,47 @@ describe(`Commands`, () => {
           ({code, stdout, stderr} = error);
         }
 
-        await expect(readConfiguration(homePath, {filename: SPEC_RC_FILENAME})).resolves.toStrictEqual({
+        await expect(yarn.readConfiguration(homePath, {
+          filename: SPEC_RC_FILENAME,
+        })).resolves.toStrictEqual({
           npmRegistries: {
             [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
           },
+          npmScopes: {
+            [FAKE_FIRST_SCOPE]: FAKE_REGISTRY_CREDENTIALS,
+          },
         });
+
         expect({code, stdout, stderr}).toMatchSnapshot();
       })
     );
 
     it(
-      `should logout a user from all registries when the -A,--all flag is used`,
+      `should logout a user from all registries and all scopes when the -A,--all flag is used`,
       makeTemporaryEnv({}, {
         npmRegistryServer: FAKE_REGISTRY_URL,
         npmPublishRegistry: FAKE_PUBLISH_REGISTRY_URL,
       }, async ({path, run, source}) => {
-        const homePath = await createTemporaryFolder();
-        await writeConfiguration(homePath, {
+        const homePath = await xfs.mktempPromise();
+
+        await yarn.writeConfiguration(homePath, {
           npmRegistries: {
             [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
           },
-        }, {filename: SPEC_RC_FILENAME});
+          npmScopes: {
+            [FAKE_FIRST_SCOPE]: FAKE_REGISTRY_CREDENTIALS,
+            [FAKE_SECOND_SCOPE]: CLASSIC_SCOPE_SETTINGS,
+            [FAKE_THIRD_SCOPE]: {
+              ...CLASSIC_SCOPE_SETTINGS,
+              ...FAKE_REGISTRY_CREDENTIALS,
+            },
+          },
+        }, {
+          filename: SPEC_RC_FILENAME,
+        });
 
         let code: number;
         let stdout: string;
@@ -93,7 +119,15 @@ describe(`Commands`, () => {
           ({code, stdout, stderr} = error);
         }
 
-        await expect(readConfiguration(homePath, {filename: SPEC_RC_FILENAME})).resolves.toStrictEqual({});
+        await expect(yarn.readConfiguration(homePath, {
+          filename: SPEC_RC_FILENAME,
+        })).resolves.toStrictEqual({
+          npmScopes: {
+            [FAKE_SECOND_SCOPE]: CLASSIC_SCOPE_SETTINGS,
+            [FAKE_THIRD_SCOPE]: CLASSIC_SCOPE_SETTINGS,
+          },
+        });
+
         expect({code, stdout, stderr}).toMatchSnapshot();
       })
     );
@@ -104,14 +138,17 @@ describe(`Commands`, () => {
         npmRegistryServer: FAKE_REGISTRY_URL,
         npmPublishRegistry: FAKE_PUBLISH_REGISTRY_URL,
       }, async ({path, run, source}) => {
-        const homePath = await createTemporaryFolder();
-        await writeConfiguration(homePath, {
+        const homePath = await xfs.mktempPromise();
+
+        await yarn.writeConfiguration(homePath, {
           npmRegistries: {
             [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
           },
-        }, {filename: SPEC_RC_FILENAME});
+        }, {
+          filename: SPEC_RC_FILENAME,
+        });
 
         let code: number;
         let stdout: string;
@@ -130,12 +167,15 @@ describe(`Commands`, () => {
           ({code, stdout, stderr} = error);
         }
 
-        await expect(readConfiguration(homePath, {filename: SPEC_RC_FILENAME})).resolves.toStrictEqual({
+        await expect(yarn.readConfiguration(homePath, {
+          filename: SPEC_RC_FILENAME,
+        })).resolves.toStrictEqual({
           npmRegistries: {
             [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
             [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
           },
         });
+
         expect({code, stdout, stderr}).toMatchSnapshot();
       })
     );
@@ -146,25 +186,16 @@ describe(`Commands`, () => {
         npmRegistryServer: FAKE_REGISTRY_URL,
         npmPublishRegistry: FAKE_PUBLISH_REGISTRY_URL,
       }, async ({path, run, source}) => {
-        // This can't be set in the subdefinition :(
-        await writeConfiguration(path, {
-          npmScopes: {
-            yarnpkg: {
-              npmRegistryServer: FAKE_THIRD_REGISTRY_URL,
-              npmPublishRegistry: FAKE_FOURTH_REGISTRY_URL,
-            },
-          },
-        }, {filename: SPEC_RC_FILENAME});
+        const homePath = await xfs.mktempPromise();
 
-        const homePath = await createTemporaryFolder();
-        await writeConfiguration(homePath, {
-          npmRegistries: {
-            [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_FOURTH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
+        await yarn.writeConfiguration(homePath, {
+          npmScopes: {
+            [FAKE_FIRST_SCOPE]: FAKE_REGISTRY_CREDENTIALS,
+            [FAKE_SECOND_SCOPE]: FAKE_REGISTRY_CREDENTIALS,
           },
-        }, {filename: SPEC_RC_FILENAME});
+        }, {
+          filename: SPEC_RC_FILENAME,
+        });
 
         let code: number;
         let stdout: string;
@@ -172,7 +203,7 @@ describe(`Commands`, () => {
 
         try {
           // @ts-ignore
-          ({code, stdout, stderr} = await run(`npm`, `logout`, `--scope`, `yarnpkg`, {
+          ({code, stdout, stderr} = await run(`npm`, `logout`, `--scope`, FAKE_FIRST_SCOPE, {
             env: {
               HOME: homePath,
               USERPROFILE: homePath,
@@ -183,67 +214,14 @@ describe(`Commands`, () => {
           ({code, stdout, stderr} = error);
         }
 
-        await expect(readConfiguration(homePath, {filename: SPEC_RC_FILENAME})).resolves.toStrictEqual({
-          npmRegistries: {
-            [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_FOURTH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-          },
-        });
-        expect({code, stdout, stderr}).toMatchSnapshot();
-      })
-    );
-
-    it(
-      `should logout a user from the scope publish registry when the -s,--scope and --publish flags are used`,
-      makeTemporaryEnv({}, {
-        npmRegistryServer: FAKE_REGISTRY_URL,
-        npmPublishRegistry: FAKE_PUBLISH_REGISTRY_URL,
-      }, async ({path, run, source}) => {
-        // This can't be set in the subdefinition :(
-        await writeConfiguration(path, {
+        await expect(yarn.readConfiguration(homePath, {
+          filename: SPEC_RC_FILENAME,
+        })).resolves.toStrictEqual({
           npmScopes: {
-            yarnpkg: {
-              npmRegistryServer: FAKE_THIRD_REGISTRY_URL,
-              npmPublishRegistry: FAKE_FOURTH_REGISTRY_URL,
-            },
-          },
-        }, {filename: SPEC_RC_FILENAME});
-
-        const homePath = await createTemporaryFolder();
-        await writeConfiguration(homePath, {
-          npmRegistries: {
-            [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_FOURTH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-          },
-        }, {filename: SPEC_RC_FILENAME});
-
-        let code: number;
-        let stdout: string;
-        let stderr: string;
-
-        try {
-          // @ts-ignore
-          ({code, stdout, stderr} = await run(`npm`, `logout`, `--publish`, `--scope`, `yarnpkg`, {
-            env: {
-              HOME: homePath,
-              USERPROFILE: homePath,
-              YARN_RC_FILENAME: SPEC_RC_FILENAME,
-            },
-          }));
-        } catch (error) {
-          ({code, stdout, stderr} = error);
-        }
-
-        await expect(readConfiguration(homePath, {filename: SPEC_RC_FILENAME})).resolves.toStrictEqual({
-          npmRegistries: {
-            [FAKE_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_PUBLISH_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
-            [FAKE_THIRD_REGISTRY_URL]: FAKE_REGISTRY_CREDENTIALS,
+            [FAKE_SECOND_SCOPE]: FAKE_REGISTRY_CREDENTIALS,
           },
         });
+
         expect({code, stdout, stderr}).toMatchSnapshot();
       })
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -1,27 +1,26 @@
-import {xfs, ppath, Filename} from '@yarnpkg/fslib';
-import {fs, yarn}             from 'pkg-tests-core';
+import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
+import {fs, yarn}                    from 'pkg-tests-core';
 
 describe(`Commands`, () => {
   describe(`plugin import`, () => {
     test(
       `it should support adding a plugin via its path`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        await run(`plugin`, `import`, require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`));
+        const helloWorldSource = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`);
 
-        const relativePluginPath = yarn.getRelativePluginPath(`@yarnpkg/plugin-hello-world`);
+        await run(`plugin`, `import`, helloWorldSource);
 
-        const absolutePluginPath = ppath.resolve(path, relativePluginPath);
-        expect(xfs.existsSync(absolutePluginPath)).toBeTruthy();
+        const helloWorldPlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-hello-world`);
+        await expect(xfs.existsPromise(helloWorldPlugin)).resolves.toEqual(true);
 
-        const rcContent = await fs.readSyml(ppath.join(path, Filename.rc));
-        expect(rcContent).toHaveProperty(`plugins`);
-        expect(rcContent.plugins).toContainEqual(expect.objectContaining({
-          path: relativePluginPath,
-        }));
+        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+          plugins: [{
+            path: ppath.relative(path, helloWorldPlugin),
+            spec: ppath.relative(path, npath.toPortablePath(helloWorldSource)),
+          }],
+        });
 
-        await expect(
-          () => run(`hello`, `--email`, `postmaster@example.org`)
-        ).not.toThrow();
+        await run(`hello`, `--email`, `postmaster@example.org`);
       }),
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/remove.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/remove.test.ts
@@ -1,23 +1,57 @@
-import {xfs, ppath, Filename} from '@yarnpkg/fslib';
-import {fs, yarn}             from 'pkg-tests-core';
+import {xfs, ppath, Filename, PortablePath, npath} from '@yarnpkg/fslib';
+import {fs, yarn}                                  from 'pkg-tests-core';
 
 describe(`Commands`, () => {
   describe(`plugin remove`, () => {
     test(
       `it should support removing a plugin via its name`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        // Note: we already know if `plugin import` works, based on the import.test.ts file
-        await run(`plugin`, `import`, require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`));
+        const helloWorldSource = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`);
+        const helloUniverseSource = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-universe.js`);
+
+        // Note: we assume that `plugin import` works, since it has its own tests
+        await run(`plugin`, `import`, helloWorldSource);
+        await run(`plugin`, `import`, helloUniverseSource);
+
+        const helloWorldPlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-hello-world`);
+        const helloUniversePlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-hello-universe`);
+
+        await expect(xfs.existsPromise(helloWorldPlugin)).resolves.toEqual(true);
+        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+          plugins: [{
+            path: ppath.relative(path, helloWorldPlugin),
+            spec: ppath.relative(path, npath.toPortablePath(helloWorldSource)),
+          }, {
+            path: ppath.relative(path, helloUniversePlugin),
+            spec: ppath.relative(path, npath.toPortablePath(helloUniverseSource)),
+          }],
+        });
+
         await run(`plugin`, `remove`, `@yarnpkg/plugin-hello-world`);
 
-        const relativePluginPath = yarn.getRelativePluginPath(`@yarnpkg/plugin-hello-world`);
+        await expect(xfs.existsPromise(helloWorldPlugin)).resolves.toEqual(false);
+        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+          plugins: [{
+            path: ppath.relative(path, helloUniversePlugin),
+            spec: ppath.relative(path, npath.toPortablePath(helloUniverseSource)),
+          }],
+        });
+      }),
+    );
 
-        const absolutePluginPath = ppath.resolve(path, relativePluginPath);
-        expect(xfs.existsSync(absolutePluginPath)).toBeFalsy();
+    test(
+      `it should completely remove the key when removing the last plugin`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const helloWorldSource = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`);
+
+        await run(`plugin`, `import`, helloWorldSource);
+        await run(`plugin`, `remove`, `@yarnpkg/plugin-hello-world`);
+
+        const helloWorldPlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-hello-world`);
+        expect(xfs.existsSync(helloWorldPlugin)).toBeFalsy();
 
         const rcContent = await fs.readSyml(ppath.join(path, Filename.rc));
-        expect(rcContent).toHaveProperty(`plugins`);
-        expect(rcContent.plugins).toHaveLength(0);
+        expect(rcContent).not.toHaveProperty(`plugins`);
       }),
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/remove.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/remove.test.ts
@@ -1,5 +1,5 @@
-import {xfs, ppath, Filename, PortablePath, npath} from '@yarnpkg/fslib';
-import {fs, yarn}                                  from 'pkg-tests-core';
+import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
+import {fs, yarn}                    from 'pkg-tests-core';
 
 describe(`Commands`, () => {
   describe(`plugin remove`, () => {

--- a/packages/plugin-essentials/sources/commands/plugin/remove.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/remove.ts
@@ -49,12 +49,21 @@ export default class PluginRemoveCommand extends BaseCommand {
       }
 
       report.reportInfo(MessageName.UNNAMED, `Updating the configuration...`);
-      await Configuration.updateConfiguration(project.cwd, (current: any) => {
+      await Configuration.updateConfiguration(project.cwd, (current: {[key: string]: unknown}) => {
         if (!Array.isArray(current.plugins))
-          return {};
+          return current;
 
-        const plugins = current.plugins.filter((plugin: {path: string}) => plugin.path !== relativePath);
-        return {plugins};
+        const plugins = current.plugins.filter((plugin: {path: string}) => {
+          return plugin.path !== relativePath;
+        });
+
+        if (current.plugins.length === plugins.length)
+          return current;
+
+        return {
+          ...current,
+          plugins,
+        };
       });
     });
 

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -1,10 +1,10 @@
-import {BaseCommand, openWorkspace}         from '@yarnpkg/cli';
-import {Configuration, MessageName, Report} from '@yarnpkg/core';
-import {StreamReport}                       from '@yarnpkg/core';
-import {PortablePath}                       from '@yarnpkg/fslib';
-import {npmConfigUtils, npmHttpUtils}       from '@yarnpkg/plugin-npm';
-import {Command, Usage}                     from 'clipanion';
-import {prompt}                             from 'enquirer';
+import {BaseCommand, openWorkspace}                    from '@yarnpkg/cli';
+import {Configuration, MessageName, Report, miscUtils} from '@yarnpkg/core';
+import {StreamReport}                                  from '@yarnpkg/core';
+import {PortablePath}                                  from '@yarnpkg/fslib';
+import {npmConfigUtils, npmHttpUtils}                  from '@yarnpkg/plugin-npm';
+import {Command, Usage}                                from 'clipanion';
+import {prompt}                                        from 'enquirer';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NpmLoginCommand extends BaseCommand {
@@ -57,8 +57,8 @@ export default class NpmLoginCommand extends BaseCommand {
         stdin: this.context.stdin as NodeJS.ReadStream,
         stdout: this.context.stdout as NodeJS.WriteStream,
       });
-      const url = `/-/user/org.couchdb.user:${encodeURIComponent(credentials.name)}`;
 
+      const url = `/-/user/org.couchdb.user:${encodeURIComponent(credentials.name)}`;
       const response = await npmHttpUtils.put(url, credentials, {
         attemptedAs: credentials.name,
         configuration,
@@ -89,27 +89,30 @@ export async function getRegistry({scope, publish, configuration, cwd}: {scope?:
 }
 
 async function setAuthToken(registry: string, npmAuthToken: string, {configuration, scope}: {configuration: Configuration, scope?: string}) {
-  if (scope) {
-    return await Configuration.updateHomeConfiguration({
-      npmScopes: (scopes: {[key: string]: any} = {}) => ({
-        ...scopes,
-        [scope]: {
-          ...scopes[scope],
-          npmAuthToken,
-        },
-      }),
-    });
-  }
+  const makeUpdater = (entryName: string) => (unknownStore: unknown) => {
+    const store = miscUtils.isIndexableObject(unknownStore)
+      ? unknownStore
+      : {};
 
-  return await Configuration.updateHomeConfiguration({
-    npmRegistries: (registries: {[key: string]: any} = {}) => ({
-      ...registries,
-      [registry]: {
-        ...registries[registry],
+    const entryUnknown = store[entryName];
+    const entry = miscUtils.isIndexableObject(entryUnknown)
+      ? entryUnknown
+      : {};
+
+    return {
+      ...store,
+      [entryName]: {
+        ...entry,
         npmAuthToken,
       },
-    }),
-  });
+    };
+  };
+
+  const update = scope
+    ? {npmScopes: makeUpdater(scope)}
+    : {npmRegistries: makeUpdater(registry)};
+
+  return await Configuration.updateHomeConfiguration(update);
 }
 
 async function getCredentials({registry, report, stdin, stdout}: {registry: string, report: Report, stdin: NodeJS.ReadStream, stdout: NodeJS.WriteStream}) {

--- a/packages/plugin-npm-cli/sources/commands/npm/logout.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/logout.ts
@@ -1,9 +1,15 @@
-import {BaseCommand}                from '@yarnpkg/cli';
-import {Configuration, MessageName} from '@yarnpkg/core';
-import {StreamReport}               from '@yarnpkg/core';
-import {Command, Usage}             from 'clipanion';
+import {BaseCommand}                                        from '@yarnpkg/cli';
+import {Configuration, MessageName, miscUtils, structUtils} from '@yarnpkg/core';
+import {StreamReport}                                       from '@yarnpkg/core';
+import {npmConfigUtils}                                     from '@yarnpkg/plugin-npm';
+import {Command, Usage}                                     from 'clipanion';
 
-import {getRegistry}                from './login';
+import {getRegistry}                                        from './login';
+
+const LOGOUT_KEYS = new Set([
+  `npmAuthIdent`,
+  `npmAuthToken`,
+]);
 
 // eslint-disable-next-line arca/no-default-export
 export default class NpmLogoutCommand extends BaseCommand {
@@ -26,20 +32,17 @@ export default class NpmLogoutCommand extends BaseCommand {
 
       Adding the \`--publish\` flag will cause the deletion to be done against the registry used when publishing the package (see also \`publishConfig.registry\` and \`npmPublishRegistry\`).
 
-      Adding the \`-A,--all\` flag will cause the deletion to be done against all registries.
+      Adding the \`-A,--all\` flag will cause the deletion to be done against all registries and scopes.
     `,
     examples: [[
       `Logout of the default registry`,
       `yarn npm logout`,
     ], [
-      `Logout of the registry linked to the @my-scope registry`,
+      `Logout of the @my-scope scope`,
       `yarn npm logout --scope my-scope`,
     ], [
       `Logout of the publish registry for the current package`,
       `yarn npm logout --publish`,
-    ], [
-      `Logout of the publish registry for the current package linked to the @my-scope registry`,
-      `yarn npm logout --publish --scope my-scope`,
     ], [
       `Logout of all registries`,
       `yarn npm logout --all`,
@@ -50,38 +53,166 @@ export default class NpmLogoutCommand extends BaseCommand {
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
-    const registry: string | null = this.all
-      ? null
-      : await getRegistry({
+    const checkLogout = async () => {
+      const registry: string | null = await getRegistry({
         configuration,
         cwd: this.context.cwd,
         publish: this.publish,
         scope: this.scope,
       });
 
+      const refreshedConfiguration = await Configuration.find(this.context.cwd, this.context.plugins);
+      const fakeIdent = structUtils.makeIdent(this.scope ?? null, `pkg`);
+
+      const authConfiguration = npmConfigUtils.getAuthConfiguration(registry, {
+        configuration: refreshedConfiguration,
+        ident: fakeIdent,
+      });
+
+      return !authConfiguration.get(`npmAuthToken`);
+    };
+
     const report = await StreamReport.start({
       configuration,
       stdout: this.context.stdout,
     }, async report => {
-      await logout(registry);
-      return report.reportInfo(MessageName.UNNAMED, `Successfully logged out of ${
-        registry === null ? `all registries` : registry
-      }`);
+      if (this.all) {
+        await logoutFromEverything();
+        report.reportInfo(MessageName.UNNAMED, `Successfully logged out from everything`);
+      }
+
+      if (this.scope) {
+        await logoutFrom(`npmScopes`, this.scope);
+
+        if (await checkLogout())
+          report.reportInfo(MessageName.UNNAMED, `Successfully logged out from ${this.scope}`);
+        else
+          report.reportWarning(MessageName.UNNAMED, `Scope authentication settings removed, but some other ones settings still apply to it`);
+
+        return;
+      }
+
+      const registry: string | null = await getRegistry({
+        configuration,
+        cwd: this.context.cwd,
+        publish: this.publish,
+      });
+
+      await logoutFrom(`npmRegistries`, registry);
+
+      if (await checkLogout()) {
+        report.reportInfo(MessageName.UNNAMED, `Successfully logged out from ${registry}`);
+      } else {
+        report.reportWarning(MessageName.UNNAMED, `Registry authentication settings removed, but some other ones settings still apply to it`);
+      }
     });
 
     return report.exitCode();
   }
 }
 
-async function logout(registry: string | null) {
+function removeTokenFromStore(nextStore: {[key: string]: unknown}, entryName: string) {
+  const entry = nextStore[entryName];
+  if (!miscUtils.isIndexableObject(entry))
+    return false;
+
+  const keys = new Set(Object.keys(entry));
+  if ([...LOGOUT_KEYS].every(key => !keys.has(key)))
+    return false;
+
+  for (const key of LOGOUT_KEYS)
+    keys.delete(key);
+
+  if (keys.size === 0) {
+    nextStore[entryName] = undefined;
+    return true;
+  }
+
+  const nextEntry = {...entry};
+  for (const key of LOGOUT_KEYS)
+    delete nextEntry[key];
+
+  nextStore[entryName] = nextEntry;
+
+  return true;
+}
+
+async function logoutFromEverything() {
+  const updater = (unknownStore: unknown) => {
+    let updated = false;
+
+    const nextStore = miscUtils.isIndexableObject(unknownStore)
+      ? {...unknownStore}
+      : {};
+
+    if (nextStore.npmAuthToken) {
+      delete nextStore.npmAuthToken;
+      updated = true;
+    }
+
+    for (const entryName of Object.keys(nextStore))
+      if (removeTokenFromStore(nextStore, entryName))
+        updated = true;
+
+    if (Object.keys(nextStore).length === 0)
+      return undefined;
+
+    if (updated) {
+      return nextStore;
+    } else {
+      return unknownStore;
+    }
+  };
+
   return await Configuration.updateHomeConfiguration({
-    npmRegistries: (registries: {[key: string]: any} = {}) => (
-      registry === null
-        ? undefined
-        : {
-          ...registries,
-          [registry]: undefined,
-        }
-    ),
+    npmRegistries: updater,
+    npmScopes: updater,
+  });
+}
+
+async function logoutFrom(entryType: `npmRegistries` | `npmScopes`, entryName: string) {
+  return await Configuration.updateHomeConfiguration({
+    [entryType]: (unknownStore: unknown) => {
+      const nextStore = miscUtils.isIndexableObject(unknownStore)
+        ? unknownStore
+        : {};
+
+      if (!Object.prototype.hasOwnProperty.call(nextStore, entryName))
+        return unknownStore;
+
+      const unknownEntry = nextStore[entryName];
+      const nextEntry = miscUtils.isIndexableObject(unknownEntry)
+        ? unknownEntry
+        : {};
+
+      const keys = new Set(Object.keys(nextEntry));
+      if ([...LOGOUT_KEYS].every(key => !keys.has(key)))
+        return unknownStore;
+
+      for (const key of LOGOUT_KEYS)
+        keys.delete(key);
+
+      if (keys.size === 0) {
+        if (Object.keys(nextStore).length === 1)
+          return undefined;
+
+        return {
+          ...nextStore,
+          [entryName]: undefined,
+        };
+      }
+
+      const eraser: {[key: string]: undefined} = {};
+      for (const key of LOGOUT_KEYS)
+        eraser[key] = undefined;
+
+      return {
+        ...nextStore,
+        [entryName]: {
+          ...nextEntry,
+          ...eraser,
+        },
+      };
+    },
   });
 }

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1023,6 +1023,10 @@ export class Configuration {
       } catch {
         replacement = patch({});
       }
+
+      if (replacement === current) {
+        return;
+      }
     } else {
       replacement = current;
 

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -41,6 +41,10 @@ export function mapAndFind<In, Out>(iterable: Iterable<In>, cb: (value: In) => O
 const mapAndFindSkip = Symbol();
 mapAndFind.skip = mapAndFindSkip;
 
+export function isIndexableObject(value: unknown): value is {[key: string]: unknown} {
+  return typeof value === `object` && value !== null;
+}
+
 export function getFactoryWithDefault<K, T>(map: Map<K, T>, key: K, factory: () => T) {
   let value = map.get(key);
 

--- a/packages/yarnpkg-parsers/sources/syml.ts
+++ b/packages/yarnpkg-parsers/sources/syml.ts
@@ -22,6 +22,16 @@ function stringifyString(value: string): string {
   }
 }
 
+function isRemovableField(value: any): boolean {
+  if (typeof value === `undefined`)
+    return true;
+
+  if (typeof value === `object` && value !== null)
+    return Object.keys(value).every(key => isRemovableField(value[key]));
+
+  return false;
+}
+
 function stringifyValue(value: any, indentLevel: number, newLineIfObject: boolean): string {
   if (value === null)
     return `null\n`;
@@ -78,7 +88,7 @@ function stringifyValue(value: any, indentLevel: number, newLineIfObject: boolea
     }
 
     const fields = keys.filter(key => {
-      return data[key] !== undefined;
+      return !isRemovableField(data[key]);
     }).map((key, index) => {
       const value = data[key];
 
@@ -108,7 +118,8 @@ function stringifyValue(value: any, indentLevel: number, newLineIfObject: boolea
 
 export function stringifySyml(value: any) {
   try {
-    return stringifyValue(value, 0, false);
+    const stringified = stringifyValue(value, 0, false);
+    return stringified !== `\n` ? stringified : ``;
   } catch (error) {
     if (error.location)
       error.message = error.message.replace(/(\.)?$/, ` (line ${error.location.start.line}, column ${error.location.start.column})$1`);

--- a/scripts/plugin-hello-universe.js
+++ b/scripts/plugin-hello-universe.js
@@ -1,0 +1,46 @@
+module.exports = {
+  name: `@yarnpkg/plugin-hello-universe`,
+  factory: require => {
+    const {Command} = require(`clipanion`);
+    const yup = require(`yup`);
+
+    class HelloUniverseCommand extends Command {
+      async execute() {
+        this.context.stdout.write(`Hello ${this.email} 💌\n`);
+      }
+    }
+
+    // Note: This curious syntax is because @Command.String is actually
+    // a decorator! But since they aren't supported in native JS at the
+    // moment, we need to call them manually.
+    HelloUniverseCommand.addOption(`email`, Command.String(`--email`));
+
+    // Similarly we would be able to use a decorator here too, but since
+    // we're writing our code in JS-only we need to go through "addPath".
+    HelloUniverseCommand.addPath(`hello`, `universe`);
+
+    // Similarly, native JS doesn't support member variable as of today,
+    // hence the awkward writing.
+    HelloUniverseCommand.schema = yup.object().shape({
+      email: yup.string().required().email(),
+    });
+
+    // Show descriptive usage for a --help argument passed to this command
+    HelloUniverseCommand.usage = Command.Usage({
+      description: `hello universe!`,
+      details: `
+        This command will print a nice message.
+      `,
+      examples: [[
+        `Say hello to an email user`,
+        `yarn hello universe --email acidburn@example.com`,
+      ]],
+    });
+
+    return {
+      commands: [
+        HelloUniverseCommand,
+      ],
+    };
+  },
+};


### PR DESCRIPTION
**What's the problem this PR addresses?**
The configuration patch workflow was so-so, which was causing issues like #1663 (running `yarn logout` was leaving empty fields).

**How did you fix it?**
Various fixes:
- Empty objects won't be serialized anymore (instead of serializing to empty strings)
- Non-indexable fields will be ignored from updates (instead of crashing)
- Improved the typing by using `unknown` instead of `any`
- Uniformized `logout -s` to follow the same logic as `login -s`
- Added a warning when there are remaining auth tokens even after logout (it can happen if the user specified auth tokens in both registry and top-level, for example).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
