### PR TITLE
fix(doctor): respect gitignore

### DIFF
--- a/.yarn/versions/6f867693.yml
+++ b/.yarn/versions/6f867693.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": patch

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -25,6 +25,7 @@ async function findFiles(pattern: string, cwd: PortablePath, {ignoredFolders = [
     absolute: true,
     cwd: npath.fromPortablePath(cwd),
     ignore: [`**/node_modules/**`, ...ignoredFolders.map(p => `${npath.fromPortablePath(p)}/**`)],
+    gitignore: true,
   });
 
   return files.map(p => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/doctor` is checking gitignored files, while technically correct it produces a lot of redundant missing dependency reports as it's reported for both the source and the build output

**How did you fix it?**

Enable the gitignore option in globby

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
