### PR TITLE
Mark `--frozen-lockfile` as a warning in Travis CI

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -9146,6 +9146,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-essentials-virtual-ba2aa356ff/1/packages/plugin-essentials/",
           "packageDependencies": [
             ["@yarnpkg/plugin-essentials", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-essentials"],
+            ["@types/ci-info", "npm:2.0.0"],
             ["@types/lodash", "npm:4.14.136"],
             ["@types/micromatch", "npm:4.0.1"],
             ["@types/semver", "npm:7.1.0"],
@@ -9157,6 +9158,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
+            ["ci-info", "npm:2.0.0"],
             ["clipanion", "npm:2.4.4"],
             ["enquirer", "npm:2.3.6"],
             ["lodash", "npm:4.17.15"],
@@ -9178,6 +9180,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./.yarn/$$virtual/@yarnpkg-plugin-essentials-virtual-a18b52070a/1/packages/plugin-essentials/",
           "packageDependencies": [
             ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
+            ["@types/ci-info", "npm:2.0.0"],
             ["@types/lodash", "npm:4.14.136"],
             ["@types/micromatch", "npm:4.0.1"],
             ["@types/semver", "npm:7.1.0"],
@@ -9189,6 +9192,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
+            ["ci-info", "npm:2.0.0"],
             ["clipanion", "npm:2.4.4"],
             ["enquirer", "npm:2.3.6"],
             ["lodash", "npm:4.17.15"],
@@ -9210,6 +9214,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/plugin-essentials/",
           "packageDependencies": [
             ["@yarnpkg/plugin-essentials", "workspace:packages/plugin-essentials"],
+            ["@types/ci-info", "npm:2.0.0"],
             ["@types/lodash", "npm:4.14.136"],
             ["@types/micromatch", "npm:4.0.1"],
             ["@types/semver", "npm:7.1.0"],
@@ -9219,6 +9224,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/json-proxy", "workspace:packages/yarnpkg-json-proxy"],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
+            ["ci-info", "npm:2.0.0"],
             ["clipanion", "npm:2.4.4"],
             ["enquirer", "npm:2.3.6"],
             ["lodash", "npm:4.17.15"],

--- a/.yarn/versions/88e02473.yml
+++ b/.yarn/versions/88e02473.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -7,6 +7,7 @@
     "@yarnpkg/fslib": "workspace:^2.1.0",
     "@yarnpkg/json-proxy": "workspace:^2.1.0",
     "@yarnpkg/parsers": "workspace:^2.1.0",
+    "ci-info": "^2.0.0",
     "clipanion": "^2.4.4",
     "enquirer": "^2.3.6",
     "lodash": "^4.17.15",
@@ -21,6 +22,7 @@
     "@yarnpkg/core": "^2.1.1"
   },
   "devDependencies": {
+    "@types/ci-info": "^2",
     "@types/lodash": "^4.14.136",
     "@types/micromatch": "^4.0.1",
     "@types/semver": "^7.1.0",

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -93,7 +93,7 @@ export default class YarnCommand extends BaseCommand {
     const isZeitNow = !!process.env.NOW_BUILDER;
     const isNetlify = !!process.env.NETLIFY;
     const isGCF = !!process.env.FUNCTION_TARGET;
-    const isTravis = !!process.env.TRAVIS && !!process.env.CI ;
+    const isTravis = !!process.env.TRAVIS && !!process.env.CI;
 
     const reportDeprecation = async (message: string, {error}: {error: boolean}) => {
       const deprecationReport = await StreamReport.start({

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -2,6 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}                                    
 import {Configuration, Cache, MessageName, Project, ReportError, StreamReport, FormatType} from '@yarnpkg/core';
 import {xfs, ppath}                                                                        from '@yarnpkg/fslib';
 import {parseSyml, stringifySyml}                                                          from '@yarnpkg/parsers';
+import {TRAVIS}                                                                            from 'ci-info';
 import {Command, Usage}                                                                    from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
@@ -93,7 +94,6 @@ export default class YarnCommand extends BaseCommand {
     const isZeitNow = !!process.env.NOW_BUILDER;
     const isNetlify = !!process.env.NETLIFY;
     const isGCF = !!process.env.FUNCTION_TARGET;
-    const isTravis = !!process.env.TRAVIS && !!process.env.CI;
 
     const reportDeprecation = async (message: string, {error}: {error: boolean}) => {
       const deprecationReport = await StreamReport.start({
@@ -192,7 +192,7 @@ export default class YarnCommand extends BaseCommand {
     // lockfile - for example the PnP artifacts will also be locked.
     if (typeof this.frozenLockfile !== `undefined`) {
       const exitCode = await reportDeprecation(`The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead`, {
-        error: !isGCF && !isTravis,
+        error: !isGCF && !TRAVIS,
       });
 
       if (exitCode !== null) {

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -93,6 +93,7 @@ export default class YarnCommand extends BaseCommand {
     const isZeitNow = !!process.env.NOW_BUILDER;
     const isNetlify = !!process.env.NETLIFY;
     const isGCF = !!process.env.FUNCTION_TARGET;
+    const isTravis = !!process.env.TRAVIS && !!process.env.CI ;
 
     const reportDeprecation = async (message: string, {error}: {error: boolean}) => {
       const deprecationReport = await StreamReport.start({
@@ -191,7 +192,7 @@ export default class YarnCommand extends BaseCommand {
     // lockfile - for example the PnP artifacts will also be locked.
     if (typeof this.frozenLockfile !== `undefined`) {
       const exitCode = await reportDeprecation(`The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead`, {
-        error: !isGCF,
+        error: !isGCF && !isTravis,
       });
 
       if (exitCode !== null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,6 +5710,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-essentials@workspace:packages/plugin-essentials"
   dependencies:
+    "@types/ci-info": ^2
     "@types/lodash": ^4.14.136
     "@types/micromatch": ^4.0.1
     "@types/semver": ^7.1.0
@@ -5719,6 +5720,7 @@ __metadata:
     "@yarnpkg/fslib": "workspace:^2.1.0"
     "@yarnpkg/json-proxy": "workspace:^2.1.0"
     "@yarnpkg/parsers": "workspace:^2.1.0"
+    ci-info: ^2.0.0
     clipanion: ^2.4.4
     enquirer: ^2.3.6
     lodash: ^4.17.15


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Travis CI is calling `yarn --frozen-lockfile` by default and that behaviour cannot be overriden (as far as I know).
When bumping from Yarn to Berry it make builds crash at start-up on Travis.

This [PR](https://github.com/dubzzz/fast-check/pull/867) shows that Travis can be detected by using the check `!!process.env.TRAVIS && !!process.env.CI`.

Associated Travis build can be seen here: https://travis-ci.com/github/dubzzz/fast-check/builds/179306747 (by the way you can see that this job automatically calls `yarn --frozen-lockfile`)

And uses the following Travis configuration file: https://github.com/dubzzz/fast-check/blob/fa7e754eb5e4c4e348e8813469dbd964a9d70610/.travis.yml

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I changed the error into a warning for Travis CI as suggested by @arcanis on [Twitter](https://twitter.com/arcanis/status/1292932411089715202?s=20).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
