### PR TITLE
fix(libzip): return libzip from getLibzipPromise in browser version

### DIFF
--- a/.yarn/versions/082ad24b.yml
+++ b/.yarn/versions/082ad24b.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/core": patch
+  "@yarnpkg/fslib": patch
+  "@yarnpkg/libzip": patch
+
+declined:
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-libzip/sources/async.ts
+++ b/packages/yarnpkg-libzip/sources/async.ts
@@ -14,6 +14,8 @@ export async function getLibzipPromise() {
       });
     });
   }
+
+  return promise;
 }
 
 export type {Libzip} from './makeInterface';


### PR DESCRIPTION
**What's the problem this PR addresses?**

The browser version of `getLibzipPromise` isn't returning anything

**How did you fix it?**

Add a missing return statement

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
