### PR TITLE
fix: don't report 403 as invalid authentication

### DIFF
--- a/.yarn/versions/9df8808e.yml
+++ b/.yarn/versions/9df8808e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -27,6 +27,18 @@ type RegistryOptions = {
 
 export type Options = httpUtils.Options & AuthOptions & RegistryOptions;
 
+/**
+ * Consumes all 401 Unauthorized errors and reports them as `AUTHENTICATION_INVALID`.
+ *
+ * It doesn't handle 403 Forbidden, as the npm registry uses it when the user attempts
+ * a prohibited action, such as publishing a package with a similar name to an existing package.
+ */
+export async function handleInvalidAuthenticationError(error: any, {registry, headers, configuration}: {registry: string, headers: {[key: string]: string} | undefined, configuration: Configuration}) {
+  if (error.name === `HTTPError` && error.response.statusCode === 401) {
+    throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (as ${await whoami(registry, headers, {configuration})})`);
+  }
+}
+
 export function getIdentUrl(ident: Ident) {
   if (ident.scope) {
     return `/@${ident.scope}%2f${ident.name}`;
@@ -58,11 +70,9 @@ export async function get(path: string, {configuration, headers, ident, authType
   try {
     return await httpUtils.get(url.href, {configuration, headers, ...rest});
   } catch (error) {
-    if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-      throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (as ${await whoami(registry, headers, {configuration})})`);
-    } else {
-      throw error;
-    }
+    await handleInvalidAuthenticationError(error, {registry, configuration, headers});
+
+    throw error;
   }
 }
 
@@ -81,11 +91,9 @@ export async function put(path: string, body: httpUtils.Body, {attemptedAs, conf
     return await httpUtils.put(registry + path, body, {configuration, headers, ...rest});
   } catch (error) {
     if (!isOtpError(error)) {
-      if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-        throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headers, {configuration})}` : `attempted as ${attemptedAs}`})`);
-      } else {
-        throw error;
-      }
+      await handleInvalidAuthenticationError(error, {registry, configuration, headers});
+
+      throw error;
     }
 
     const otp = await askForOtp();
@@ -95,11 +103,9 @@ export async function put(path: string, body: httpUtils.Body, {attemptedAs, conf
     try {
       return await httpUtils.put(`${registry}${path}`, body, {configuration, headers: headersWithOtp, ...rest});
     } catch (error) {
-      if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-        throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headersWithOtp, {configuration})}` : `attempted as ${attemptedAs}`})`);
-      } else {
-        throw error;
-      }
+      await handleInvalidAuthenticationError(error, {registry, configuration, headers});
+
+      throw error;
     }
   }
 }
@@ -119,11 +125,9 @@ export async function del(path: string, {attemptedAs, configuration, headers, id
     return await httpUtils.del(registry + path, {configuration, headers, ...rest});
   } catch (error) {
     if (!isOtpError(error)) {
-      if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-        throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headers, {configuration})}` : `attempted as ${attemptedAs}`})`);
-      } else {
-        throw error;
-      }
+      await handleInvalidAuthenticationError(error, {registry, configuration, headers});
+
+      throw error;
     }
 
     const otp = await askForOtp();
@@ -133,11 +137,9 @@ export async function del(path: string, {attemptedAs, configuration, headers, id
     try {
       return await httpUtils.del(`${registry}${path}`, {configuration, headers: headersWithOtp, ...rest});
     } catch (error) {
-      if (error.name === `HTTPError` && (error.response.statusCode === 401 || error.response.statusCode === 403)) {
-        throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headersWithOtp, {configuration})}` : `attempted as ${attemptedAs}`})`);
-      } else {
-        throw error;
-      }
+      await handleInvalidAuthenticationError(error, {registry, configuration, headers});
+
+      throw error;
     }
   }
 }

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -186,9 +186,10 @@ async function whoami(registry: string, headers: {[key: string]: string} | undef
     const response = await httpUtils.get(new URL(`${registry}/-/whoami`).href, {
       configuration,
       headers,
+      jsonResponse: true,
     });
 
-    return response.username;
+    return response.username ?? `an unknown user`;
   } catch {
     return `an unknown user`;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR fixes 2 issues:
1) When reporting invalid authentication errors, the `as` part reported `as undefined` because the response wasn't JSON.
2) 403 Forbidden was treated as invalid authentication, even though the npm registry uses it for prohibited actions, such as publishing a package with a name too similar to an exisiting package.

This PR helps people experiencing #1641 see what the actual cause is. (I'll only close that issue once it's confirmed that the remaining problems aren't on our side).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

1) The whoami response is now JSON.
2) 403 isn't treated as invalid authentication anymore, which will make Yarn show the actual error message.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
