### PR TITLE
Fixes time typo in packUtils

### DIFF
--- a/.yarn/versions/2e501780.yml
+++ b/.yarn/versions/2e501780.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/2e501780.yml
+++ b/.yarn/versions/2e501780.yml
@@ -1,5 +1,6 @@
 releases:
   "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
   "@yarnpkg/plugin-pack": patch
 
 declined:
@@ -7,9 +8,16 @@ declined:
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
   - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-patch"
   - "@yarnpkg/plugin-pnp"
@@ -18,5 +26,5 @@ declined:
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
-  - "@yarnpkg/core"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -83,7 +83,7 @@ export async function genPackStream(workspace: Workspace, files?: Array<Portable
       const dest = ppath.join(`package` as PortablePath, file);
 
       const stat = await xfs.lstatPromise(source);
-      const opts = {name: dest, mtime: new Date(315532800)};
+      const opts = {name: dest, mtime: new Date(315532800000)};
 
       const mode = executableFiles.has(file)
         ? 0o755

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -11,7 +11,7 @@ import * as miscUtils                                                   from './
 import * as structUtils                                                 from './structUtils';
 import {LocatorHash, Locator}                                           from './types';
 
-const CACHE_VERSION = 6;
+const CACHE_VERSION = 7;
 
 export type FetchFromCacheOptions = {
   checksums: Map<LocatorHash, Locator>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,7 +3,7 @@
 
 __metadata:
   version: 4
-  cacheKey: 6
+  cacheKey: 7
 
 "@algolia/cache-browser-local-storage@npm:4.2.0":
   version: 4.2.0


### PR DESCRIPTION
**What's the problem this PR addresses?**

We're currently packing archives by setting their mtime via a "second" timestamp, instead of a "millisecond" one. As a result, the files within the archive are outside the supported range for zip archives.

**How did you fix it?**

Properly multiplies the seconds before instantiating them via the `Date` constructor.

Fixes #1882

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I have verified that all automated PR checks pass.
