### PR TITLE
feat(pnpify): add flow-bin to editor SDK

### DIFF
--- a/.yarn/versions/4c0177ff.yml
+++ b/.yarn/versions/4c0177ff.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": minor
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/gatsby/content/advanced/editor-sdks.md
+++ b/packages/gatsby/content/advanced/editor-sdks.md
@@ -27,7 +27,10 @@ Generally speaking:
 | Builtin VSCode TypeScript Server | [typescript](https://yarnpkg.com/package/typescript) |
 | [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
 | [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
-| [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) | [stylelint](https://stylelint.io/)
+| [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) | [stylelint](https://stylelint.io/) |
+| [flow-for-vscode*](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode) | [flow-bin](https://flow.org/) |
+
+> \* Flow is [incompatible with PnP](/features/pnp#incompatible) yet.
 
 If you'd like to contribute more, [take a look here!](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-pnpify/sources/generateSdk.ts)
 

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -175,7 +175,8 @@ export type SupportedSdk =
  | 'typescript-language-server'
  | 'typescript'
  | 'stylelint'
- | 'svelte-language-server';
+ | 'svelte-language-server'
+ | 'flow-bin';
 
 export type BaseSdks = Array<[SupportedSdk, GenerateBaseWrapper]>;
 

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -115,6 +115,16 @@ export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = asyn
   return wrapper;
 };
 
+export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`flow-bin` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`cli.js` as PortablePath);
+
+  return wrapper;
+};
+
 export const BASE_SDKS: BaseSdks = [
   [`eslint`, generateEslintBaseWrapper],
   [`prettier`, generatePrettierBaseWrapper],
@@ -122,4 +132,5 @@ export const BASE_SDKS: BaseSdks = [
   [`typescript`, generateTypescriptBaseWrapper],
   [`stylelint`, generateStylelintBaseWrapper],
   [`svelte-language-server`, generateSvelteLanguageServerBaseWrapper],
+  [`flow-bin`, generateFlowBinBaseWrapper],
 ];

--- a/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/vscode.ts
@@ -108,6 +108,22 @@ export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = a
   });
 };
 
+export const generateFlowBinWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
+    [`flow.pathToFlow`]: npath.fromPortablePath(
+      `\${workspaceFolder}/${wrapper.getProjectPathTo(
+        `cli.js` as PortablePath,
+      )}`,
+    ),
+  });
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
+    [`recommendations`]: [
+      `flowtype.flow-for-vscode`,
+    ],
+  });
+};
+
 export const VSCODE_SDKS: IntegrationSdks = [
   [null, generateDefaultWrapper],
   [`eslint`, generateEslintWrapper],
@@ -116,4 +132,5 @@ export const VSCODE_SDKS: IntegrationSdks = [
   [`typescript`, generateTypescriptWrapper],
   [`stylelint`, generateStylelintWrapper],
   [`svelte-language-server`, generateSvelteLanguageServerWrapper],
+  [`flow-bin`, generateFlowBinWrapper],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
This PR adds `flow-bin` to editor SDKs.

**How did you fix it?**
- Wrap `flow-bin/cli.js` and set as `flow.pathToFlow` for `flowtype.flow-for-vscode`
- Add documentation with incompatibility warning

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
