### PR TITLE
Fixes the shell default variables

### DIFF
--- a/.yarn/versions/4654c182.yml
+++ b/.yarn/versions/4654c182.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "test:lint": "eslint --max-warnings 0 \"packages/**/@(sources|tests)/**/!(libzip).@(tsx|ts|js)\"",
     "test:unit": "jest",
     "sleep": "node ./x",
-    "typecheck:all": "tsc --noEmit"
+      "typecheck:all": "tsc --noEmit",
+      "foo": "echo ${1:-x}"
   },
   "sherlock": {
     "requireList": [

--- a/package.json
+++ b/package.json
@@ -76,9 +76,7 @@
     "build:compile-inline": "find \"$0\"/sources -name '*.js' && babel \"$0\"/sources --out-dir \"$0\"/sources --extensions .ts,.tsx",
     "test:lint": "eslint --max-warnings 0 \"packages/**/@(sources|tests)/**/!(libzip).@(tsx|ts|js)\"",
     "test:unit": "jest",
-    "sleep": "node ./x",
-      "typecheck:all": "tsc --noEmit",
-      "foo": "echo ${1:-x}"
+    "typecheck:all": "tsc --noEmit"
   },
   "sherlock": {
     "requireList": [

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -274,10 +274,12 @@ async function evaluateVariable(segment: ArgumentSegment & {type: `variable`}, o
       const argIndex = parseInt(segment.name, 10);
 
       if (Number.isFinite(argIndex)) {
-        if (!(argIndex >= 0 && argIndex < opts.args.length)) {
-          throw new Error(`Unbound argument #${argIndex}`);
-        } else {
+        if (argIndex >= 0 && argIndex < opts.args.length) {
           push(opts.args[argIndex]);
+        } else if (segment.defaultValue) {
+          push((await interpolateArguments(segment.defaultValue, opts, state)).join(` `));
+        } else {
+          throw new Error(`Unbound argument #${argIndex}`);
         }
       } else {
         if (Object.prototype.hasOwnProperty.call(state.variables, segment.name)) {

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -425,9 +425,18 @@ describe(`Shell`, () => {
       });
     });
 
-    it(`should support default arguments via \${...:-...}`, async () => {
+    it(`should support default arguments via \${ARG:-...}`, async () => {
       await expect(bufferResult(
         `echo "\${DOESNT_EXIST:-hello world}"`,
+      )).resolves.toMatchObject({
+        stdout: `hello world\n`,
+      });
+    });
+
+    it(`should support default arguments via \${N:-...}`, async () => {
+      await expect(bufferResult(
+        `echo "\${1:-hello world}"`,
+        [],
       )).resolves.toMatchObject({
         stdout: `hello world\n`,
       });


### PR DESCRIPTION
**What's the problem this PR addresses?**

We support default variables, but only on the named variables codepath - not on positional variables (`$1` etc).

**How did you fix it?**

Added support for default variables to both codepaths.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
