### PR TITLE
Fixes bootstraping for modules

### DIFF
--- a/.yarn/versions/402ce7a1.yml
+++ b/.yarn/versions/402ce7a1.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-cli/sources/boot-cli-dev.js
+++ b/packages/yarnpkg-cli/sources/boot-cli-dev.js
@@ -55,5 +55,9 @@ function getPluginConfiguration() {
     pluginConfiguration.modules.set(`@yarnpkg/${folder}`, require(`../../${folder}`));
   }
 
+  const {getDynamicLibs} = require(`./tools/getDynamicLibs`);
+  for (const [name, module] of getDynamicLibs())
+    pluginConfiguration.modules.set(name, module);
+
   return pluginConfiguration;
 }

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -821,7 +821,6 @@ export class Configuration {
           if (pluginRequireEntries.has(request)) {
             return pluginRequireEntries.get(request)();
           } else {
-            console.log(pluginRequireEntries);
             throw new UsageError(`This plugin cannot access the package referenced via ${request} which is neither a builtin, nor an exposed entry`);
           }
         };

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -821,6 +821,7 @@ export class Configuration {
           if (pluginRequireEntries.has(request)) {
             return pluginRequireEntries.get(request)();
           } else {
+            console.log(pluginRequireEntries);
             throw new UsageError(`This plugin cannot access the package referenced via ${request} which is neither a builtin, nor an exposed entry`);
           }
         };


### PR DESCRIPTION
**What's the problem this PR addresses?**

Inside our own repository we dynamically load the plugins and generate a runtime plugin configuration based on the repo state (whereas in the bundles we simply bundle up everything with a specific require function). While plugins are correctly exported this way, we forgot to do it for the regular dynamic libraries (for example the Yarn core). While it's not a problem in general because each plugin lists its dependency on the core anyway, it matters when using `yarn link` with external projects that use external plugins, since `yarn link` will provide the local (incomplete) module configuration.

**How did you fix it?**

Simply exposes the dynamic libs through the runtime configuration.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
