### PR TITLE
[node_modules] Forgiving hoisting preference

### DIFF
--- a/.yarn/versions/445c40cd.yml
+++ b/.yarn/versions/445c40cd.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Installs
 
 - Cyclic peer dependencies inside `node_modules` are hoisted now in all possible cases
+- `node-modules` linker is more forgiving now for packages with incorrect assumptions about hoisting layout,
+  thanks to maximizing package exposure at the top-level first and only after that minimizing package duplicates during hoisting.
 
 ## Bugfixes
 

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -183,7 +183,7 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): Hoister
 
     if (!isSeen && shouldAddChildrenDependencies) {
       for (const [name, referencish] of pkg.packageDependencies) {
-        if (referencish !== null && !node.peerNames.has(name)) {
+        if (referencish !== null) {
           const depLocator = pnp.getLocator(name, referencish);
           const pkgLocator = pnp.getLocator(name.replace(`$wsroot$`, ``), referencish);
 

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -10,11 +10,11 @@
  * root node into which you are hoisting
  * 3. Traverse the dependency graph from the current root node and for each package name
  * that can be potentially hoisted to the current root node build a list of idents
- * in descending popularity. You will check in next steps whether most popular ident
+ * in descending hoisting preference. You will check in next steps whether most preferred ident
  * for the given package name can be hoisted first, and if not, then you check the
- * lest popular ident, etc, until either some ident will be hoisted
+ * less preferred ident, etc, until either some ident will be hoisted
  * or you run out of idents to check
- * (no need to convert the graph to the tree when you build this popularity map).
+ * (no need to convert the graph to the tree when you build this preference map).
  * 4. The children of the root node are already "hoisted", so you need to start
  * from the dependencies of these children. You take some child and
  * sort its dependencies so that regular dependencies without peer dependencies
@@ -29,7 +29,7 @@
  * and DEPENDS - the node is hoistable to the root if nodes X, Y, Z are hoistable
  * to the root. The case DEPENDS happens when all the require and other
  * constraints are met, except peer dependency constraints. Note, that the nodes
- * that are not package idents currently at the top of popularity list are considered
+ * that are not package idents currently at the top of preference list are considered
  * to have the answer NO right away, before doing any other constraint checks.
  * 6. When you have hoistable answer for each dependency of a node you then build
  * a list of nodes that are NOT hoistable. These are the nodes that have answer NO
@@ -57,7 +57,7 @@ type HoisterWorkTree = {name: PackageName, references: Set<string>, ident: Ident
  * e.g. which one among the group of packages with the same name should be hoisted.
  * The package having the biggest number of parents using this package will be hoisted.
  */
-type PopularityMap = Map<string, Set<Ident>>;
+type PreferenceMap = Map<string, { minDepth: number, peerDependents: Set<Ident>, dependents: Set<Ident> }>;
 
 enum Hoistable { YES, NO, DEPENDS }
 type HoistInfo = {
@@ -198,16 +198,16 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
 };
 
 /**
- * Builds a map of most popular packages that might be hoisted to the root node.
+ * Builds a map of most preferred packages that might be hoisted to the root node.
  *
- * The values in the map are idents sorted by popularity from most popular to less popular.
+ * The values in the map are idents sorted by preference from most preferred to less preferred.
  * If the root node has already some version of a package, the value array will contain only
  * one element, since it is not possible for other versions of a package to be hoisted.
  *
  * @param rootNode root node
- * @param popularityMap popularity map
+ * @param preferenceMap preference map
  */
-const getHoistIdentMap = (rootNode: HoisterWorkTree, popularityMap: PopularityMap): Map<PackageName, Array<Ident>> => {
+const getHoistIdentMap = (rootNode: HoisterWorkTree, preferenceMap: PreferenceMap): Map<PackageName, Array<Ident>> => {
   const identMap = new Map<PackageName, Array<Ident>>([[rootNode.name, [rootNode.ident]]]);
 
   for (const dep of rootNode.dependencies.values()) {
@@ -216,8 +216,18 @@ const getHoistIdentMap = (rootNode: HoisterWorkTree, popularityMap: PopularityMa
     }
   }
 
-  const keyList = Array.from(popularityMap.keys());
-  keyList.sort((key1, key2) => popularityMap.get(key2)!.size - popularityMap.get(key1)!.size);
+  const keyList = Array.from(preferenceMap.keys());
+  keyList.sort((key1, key2) => {
+    const entry1 = preferenceMap.get(key1)!;
+    const entry2 = preferenceMap.get(key2)!;
+    if (entry2.peerDependents.size !== entry1.peerDependents.size) {
+      return entry2.peerDependents.size - entry1.peerDependents.size;
+    } else if (entry1.minDepth !== entry2.minDepth) {
+      return entry1.minDepth - entry2.minDepth;
+    } else {
+      return entry2.dependents.size - entry1.dependents.size;
+    }
+  });
 
   for (const key of keyList) {
     const name = key.substring(0, key.indexOf(`@`, 1));
@@ -305,9 +315,9 @@ const hoistTo = (tree: HoisterWorkTree, rootNode: HoisterWorkTree, rootNodePath:
     return;
   seenNodes.add(rootNode);
 
-  const popularityMap = buildPopularityMap(rootNode);
+  const preferenceMap = buildPreferenceMap(rootNode);
 
-  const hoistIdentMap = getHoistIdentMap(rootNode, popularityMap);
+  const hoistIdentMap = getHoistIdentMap(rootNode, preferenceMap);
 
   const hoistIdents = new Map(Array.from(hoistIdentMap.entries()).map(([k, v]) => [k, v[0]]));
 
@@ -696,30 +706,40 @@ const shrinkTree = (tree: HoisterWorkTree): HoisterResult => {
  *
  * @param rootNode package tree root node
  *
- * @returns popularity map
+ * @returns preference map
  */
-const buildPopularityMap = (rootNode: HoisterWorkTree): PopularityMap => {
-  const popularityMap: PopularityMap = new Map();
+const buildPreferenceMap = (rootNode: HoisterWorkTree): PreferenceMap => {
+  const preferenceMap: PreferenceMap = new Map();
 
   const seenNodes = new Set<HoisterWorkTree>([rootNode]);
-  const getPopularityKey = (node: HoisterWorkTree) => `${node.name}@${node.ident}`;
+  const getPreferenceKey = (node: HoisterWorkTree) => `${node.name}@${node.ident}`;
 
-  const addParent = (parentNode: HoisterWorkTree, node: HoisterWorkTree) => {
+  const getOrCreatePreferenceEntry = (node: HoisterWorkTree) => {
+    const key = getPreferenceKey(node);
+    let entry = preferenceMap.get(key);
+    if (!entry) {
+      entry = {minDepth: Number.MAX_SAFE_INTEGER, dependents: new Set<Ident>(), peerDependents: new Set<Ident>()};
+      preferenceMap.set(key, entry);
+    }
+    return entry;
+  };
+
+  const addDependent = (dependent: HoisterWorkTree, node: HoisterWorkTree, depth: number) => {
     const isSeen = !!seenNodes.has(node);
 
-    const key = getPopularityKey(node);
-    let parents = popularityMap.get(key);
-    if (!parents) {
-      parents = new Set<Ident>();
-      popularityMap.set(key, parents);
-    }
-    parents.add(parentNode.ident);
+    const entry = getOrCreatePreferenceEntry(node);
+    entry.dependents.add(dependent.ident);
+    if (depth < entry.minDepth)
+      entry.minDepth = depth;
 
     if (!isSeen) {
       seenNodes.add(node);
       for (const dep of node.dependencies.values()) {
-        if (!node.peerNames.has(dep.name)) {
-          addParent(node, dep);
+        if (node.peerNames.has(dep.name)) {
+          const entry = getOrCreatePreferenceEntry(dep);
+          entry.peerDependents.add(node.ident);
+        } else {
+          addDependent(node, dep, depth + 1);
         }
       }
     }
@@ -727,9 +747,11 @@ const buildPopularityMap = (rootNode: HoisterWorkTree): PopularityMap => {
 
   for (const dep of rootNode.dependencies.values())
     if (!rootNode.peerNames.has(dep.name))
-      addParent(rootNode, dep);
+      addDependent(rootNode, dep, 1);
 
-  return popularityMap;
+  // console.log(require(`util`).inspect(preferenceMap, false, null));
+
+  return preferenceMap;
 };
 
 const prettyPrintLocator = (locator: Locator) => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We know that dependencies relying on node_modules install strategy often have wrong assumptions about resulting node_modules layout. Because the idea of nm linker is to be as frictionless as possible we can adjust the preference for the packages we hoist to increase the probability that broken assumptions will work. 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

In order to increase this probability we make hoisting to prefer in the order below:
1. Packages having the most peer dependents (thus we increase the accessibility of the most nodes from the top level to maximum)
2. Packages having the most dependents (to reduce number of duplicates)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
