### PR TITLE
perf(plugin-npm): use cached range in NpmSemverResolver.getSatisfying

### DIFF
--- a/.yarn/versions/7fc37e0a.yml
+++ b/.yarn/versions/7fc37e0a.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -83,7 +83,9 @@ export class NpmSemverResolver implements Resolver {
   }
 
   async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    const range = new semver.Range(descriptor.range.slice(PROTOCOL.length));
+    const range = semverUtils.validRange(descriptor.range.slice(PROTOCOL.length));
+    if (range === null)
+      throw new Error(`Expected a valid range, got ${descriptor.range.slice(PROTOCOL.length)}`);
 
     return references
       .map(reference => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`NpmSemverResolver.getSatisfying` doesn't use the cached semver range because https://github.com/yarnpkg/berry/pull/1558 was merged 2 minutes after the semver range cached was merged

**How did you fix it?**

Make `NpmSemverResolver.getSatisfying` use `semverUtils.validRange` which caches the result

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
