### PR TITLE
feat(core): merge map configuration properties

### DIFF
--- a/.yarn/versions/871aaa79.yml
+++ b/.yarn/versions/871aaa79.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1102,7 +1102,7 @@ export class Configuration {
           ? [...previousValue, ...parsed as Map<string, any>]
           : [...parsed as Map<string, any>, ...previousValue]
         ));
-        this.sources.set(key, `${this.sources.get(key)}, source`);
+        this.sources.set(key, `${this.sources.get(key)}, ${source}`);
       } else {
         this.values.set(key, parsed);
         this.sources.set(key, source);

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1048,16 +1048,16 @@ export class Configuration {
     }
   }
 
-  useWithSource(source: string, data: {[key: string]: unknown}, folder: PortablePath, {strict = true, overwrite = false}: {strict?: boolean, overwrite?: boolean}) {
+  useWithSource(source: string, data: {[key: string]: unknown}, folder: PortablePath, opts?: {strict?: boolean, overwrite?: boolean}) {
     try {
-      this.use(source, data, folder, {strict, overwrite});
+      this.use(source, data, folder, opts);
     } catch (error) {
       error.message += ` (in ${source})`;
       throw error;
     }
   }
 
-  use(source: string, data: {[key: string]: unknown}, folder: PortablePath, {strict = true, overwrite = false}: {strict?: boolean, overwrite?: boolean}) {
+  use(source: string, data: {[key: string]: unknown}, folder: PortablePath, {strict = true, overwrite = false}: {strict?: boolean, overwrite?: boolean} = {}) {
     for (const key of Object.keys(data)) {
       const value = data[key];
       if (typeof value === `undefined`)
@@ -1085,7 +1085,7 @@ export class Configuration {
         }
       }
 
-      if (this.sources.has(key) && !overwrite)
+      if (this.sources.has(key) && !(overwrite || definition.type === SettingsType.MAP))
         continue;
 
       let parsed;
@@ -1096,8 +1096,17 @@ export class Configuration {
         throw error;
       }
 
-      this.values.set(key, parsed);
-      this.sources.set(key, source);
+      if (definition.type === SettingsType.MAP) {
+        const previousValue = this.values.get(key) as Map<string, any>;
+        this.values.set(key, new Map(overwrite
+          ? [...previousValue, ...parsed as Map<string, any>]
+          : [...parsed as Map<string, any>, ...previousValue]
+        ));
+        this.sources.set(key, `${this.sources.get(key)}, source`);
+      } else {
+        this.values.set(key, parsed);
+        this.sources.set(key, source);
+      }
     }
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Closes #779

**How did you fix it?**

Map configurations are now merged. The `overwrite` option defines the order in which the merge happens, i.e. with `overwrite: true` the newly loaded config overrules any previous config, otherwise existing configuration is kept.

I've opted for only merging maps because merging maps makes sense.
For shape configuration types it doesn't really make sense. What would the expected result be when merging

```yaml
npmScopes:
  foo:
    npmAuthIdent: someIdent==
```

into

```yaml
npmScopes:
  foo:
    npmAuthToken: a-token
```

?
The object would have both ident and token, so how do we decide which one to take?
What if the configs were turned around?

We could add a function on the `ShapeSettingsDefinition` type to perform this merge, but I'm not sure that's worth it. Wouldn't that always come down to not merging anyway? I mean: why would you want to replace the `npmRegistryServer` for a scope but keep the `npmPublishRegistry` and the configured authentication? If you want to configure auth and registry separately for a scope we already provide a way to do so via `npmRegistries`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
