### PR TITLE
Fixes build execution

### DIFF
--- a/.yarn/versions/2136b86b.yml
+++ b/.yarn/versions/2136b86b.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-npm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `yarn pack` will properly include main/module/bin files, even when not explicitly referenced through the `files` field.
 - Local git repositories can now be fetched via the `git+file:` protocol.
 - The progress bars will be properly styled when using the new Windows terminal on certain days.
+- Yarn will now avoid using deprecated versions of the dependencies, unless only deprecated versions are available for the requested ranges.
+- Build keys are now properly computed, which fixes issues where build scripts weren't always triggered when they should have been.
 
 ### CLI
 

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -57,11 +57,20 @@ export class NpmSemverResolver implements Resolver {
     const versions = Object.keys(registryData.versions);
     const candidates = versions.filter(version => semver.satisfies(version, range));
 
-    candidates.sort((a, b) => {
+    const noDeprecatedCandidates = candidates.filter(version => {
+      return !registryData.versions[version].deprecated;
+    });
+
+    // If there are versions that aren't deprecated, use them
+    const finalCandidates = noDeprecatedCandidates.length > 0
+      ? noDeprecatedCandidates
+      : candidates;
+
+    finalCandidates.sort((a, b) => {
       return -semver.compare(a, b);
     });
 
-    return candidates.map(version => {
+    return finalCandidates.map(version => {
       const versionLocator = structUtils.makeLocator(descriptor, `${PROTOCOL}${version}`);
       const archiveUrl = registryData.versions[version].dist.tarball;
 

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -47,6 +47,7 @@ const LOCKFILE_VERSION = 4;
 const INSTALL_STATE_VERSION = 1;
 
 const MULTIPLE_KEYS_REGEXP = / *, */g;
+const TRAILING_SLASH_REGEXP = /\/$/;
 
 const FETCHER_CONCURRENCY = 32;
 
@@ -523,7 +524,7 @@ export class Project {
         // not merely contained in a package.
         if (strict) {
           const location = await linker.findPackageLocation(locator, linkerOptions);
-          if (location !== cwd) {
+          if (location.replace(TRAILING_SLASH_REGEXP, ``) !== cwd.replace(TRAILING_SLASH_REGEXP, ``)) {
             continue;
           }
         }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1319,7 +1319,6 @@ export class Project {
           throw new Error(`Assertion failed: The build directive should have been registered`);
 
         const buildHash = getBuildHash(pkg, buildInfo.buildLocations);
-        console.log(structUtils.prettyLocator(this.configuration, pkg), buildHash);
 
         // No need to rebuild the package if its hash didn't change
         if (Object.prototype.hasOwnProperty.call(bstate, pkg.locatorHash) && bstate[pkg.locatorHash] === buildHash) {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -107,7 +107,7 @@ export class Project {
     while (currentCwd !== configuration.projectCwd) {
       currentCwd = nextCwd;
 
-      if (xfs.existsSync(ppath.join(currentCwd, `package.json` as Filename))) {
+      if (xfs.existsSync(ppath.join(currentCwd, Filename.manifest))) {
         packageCwd = currentCwd;
         break;
       }
@@ -132,11 +132,11 @@ export class Project {
 
     // Otherwise, we need to ask the project (which will in turn ask the linkers for help)
     // Note: the trailing slash is caused by a quirk in the PnP implementation that requires folders to end with a trailing slash to disambiguate them from regular files
-    const locator = await project.findLocatorForLocation(`${packageCwd}/` as PortablePath);
+    const locator = await project.findLocatorForLocation(`${packageCwd}/` as PortablePath, {strict: true});
     if (locator)
       return {project, locator, workspace: null};
 
-    throw new UsageError(`The nearest package directory (${packageCwd}) doesn't seem to be part of the project declared at ${project.cwd}. If the project directory is right, it might be that you forgot to list a workspace. If it isn't, it's likely because you have a yarn.lock file at the detected location, confusing the project detection.`);
+    throw new UsageError(`The nearest package directory (${configuration.format(packageCwd, FormatType.PATH)}) doesn't seem to be part of the project declared in ${configuration.format(project.cwd, FormatType.PATH)}.\n\n- If the project directory is right, it might be that you forgot to list ${configuration.format(ppath.relative(project.cwd, packageCwd), FormatType.PATH)} as a workspace.\n- If it isn't, it's likely because you have a yarn.lock or package.json file there, confusing the project root detection.`);
   }
 
   static generateBuildStateFile(buildState: Map<LocatorHash, string>, locatorStore: Map<LocatorHash, Locator>) {
@@ -510,7 +510,7 @@ export class Project {
     return dependencyMeta;
   }
 
-  async findLocatorForLocation(cwd: PortablePath) {
+  async findLocatorForLocation(cwd: PortablePath, {strict = false}: {strict?: boolean} = {}) {
     const report = new ThrowReport();
 
     const linkers = this.configuration.getLinkers();
@@ -519,6 +519,14 @@ export class Project {
     for (const linker of linkers) {
       const locator = await linker.findPackageLocator(cwd, linkerOptions);
       if (locator) {
+        // If strict mode, the specified cwd must be a package,
+        // not merely contained in a package.
+        if (strict) {
+          const location = await linker.findPackageLocation(locator, linkerOptions);
+          if (location !== cwd) {
+            continue;
+          }
+        }
         return locator;
       }
     }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1256,7 +1256,7 @@ export class Project {
         if (typeof dependency === `undefined`)
           throw new Error(`Assertion failed: The package should have been registered`);
 
-        builder.update(getBaseHash(pkg));
+        builder.update(getBaseHash(dependency));
       }
 
       hash = builder.digest(`hex`);
@@ -1319,6 +1319,7 @@ export class Project {
           throw new Error(`Assertion failed: The build directive should have been registered`);
 
         const buildHash = getBuildHash(pkg, buildInfo.buildLocations);
+        console.log(structUtils.prettyLocator(this.configuration, pkg), buildHash);
 
         // No need to rebuild the package if its hash didn't change
         if (Object.prototype.hasOwnProperty.call(bstate, pkg.locatorHash) && bstate[pkg.locatorHash] === buildHash) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

- A typo was causing incorrect build executions
- The changelog was missing a few items (it still does)
- The incorrect error message was printed when running Yarn from a non-workspace directory
- Yarn wasn't differentiating deprecated versions from non-deprecated ones

**How did you fix it?**

- Fixed the typo, added tests
- Print a more helpful error message when Yarn is used on something that isn't a workspace
- Deprecated versions won't be used if other versions satisfy the range

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
