### PR TITLE
test: set LC_ALL=C in `git merge` calls

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/mergeConflictResolution.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/mergeConflictResolution.test.js
@@ -55,7 +55,7 @@ describe(`Features`, () => {
           await execFile(`git`, [`checkout`, `master`], {cwd: path});
           await execFile(`git`, [`merge`, `1.0.0`], {cwd: path});
 
-          await expect(execFile(`git`, [`merge`, `2.0.0`], {cwd: path})).rejects.toThrow(/CONFLICT/);
+          await expect(execFile(`git`, [`merge`, `2.0.0`], {cwd: path, env: {LC_ALL: `C`}})).rejects.toThrow(/CONFLICT/);
 
           let lockfile = await readFile(`${path}/yarn.lock`, `utf8`);
           lockfile = lockfile.replace(/(checksum: ).*/g, `$1<checksum stripped>`);
@@ -96,7 +96,7 @@ describe(`Features`, () => {
           await execFile(`git`, [`checkout`, `master`], {cwd: path});
           await execFile(`git`, [`merge`, `2.0.0`], {cwd: path});
 
-          await expect(execFile(`git`, [`merge`, `yarn2`], {cwd: path})).rejects.toThrow(/CONFLICT/);
+          await expect(execFile(`git`, [`merge`, `yarn2`], {cwd: path, env: {LC_ALL: `C`}})).rejects.toThrow(/CONFLICT/);
 
           let lockfile = await readFile(`${path}/yarn.lock`, `utf8`);
           lockfile = lockfile.replace(/(checksum: ).*/g, `$1<checksum stripped>`);


### PR DESCRIPTION
**What's the problem this PR addresses?**
```
  ● Features › Merge Conflict Resolution › it should properly fix merge conflicts when old is Yarn 1 and new is Yarn 2

    Temporary fixture folder: /tmp/xfs-8b0b32e9

    expect(received).rejects.toThrow(expected)

    Expected pattern: /CONFLICT/
    Received message: "Command failed: git merge yarn2··
    ===== stdout:·
    ```
    <Localized message>
    ```·
    ===== stderr:·
    ```
    ```·
    "

       99 |           await execFile(`git`, [`merge`, `2.0.0`], {cwd: path});
      100 | 
    > 101 |           await expect(execFile(`git`, [`merge`, `yarn2`], {cwd: path})).rejects.toThrow(/CONFLICT/);
          |                                                                                  ^
      102 | 
      103 |           let lockfile = await readFile(`${path}/yarn.lock`, `utf8`);
      104 |           lockfile = lockfile.replace(/(checksum: ).*/g, `$1<checksum stripped>`);
```

`git merge` produces different outputs depending on the locale.

**How did you fix it?**
Set `LC_ALL=C` in `git merge` calls

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
