### PR TITLE
feat(pnp) Skip lingering node_modules removal inside pnpIgnorePatterns matched folders

### DIFF
--- a/.yarn/versions/35625539.yml
+++ b/.yarn/versions/35625539.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Scripts can now use the `$RANDOM` variable as well as simple calculations using `+`, `-`, `*`, `/` and `()` inside `$(())`
 - Scripts can now use grouping curly braces (`{echo foo}`) to execute a command in the context of the current shell (without creating a subshell like in the case of `(echo foo)`).
 - Scripts can now end with a semicolon.
-- PnP linker will not remove lingering node_modules anymore inside inner project directories having parent .yarnrc.yml
+- PnP linker will not remove lingering node_modules inside folders matching `pnpIgnorePattern`
 
 ### Third-party integrations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Scripts can now use the `$RANDOM` variable as well as simple calculations using `+`, `-`, `*`, `/` and `()` inside `$(())`
 - Scripts can now use grouping curly braces (`{echo foo}`) to execute a command in the context of the current shell (without creating a subshell like in the case of `(echo foo)`).
 - Scripts can now end with a semicolon.
+- PnP linker will not remove lingering node_modules anymore inside inner project directories having parent .yarnrc.yml
 
 ### Third-party integrations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Scripts can now use the `$RANDOM` variable as well as simple calculations using `+`, `-`, `*`, `/` and `()` inside `$(())`
 - Scripts can now use grouping curly braces (`{echo foo}`) to execute a command in the context of the current shell (without creating a subshell like in the case of `(echo foo)`).
 - Scripts can now end with a semicolon.
-- PnP linker will not remove lingering node_modules inside folders matching `pnpIgnorePattern`
+- PnP linker will not remove lingering node_modules inside folders matching `pnpIgnorePatterns`
 
 ### Third-party integrations
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1505,19 +1505,19 @@ describe(`Plug'n'Play`, () => {
     }),
   );
 
-  test(`it should NOT remove lingering node_modules folders if their parent folder has yarnrc file`,
+  test(`it should NOT remove lingering node_modules inside folders matched by pnpIgnorePatterns`,
     makeTemporaryEnv({
       workspaces: [`foo`],
+    }, {
+      pnpIgnorePatterns: `foo/**`,
     }, async ({path, run, source}) => {
       await xfs.mkdirpPromise(`${path}/node_modules/foo`);
-      await xfs.writeFileSync(`${path}/.yarnrc.yml`, ``);
       await writeJson(`${path}/foo/package.json`, {
         name: `foo`,
         version: `1.0.0`,
         workspaces: [`baz`],
       });
       await xfs.mkdirpPromise(`${path}/foo/node_modules/dep`);
-      await xfs.writeFileSync(`${path}/foo/.yarnrc.yml`, ``);
       await writeJson(`${path}/foo/baz/package.json`, {
         name: `baz`,
         version: `1.0.0`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1505,6 +1505,33 @@ describe(`Plug'n'Play`, () => {
     }),
   );
 
+  test(`it should NOT remove lingering node_modules folders if their parent folder has yarnrc file`,
+    makeTemporaryEnv({
+      workspaces: [`foo`],
+    }, async ({path, run, source}) => {
+      await xfs.mkdirpPromise(`${path}/node_modules/foo`);
+      await xfs.writeFileSync(`${path}/.yarnrc.yml`, ``);
+      await writeJson(`${path}/foo/package.json`, {
+        name: `foo`,
+        version: `1.0.0`,
+        workspaces: [`baz`],
+      });
+      await xfs.mkdirpPromise(`${path}/foo/node_modules/dep`);
+      await xfs.writeFileSync(`${path}/foo/.yarnrc.yml`, ``);
+      await writeJson(`${path}/foo/baz/package.json`, {
+        name: `baz`,
+        version: `1.0.0`,
+      });
+      await xfs.mkdirpPromise(`${path}/foo/baz/node_modules/dep`);
+
+      await run(`install`);
+
+      await expect(xfs.readdirPromise(path)).resolves.not.toContain(`node_modules`);
+      await expect(xfs.readdirPromise(`${path}/foo/baz`)).resolves.toContain(`node_modules`);
+      await expect(xfs.readdirPromise(`${path}/foo`)).resolves.toContain(`node_modules`);
+    }),
+  );
+
   test(
     `it should transparently support the "resolve" package`,
     makeTemporaryEnv(

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -30,8 +30,6 @@ const FORCED_UNPLUG_FILETYPES = new Set([
   `.node`,
 ]);
 
-type YARNRC_PATHS_TREE = Map<Filename, YARNRC_PATHS_TREE>;
-
 export class PnpLinker implements Linker {
   protected mode = `strict`;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Using both pnp and node_modules linker in a single monorepo is not possible now, because pnp linker tries to remove node_modules. Example monorepo structure with the problem:
```
<pnp_monorepo_root>/
  packages/
     pnp-package/
       ...
     nm-package/
       .yarnrc.yml
       yarn.lock
  .yarnrc.yml
  yarn.lock
```

PnP linker will remove node_modules inside `nm-package`, even though `nm-package` is meant to be managed by node-modules linker

**How did you fix it?**
<!-- A detailed description of your implementation. -->

PnP linker will not remove lingering node_modules if the folder matches `pnpIgnorePattern`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
