### PR TITLE
fix(plugin-constraints): update manifest before persisting

### DIFF
--- a/.yarn/versions/2b28b2f0.yml
+++ b/.yarn/versions/2b28b2f0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch

--- a/.yarn/versions/2b28b2f0.yml
+++ b/.yarn/versions/2b28b2f0.yml
@@ -1,2 +1,30 @@
 releases:
+  "@yarnpkg/core": patch
   "@yarnpkg/plugin-constraints": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -75,6 +75,9 @@ export default class ConstraintsCheckCommand extends BaseCommand {
 
       // save all modified manifests
       await Promise.all([...allSaves].map(async workspace => {
+        // Constraints modify the raw manifest so we need to reload it here
+        // otherwise changes are not persisted
+        workspace.manifest.load(workspace.manifest.raw);
         await workspace.persistManifest();
       }));
 

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -601,12 +601,12 @@ export class Manifest {
     if (this.os !== null)
       data.os = this.os;
     else
-      delete this.os;
+      delete data.os;
 
     if (this.cpu !== null)
       data.cpu = this.cpu;
     else
-      delete this.cpu;
+      delete data.cpu;
 
     if (this.type !== null)
       data.type = this.type;


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn constraints --fix` doesn't persist changes when modifying manifest fields that are parsed by `Manifest.load`
https://github.com/yarnpkg/berry/blob/9a1ec1ab8d670f5913a3b91fc51c3af3ac0e981a/packages/yarnpkg-core/sources/Manifest.ts#L41-L74

The reason for this is that the fixes are applied to `Manifest.raw` but `Manifest.exportTo` overwrites the raw data with the parsed data so the changes are lost.

**How did you fix it?**

Reload the manifest from `manifest.raw` before persisting.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
