### PR TITLE
perf(core): make check for cache entries async

### DIFF
--- a/.yarn/versions/88041e15.yml
+++ b/.yarn/versions/88041e15.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -191,7 +191,7 @@ export class Cache {
     };
 
     const loadPackageThroughMirror = async () => {
-      if (mirrorPath === null || !xfs.existsSync(mirrorPath)) {
+      if (mirrorPath === null || !(await xfs.existsPromise(mirrorPath))) {
         const zipFs = await loader!();
         const realPath = zipFs.getRealPath();
         zipFs.saveAndClose();
@@ -236,7 +236,40 @@ export class Cache {
     };
 
     const loadPackageThroughMutex = async () => {
-      const mutex = loadPackage();
+      const mutexedLoad = async () => {
+        // We don't yet know whether the cache path can be computed yet, since that
+        // depends on whether the cache is actually the mirror or not, and whether
+        // the checksum is known or not.
+        const tentativeCachePath = this.getLocatorPath(locator, expectedChecksum);
+
+        const cacheExists = tentativeCachePath !== null
+          ? await baseFs.existsPromise(tentativeCachePath)
+          : false;
+
+        const action = cacheExists
+          ? onHit
+          : onMiss;
+
+        // Note: must be synchronous, otherwise the mutex may break (a concurrent
+        // execution may start while we're running the action)
+        if (action)
+          action();
+
+        if (!cacheExists) {
+          return loadPackage();
+        } else {
+          let checksum: string | null = null;
+          const cachePath = tentativeCachePath!;
+          if (this.check)
+            checksum = await validateFileAgainstRemote(cachePath);
+          else
+            checksum = await validateFile(cachePath);
+
+          return [cachePath, checksum] as const;
+        }
+      };
+
+      const mutex = mutexedLoad();
       this.mutexes.set(locator.locatorHash, mutex);
 
       try {
@@ -249,37 +282,7 @@ export class Cache {
     for (let mutex; (mutex = this.mutexes.get(locator.locatorHash));)
       await mutex;
 
-    // We don't yet know whether the cache path can be computed yet, since that
-    // depends on whether the cache is actually the mirror or not, and whether
-    // the checksum is known or not.
-    const tentativeCachePath = this.getLocatorPath(locator, expectedChecksum);
-
-    const cacheExists = tentativeCachePath !== null
-      ? baseFs.existsSync(tentativeCachePath)
-      : false;
-
-    const action = cacheExists
-      ? onHit
-      : onMiss;
-
-    // Note: must be synchronous, otherwise the mutex may break (a concurrent
-    // execution may start while we're running the action)
-    if (action)
-      action();
-
-    let cachePath: PortablePath;
-    let checksum: string;
-
-    if (!cacheExists) {
-      [cachePath, checksum] = await loadPackageThroughMutex();
-    } else {
-      cachePath = tentativeCachePath!;
-      if (this.check) {
-        checksum = await validateFileAgainstRemote(cachePath);
-      } else {
-        checksum = await validateFile(cachePath);
-      }
-    }
+    const [cachePath, checksum] = await loadPackageThroughMutex();
 
     this.markedFiles.add(cachePath);
 

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -250,8 +250,6 @@ export class Cache {
           ? onHit
           : onMiss;
 
-        // Note: must be synchronous, otherwise the mutex may break (a concurrent
-        // execution may start while we're running the action)
         if (action)
           action();
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When running `fetchPackageFromCache` Yarn checks if the file already exists using `existsSync` instead of `existsPromise` blocking the event loop.

**How did you fix it?**

Changed `existsSync` to `existsPromise`, however this caused race conditions (which lead to https://github.com/yarnpkg/berry/pull/1684) so I moved the load logic into `loadPackageThroughMutex` to make sure any part of the fetch for a specific locator is mutexed.

**Result**

When testing the gatsby benchmark `install-cache-and-lock` locally this reduces the time spent in `fetchPackageFromCache` from 1001ms to 393ms

Before: https://github.com/yarnpkg/berry/actions/runs/200598797
After: https://github.com/yarnpkg/berry/actions/runs/200603660

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
