### PR TITLE
docs(plugin-essentials): document difference between `yarn upgrade` and `up`

### DIFF
--- a/.yarn/versions/a3cd4d4e.yml
+++ b/.yarn/versions/a3cd4d4e.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -38,7 +38,7 @@ export default class UpCommand extends BaseCommand {
 
       The, \`-C,--caret\`, \`-E,--exact\` and  \`-T,--tilde\` options have the same meaning as in the \`add\` command (they change the modifier used when the range is missing or a tag, and are ignored when the range is explicitly set).
 
-      Generally you can see \`yarn up\` as a counterpart to what was \`yarn upgrade --latest\` in Yarn 1 (ie it ignores the version range specified in \`package.json\`), but unlike \`yarn upgrade\` which only upgraded dependencies in the current workspace, \`yarn up\` will upgrade all workspaces at the same time.
+      Generally you can see \`yarn up\` as a counterpart to what was \`yarn upgrade --latest\` in Yarn 1 (ie it ignores the ranges previously listed in your manifests), but unlike \`yarn upgrade\` which only upgraded dependencies in the current workspace, \`yarn up\` will upgrade all workspaces at the same time.
 
       This command accepts glob patterns as arguments (if valid Descriptors and supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
 

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -41,6 +41,8 @@ export default class UpCommand extends BaseCommand {
       This command accepts glob patterns as arguments (if valid Descriptors and supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
 
       **Note:** The ranges have to be static, only the package scopes and names can contain glob patterns.
+
+      This command is similar to \`yarn upgrade --latest\` from Yarn 1, i.e., ignores the version range specified in \`package.json\`, but unlike \`yarn upgrade\` which only upgrades the current workspace, this command upgrades all workspaces.
     `,
     examples: [[
       `Upgrade all instances of lodash to the latest release`,

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -38,11 +38,11 @@ export default class UpCommand extends BaseCommand {
 
       The, \`-C,--caret\`, \`-E,--exact\` and  \`-T,--tilde\` options have the same meaning as in the \`add\` command (they change the modifier used when the range is missing or a tag, and are ignored when the range is explicitly set).
 
+      Generally you can see \`yarn up\` as a counterpart to what was \`yarn upgrade --latest\` in Yarn 1 (ie it ignores the version range specified in \`package.json\`), but unlike \`yarn upgrade\` which only upgraded dependencies in the current workspace, \`yarn up\` will upgrade all workspaces at the same time.
+
       This command accepts glob patterns as arguments (if valid Descriptors and supported by [micromatch](https://github.com/micromatch/micromatch)). Make sure to escape the patterns, to prevent your own shell from trying to expand them.
 
       **Note:** The ranges have to be static, only the package scopes and names can contain glob patterns.
-
-      This command is similar to \`yarn upgrade --latest\` from Yarn 1, i.e., ignores the version range specified in \`package.json\`, but unlike \`yarn upgrade\` which only upgrades the current workspace, this command upgrades all workspaces.
     `,
     examples: [[
       `Upgrade all instances of lodash to the latest release`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
`yarn up` has several differences from `yarn upgrade` in Yarn 1. (#246)

**How did you fix it?**
Added documentation regarding difference between `yarn upgrade` and `up`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
