### PR TITLE
[node_modules] Fixes regression - bin symlinks were not removed starting from 2.2.0

### DIFF
--- a/.yarn/versions/7fafd176.yml
+++ b/.yarn/versions/7fafd176.yml
@@ -1,6 +1,5 @@
 releases:
   "@yarnpkg/cli": patch
-  "@yarnpkg/doctor": patch
   "@yarnpkg/plugin-node-modules": patch
 
 declined:
@@ -20,3 +19,4 @@ declined:
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/7fafd176.yml
+++ b/.yarn/versions/7fafd176.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/doctor": patch
+  "@yarnpkg/plugin-node-modules": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@
 
 ### Installs
 
-- Cyclic peer dependencies inside node_modules are hoisted now in all possible cases
+- Cyclic peer dependencies inside `node_modules` are hoisted now in all possible cases
 
 ## Bugfixes
 
-- The bin symlinks are properly removed by node-modules linker when the corresponding dependencies
+- The bin symlinks are properly removed from `node_modules/.bin` when the corresponding dependencies
   are removed. This bug was a regression starting from 2.2.0. Integration tests added to prevent future regressions.
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 - The `yarn tag` commands have been ported over from Yarn Classic as `yarn npm tag`.
 
+### Installs
+
+- Cyclic peer dependencies inside node_modules are hoisted now in all possible cases
+
+## Bugfixes
+
+- The bin symlinks are properly removed by node-modules linker when the corresponding dependencies
+  are removed. This bug was a regression starting from 2.2.0. Integration tests added to prevent future regressions.
+
 ## 2.2.0
 
 ### Ecosystem

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -13,9 +13,10 @@ describe(`Node_Modules`, () => {
           [`resolve`]: `1.9.0`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `nodeLinker: "node-modules"\n`);
-
         await run(`install`);
 
         await expect(source(`require('resolve').sync('resolve')`)).resolves.toEqual(
@@ -58,12 +59,11 @@ describe(`Node_Modules`, () => {
           [`no-deps`]: `*`,
         },
       },
+      {
+        enableTransparentWorkspaces: false,
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          enableTransparentWorkspaces: false
-          nodeLinker: "node-modules"
-        `);
-
         await writeFile(
           npath.toPortablePath(`${path}/index.js`),
           `
@@ -102,11 +102,10 @@ describe(`Node_Modules`, () => {
           pkg: `file:./pkg`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          nodeLinker: "node-modules"
-        `);
-
         await writeJson(npath.toPortablePath(`${path}/pkg/package.json`), {
           name: `pkg`,
           scripts: {
@@ -126,11 +125,10 @@ describe(`Node_Modules`, () => {
         name: `pkg`,
         bin: `dist/bin/index.js`,
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          nodeLinker: "node-modules"
-        `);
-
         await expect(run(`install`)).resolves.toBeTruthy();
         await expect(xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/.bin/pkg`))).rejects.toThrow();
 
@@ -156,12 +154,11 @@ describe(`Node_Modules`, () => {
           abc: `link:../abc`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
         await writeFile(npath.toPortablePath(`${path}/../one-fixed-dep.local/abc.js`), ``);
-
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-        nodeLinker: "node-modules"
-      `);
 
         await expect(run(`install`)).resolves.toBeTruthy();
 
@@ -178,6 +175,9 @@ describe(`Node_Modules`, () => {
           [`one-fixed-dep`]: `*`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
         await writeJson(npath.toPortablePath(`${path}/../one-fixed-dep.local/package.json`), {
           name: `one-fixed-dep`,
@@ -187,10 +187,6 @@ describe(`Node_Modules`, () => {
           },
         });
         await writeFile(npath.toPortablePath(`${path}/../one-fixed-dep.local/abc.js`), ``);
-
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          nodeLinker: "node-modules"
-        `);
 
         await expect(run(`install`)).resolves.toBeTruthy();
 
@@ -214,11 +210,10 @@ describe(`Node_Modules`, () => {
         private: true,
         workspaces: [`packages/*`],
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          nodeLinker: "node-modules"
-        `);
-
         await writeJson(npath.toPortablePath(`${path}/packages/workspace/package.json`), {
           name: `workspace`,
           version: `1.0.0`,
@@ -242,11 +237,10 @@ describe(`Node_Modules`, () => {
           [`no-deps`]: `1.0.0`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          nodeLinker: "node-modules"
-        `);
-
         await expect(run(`install`)).resolves.toBeTruthy();
 
         const nmFolderInode = xfs.statSync(npath.toPortablePath(`${path}/node_modules`)).ino;
@@ -275,11 +269,10 @@ describe(`Node_Modules`, () => {
           dep: `file:./dep`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-        nodeLinker: "node-modules"
-      `);
-
         await writeJson(npath.toPortablePath(`${path}/dep/package.json`), {
           name: `dep`,
           version: `1.0.0`,
@@ -313,11 +306,10 @@ describe(`Node_Modules`, () => {
           [`no-deps2`]: `npm:no-deps@2.0.0`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-          nodeLinker: "node-modules"
-        `);
-
         await writeJson(npath.toPortablePath(`${path}/packages/workspace/package.json`), {
           name: `workspace`,
           version: `1.0.0`,
@@ -365,11 +357,10 @@ describe(`Node_Modules`, () => {
           conflict: `file:./conflict1`,
         },
       },
+      {
+        nodeLinker: `node-modules`,
+      },
       async ({path, run, source}) => {
-        await writeFile(npath.toPortablePath(`${path}/.yarnrc.yml`), `
-        nodeLinker: "node-modules"
-      `);
-
         await writeJson(npath.toPortablePath(`${path}/conflict1/package.json`), {
           name: `conflict`,
           version: `1.0.0`,
@@ -404,6 +395,42 @@ describe(`Node_Modules`, () => {
         await run(`install`);
 
         expect(await xfs.existsPromise(`${path}/node_modules/unhoistable` as PortablePath)).toBe(false);
+      },
+    ),
+  );
+
+  test(`should not produce orphaned symlinks on dependency removal having bin entries`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        dependencies: {
+          dep1: `file:./dep1`,
+          dep2: `file:./dep2`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await writeJson(npath.toPortablePath(`${path}/dep1/package.json`), {
+          name: `dep1`,
+          version: `1.0.0`,
+          bin: `bin1.js`,
+        });
+        await writeFile(`${path}/dep1/bin1.js`, ``);
+        await writeJson(npath.toPortablePath(`${path}/dep2/package.json`), {
+          name: `dep2`,
+          version: `1.0.0`,
+          bin: `bin2.js`,
+        });
+        await writeFile(`${path}/dep2/bin2.js`, ``);
+
+        await run(`install`);
+
+        const binPath = `${path}/node_modules/.bin/dep1` as PortablePath;
+        expect(xfs.lstatPromise(binPath)).resolves.toBeDefined();
+        await run(`remove`, `dep1`);
+        expect(xfs.lstatPromise(binPath)).rejects.toBeDefined();
       },
     ),
   );


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I have noticed that bin symlinks are not removed starting from 2.2.0 (they were properly removed in previous Yarn 2 versions)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The nm linker had written bin state to the top level locator, the algorithm to determine top level locator was path based and because of that fragile. Now we take top level locator directly from project.topLevelWorkspace instead. I have added integration tests to prevent future regressions.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
