### PR TITLE
removes nonexistent command reference

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -2,7 +2,6 @@ constraints_min_version(1).
 
 % This file is written in Prolog
 % It contains rules that the project must respect.
-% In order to see them in action, run `yarn constraints detail`
 
 % This rule will enforce that a workspace MUST depend on the same version of a dependency as the one used by the other workspaces
 gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange2, DependencyType) :-

--- a/constraints.pro
+++ b/constraints.pro
@@ -2,6 +2,7 @@ constraints_min_version(1).
 
 % This file is written in Prolog
 % It contains rules that the project must respect.
+% In order to see them in action, run `yarn constraints source`	
 
 % This rule will enforce that a workspace MUST depend on the same version of a dependency as the one used by the other workspaces
 gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange2, DependencyType) :-


### PR DESCRIPTION
**What's the problem this PR addresses?**

`detail` is referenced as a command but does not exist on any direct google search nor documentation.

...

**How did you fix it?**
```diff
  % This file is written in Prolog
  % It contains rules that the project must respect.
- % In order to see them in action, run `yarn constraints detail`
```

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
