### PR TITLE
perf(cli): perform async temp cleanup

### DIFF
--- a/.yarn/versions/466290f7.yml
+++ b/.yarn/versions/466290f7.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/fslib": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -125,7 +125,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
         }
       }
 
-      cli.runExit(command, {
+      await cli.runExit(command, {
         cwd: npath.toPortablePath(process.cwd()),
         plugins: pluginConfiguration,
         quiet: false,
@@ -136,8 +136,10 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     }
   }
 
-  return run().catch(error => {
-    process.stdout.write(error.stack || error.message);
-    process.exitCode = 1;
-  });
+  return run()
+    .catch(error => {
+      process.stdout.write(error.stack || error.message);
+      process.exitCode = 1;
+    })
+    .finally(() => xfs.rmtempPromise());
 }

--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -309,7 +309,9 @@ function registerCleanExit() {
     return;
 
   cleanExitRegistered = true;
-  process.once(`exit`, xfs.rmtempSync);
+  process.once(`exit`, () => {
+    xfs.rmtempSync();
+  });
 }
 
 export const xfs: XFS = Object.assign(new NodeFS(), {

--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -290,12 +290,12 @@ export type XFS = NodeFS & {
   mktempPromise<T>(cb: (p: PortablePath) => Promise<T>): Promise<T>;
 
   /**
-   * Unregisters and tries to remove all temp folders created by mktempSync and mktempPromise
+   * Tries to remove all temp folders created by mktempSync and mktempPromise
    */
   rmtempPromise(): Promise<void>;
 
   /**
-   * Unregisters and tries to remove all temp folders created by mktempSync and mktempPromise
+   * Tries to remove all temp folders created by mktempSync and mktempPromise
    */
   rmtempSync(): void;
 };
@@ -397,9 +397,9 @@ export const xfs: XFS = Object.assign(new NodeFS(), {
 
   async rmtempPromise() {
     await Promise.all(Array.from(tmpdirs.values()).map(async p => {
-      tmpdirs.delete(p);
       try {
         await xfs.removePromise(p, {maxRetries: 0});
+        tmpdirs.delete(p);
       } catch {
         // Too bad if there's an error
       }
@@ -408,9 +408,9 @@ export const xfs: XFS = Object.assign(new NodeFS(), {
 
   rmtempSync() {
     for (const p of tmpdirs) {
-      tmpdirs.delete(p);
       try {
         xfs.removeSync(p);
+        tmpdirs.delete(p);
       } catch {
         // Too bad if there's an error
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn is cleaning up its temp folders in the `exit` event which forces us to use sync IO calls which has a performance impact.

**How did you fix it?**

Implemented `rmtempPromise` and call it right after the CLI is done and about to exit, where we can run async IO without problems.

**Result**

Time spent cleaning up temp folders after a install with a hot cache and lockfile (`install-cache-and-lock` in the benchmarks)

| | before | after |
|--|--|--|
| Nextjs benchmark | 326ms | 25ms |
| Gatsby benchmark | 654ms | 20ms |
| Typescript Website | 846ms | 44ms |

Benchmark workflow result:
Before: https://github.com/yarnpkg/berry/actions/runs/200276519
After: https://github.com/yarnpkg/berry/actions/runs/200408519

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
