### PR TITLE
docs(contributing): fix link to release workflow docs

### DIFF
--- a/packages/gatsby/content/advanced/contributing.md
+++ b/packages/gatsby/content/advanced/contributing.md
@@ -103,7 +103,7 @@ Constraints can be checked with `yarn constraints`, and fixed with `yarn constra
 
 ## Preparing your PR to be released
 
-In order to track which packages need to be released, we use the workflow described in the [following document](https://yarnpkg.com/advanced/managing-releases). To summarize, you must run `yarn version check --interactive` on each PR you make, and select which packages should be released again for your changes to be effective (and to which version), if any.
+In order to track which packages need to be released, we use the workflow described in the [following document](https://yarnpkg.com/features/release-workflow). To summarize, you must run `yarn version check --interactive` on each PR you make, and select which packages should be released again for your changes to be effective (and to which version), if any.
 
 You can check if you've set everything correctly with `yarn version check`.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The contributing docs link to a page on package version management that no longer exists. ([Old link](https://yarnpkg.com/advanced/managing-releases))

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Repoint the link [here](https://yarnpkg.com/features/release-workflow).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
