### PR TITLE
Fixes support for the browser field

### DIFF
--- a/.yarn/versions/399a3585.yml
+++ b/.yarn/versions/399a3585.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -96,6 +96,32 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should support when the "browser" field is an object`,
+      makeTemporaryEnv({
+        browser: {
+          [`ok1.js`]: false,
+          [`ok2.js`]: `ok3.js`,
+        },
+        files: [
+          `/bad`,
+        ],
+      }, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/ok1.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ok2.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ok3.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/ko.js`, `module.exports = 42;\n`);
+
+        await run(`install`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        expect(stdout).toMatch(/ok1\.js/);
+        expect(stdout).toMatch(/ok2\.js/);
+        expect(stdout).toMatch(/ok3\.js/);
+        expect(stdout).not.toMatch(/ko\.js/);
+      }),
+    );
+
+    test(
       `it should always include the binary files, even with a "files" field`,
       makeTemporaryEnv({
         bin: {

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -207,10 +207,19 @@ export async function genPackList(workspace: Workspace) {
     ignoreList.accept.push(ppath.resolve(PortablePath.root, main));
   if (module != null)
     ignoreList.accept.push(ppath.resolve(PortablePath.root, module));
-  if (browser != null)
+  if (typeof browser === `string`)
     ignoreList.accept.push(ppath.resolve(PortablePath.root, browser));
   for (const path of bins.values())
     ignoreList.accept.push(ppath.resolve(PortablePath.root, path));
+
+  if (browser instanceof Map) {
+    for (const [original, replacement] of browser.entries()) {
+      ignoreList.accept.push(ppath.resolve(PortablePath.root, original));
+      if (typeof replacement === `string`) {
+        ignoreList.accept.push(ppath.resolve(PortablePath.root, replacement));
+      }
+    }
+  }
 
   const hasExplicitFileList = workspace.manifest.files !== null;
   if (hasExplicitFileList) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

We didn't properly account for the `browser` field when it's a map.

Fixes #1794

**How did you fix it?**

Adds support for the map. The code is also more defensive now.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
