### PR TITLE
fix(plugin-pnp): fix yarn unplug with packages with peer deps

### DIFF
--- a/.yarn/versions/822401f0.yml
+++ b/.yarn/versions/822401f0.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": prerelease
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/unplug.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/unplug.test.ts
@@ -30,6 +30,23 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should be able to unplug packages with peer dependencies`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`peer-deps`]: `npm:peer-deps@1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await run(`unplug`, `peer-deps`);
+
+        await expect(readManifest(path, {key: `dependenciesMeta`})).resolves.toEqual({
+          [`peer-deps@1.0.0`]: unplugged,
+        });
+      }),
+    );
+
+    test(
       `it should unplug all dependencies matching a glob pattern`,
       makeTemporaryEnv({
         dependencies: {

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -1,12 +1,12 @@
-import {BaseCommand, WorkspaceRequiredError}       from '@yarnpkg/cli';
-import {Configuration, Cache, Descriptor, Project} from '@yarnpkg/core';
-import {StreamReport, Workspace}                   from '@yarnpkg/core';
-import {structUtils}                               from '@yarnpkg/core';
-import {Command, Usage, UsageError}                from 'clipanion';
-import micromatch                                  from 'micromatch';
+import {BaseCommand, WorkspaceRequiredError}                                from '@yarnpkg/cli';
+import {Configuration, Cache, Descriptor, Project, formatUtils, FormatType} from '@yarnpkg/core';
+import {StreamReport, Workspace}                                            from '@yarnpkg/core';
+import {structUtils}                                                        from '@yarnpkg/core';
+import {Command, Usage, UsageError}                                         from 'clipanion';
+import micromatch                                                           from 'micromatch';
 
-import * as suggestUtils                           from '../suggestUtils';
-import {Hooks}                                     from '..';
+import * as suggestUtils                                                    from '../suggestUtils';
+import {Hooks}                                                              from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class RemoveCommand extends BaseCommand {
@@ -132,7 +132,7 @@ export default class RemoveCommand extends BaseCommand {
       : `this`;
 
     if (unreferencedPatterns.length > 0)
-      throw new UsageError(`${patterns} ${unreferencedPatterns.join(`, `)} ${dont} match any package referenced by ${which} workspace`);
+      throw new UsageError(`${patterns} ${formatUtils.prettyList(configuration, unreferencedPatterns, FormatType.CODE)} ${dont} match any packages referenced by ${which} workspace`);
 
     if (hasChanged) {
       await configuration.triggerMultipleHooks(

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -1,13 +1,13 @@
-import {BaseCommand, WorkspaceRequiredError}                                               from '@yarnpkg/cli';
-import {Cache, Configuration, Descriptor, LightReport, MessageName, MinimalResolveOptions} from '@yarnpkg/core';
-import {Project, StreamReport, Workspace}                                                  from '@yarnpkg/core';
-import {structUtils}                                                                       from '@yarnpkg/core';
-import {Command, Usage, UsageError}                                                        from 'clipanion';
-import {prompt}                                                                            from 'enquirer';
-import micromatch                                                                          from 'micromatch';
+import {BaseCommand, WorkspaceRequiredError}                                                                        from '@yarnpkg/cli';
+import {Cache, Configuration, Descriptor, LightReport, MessageName, MinimalResolveOptions, formatUtils, FormatType} from '@yarnpkg/core';
+import {Project, StreamReport, Workspace}                                                                           from '@yarnpkg/core';
+import {structUtils}                                                                                                from '@yarnpkg/core';
+import {Command, Usage, UsageError}                                                                                 from 'clipanion';
+import {prompt}                                                                                                     from 'enquirer';
+import micromatch                                                                                                   from 'micromatch';
 
-import * as suggestUtils                                                                   from '../suggestUtils';
-import {Hooks}                                                                             from '..';
+import * as suggestUtils                                                                                            from '../suggestUtils';
+import {Hooks}                                                                                                      from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UpCommand extends BaseCommand {
@@ -133,9 +133,9 @@ export default class UpCommand extends BaseCommand {
     }
 
     if (unreferencedPatterns.length > 1)
-      throw new UsageError(`Patterns ${unreferencedPatterns.join(`, `)} don't match any packages referenced by any workspace`);
+      throw new UsageError(`Patterns ${formatUtils.prettyList(configuration, unreferencedPatterns, FormatType.CODE)} don't match any packages referenced by any workspace`);
     if (unreferencedPatterns.length > 0)
-      throw new UsageError(`Pattern ${unreferencedPatterns[0]} doesn't match any packages referenced by any workspace`);
+      throw new UsageError(`Pattern ${formatUtils.prettyList(configuration, unreferencedPatterns, FormatType.CODE)} doesn't match any packages referenced by any workspace`);
 
     const allSuggestions = await Promise.all(allSuggestionsPromises);
 

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -153,24 +153,25 @@ export default class UnplugCommand extends BaseCommand {
     };
 
     let selection: Array<Package>;
+    let projectOrWorkspaces: string;
 
     // We can shortcut the execution if we want all the dependencies and
     // transitive dependencies of all the branches: it means we want everything!
-    if (this.all && this.recursive)
+    if (this.all && this.recursive) {
       selection = getAllMatchingPackages();
-    else if (this.all)
+      projectOrWorkspaces = `the project`;
+    } else if (this.all) {
       selection = getSelectedPackages(project.workspaces);
-    else
+      projectOrWorkspaces = `any workspace`;
+    } else {
       selection = getSelectedPackages([workspace]);
-
-    const projectOrWorkspaces = this.recursive
-      ? `the project`
-      : `any workspace`;
+      projectOrWorkspaces = `this workspace`;
+    }
 
     if (unreferencedPatterns.size > 1)
-      throw new UsageError(`Patterns ${[...unreferencedPatterns].join(`, `)} don't match any packages referenced by ${projectOrWorkspaces}`);
+      throw new UsageError(`Patterns ${formatUtils.prettyList(configuration, unreferencedPatterns, formatUtils.Type.CODE)} don't match any packages referenced by ${projectOrWorkspaces}`);
     if (unreferencedPatterns.size > 0)
-      throw new UsageError(`Pattern ${[...unreferencedPatterns][0]} doesn't match any packages referenced by ${projectOrWorkspaces}`);
+      throw new UsageError(`Pattern ${formatUtils.prettyList(configuration, unreferencedPatterns, formatUtils.Type.CODE)} doesn't match any packages referenced by ${projectOrWorkspaces}`);
 
     selection = miscUtils.sortMap(selection, pkg => {
       return structUtils.stringifyLocator(pkg);

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -101,6 +101,8 @@ export default class UnplugCommand extends BaseCommand {
       const selection: Array<Package> = [];
 
       for (const pkg of project.storedPackages.values())
+        // Note: We can safely skip virtual packages here, as the
+        // devirtualized copy will always exist inside storedPackages.
         if (!project.tryWorkspaceByLocator(pkg) && !structUtils.isVirtualLocator(pkg) && matchers.some(matcher => matcher(pkg)))
           selection.push(pkg);
 
@@ -117,7 +119,9 @@ export default class UnplugCommand extends BaseCommand {
 
         seen.add(pkg.locatorHash);
 
-        if (!project.tryWorkspaceByLocator(pkg) && !structUtils.isVirtualLocator(pkg) && matchers.some(matcher => matcher(pkg)))
+        // Note: We shouldn't skip virtual packages, as
+        // we don't iterate over the devirtualized copies.
+        if (!project.tryWorkspaceByLocator(pkg) && matchers.some(matcher => matcher(pkg)))
           selection.push(pkg);
 
         // Don't recurse unless requested

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -245,6 +245,10 @@ export function pretty<T extends Type>(configuration: Configuration, value: Sour
   return applyColor(configuration, value, formatType);
 }
 
+export function prettyList<T extends Type>(configuration: Configuration, values: Iterable<Source<T>>, formatType: T | string, {separator = `, `}: {separator?: string} = {}): string {
+  return [...values].map(value => pretty(configuration, value, formatType)).join(separator);
+}
+
 export function json<T extends Type>(value: Source<T>, formatType: T | string): any {
   if (value === null)
     return null;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn unplug` without `-AR` failed to find packages with peer dependencies because we were skipping virtual packages when we weren't supposed to. More details can be found on Discord: https://discordapp.com/channels/226791405589233664/654372321225605128/757931201364230184.

**How did you fix it?**
<!-- A detailed description of your implementation. -->


I removed the virtual package check inside the `traverse` implementation. I've also added an integration test.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
