### PR TITLE
fix(fslib): Support package.json in Windows drive root directory

### DIFF
--- a/.yarn/versions/b533e31b.yml
+++ b/.yarn/versions/b533e31b.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/fslib": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -34,9 +34,19 @@ export const ppath: PathUtils<PortablePath> = Object.create(path.posix) as any;
 npath.cwd = () => process.cwd();
 ppath.cwd = () => toPortablePath(process.cwd());
 
+const fixWindowsDriveRoot = (p: PortablePath): PortablePath => {
+  if (p.length == 3 && p[2] == `:`)
+    return `${p}/` as PortablePath;
+  return p as PortablePath;
+};
+
+ppath.dirname = (p: PortablePath): PortablePath => {
+  return fixWindowsDriveRoot(path.posix.dirname(p) as PortablePath);
+};
+
 ppath.resolve = (...segments: Array<PortablePath | Filename>) => {
   if (segments.length > 0 && ppath.isAbsolute(segments[0])) {
-    return path.posix.resolve(...segments) as PortablePath;
+    return fixWindowsDriveRoot(path.posix.resolve(...segments) as PortablePath);
   } else {
     return path.posix.resolve(ppath.cwd(), ...segments) as PortablePath;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR resolves https://github.com/yarnpkg/berry/issues/844.

Yarn2 currently cannot work when the package.json is in Windows drive root directory (e.g. u:\). While this sounds an odd case.  It is actually a common trick on windows to substitute a deep directory with a drive letter using:

```
subst u: c:\my\deep\deep\dir
```

The cause of the problem is the code uses posix path functions, which doesn't handle windows drive root directory correctly. On Windows, each drive has a root, e.g. `u:\`. It can not be written as `u:`, this represents for the current working directory of U drive. So it is incorrect for

```javascript
path.posix.resolve('/u:/', '.') 
'/u:' # it needs be fixed as '/u:/'
```

likewise:

```javascript
path.posix.dirname('/u:/packages') 
'/u:' # should also be fixed as '/u:/'
```


**How did you fix it?**

I added a function to post-process '/u:' to '/u:/', it only add trailing slash when the total length is 3 and the last character is '/'.

This function is used in ppath.resolve and ppath.dirname

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
