### PR TITLE
[node_modules] Inherit peer dependencies based on directory hierarchy

### DIFF
--- a/.yarn/versions/df735296.yml
+++ b/.yarn/versions/df735296.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ via `nmHoistingLimits` global setting and `installConfig.hoistingLimits` `packag
 - Cyclic peer dependencies inside `node_modules` are hoisted now in all possible cases
 - `node-modules` linker is more forgiving now for packages with incorrect assumptions about hoisting layout,
   thanks to maximizing package exposure at the top-level first and only after that minimizing package duplicates during hoisting.
+- In case of `node_modules` the workspace peer dependencies are no longer ingnored. They are picked up
+  from the closest workspace, that is upper in directory hierarchy.
 
 ## Bugfixes
 

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -117,7 +117,7 @@ class NodeModulesInstaller extends AbstractPnpInstaller {
         return [relativeCwd, hoistingLimits];
       }
     ));
-    const nmTree = buildNodeModulesTree(pnp, {pnpifyFs: false, hoistingLimitsByCwd});
+    const nmTree = buildNodeModulesTree(pnp, {pnpifyFs: false, hoistingLimitsByCwd, project: this.opts.project});
     const locatorMap = buildLocatorMap(nmTree);
 
     await persistNodeModules(preinstallState, locatorMap, {

--- a/packages/plugin-node-modules/sources/PnpLooseLinker.ts
+++ b/packages/plugin-node-modules/sources/PnpLooseLinker.ts
@@ -29,7 +29,7 @@ class PnpLooseInstaller extends PnpInstaller {
     });
 
     const pnp = makeRuntimeApi(pnpSettings, this.opts.project.cwd, defaultFsLayer);
-    const nmTree = buildNodeModulesTree(pnp, {pnpifyFs: false});
+    const nmTree = buildNodeModulesTree(pnp, {pnpifyFs: false, project: this.opts.project});
 
     const fallbackPool = new Map<string, DependencyTarget>();
     pnpSettings.fallbackPool = fallbackPool;

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -265,7 +265,6 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
         for (const peerName of node.peerNames) {
           if (!pkg.packagePeers.has(peerName)) {
             allDependencies.set(peerName, parentDependencies.get(peerName) || null);
-            console.log(`${locator.name} pick ${peerName} from ${parent.name}: ${parentDependencies.get(peerName)}`);
           }
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Peer dependencies in workspaces are ignored by nm linker now.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have implemented peer deps inheritance for nm linker from the closest workspace up in directory hierarchy

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
