### PR TITLE
fix(shell): fix glob support

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -10132,12 +10132,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/shell", "workspace:packages/yarnpkg-shell"],
             ["@types/cross-spawn", "npm:6.0.0"],
+            ["@types/micromatch", "npm:4.0.1"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/monorepo", "workspace:."],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
             ["clipanion", "npm:2.4.4"],
             ["cross-spawn", "npm:7.0.3"],
             ["fast-glob", "npm:3.2.2"],
+            ["micromatch", "npm:4.0.2"],
             ["stream-buffers", "npm:3.0.2"],
             ["tslib", "npm:1.13.0"]
           ],

--- a/.yarn/versions/0f798784.yml
+++ b/.yarn/versions/0f798784.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/core": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -10,11 +10,13 @@
     "clipanion": "^2.4.4",
     "cross-spawn": "7.0.3",
     "fast-glob": "^3.2.2",
+    "micromatch": "^4.0.2",
     "stream-buffers": "^3.0.2",
     "tslib": "^1.13.0"
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.0",
+    "@types/micromatch": "^4.0.1",
     "@yarnpkg/monorepo": "workspace:0.0.0"
   },
   "scripts": {

--- a/packages/yarnpkg-shell/sources/globUtils.ts
+++ b/packages/yarnpkg-shell/sources/globUtils.ts
@@ -1,0 +1,47 @@
+import {PortablePath, FakeFS, NodeFS, npath, PosixFS} from '@yarnpkg/fslib';
+import fastGlob                                       from 'fast-glob';
+import micromatch                                     from 'micromatch';
+
+export type Glob = {
+  isGlobPattern: (pattern: string) => boolean,
+  match: (pattern: string, options: {cwd: PortablePath, fs?: FakeFS<PortablePath>}) => Promise<Array<string>>,
+};
+
+export const micromatchOptions: micromatch.Options = {
+  // This is required because we don't want ")/*" to be a valid shell glob pattern.
+  strictBrackets: true,
+};
+
+export const fastGlobOptions: fastGlob.Options = {
+  onlyDirectories: false,
+  onlyFiles: false,
+};
+
+/**
+ * Decides whether a string is a glob pattern, using micromatch.
+ *
+ * Required because `fastGlob.isDynamicPattern` doesn't have the `strictBrackets` option.
+ */
+export function isGlobPattern(pattern: string) {
+  // The scanner extracts globs from a pattern, but doesn't throw errors
+  if (!micromatch.scan(pattern, micromatchOptions).isGlob)
+    return false;
+
+  // The parser is the one that throws errors
+  try {
+    micromatch.parse(pattern, micromatchOptions);
+  } catch {
+    return false;
+  }
+
+  return true;
+}
+
+export function match(pattern: string, {cwd, fs = new NodeFS()}: {cwd: PortablePath, fs?: FakeFS<PortablePath>}) {
+  return fastGlob(pattern, {
+    ...fastGlobOptions,
+    cwd: npath.fromPortablePath(cwd),
+    // @ts-expect-error: `fs` is wrapped in `PosixFS`
+    fs: new PosixFS(fs),
+  });
+}

--- a/packages/yarnpkg-shell/sources/globUtils.ts
+++ b/packages/yarnpkg-shell/sources/globUtils.ts
@@ -1,10 +1,11 @@
-import {PortablePath, FakeFS, NodeFS, npath, PosixFS} from '@yarnpkg/fslib';
-import fastGlob                                       from 'fast-glob';
-import micromatch                                     from 'micromatch';
+import {PortablePath, FakeFS, npath, PosixFS, extendFs} from '@yarnpkg/fslib';
+import fastGlob                                         from 'fast-glob';
+import fs                                               from 'fs';
+import micromatch                                       from 'micromatch';
 
 export type Glob = {
   isGlobPattern: (pattern: string) => boolean,
-  match: (pattern: string, options: {cwd: PortablePath, fs?: FakeFS<PortablePath>}) => Promise<Array<string>>,
+  match: (pattern: string, options: {cwd: PortablePath, baseFs: FakeFS<PortablePath>}) => Promise<Array<string>>,
 };
 
 export const micromatchOptions: micromatch.Options = {
@@ -37,11 +38,10 @@ export function isGlobPattern(pattern: string) {
   return true;
 }
 
-export function match(pattern: string, {cwd, fs = new NodeFS()}: {cwd: PortablePath, fs?: FakeFS<PortablePath>}) {
+export function match(pattern: string, {cwd, baseFs}: {cwd: PortablePath, baseFs: FakeFS<PortablePath>}) {
   return fastGlob(pattern, {
     ...fastGlobOptions,
     cwd: npath.fromPortablePath(cwd),
-    // @ts-expect-error: `fs` is wrapped in `PosixFS`
-    fs: new PosixFS(fs),
+    fs: extendFs(fs, new PosixFS(baseFs)),
   });
 }

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -11,6 +11,8 @@ import {makeBuiltin, makeProcess}                                               
 
 export {globUtils};
 
+export type Glob = globUtils.Glob;
+
 export type UserOptions = {
   baseFs: FakeFS<PortablePath>,
   builtins: {[key: string]: ShellBuiltin},

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -1153,6 +1153,54 @@ describe(`Shell`, () => {
         });
       });
     });
+
+    describe(`Integrations`, () => {
+      it(`should work with environment variables`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const subdir = ppath.join(tmpDir, `subdir` as Filename);
+          await xfs.mkdirPromise(subdir);
+
+          await xfs.writeFilePromise(ppath.join(subdir, `a.txt` as Filename), ``);
+          await xfs.writeFilePromise(ppath.join(subdir, `b.txt` as Filename), ``);
+          await xfs.writeFilePromise(ppath.join(subdir, `c.txt` as Filename), ``);
+
+          await expect(bufferResult(
+            `echo $DIRNAME/*`,
+            [],
+            {cwd: tmpDir, env: {DIRNAME: `subdir`}}
+          )).resolves.toMatchObject({
+            stdout: `subdir/a.txt subdir/b.txt subdir/c.txt\n`,
+          });
+
+          await expect(bufferResult(
+            `echo \${DIRNAME}/*`,
+            [],
+            {cwd: tmpDir, env: {DIRNAME: `subdir`}}
+          )).resolves.toMatchObject({
+            stdout: `subdir/a.txt subdir/b.txt subdir/c.txt\n`,
+          });
+        });
+      });
+
+      it(`should work with arithmetics`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const subdir = ppath.join(tmpDir, `1234` as Filename);
+          await xfs.mkdirPromise(subdir);
+
+          await xfs.writeFilePromise(ppath.join(subdir, `a.txt` as Filename), ``);
+          await xfs.writeFilePromise(ppath.join(subdir, `b.txt` as Filename), ``);
+          await xfs.writeFilePromise(ppath.join(subdir, `c.txt` as Filename), ``);
+
+          await expect(bufferResult(
+            `echo $(( 1000 + 234 ))/*`,
+            [],
+            {cwd: tmpDir}
+          )).resolves.toMatchObject({
+            stdout: `1234/a.txt 1234/b.txt 1234/c.txt\n`,
+          });
+        });
+      });
+    });
   });
 
   describe(`Calculations`, () => {

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -750,405 +750,423 @@ describe(`Shell`, () => {
   });
 
   describe(`Glob support`, () => {
-    describe(`Basic Syntax`, () => {
-      it(`should support glob patterns with asterisk`, async () => {
+    describe(`Syntax`, () => {
+      describe(`Basic Syntax`, () => {
+        it(`should support glob patterns with asterisk`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `b.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `c.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo *`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a.txt b.txt c.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo *.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a.txt b.txt c.txt\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with globstar`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.mkdirpPromise(ppath.join(tmpDir, `foo/bar` as PortablePath));
+
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo/b.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo/bar/c.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo **`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a.txt foo foo/b.txt foo/bar foo/bar/c.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo **/*.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a.txt foo/b.txt foo/bar/c.txt\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with question mark`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `ax.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `axxa.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a.txtx` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo a?.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `ax.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo a??a.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `axxa.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo a.txt?`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a.txtx\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with sequence`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a1.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a2.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a3.txt` as Filename), ``);
+
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.js` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.ts` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.cs` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo a[23].txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a2.txt a3.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo foo.[jt]s`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `foo.js foo.ts\n`,
+            });
+
+            await expect(bufferResult(
+              `echo foo.[!jt]s`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `foo.cs\n`,
+            });
+
+            await expect(bufferResult(
+              `echo foo.[^jt]s`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `foo.cs\n`,
+            });
+          });
+        });
+
+        // This test worked before, but it worked by mistake. Even though escape
+        // characters were used, the arguments were still interpreted as glob patterns.
+        // The actual problem is that our shell doesn't support escaping correctly.
+
+        //   it(`should support glob patterns with escape characters`, async () => {
+        //     await xfs.mktempPromise(async tmpDir => {
+        //       await expect(bufferResult(
+        //         `echo a\\*b.txt`,
+        //         [],
+        //         {cwd: tmpDir}
+        //       )).resolves.toMatchObject({
+        //         stdout: `a*b.txt\n`,
+        //       });
+
+        //       await expect(bufferResult(
+        //         `echo a\\?b.txt`,
+        //         [],
+        //         {cwd: tmpDir}
+        //       )).resolves.toMatchObject({
+        //         stdout: `a?b.txt\n`,
+        //       });
+
+        //       await expect(bufferResult(
+        //         `echo a\\{c,d}b.txt`,
+        //         [],
+        //         {cwd: tmpDir}
+        //       )).resolves.toMatchObject({
+        //         stdout: `a{c,d}b.txt\n`,
+        //       });
+        //     });
+        //   });
+      });
+
+      describe(`Advanced Syntax`, () => {
+        it(`should support glob patterns with posix character classes`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `abc.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `123.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo123.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `BAR.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `hello_world123.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `&434)hello.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `😀.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo +([[:alnum:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `123.txt BAR.txt abc.txt foo.txt foo123.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:alpha:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `BAR.txt abc.txt foo.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:ascii:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `&434)hello.txt 123.txt BAR.txt abc.txt foo.txt foo123.txt hello_world123.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:digit:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `123.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:lower:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `abc.txt foo.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:upper:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `BAR.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:word:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `123.txt BAR.txt abc.txt foo.txt foo123.txt hello_world123.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([[:xdigit:]]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `123.txt abc.txt\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with extglobs`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `f.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fo.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fooo.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo f@(o).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `fo.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo f*(o).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `f.txt fo.txt foo.txt fooo.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo f+(o).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `fo.txt foo.txt fooo.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo f?(o).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `f.txt fo.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo f!(o).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `f.txt\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with braces`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `b.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `c.txt` as Filename), ``);
+
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.js` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.ts` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foo.vue` as Filename), ``);
+
+            await xfs.writeFilePromise(ppath.join(tmpDir, `cbaxbc.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `cbstbc.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `ftaxwy.txt` as Filename), ``);
+
+            await xfs.writeFilePromise(ppath.join(tmpDir, `abc.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `acd.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `ade.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `aef.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo {a,b}.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `a.txt b.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo {cb,ft}{ax,st}{bc,wy}.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `cbaxbc.txt cbstbc.txt ftaxwy.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo a{bc,{cd,{de,ef}}}.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `abc.txt acd.txt ade.txt aef.txt\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with regexp character classes`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `abcd.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `abcdxyz.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `12345.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `0123456789.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `abcdxyz0123456789.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo +([a-d]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `abcd.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([1-5]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `12345.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo +([a-d])+([x-z])+([0-9]).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `abcdxyz0123456789.txt\n`,
+            });
+          });
+        });
+
+        it(`should support glob patterns with regexp groups`, async () => {
+          await xfs.mktempPromise(async tmpDir => {
+            await xfs.writeFilePromise(ppath.join(tmpDir, `ab12.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `pq56.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `xy89.txt` as Filename), ``);
+
+            await xfs.writeFilePromise(ppath.join(tmpDir, `foox1.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fooxa1.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fooxb1.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fooy1.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fooya1.txt` as Filename), ``);
+            await xfs.writeFilePromise(ppath.join(tmpDir, `fooyb1.txt` as Filename), ``);
+
+            await expect(bufferResult(
+              `echo (ab|xy)(12|89).txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `ab12.txt xy89.txt\n`,
+            });
+
+            await expect(bufferResult(
+              `echo foo(x!(a)|y!(b))1.txt`,
+              [],
+              {cwd: tmpDir}
+            )).resolves.toMatchObject({
+              stdout: `foox1.txt fooxb1.txt fooy1.txt fooya1.txt\n`,
+            });
+          });
+        });
+      });
+    });
+
+    describe(`Functionality`, () => {
+      it(`should include directories`, async () => {
         await xfs.mktempPromise(async tmpDir => {
           await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
           await xfs.writeFilePromise(ppath.join(tmpDir, `b.txt` as Filename), ``);
           await xfs.writeFilePromise(ppath.join(tmpDir, `c.txt` as Filename), ``);
+
+          await xfs.mkdirPromise(ppath.join(tmpDir, `d` as Filename));
+          await xfs.mkdirPromise(ppath.join(tmpDir, `e` as Filename));
 
           await expect(bufferResult(
             `echo *`,
             [],
             {cwd: tmpDir}
           )).resolves.toMatchObject({
-            stdout: `a.txt b.txt c.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo *.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a.txt b.txt c.txt\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with globstar`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.mkdirpPromise(ppath.join(tmpDir, `foo/bar` as PortablePath));
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo/b.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo/bar/c.txt` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo **`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a.txt foo/b.txt foo/bar/c.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo **/*.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a.txt foo/b.txt foo/bar/c.txt\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with question mark`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `ax.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `axxa.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a.txtx` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo a?.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `ax.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo a??a.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `axxa.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo a.txt?`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a.txtx\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with sequence`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a1.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a2.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a3.txt` as Filename), ``);
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.js` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.ts` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.cs` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo a[23].txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a2.txt a3.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo foo.[jt]s`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `foo.js foo.ts\n`,
-          });
-
-          await expect(bufferResult(
-            `echo foo.[!jt]s`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `foo.cs\n`,
-          });
-
-          await expect(bufferResult(
-            `echo foo.[^jt]s`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `foo.cs\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with escape characters`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          if (isNotWin32) {
-            await xfs.writeFilePromise(ppath.join(tmpDir, `a*b.txt` as Filename), ``);
-            await xfs.writeFilePromise(ppath.join(tmpDir, `a?b.txt` as Filename), ``);
-          }
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a{c,d}b.txt` as Filename), ``);
-
-          if (isNotWin32) {
-            await expect(bufferResult(
-              `echo a\\*b.txt`,
-              [],
-              {cwd: tmpDir}
-            )).resolves.toMatchObject({
-              stdout: `a*b.txt\n`,
-            });
-
-            await expect(bufferResult(
-              `echo a\\?b.txt`,
-              [],
-              {cwd: tmpDir}
-            )).resolves.toMatchObject({
-              stdout: `a?b.txt\n`,
-            });
-          }
-
-          await expect(bufferResult(
-            `echo a\\{c,d}b.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a{c,d}b.txt\n`,
-          });
-        });
-      });
-    });
-
-    describe(`Advanced Syntax`, () => {
-      it(`should support glob patterns with posix character classes`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `abc.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `123.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo123.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `BAR.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `hello_world123.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `&434)hello.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `😀.txt` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo +([[:alnum:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `123.txt BAR.txt abc.txt foo.txt foo123.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:alpha:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `BAR.txt abc.txt foo.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:ascii:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `&434)hello.txt 123.txt BAR.txt abc.txt foo.txt foo123.txt hello_world123.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:digit:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `123.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:lower:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `abc.txt foo.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:upper:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `BAR.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:word:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `123.txt BAR.txt abc.txt foo.txt foo123.txt hello_world123.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([[:xdigit:]]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `123.txt abc.txt\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with extglobs`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `f.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fo.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fooo.txt` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo f@(o).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `fo.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo f*(o).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `f.txt fo.txt foo.txt fooo.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo f+(o).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `fo.txt foo.txt fooo.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo f?(o).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `f.txt fo.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo f!(o).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `f.txt\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with braces`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `a.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `b.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `c.txt` as Filename), ``);
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.js` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.ts` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foo.vue` as Filename), ``);
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `cbaxbc.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `cbstbc.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `ftaxwy.txt` as Filename), ``);
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `abc.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `acd.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `ade.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `aef.txt` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo {a,b}.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `a.txt b.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo {cb,ft}{ax,st}{bc,wy}.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `cbaxbc.txt cbstbc.txt ftaxwy.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo a{bc,{cd,{de,ef}}}.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `abc.txt acd.txt ade.txt aef.txt\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with regexp character classes`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `abcd.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `abcdxyz.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `12345.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `0123456789.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `abcdxyz0123456789.txt` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo +([a-d]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `abcd.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([1-5]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `12345.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo +([a-d])+([x-z])+([0-9]).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `abcdxyz0123456789.txt\n`,
-          });
-        });
-      });
-
-      it(`should support glob patterns with regexp groups`, async () => {
-        await xfs.mktempPromise(async tmpDir => {
-          await xfs.writeFilePromise(ppath.join(tmpDir, `ab12.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `pq56.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `xy89.txt` as Filename), ``);
-
-          await xfs.writeFilePromise(ppath.join(tmpDir, `foox1.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fooxa1.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fooxb1.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fooy1.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fooya1.txt` as Filename), ``);
-          await xfs.writeFilePromise(ppath.join(tmpDir, `fooyb1.txt` as Filename), ``);
-
-          await expect(bufferResult(
-            `echo (ab|xy)(12|89).txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `ab12.txt xy89.txt\n`,
-          });
-
-          await expect(bufferResult(
-            `echo foo(x!(a)|y!(b))1.txt`,
-            [],
-            {cwd: tmpDir}
-          )).resolves.toMatchObject({
-            stdout: `foox1.txt fooxb1.txt fooy1.txt fooya1.txt\n`,
+            stdout: `a.txt b.txt c.txt d e\n`,
           });
         });
       });
@@ -1174,6 +1192,25 @@ describe(`Shell`, () => {
 
           await expect(bufferResult(
             `echo \${DIRNAME}/*`,
+            [],
+            {cwd: tmpDir, env: {DIRNAME: `subdir`}}
+          )).resolves.toMatchObject({
+            stdout: `subdir/a.txt subdir/b.txt subdir/c.txt\n`,
+          });
+        });
+      });
+
+      it(`should work with subshells`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const subdir = ppath.join(tmpDir, `subdir` as Filename);
+          await xfs.mkdirPromise(subdir);
+
+          await xfs.writeFilePromise(ppath.join(subdir, `a.txt` as Filename), ``);
+          await xfs.writeFilePromise(ppath.join(subdir, `b.txt` as Filename), ``);
+          await xfs.writeFilePromise(ppath.join(subdir, `c.txt` as Filename), ``);
+
+          await expect(bufferResult(
+            `echo $(echo subdir)/*`,
             [],
             {cwd: tmpDir, env: {DIRNAME: `subdir`}}
           )).resolves.toMatchObject({

--- a/yarn.lock
+++ b/yarn.lock
@@ -6130,12 +6130,14 @@ __metadata:
   resolution: "@yarnpkg/shell@workspace:packages/yarnpkg-shell"
   dependencies:
     "@types/cross-spawn": 6.0.0
+    "@types/micromatch": ^4.0.1
     "@yarnpkg/fslib": "workspace:^2.2.1"
     "@yarnpkg/monorepo": "workspace:0.0.0"
     "@yarnpkg/parsers": "workspace:^2.2.0"
     clipanion: ^2.4.4
     cross-spawn: 7.0.3
     fast-glob: ^3.2.2
+    micromatch: ^4.0.2
     stream-buffers: ^3.0.2
     tslib: ^1.13.0
   bin:


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Arguments containing glob patterns weren't correctly interpolated because we were resolving each glob segment individually, instead of resolving the entire interpolated argument.

This meant that `echo $DIR/*` didn't work (I mean, ~~it worked because `*` matched `$DIR` instead of matching its contents, but that was incorrect~~ Edit: Actually it didn't, because `onlyFiles` was set to true.).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've fixed this by resolving the entire interpolated argument. Glob patterns can currently be interpolated with variables and arithmetics, ~~but not with subshells because of a bug in the parser that causes `)/*` to be considered a valid glob pattern (well, it is a valid glob pattern in general, but not inside the shell). I'm not sure how this could be solved, other than rewriting our glob support from scratch inside the parser. 🤔~~ I've since managed to fix this with some micromatch magic.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
