### PR TITLE
fix(core): format PortablePath as NativePath

### DIFF
--- a/.yarn/versions/9ed95b15.yml
+++ b/.yarn/versions/9ed95b15.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -1,3 +1,5 @@
+import {npath}                      from '@yarnpkg/fslib';
+
 import chalk                        from 'chalk';
 
 import {Configuration}              from './Configuration';
@@ -179,6 +181,15 @@ const transforms = {
       return size;
     },
   }),
+
+  [Type.PATH]: validateTransform({
+    pretty: (configuration: Configuration, filePath: string) => {
+      return applyColor(configuration, npath.fromPortablePath(filePath), Type.PATH);
+    },
+    json: (filePath: string) => {
+      return npath.fromPortablePath(filePath) as string;
+    },
+  }),
 };
 
 type AllTransforms = typeof transforms;
@@ -236,7 +247,7 @@ export function pretty<T extends Type>(configuration: Configuration, value: Sour
 
   if (Object.prototype.hasOwnProperty.call(transforms, formatType)) {
     miscUtils.overrideType<keyof AllTransforms>(formatType);
-    return transforms[formatType].pretty(configuration, value as any);
+    return transforms[formatType].pretty(configuration, value as never);
   }
 
   if (typeof value !== `string`)
@@ -251,7 +262,7 @@ export function json<T extends Type>(value: Source<T>, formatType: T | string): 
 
   if (Object.prototype.hasOwnProperty.call(transforms, formatType)) {
     miscUtils.overrideType<keyof AllTransforms>(formatType);
-    return transforms[formatType].json(value as any);
+    return transforms[formatType].json(value as never);
   }
 
   if (typeof value !== `string`)

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -246,8 +246,9 @@ export function pretty<T extends Type>(configuration: Configuration, value: Sour
     return applyColor(configuration, `null`, Type.NULL);
 
   if (Object.prototype.hasOwnProperty.call(transforms, formatType)) {
-    miscUtils.overrideType<keyof AllTransforms>(formatType);
-    return transforms[formatType].pretty(configuration, value as never);
+    const transform = transforms[formatType as keyof typeof transforms];
+    const typedTransform = transform as Extract<typeof transform, {pretty: (configuration: Configuration, val: Source<T>) => any}>;
+    return typedTransform.pretty(configuration, value);
   }
 
   if (typeof value !== `string`)


### PR DESCRIPTION
**What's the problem this PR addresses?**

`PortablePath` isn't formated as `NativePath` on Windows.
Originally fixed in https://github.com/yarnpkg/berry/pull/1361 but reverted by https://github.com/yarnpkg/berry/pull/1757

**How did you fix it?**

Add a formatter for `PortablePath`s

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [ ] I have verified that all automated PR checks pass.
