### PR TITLE
fix(core): use semver.valid in ProtocolResolver.supportsLocator

### DIFF
--- a/.yarn/versions/0984a50f.yml
+++ b/.yarn/versions/0984a50f.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/doctor": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/ProtocolResolver.ts
+++ b/packages/yarnpkg-core/sources/ProtocolResolver.ts
@@ -18,7 +18,7 @@ export class ProtocolResolver implements Resolver {
   }
 
   supportsLocator(locator: Locator, opts: MinimalResolveOptions) {
-    if (semver.validRange(locator.reference))
+    if (semver.valid(locator.reference))
       return true;
 
     if (TAG_REGEXP.test(locator.reference))


### PR DESCRIPTION
**What's the problem this PR addresses?**

`ProtocolResolver.supportsLocator` uses `semver.validRange` to check if it supports a locator, but locators are versions not ranges so this should use `semver.valid`

**How did you fix it?**

Replace `semver.validRange` with `semver.valid` which reduces the time spent in `ProtocolResolver.supportsLocator` from 538ms to 5.5ms in the gatsby benchmark

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
