### PR TITLE
fix(shell): respect left associativity for list operators

### DIFF
--- a/.yarn/versions/f939c5fd.yml
+++ b/.yarn/versions/f939c5fd.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Yarn will now show the actual error when it fails to resolve a request during `yarn add` and `yarn up`
 - The portable shell will now support calling `cd` and `exit` without arguments
 - Yarn will now show the exit code when a lifecycle script fails
+- Yarn's portable shell will now respect the left associativity of list operators
 
 ### CLI
 

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -628,6 +628,31 @@ describe(`Shell`, () => {
     });
   });
 
+  describe(`Lists`, () => {
+    it(`should execute lists with left associativity`, async () => {
+      await expect(bufferResult(
+        `inexistent && echo yes || echo no`,
+      )).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: `no\n`,
+      });
+
+      await expect(bufferResult(
+        `inexistent || echo no && echo yes`,
+      )).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: `no\nyes\n`,
+      });
+
+      await expect(bufferResult(
+        `inexistent && echo yes || inexistent && echo yes || echo no`,
+      )).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: `no\n`,
+      });
+    });
+  });
+
   describe(`Glob support`, () => {
     describe(`Basic Syntax`, () => {
       it(`should support glob patterns with asterisk`, async () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell wasn't respecting the left associativity of list operators, which caused commands like `inexistent && echo yes || echo no` to break the chain and exit with code `127` instead of triggering the next triggerable command in the chain.

Fixes #1694.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've refactored the `executeCommandLine` function and made it loop through the entire chain instead of breaking it too early.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
