### PR TITLE
fix(doctor): handle peer dependency met by parent

### DIFF
--- a/.yarn/versions/c0d3bd74.yml
+++ b/.yarn/versions/c0d3bd74.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": patch

--- a/packages/yarnpkg-doctor/fixtures/peer-met-by-parent/package.json
+++ b/packages/yarnpkg-doctor/fixtures/peer-met-by-parent/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "react",
+  "dependencies": {
+    "react-dom": "*"
+  }
+}

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -226,6 +226,8 @@ async function checkForUnmetPeerDependency(workspace: Workspace, dependencyType:
     return;
   if (dependencyType === `devDependencies` && workspace.manifest.hasHardDependency(peer))
     return;
+  if (workspace.manifest.name?.identHash === peer.identHash)
+    return;
 
   const propertyNode = await buildJsonNode(ppath.join(workspace.cwd, Manifest.fileName), [dependencyType, structUtils.stringifyIdent(via)]);
   const prettyLocation = ast.prettyNodeLocation(configuration, propertyNode);


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/doctor` reports a missing peer dependency even if the parent is that dependency

**How did you fix it?**

Skip if the workspace identHash matches the peerDependency

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
