### PR TITLE
perf(plugin-patch): remove unneeded saveAndClose

### DIFF
--- a/.yarn/versions/92d834ce.yml
+++ b/.yarn/versions/92d834ce.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/PatchFetcher.ts
+++ b/packages/plugin-patch/sources/PatchFetcher.ts
@@ -49,24 +49,17 @@ export class PatchFetcher implements Fetcher {
 
     const libzip = await getLibzipPromise();
 
-    const copiedPackage = new ZipFS(tmpFile, {
+    const patchedPackage = new ZipFS(tmpFile, {
       libzip,
       create: true,
       level: opts.project.configuration.get(`compressionLevel`),
     });
 
-    await copiedPackage.mkdirpPromise(prefixPath);
+    await patchedPackage.mkdirpPromise(prefixPath);
 
     await miscUtils.releaseAfterUseAsync(async () => {
-      await copiedPackage.copyPromise(prefixPath, sourceFetch.prefixPath, {baseFs: sourceFetch.packageFs, stableSort: true});
+      await patchedPackage.copyPromise(prefixPath, sourceFetch.prefixPath, {baseFs: sourceFetch.packageFs, stableSort: true});
     }, sourceFetch.releaseFs);
-
-    copiedPackage.saveAndClose();
-
-    const patchedPackage = new ZipFS(tmpFile, {
-      libzip,
-      level: opts.project.configuration.get(`compressionLevel`),
-    });
 
     const patchFs = new CwdFS(ppath.resolve(PortablePath.root, prefixPath), {baseFs: patchedPackage});
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Now that we've implemented support for read-after-write in `ZipFS` in #1675, there's no need for the extra `copiedPackage` `ZipFS` step inside the `PatchFetcher`. This is important, because we had to use `saveAndClose` to persist the copied package on disk, even when everything can actually be done in memory.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've removed the extra `copiedPackage` and `saveAndClose` parts. This saves `11485.5 ms` of the fetch step when running `yarn install` on the `TypeScript-Website` repo with a cold cache. 

I really hope that the tests are passing, haven't checked yet 😄.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
