### PR TITLE
fix(cli): avoid unnecessary spawn when run directly

### DIFF
--- a/.yarn/versions/dfb7d015.yml
+++ b/.yarn/versions/dfb7d015.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -77,7 +77,14 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     const ignorePath = configuration.get(`ignorePath`);
     const ignoreCwd = configuration.get(`ignoreCwd`);
 
-    if (yarnPath !== null && !ignorePath) {
+    // Avoid unnecessary spawn when run directly
+    if (!ignorePath && !ignoreCwd && yarnPath === npath.toPortablePath(process.argv[1])) {
+      process.env.YARN_IGNORE_PATH = `1`;
+      process.env.YARN_IGNORE_CWD = `1`;
+
+      await exec(cli);
+      return;
+    } else if (yarnPath !== null && !ignorePath) {
       if (!xfs.existsSync(yarnPath)) {
         process.stdout.write(cli.error(new Error(`The "yarn-path" option has been set (in ${configuration.sources.get(`yarnPath`)}), but the specified location doesn't exist (${yarnPath}).`)));
         process.exitCode = 1;

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -78,7 +78,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     const ignoreCwd = configuration.get(`ignoreCwd`);
 
     // Avoid unnecessary spawn when run directly
-    if (!ignorePath && !ignoreCwd && yarnPath === npath.toPortablePath(process.argv[1])) {
+    if (!ignorePath && !ignoreCwd && yarnPath === npath.toPortablePath(npath.resolve(process.argv[1]))) {
       process.env.YARN_IGNORE_PATH = `1`;
       process.env.YARN_IGNORE_CWD = `1`;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When a script spawns Yarn using either `run`, `yarn`, `yarnpkg`, or `node-gyp`, that Yarn instance will spawn itself again. While this doesn't use much resources when the CLI is built it really slows down running commands in this repo.

Noticed while working on #1808

**How did you fix it?**

If the entrypoint of the current node instance is `yarnPath` avoid unnecessarily spawning of subprocesses

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I have verified that all automated PR checks pass.
