### PR TITLE
fix(pnpify): prefix zip protocol with a caret for VSCode 1.48

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -35,11 +35,13 @@ const moduleWrapper = tsserver => {
 
   function addZipPrefix(str) {
     // We add the `zip:` prefix to both `.zip/` paths and virtual paths
-    if (isAbsolute(str) && !str.match(/^zip:/) && (str.match(/\.zip\//) || str.match(/\$\$virtual\//))) {
+    if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || str.match(/\$\$virtual\//))) {
       // Absolute VSCode `Uri.fsPath`s need to start with a slash.
       // VSCode only adds it automatically for supported schemes,
       // so we have to do it manually for the `zip` scheme.
-      return `zip:${str.replace(/^\/?/, `/`)}`;
+      // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
+      // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
+      return `^zip:${str.replace(/^\/?/, `/`)}`;
     } else {
       return str;
     }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -49,8 +49,8 @@ const moduleWrapper = tsserver => {
 
   function removeZipPrefix(str) {
     return process.platform === 'win32'
-      ? str.replace(/^zip:\//, ``)
-      : str.replace(/^zip:/, ``);
+      ? str.replace(/^\^?zip:\//, ``)
+      : str.replace(/^\^?zip:/, ``);
   }
 };
 

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -18,10 +18,22 @@ const moduleWrapper = tsserver => {
 
   const Session = tsserver.server.Session;
   const {onMessage: originalOnMessage, send: originalSend} = Session.prototype;
+  let isVSCode = false;
 
   return Object.assign(Session.prototype, {
     onMessage(/** @type {string} */ message) {
-      return originalOnMessage.call(this, JSON.stringify(JSON.parse(message), (key, value) => {
+      const parsedMessage = JSON.parse(message)
+
+      if (
+        parsedMessage != null &&
+        typeof parsedMessage === 'object' &&
+        parsedMessage.arguments &&
+        parsedMessage.arguments.hostInfo === 'vscode'
+      ) {
+        isVSCode = true;
+      }
+
+      return originalOnMessage.call(this, JSON.stringify(parsedMessage, (key, value) => {
         return typeof value === 'string' ? removeZipPrefix(value) : value;
       }));
     },
@@ -41,7 +53,7 @@ const moduleWrapper = tsserver => {
       // so we have to do it manually for the `zip` scheme.
       // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
       // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
-      return `^zip:${str.replace(/^\/?/, `/`)}`;
+      return `${isVSCode ? '^' : ''}zip:${str.replace(/^\/?/, `/`)}`;
     } else {
       return str;
     }

--- a/.yarn/versions/e1155f85.yml
+++ b/.yarn/versions/e1155f85.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -62,11 +62,13 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
       function addZipPrefix(str) {
         // We add the \`zip:\` prefix to both \`.zip/\` paths and virtual paths
-        if (isAbsolute(str) && !str.match(/^zip:/) && (str.match(/\\.zip\\//) || str.match(/\\$\\$virtual\\//))) {
+        if (isAbsolute(str) && !str.match(/^\\^zip:/) && (str.match(/\\.zip\\//) || str.match(/\\$\\$virtual\\//))) {
           // Absolute VSCode \`Uri.fsPath\`s need to start with a slash.
           // VSCode only adds it automatically for supported schemes,
           // so we have to do it manually for the \`zip\` scheme.
-          return \`zip:\${str.replace(/^\\/?/, \`/\`)}\`;
+          // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
+          // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
+          return \`^zip:\${str.replace(/^\\/?/, \`/\`)}\`;
         } else {
           return str;
         }

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -76,8 +76,8 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
       function removeZipPrefix(str) {
         return process.platform === 'win32'
-          ? str.replace(/^zip:\\//, \`\`)
-          : str.replace(/^zip:/, \`\`);
+          ? str.replace(/^\\^?zip:\\//, \`\`)
+          : str.replace(/^\\^?zip:/, \`\`);
       }
     };
   `;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The typescript SDK stopped working due to changes in VSCode 1.48, see https://github.com/microsoft/vscode/issues/105014 for more

Fixes https://github.com/yarnpkg/berry/issues/1758
Fixes https://github.com/yarnpkg/berry/issues/1791
Fixes https://github.com/microsoft/vscode/issues/105014

**How did you fix it?**

Prefix the scheme with a caret

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.