### PR TITLE
fix(plugin-essentials): use temporary cache in extractDescriptorFromPath

### DIFF
--- a/.yarn/versions/7baa37a5.yml
+++ b/.yarn/versions/7baa37a5.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -120,7 +120,7 @@ export default class AddCommand extends BaseCommand {
 
     const allSuggestions = await Promise.all(this.packages.map(async pseudoDescriptor => {
       const request = pseudoDescriptor.match(/^\.{0,2}\//)
-        ? await suggestUtils.extractDescriptorFromPath(pseudoDescriptor as PortablePath, {cache, cwd: this.context.cwd, workspace})
+        ? await suggestUtils.extractDescriptorFromPath(pseudoDescriptor as PortablePath, {cwd: this.context.cwd, workspace})
         : structUtils.parseDescriptor(pseudoDescriptor);
 
       const target = suggestTarget(workspace, request, {

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -339,16 +339,16 @@ export async function fetchDescriptorFrom(ident: Ident, range: string, {project,
 }
 
 export async function makeTemporaryCache() {
-  return await xfs.mktempPromise(async cacheDir => {
-    const configuration = Configuration.create(cacheDir);
+  const cacheDir = await xfs.mktempPromise();
 
-    configuration.useWithSource(cacheDir, {
-      // Don't pollute the mirror with temporary archives
-      enableMirror: false,
-      // Don't spend time compressing what gets deleted later
-      compressionLevel: 0,
-    }, cacheDir, {overwrite: true});
+  const configuration = Configuration.create(cacheDir);
 
-    return new Cache(cacheDir, {configuration, check: false, immutable: false});
-  });
+  configuration.useWithSource(cacheDir, {
+    // Don't pollute the mirror with temporary archives
+    enableMirror: false,
+    // Don't spend time compressing what gets deleted later
+    compressionLevel: 0,
+  }, cacheDir, {overwrite: true});
+
+  return new Cache(cacheDir, {configuration, check: false, immutable: false});
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`extractDescriptorFromPath` was fetching temporary `archive` archives using the project cache, which caused it to get polluted.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've made `extractDescriptorFromPath` use a temporary cache.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
