### PR TITLE
Prevents telemetry from crashing on low access perms

### DIFF
--- a/.yarn/versions/52a1a172.yml
+++ b/.yarn/versions/52a1a172.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/TelemetryManager.ts
+++ b/packages/yarnpkg-core/sources/TelemetryManager.ts
@@ -117,10 +117,13 @@ export class TelemetryManager {
     if (nextUpdate > now && content.lastUpdate != null)
       return;
 
-    xfs.mkdirSync(ppath.dirname(registryFile), {recursive: true});
-    xfs.writeJsonSync(registryFile, {
-      lastUpdate: now,
-    });
+    try {
+      xfs.mkdirSync(ppath.dirname(registryFile), {recursive: true});
+      xfs.writeJsonSync(registryFile, {lastUpdate: now});
+    } catch {
+      // In some cases this location is read-only. Too bad 🤷‍♀️
+      return;
+    }
 
     if (nextUpdate > now)
       return;


### PR DESCRIPTION
**What's the problem this PR addresses?**

There's one telemetry-related codepath that isn't properly wrapped inside a try/catch and may cause commands to fail when the `.yarn` folder is read-only. Since telemetry isn't a critical component, it shouldn't affect the experience in any way.

**How did you fix it?**

Write the file access inside a try/catch and ignore any error within it.

Fixes #1780 1780

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
