### PR TITLE
[node-modules] Fixes hoisting when package peer depends on parent itself

### DIFF
--- a/.yarn/versions/c03daef8.yml
+++ b/.yarn/versions/c03daef8.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -191,10 +191,6 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): Hoister
           if (depPkg === null)
             throw new Error(`Assertion failed: Expected the package to have been registered`);
 
-          // Skip package self-references
-          if (depLocator.name === locator.name && depLocator.reference === locator.reference)
-            continue;
-
           addPackageToTree(name, depPkg, depLocator, node, pkg);
         }
       }

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -215,7 +215,7 @@ const hoistTo = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath:
 
   const hoistIdentMap = getHoistIdentMap(rootNode, popularityMap);
 
-  const hoistIdents = new Set(Array.from(hoistIdentMap.values()).map(x => x[0]));
+  const hoistIdents = new Map(Array.from(hoistIdentMap.entries()).map(([k, v]) => [k, v[0]]));
 
   const hoistedDependencies = rootNode === tree ? new Map() : getHoistedDependencies(rootNode);
 
@@ -225,9 +225,9 @@ const hoistTo = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath:
     wasStateChanged = false;
     for (const [name, idents] of hoistIdentMap) {
       if (idents.length > 1 && !rootNode.dependencies.has(name)) {
-        hoistIdents.delete(idents[0]);
+        hoistIdents.delete(name);
         idents.shift();
-        hoistIdents.add(idents[0]);
+        hoistIdents.set(name, idents[0]);
         wasStateChanged = true;
       }
     }
@@ -286,7 +286,7 @@ const getSortedReglarDependencies = (node: HoisterWorkTree): Set<HoisterWorkTree
  * @param hoistedDependencies map of dependencies that were hoisted to parent nodes
  * @param hoistIdents idents that should be attempted to be hoisted to the root node
  */
-const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath: Set<Locator>, hoistedDependencies: Map<PackageName, HoisterWorkTree>, hoistIdents: Set<Ident>, hoistIdentMap: Map<Ident, Array<Ident>>, options: InternalHoistOptions) => {
+const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath: Set<Locator>, hoistedDependencies: Map<PackageName, HoisterWorkTree>, hoistIdents: Map<PackageName, Ident>, hoistIdentMap: Map<Ident, Array<Ident>>, options: InternalHoistOptions) => {
   const seenNodes = new Set<HoisterWorkTree>();
 
   const hoistNode = (nodePath: Array<HoisterWorkTree>, locatorPath: Array<Locator>, node: HoisterWorkTree, newNodes: Set<HoisterWorkTree>) => {
@@ -300,8 +300,8 @@ const hoistGraph = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePa
 
     const parentNode = nodePath[nodePath.length - 1];
     // We cannot hoist self-references
-    const isSelfReference = node.name === parentNode.name;
-    let isHoistable = !isSelfReference && hoistIdents.has(node.ident);
+    const isSelfReference = node.ident === parentNode.ident;
+    let isHoistable = hoistIdents.get(node.name) === node.ident && !isSelfReference;
     if (options.debugLevel >= 2 && !isHoistable)
       reason = `- filled by: ${prettyPrintLocator(hoistIdentMap.get(node.name)![0])} at ${reasonRoot}`;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR fixes #1706. The nm hoister currently looses information when package peer depends on the parent package.

**How did you fix it?**

The hoister code was prematurely removing self-references from the tree. Now we keep self-references throughout hoisting process and remove them only when we build node_modules tree.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
