### PR TITLE
ci(e2e): disable fallback mode

### DIFF
--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -17,6 +17,9 @@ echo Yarn Version: $(yarn -v)
 # We want to see what fails (if anything fails)
 export YARN_ENABLE_INLINE_BUILDS=1
 
+# We want to make sure the projects work in a monorepo
+export YARN_PNP_FALLBACK_MODE=none
+
 # Otherwise git commit doesn't work, and some tools require it
 git config --global user.email "you@example.com"
 git config --global user.name "John Doe"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Not all of the projects we cover in our e2e tests work correctly in monorepos (example https://github.com/storybookjs/storybook/pull/11753) but we don't catch this because the fallback pool allows them to access undeclared dependencies.

**How did you fix it?**

Disable the fallback pool

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [ ] I have verified that all automated PR checks pass.
