### PR TITLE
feat(core): pass options to afterAllInstalled

### DIFF
--- a/.yarn/versions/48a6394e.yml
+++ b/.yarn/versions/48a6394e.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -6,7 +6,7 @@ import {SettingsDefinition, PluginConfiguration, Configuration} from './Configur
 import {Fetcher}                                                from './Fetcher';
 import {Linker}                                                 from './Linker';
 import {MessageName}                                            from './MessageName';
-import {Project}                                                from './Project';
+import {Project, InstallOptions}                                from './Project';
 import {Resolver, ResolveOptions}                               from './Resolver';
 import {Workspace}                                              from './Workspace';
 import {Locator, Descriptor}                                    from './types';
@@ -89,6 +89,7 @@ export type Hooks = {
   // completed.
   afterAllInstalled?: (
     project: Project,
+    options: InstallOptions
   ) => void,
 
   // Called during the `Validation step` of the `install` method from the `Project`

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1560,7 +1560,7 @@ export class Project {
 
     await this.configuration.triggerHook(hooks => {
       return hooks.afterAllInstalled;
-    }, this);
+    }, this, opts);
   }
 
   generateLockfile() {


### PR DESCRIPTION
**What's the problem this PR addresses?**
Currently, [my Nix plugin](https://github.com/stephank/yarn-plugin-nixify) is a separate command `yarn nixify` that generates some files, but ideally it would just keep these up-to-date almost like a lockfile. I want to use `afterAllInstalled` to keep these files up-to-date, but believe I should only do this sort of thing if `persistProject` is set. I currently can't get at that flag from within the hook, it seems.

**How did you fix it?**
I added a second parameter to `afterAllInstalled` with the `InstallOptions`.

~~I'm not sure if just a patch release of core is enough. Nothing inside Yarn itself uses the hook, but I'm not sure if other packages need a release for the release bundle to be updated, eventually.~~

I couldn't finish the test suite locally. I think it's breaking because I have the new git setting `init.defaultBranch` set to `main` instead of `master`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
