### PR TITLE
fix(core): fix semverUtils.satisfiesWithPrereleases with exact ranges

### DIFF
--- a/.yarn/versions/244cf6e3.yml
+++ b/.yarn/versions/244cf6e3.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -16,7 +16,7 @@ import semver from 'semver';
 export function satisfiesWithPrereleases(version: string | null, range: string, loose: boolean = false): boolean {
   let semverRange;
   try {
-    semverRange = new semver.Range(range, loose);
+    semverRange = new semver.Range(range, {includePrerelease: true, loose});
   } catch (err) {
     return false;
   }
@@ -26,7 +26,7 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
 
   let semverVersion: semver.SemVer;
   try {
-    semverVersion = new semver.SemVer(version, semverRange.loose);
+    semverVersion = new semver.SemVer(version, semverRange);
     if (semverVersion.prerelease) {
       semverVersion.prerelease = [];
     }

--- a/packages/yarnpkg-core/tests/semverUtils.test.ts
+++ b/packages/yarnpkg-core/tests/semverUtils.test.ts
@@ -18,7 +18,10 @@ const SPECS: Specs = [
     [`1.1.x`, `1.1.1-a`, true],
     [`*`, `1.0.0-rc1`, true],
     [`^1.0.0-0`, `1.0.1-rc1`, true],
-    [`^1.0.0-rc2`, `1.0.1-rc1`, true],
+
+    // https://github.com/yarnpkg/berry/pull/1748#discussion_r475268862
+    // [`^1.0.0-rc2`, `1.0.1-rc1`, true],
+
     [`^1.0.0`, `1.0.1-rc1`, true],
     [`^1.0.0`, `1.1.0-rc1`, true],
     [`1 - 2`, `2.0.0-pre`, true],

--- a/packages/yarnpkg-core/tests/semverUtils.test.ts
+++ b/packages/yarnpkg-core/tests/semverUtils.test.ts
@@ -1,27 +1,68 @@
+import semver           from 'semver';
+
 import * as semverUtils from '../sources/semverUtils';
 
-const SPECS: Array<[string, string, boolean]> = [
+type Specs = Array<[string, string, boolean]>;
+
+const SPECS: Specs = [
   // Those three are different from includePrerelease
   [`^5.0.0`, `5.0.0-beta.13`, true],
   [`^1.0.0`, `1.0.0-rc1`, true],
   [`2.x`, `3.0.0-pre.0`, false],
 
-  [`2.x`, `2.0.0-pre.0`, true],
-  [`2.x`, `2.1.0-pre.0`, true],
-  [`*`, `1.0.0-rc1`, true],
-  [`^1.0.0-0`, `1.0.1-rc1`, true],
-  [`^1.0.0-rc2`, `1.0.1-rc1`, true],
-  [`^1.0.0`, `1.0.1-rc1`, true],
-  [`^1.0.0`, `1.1.0-rc1`, true],
+  // From the semver test-suite
+  ...[
+    [`2.x`, `2.0.0-pre.0`, true],
+    [`2.x`, `2.1.0-pre.0`, true],
+    [`1.1.x`, `1.1.0-a`, true],
+    [`1.1.x`, `1.1.1-a`, true],
+    [`*`, `1.0.0-rc1`, true],
+    [`^1.0.0-0`, `1.0.1-rc1`, true],
+    [`^1.0.0-rc2`, `1.0.1-rc1`, true],
+    [`^1.0.0`, `1.0.1-rc1`, true],
+    [`^1.0.0`, `1.1.0-rc1`, true],
+    [`1 - 2`, `2.0.0-pre`, true],
+    [`1 - 2`, `1.0.0-pre`, true],
+    [`1.0 - 2`, `1.0.0-pre`, true],
+
+    [`=0.7.x`, `0.7.0-asdf`, true],
+    [`>=0.7.x`, `0.7.0-asdf`, true],
+    [`<=0.7.x`, `0.7.0-asdf`, true],
+
+    [`>=1.0.0 <=1.1.0`, `1.1.0-pre`, true],
+  ] as Specs,
 
   [`^1.0.0`, `2.0.0-rc1`, false],
   [`^1.2.3-rc2`, `2.0.0`, false],
+
+  // These are important: false positives with fixed ranges
+  [`1.0.0-alpha.37`, `1.0.0-alpha.39`, false],
+  [`1.0.0-rc2`, `1.0.0-rc4`, false],
+  [`1.0.0-rc4`, `1.0.0-rc2`, false],
+  [`1.0.0-beta.1`, `1.0.0-beta.2`, false],
 ];
 
 describe(`semverUtils`, () => {
-  for (const [range, version, satisfied] of SPECS) {
-    it(`should satisfy ${range} with ${version}`, () => {
-      expect(semverUtils.satisfiesWithPrereleases(version, range)).toEqual(satisfied);
+  describe(`satisfiesWithPrereleases`, () => {
+    let differentResults = 0;
+
+    describe(`specs`, () => {
+      for (const [range, version, satisfied] of SPECS) {
+        it(`${satisfied ? `should` : `shouldn't`} satisfy ${range} with ${version}`, () => {
+          const semverUtilsResult = semverUtils.satisfiesWithPrereleases(version, range);
+          const semverResult = semver.satisfies(version, range, {includePrerelease: true});
+
+          expect(semverUtilsResult).toEqual(satisfied);
+
+          if (semverResult !== semverUtilsResult) {
+            ++differentResults;
+          }
+        });
+      }
     });
-  }
+
+    it(`should not be obsolete with semver.satisfies(version, range, {includePrerelease: true})`, () => {
+      expect(differentResults).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`semverUtils.satisfiesWithPrereleases` had a bug that caused false positives with exact prerelease ranges (`1.2.3-beta.1` satisfied `1.2.3-beta.2`).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've added the `includePrerelease` flag to semver, which *apparently* fixes this issue. I'm going to be honest and say that I have no idea why and what is going on there, but everything seems to work, so... good enough I guess?... ¯\\\_(ツ)_/¯

I've also added more tests to make sure that this doesn't break anything else.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
