### PR TITLE
Fix resolving dependencies prefixed with git+ssh:// and colon after a hostname

### DIFF
--- a/.yarn/versions/52ee9b6e.yml
+++ b/.yarn/versions/52ee9b6e.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-git": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
+++ b/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
@@ -1,44 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit:hash 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit:hash"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit=hash 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit=hash"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit:hash ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit:hash"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit=hash&workspace=foo 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit=hash&workspace=foo"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit:hash ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit:hash"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#hash 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit=hash ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit=hash"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#tag=hello 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#tag=hello"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit=hash ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit=hash"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#workspace=foo 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#workspace=foo"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit=hash&workspace=foo ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit=hash&workspace=foo"`;
 
-exports[`gitUtils should properly normalize GitHubOrg/foo2bar.js 1`] = `"https://github.com/GitHubOrg/foo2bar.js.git"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#commit=hash&workspace=foo ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#commit=hash&workspace=foo"`;
 
-exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate#v1.0.1 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#hash ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
 
-exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#hash ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
 
-exports[`gitUtils should properly normalize git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#tag=hello ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#tag=hello"`;
 
-exports[`gitUtils should properly normalize git://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"git://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#tag=hello ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#tag=hello"`;
 
-exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#workspace=foo ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#workspace=foo"`;
 
-exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js#hash 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo-bar.js#workspace=foo ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#workspace=foo"`;
 
-exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo2bar.js ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo2bar.js.git"`;
 
-exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#master 1`] = `"https://github.com/TooTallNate/util-deprecate.git#master"`;
+exports[`gitUtils should properly normalize GitHubOrg/foo2bar.js ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo2bar.js.git"`;
 
-exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0 1`] = `"https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0"`;
+exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate#v1.0.1 ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
 
-exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#v1.0.0 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.0"`;
+exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate#v1.0.1 ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
 
-exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate/tarball/b3562c2798507869edb767da869cd7b85487726d 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
 
-exports[`gitUtils should properly normalize ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `"ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: false }) 1`] = `"git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: true }) 1`] = `"ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1 ({ git: false }) 1`] = `"git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1"`;
+
+exports[`gitUtils should properly normalize git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1 ({ git: true }) 1`] = `"git@github.com:yarnpkg/berry.git#v2.1.1"`;
+
+exports[`gitUtils should properly normalize git://github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: false }) 1`] = `"git://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize git://github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: true }) 1`] = `"git://github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
+
+exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
+
+exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js#hash ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
+
+exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js#hash ({ git: true }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git#hash"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#master ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#master"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#master ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#master"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0 ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0 ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#semver:v1.0.0"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#v1.0.0 ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.0"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate.git#v1.0.0 ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#v1.0.0"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate/tarball/b3562c2798507869edb767da869cd7b85487726d ({ git: false }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+
+exports[`gitUtils should properly normalize https://github.com/TooTallNate/util-deprecate/tarball/b3562c2798507869edb767da869cd7b85487726d ({ git: true }) 1`] = `"https://github.com/TooTallNate/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d"`;
+
+exports[`gitUtils should properly normalize ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: false }) 1`] = `"ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1 ({ git: true }) 1`] = `"ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1"`;
+
+exports[`gitUtils should properly normalize ssh://git@github.com:yarnpkg/berry.git#v2.1.1 ({ git: false }) 1`] = `"ssh://git@github.com:yarnpkg/berry.git#v2.1.1"`;
+
+exports[`gitUtils should properly normalize ssh://git@github.com:yarnpkg/berry.git#v2.1.1 ({ git: true }) 1`] = `"git@github.com:yarnpkg/berry.git#v2.1.1"`;
 
 exports[`gitUtils should properly split GitHubOrg/foo-bar.js 1`] = `
 Object {
@@ -165,6 +213,17 @@ Object {
 }
 `;
 
+exports[`gitUtils should properly split git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1 1`] = `
+Object {
+  "extra": Object {},
+  "repo": "git+ssh://git@github.com:yarnpkg/berry.git",
+  "treeish": Object {
+    "protocol": null,
+    "request": "v2.1.1",
+  },
+}
+`;
+
 exports[`gitUtils should properly split git://github.com/TooTallNate/util-deprecate.git#v1.0.1 1`] = `
 Object {
   "extra": Object {},
@@ -260,6 +319,17 @@ Object {
   "treeish": Object {
     "protocol": null,
     "request": "v1.0.1",
+  },
+}
+`;
+
+exports[`gitUtils should properly split ssh://git@github.com:yarnpkg/berry.git#v2.1.1 1`] = `
+Object {
+  "extra": Object {},
+  "repo": "ssh://git@github.com:yarnpkg/berry.git",
+  "treeish": Object {
+    "protocol": null,
+    "request": "v2.1.1",
   },
 }
 `;

--- a/packages/plugin-git/sources/gitUtils.test.js
+++ b/packages/plugin-git/sources/gitUtils.test.js
@@ -19,6 +19,8 @@ const VALID_PATTERNS = [
   `git://github.com/TooTallNate/util-deprecate.git#v1.0.1`,
   `git+ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,
   `ssh://git@github.com/TooTallNate/util-deprecate.git#v1.0.1`,
+  `git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1`,
+  `ssh://git@github.com:yarnpkg/berry.git#v2.1.1`,
   `git+https://github.com/TooTallNate/util-deprecate#v1.0.1`,
   `git+https://github.com/TooTallNate/util-deprecate.git#v1.0.1`,
 ];
@@ -42,8 +44,11 @@ describe(`gitUtils`, () => {
   }
 
   for (const pattern of VALID_PATTERNS) {
-    it(`should properly normalize ${pattern}`, () => {
+    it(`should properly normalize ${pattern} ({ git: false })`, () => {
       expect(gitUtils.normalizeRepoUrl(pattern)).toMatchSnapshot();
+    });
+    it(`should properly normalize ${pattern} ({ git: true })`, () => {
+      expect(gitUtils.normalizeRepoUrl(pattern, {git: true})).toMatchSnapshot();
     });
   }
 

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -2,6 +2,7 @@ import {Configuration, Locator, execUtils, structUtils} from '@yarnpkg/core';
 import {npath, xfs}                                     from '@yarnpkg/fslib';
 import querystring                                      from 'querystring';
 import semver                                           from 'semver';
+import urlLib                                           from 'url';
 
 function makeGitEnvironment() {
   return {
@@ -137,9 +138,40 @@ export function normalizeRepoUrl(url: string, {git = false}: {git?: boolean} = {
   // We support GitHub `/tarball/` URLs
   url = url.replace(/^https:\/\/github\.com\/(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)\/tarball\/(.+)?$/, `https://github.com/$1/$2.git#$3`);
 
-  // The `git+` prefix doesn't mean anything at all for Git
-  if (git)
+  if (git) {
+    // The `git+` prefix doesn't mean anything at all for Git
     url = url.replace(/^git\+([^:]+):/, `$1:`);
+
+    /*
+      The `ssh://` prefix should be removed because so URLs won't work in Git:
+        `ssh://git@github.com:yarnpkg/berry.git`.
+      Git only allows: `git@github.com:yarnpkg/berry.git` or
+        `ssh://git@github.com/yarnpkg/berry.git`.
+      But git doesn't allow `git@github.com/yarnpkg/berry.git` so
+      we should cut `ssh://` only in URLs that contain colon after a hostname.
+    */
+    const parsedUrl = urlLib.parse(url);
+    /*
+      For "ssh://git@github.com:yarnpkg/berry.git" the parsedUrl variable will look like:
+      Url {
+        protocol: 'ssh:',
+        slashes: true,
+        auth: 'git',
+        host: 'github.com',
+        port: null,
+        hostname: 'github.com',
+        hash: null,
+        search: null,
+        query: null,
+        pathname: '/:yarnpkg/berry.git',
+        path: '/:yarnpkg/berry.git',
+        href: 'ssh://git@github.com/:yarnpkg/berry.git'
+      }
+    */
+    if (parsedUrl.protocol === `ssh:` && parsedUrl.path?.startsWith(`/:`)) {
+      url = url.replace(/^ssh:\/\//, ``);
+    }
+  }
 
   return url;
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fix resolving dependencies prefixed with git+ssh:// and colon after a hostname:
`git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1`

Closes https://github.com/yarnpkg/berry/issues/1647

**How did you fix it?**

I remove `git+ssh://` prefix for dependencies prefixed with `git+ssh://` and only if they contain colon after a hostname

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
