### PR TITLE
fix(plugin-stage): stage and unstage correctly

### DIFF
--- a/.yarn/versions/13d07961.yml
+++ b/.yarn/versions/13d07961.yml
@@ -1,2 +1,7 @@
 releases:
   "@yarnpkg/plugin-stage": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"

--- a/.yarn/versions/13d07961.yml
+++ b/.yarn/versions/13d07961.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-stage": patch

--- a/packages/plugin-stage/sources/commands/stage.ts
+++ b/packages/plugin-stage/sources/commands/stage.ts
@@ -97,6 +97,8 @@ export default class StageCommand extends BaseCommand {
         await driver.makeCommit(root, changeList, commitMessage);
       } else if (this.reset) {
         await driver.makeReset(root, changeList);
+      } else {
+        await driver.makeStage(root, changeList);
       }
     }
   }

--- a/packages/plugin-stage/sources/commands/stage.ts
+++ b/packages/plugin-stage/sources/commands/stage.ts
@@ -92,7 +92,7 @@ export default class StageCommand extends BaseCommand {
       }
     } else {
       if (this.reset) {
-        const stagedChangeList = await driver.filterChanges(root, yarnPaths, yarnNames, true);
+        const stagedChangeList = await driver.filterChanges(root, yarnPaths, yarnNames, {staged: true});
         if (stagedChangeList.length === 0) {
           this.context.stdout.write(`No staged changes found!`);
         } else {

--- a/packages/plugin-stage/sources/commands/stage.ts
+++ b/packages/plugin-stage/sources/commands/stage.ts
@@ -91,14 +91,20 @@ export default class StageCommand extends BaseCommand {
         }
       }
     } else {
-      if (changeList.length === 0) {
+      if (this.reset) {
+        const stagedChangeList = await driver.filterChanges(root, yarnPaths, yarnNames, true);
+        if (stagedChangeList.length === 0) {
+          this.context.stdout.write(`No staged changes found!`);
+        } else {
+          await driver.makeReset(root, stagedChangeList);
+        }
+      } else if (changeList.length === 0) {
         this.context.stdout.write(`No changes found!`);
       } else if (this.commit) {
         await driver.makeCommit(root, changeList, commitMessage);
-      } else if (this.reset) {
-        await driver.makeReset(root, changeList);
       } else {
         await driver.makeStage(root, changeList);
+        this.context.stdout.write(commitMessage);
       }
     }
   }

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -145,10 +145,17 @@ export const Driver = {
     return await genCommitMessage(cwd, changeList);
   },
 
-  async makeCommit(cwd: PortablePath, changeList: Array<stageUtils.FileAction>, commitMessage: string) {
+  async makeStage(cwd: PortablePath, changeList: Array<stageUtils.FileAction>) {
     const localPaths = changeList.map(file => npath.fromPortablePath(file.path));
 
     await execUtils.execvp(`git`, [`add`, `-N`, `--`, ...localPaths], {cwd, strict: true});
+  },
+
+  async makeCommit(cwd: PortablePath, changeList: Array<stageUtils.FileAction>, commitMessage: string) {
+    this.makeStage(cwd, changeList);
+
+    const localPaths = changeList.map(file => npath.fromPortablePath(file.path));
+
     await execUtils.execvp(`git`, [`commit`, `-m`, `${commitMessage}\n\n${MESSAGE_MARKER}\n`, `--`, ...localPaths], {cwd, strict: true});
   },
 

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -107,11 +107,11 @@ export const Driver = {
     return await stageUtils.findVcsRoot(cwd, {marker: `.git` as Filename});
   },
 
-  async filterChanges(cwd: PortablePath, yarnRoots: Set<PortablePath>, yarnNames: Set<string>, staged = false) {
+  async filterChanges(cwd: PortablePath, yarnRoots: Set<PortablePath>, yarnNames: Set<string>, opts?: { staged?: boolean }) {
     const {stdout} = await execUtils.execvp(`git`, [`status`, `-s`], {cwd, strict: true});
     const lines = stdout.toString().split(/\n/g);
 
-    const changePrefix = staged ? stagedPrefixes : unstagedPrefixes;
+    const changePrefix = opts?.staged ? stagedPrefixes : unstagedPrefixes;
 
     const changes = ([] as Array<stageUtils.FileAction>).concat(...lines.map((line: string) => {
       if (line === ``)
@@ -121,7 +121,7 @@ export const Driver = {
       const path = ppath.resolve(cwd, line.slice(3) as PortablePath);
 
       // New directories need to be expanded to their content
-      if (!staged && prefix === `?? ` && line.endsWith(`/`)) {
+      if (!opts?.staged && prefix === `?? ` && line.endsWith(`/`)) {
         return stageUtils.expandDirectory(path).map(path => ({
           action: stageUtils.ActionType.CREATE,
           path,

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -148,13 +148,13 @@ export const Driver = {
   async makeStage(cwd: PortablePath, changeList: Array<stageUtils.FileAction>) {
     const localPaths = changeList.map(file => npath.fromPortablePath(file.path));
 
-    await execUtils.execvp(`git`, [`add`, `-N`, `--`, ...localPaths], {cwd, strict: true});
+    await execUtils.execvp(`git`, [`add`, `--`, ...localPaths], {cwd, strict: true});
   },
 
   async makeCommit(cwd: PortablePath, changeList: Array<stageUtils.FileAction>, commitMessage: string) {
-    this.makeStage(cwd, changeList);
-
     const localPaths = changeList.map(file => npath.fromPortablePath(file.path));
+
+    await execUtils.execvp(`git`, [`add`, `-N`, `--`, ...localPaths], {cwd, strict: true});
 
     await execUtils.execvp(`git`, [`commit`, `-m`, `${commitMessage}\n\n${MESSAGE_MARKER}\n`, `--`, ...localPaths], {cwd, strict: true});
   },

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -90,14 +90,28 @@ async function genCommitMessage(cwd: PortablePath, changes: Array<stageUtils.Fil
   return message;
 }
 
+const unstagedPrefixes = {
+  [stageUtils.ActionType.CREATE]: [` A `, `?? `],
+  [stageUtils.ActionType.MODIFY]: [` M `],
+  [stageUtils.ActionType.DELETE]: [` D `],
+};
+
+const stagedPrefixes = {
+  [stageUtils.ActionType.CREATE]: [`A  `],
+  [stageUtils.ActionType.MODIFY]: [`M  `],
+  [stageUtils.ActionType.DELETE]: [`D  `],
+};
+
 export const Driver = {
   async findRoot(cwd: PortablePath) {
     return await stageUtils.findVcsRoot(cwd, {marker: `.git` as Filename});
   },
 
-  async filterChanges(cwd: PortablePath, yarnRoots: Set<PortablePath>, yarnNames: Set<string>) {
+  async filterChanges(cwd: PortablePath, yarnRoots: Set<PortablePath>, yarnNames: Set<string>, staged = false) {
     const {stdout} = await execUtils.execvp(`git`, [`status`, `-s`], {cwd, strict: true});
     const lines = stdout.toString().split(/\n/g);
+
+    const changePrefix = staged ? stagedPrefixes : unstagedPrefixes;
 
     const changes = ([] as Array<stageUtils.FileAction>).concat(...lines.map((line: string) => {
       if (line === ``)
@@ -107,28 +121,22 @@ export const Driver = {
       const path = ppath.resolve(cwd, line.slice(3) as PortablePath);
 
       // New directories need to be expanded to their content
-      if (prefix === `?? ` && line.endsWith(`/`)) {
+      if (!staged && prefix === `?? ` && line.endsWith(`/`)) {
         return stageUtils.expandDirectory(path).map(path => ({
           action: stageUtils.ActionType.CREATE,
           path,
         }));
-      } else if (prefix === ` A ` || prefix === `?? `) {
-        return [{
-          action: stageUtils.ActionType.CREATE,
-          path,
-        }];
-      } else if (prefix === ` M `) {
-        return [{
-          action: stageUtils.ActionType.MODIFY,
-          path,
-        }];
-      } else if (prefix === ` D `) {
-        return [{
-          action: stageUtils.ActionType.DELETE,
-          path,
-        }];
-      }
-      else {
+      } else {
+        const actions = [stageUtils.ActionType.CREATE, stageUtils.ActionType.MODIFY, stageUtils.ActionType.DELETE] as const;
+        const action = actions.find(action => changePrefix[action].includes(prefix));
+
+        if (action) {
+          return [{
+            action,
+            path,
+          }];
+        }
+
         return [];
       }
     }));

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -130,7 +130,7 @@ export const Driver = {
         const actions = [stageUtils.ActionType.CREATE, stageUtils.ActionType.MODIFY, stageUtils.ActionType.DELETE] as const;
         const action = actions.find(action => changePrefix[action].includes(prefix));
 
-        if (action) {
+        if (action !== undefined) {
           return [{
             action,
             path,

--- a/packages/plugin-stage/sources/drivers/GitDriver.ts
+++ b/packages/plugin-stage/sources/drivers/GitDriver.ts
@@ -163,7 +163,6 @@ export const Driver = {
     const localPaths = changeList.map(file => npath.fromPortablePath(file.path));
 
     await execUtils.execvp(`git`, [`add`, `-N`, `--`, ...localPaths], {cwd, strict: true});
-
     await execUtils.execvp(`git`, [`commit`, `-m`, `${commitMessage}\n\n${MESSAGE_MARKER}\n`, `--`, ...localPaths], {cwd, strict: true});
   },
 

--- a/packages/plugin-stage/sources/drivers/MercurialDriver.ts
+++ b/packages/plugin-stage/sources/drivers/MercurialDriver.ts
@@ -15,6 +15,9 @@ export const Driver = {
     return ``;
   },
 
+  async makeStage(cwd: PortablePath, changeList: Array<stageUtils.FileAction>) {
+  },
+
   async makeCommit(cwd: PortablePath, changeList: Array<stageUtils.FileAction>, commitMessage: string) {
   },
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Staging was not actually implemented in `plugin-stage`. Only `--commit` worked. Also `--reset` did not work because it was only iterating over *unstaged* changes, and was finding none.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

* Implemented `makeStage` as a separate method in the driver. Needed to drop the `-N` argument from git for staging.
* Refactored `filterChanges` to add a parameter for whether to return staged or unstaged changes.
* Update where `--reset` is handled in order to work on the list of stashed changes.
* Instead of printing nothing, `yarn stage` will now print what would've been the commit message, if it was ran with `yarn stage --commit`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I have verified that all automated PR checks pass.
