### PR TITLE
feat(core): type plugin hooks

### DIFF
--- a/packages/plugin-compat/sources/index.ts
+++ b/packages/plugin-compat/sources/index.ts
@@ -1,10 +1,9 @@
-import {Hooks as CoreHooks, Plugin, structUtils} from '@yarnpkg/core';
-import {Hooks as PatchHooks}                     from '@yarnpkg/plugin-patch';
+import {Plugin, structUtils}            from '@yarnpkg/core';
 
-import {packageExtensions}                       from './extensions';
-import {getPatch as getFseventsPatch}            from './patches/fsevents.patch';
-import {getPatch as getResolvePatch}             from './patches/resolve.patch';
-import {getPatch as getTypescriptPatch}          from './patches/typescript.patch';
+import {packageExtensions}              from './extensions';
+import {getPatch as getFseventsPatch}   from './patches/fsevents.patch';
+import {getPatch as getResolvePatch}    from './patches/resolve.patch';
+import {getPatch as getTypescriptPatch} from './patches/typescript.patch';
 
 const PATCHES = new Map([
   [structUtils.makeIdent(null, `fsevents`).identHash, getFseventsPatch],
@@ -12,7 +11,7 @@ const PATCHES = new Map([
   [structUtils.makeIdent(null, `typescript`).identHash, getTypescriptPatch],
 ]);
 
-const plugin: Plugin<CoreHooks & PatchHooks> = {
+const plugin: Plugin = {
   hooks: {
     registerPackageExtensions: async (configuration, registerPackageExtension) => {
       for (const [descriptorStr, extensionData] of packageExtensions) {

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -37,7 +37,7 @@ import * as suggestUtils                                        from './suggestU
 
 export {suggestUtils};
 
-export interface Hooks {
+interface EssentialHooks {
   afterWorkspaceDependencyAddition?: (
     workspace: Workspace,
     target: suggestUtils.Target,
@@ -63,6 +63,39 @@ export interface Hooks {
     extra: Set<string>,
     registerData: (namespace: string, data: Array<formatUtils.Tuple> | {[key: string]: formatUtils.Tuple | undefined}) => void,
   ) => Promise<void>,
+}
+
+/** @deprecated use Hooks from @yarnpkg/core instead */
+export type Hooks = EssentialHooks;
+
+declare module '@yarnpkg/core' {
+  interface Hooks {
+    afterWorkspaceDependencyAddition?: (
+      workspace: Workspace,
+      target: `${suggestUtils.Target}`,
+      descriptor: Descriptor,
+      strategies: Array<`${suggestUtils.Strategy}`>
+    ) => Promise<void>,
+
+    afterWorkspaceDependencyReplacement?: (
+      workspace: Workspace,
+      target: `${suggestUtils.Target}`,
+      fromDescriptor: Descriptor,
+      toDescriptor: Descriptor,
+    ) => Promise<void>,
+
+    afterWorkspaceDependencyRemoval?: (
+      workspace: Workspace,
+      target: `${suggestUtils.Target}`,
+      descriptor: Descriptor,
+    ) => Promise<void>,
+
+    fetchPackageInfo?: (
+      pkg: Package,
+      extra: Set<string>,
+      registerData: (namespace: string, data: Array<formatUtils.Tuple> | {[key: string]: formatUtils.Tuple | undefined}) => void,
+    ) => Promise<void>,
+  }
 }
 
 declare module '@yarnpkg/core' {

--- a/packages/plugin-git/sources/index.ts
+++ b/packages/plugin-git/sources/index.ts
@@ -4,7 +4,7 @@ import {GitFetcher}                                               from './GitFet
 import {GitResolver}                                              from './GitResolver';
 import * as gitUtils                                              from './gitUtils';
 
-export interface Hooks {
+interface GitHooks {
   fetchHostedRepository?: (
     current: FetchResult | null,
     locator: Locator,
@@ -12,9 +12,15 @@ export interface Hooks {
   ) => Promise<FetchResult | null>,
 }
 
+/** @deprecated use Hooks from @yarnpkg/core instead */
+export type Hooks = GitHooks;
+
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     cloneConcurrency: number;
+  }
+
+  interface Hooks extends GitHooks {
   }
 }
 

--- a/packages/plugin-github/sources/index.ts
+++ b/packages/plugin-github/sources/index.ts
@@ -1,9 +1,8 @@
-import {Plugin}            from '@yarnpkg/core';
-import {Hooks as GitHooks} from '@yarnpkg/plugin-git';
+import {Plugin}        from '@yarnpkg/core';
 
-import {GithubFetcher}     from './GithubFetcher';
+import {GithubFetcher} from './GithubFetcher';
 
-const plugin: Plugin<GitHooks> = {
+const plugin: Plugin = {
   hooks: {
     async fetchHostedRepository(previous, locator, opts) {
       if (previous !== null)

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -1,16 +1,24 @@
-import {Hooks as CoreHooks, Plugin, Workspace, structUtils} from '@yarnpkg/core';
-import {MessageName, ReportError}                           from '@yarnpkg/core';
+import {Plugin, Workspace, structUtils} from '@yarnpkg/core';
+import {MessageName, ReportError}       from '@yarnpkg/core';
 
-import pack                                                 from './commands/pack';
-import * as packUtils                                       from './packUtils';
+import pack                             from './commands/pack';
+import * as packUtils                   from './packUtils';
 
 export {packUtils};
 
-export interface Hooks {
+interface PackHooks {
   beforeWorkspacePacking?: (
     workspace: Workspace,
     rawManifest: object,
   ) => Promise<void>|void;
+}
+
+/** @deprecated use Hooks from @yarnpkg/core instead */
+export type Hooks = PackHooks;
+
+declare module '@yarnpkg/core' {
+  interface Hooks extends PackHooks {
+  }
 }
 
 const DEPENDENCY_TYPES = [`dependencies`, `devDependencies`, `peerDependencies`];
@@ -66,7 +74,7 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
   }
 };
 
-const plugin: Plugin<CoreHooks & Hooks> = {
+const plugin: Plugin = {
   hooks: {
     beforeWorkspacePacking,
   },

--- a/packages/plugin-patch/sources/index.ts
+++ b/packages/plugin-patch/sources/index.ts
@@ -8,16 +8,22 @@ import * as patchUtils                 from './patchUtils';
 
 export {patchUtils};
 
-export interface Hooks {
+interface PatchHooks {
   getBuiltinPatch?: (
     project: Project,
     name: string,
   ) => Promise<string | null | void>,
 }
 
+/** @deprecated use Hooks from @yarnpkg/core instead */
+export type Hooks = PatchHooks;
+
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     enableInlineHunks: boolean;
+  }
+
+  interface Hooks extends PatchHooks {
   }
 }
 

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -1,12 +1,11 @@
-import {Hooks as CoreHooks, Plugin, Project, SettingsType} from '@yarnpkg/core';
-import {Filename, PortablePath, npath, ppath, xfs}         from '@yarnpkg/fslib';
-import {Hooks as StageHooks}                               from '@yarnpkg/plugin-stage';
+import {Plugin, Project, SettingsType}             from '@yarnpkg/core';
+import {Filename, PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
 
-import semver                                              from 'semver';
+import semver                                      from 'semver';
 
-import {PnpLinker}                                         from './PnpLinker';
-import unplug                                              from './commands/unplug';
-import * as pnpUtils                                       from './pnpUtils';
+import {PnpLinker}                                 from './PnpLinker';
+import unplug                                      from './commands/unplug';
+import * as pnpUtils                               from './pnpUtils';
 
 export {pnpUtils};
 
@@ -72,7 +71,7 @@ declare module '@yarnpkg/core' {
   }
 }
 
-const plugin: Plugin<CoreHooks & StageHooks> = {
+const plugin: Plugin = {
   hooks: {
     populateYarnPaths,
     setupScriptEnvironment,

--- a/packages/plugin-stage/sources/index.ts
+++ b/packages/plugin-stage/sources/index.ts
@@ -3,17 +3,25 @@ import {PortablePath}    from '@yarnpkg/fslib';
 
 import stage             from './commands/stage';
 
-export interface Hooks {
+interface StageHooks {
   populateYarnPaths?: (
     project: Project,
     definePath: (path: PortablePath | null) => void,
   ) => Promise<void>,
 }
 
+/** @deprecated use Hooks from @yarnpkg/core instead */
+export type Hooks = StageHooks;
+
+declare module '@yarnpkg/core' {
+  export interface Hooks extends StageHooks {}
+}
+
 const plugin: Plugin = {
   commands: [
     stage,
   ],
+  hooks: {populateYarnPaths: undefined},
 };
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-typescript/sources/index.ts
+++ b/packages/plugin-typescript/sources/index.ts
@@ -1,8 +1,6 @@
 import {Descriptor, Plugin, Workspace, ResolveOptions, Manifest, AllDependencies, DescriptorHash, Package} from '@yarnpkg/core';
 import {structUtils, ThrowReport, miscUtils}                                                               from '@yarnpkg/core';
-import {Hooks as EssentialsHooks}                                                                          from '@yarnpkg/plugin-essentials';
 import {suggestUtils}                                                                                      from '@yarnpkg/plugin-essentials';
-import {Hooks as PackHooks}                                                                                from '@yarnpkg/plugin-pack';
 import semver                                                                                              from 'semver';
 
 import {hasDefinitelyTyped}                                                                                from './typescriptUtils';
@@ -15,9 +13,9 @@ const getTypesName = (descriptor: Descriptor) => {
 
 const afterWorkspaceDependencyAddition = async (
   workspace: Workspace,
-  dependencyTarget: suggestUtils.Target,
+  dependencyTarget: unknown,
   descriptor: Descriptor,
-  strategies: Array<suggestUtils.Strategy>
+  strategies: unknown
 ) => {
   if (descriptor.scope === `types`)
     return;
@@ -99,7 +97,7 @@ const afterWorkspaceDependencyAddition = async (
 
 const afterWorkspaceDependencyRemoval = async (
   workspace: Workspace,
-  dependencyTarget: suggestUtils.Target,
+  dependencyTarget: unknown,
   descriptor: Descriptor,
 ) => {
   if (descriptor.scope === `types`)
@@ -128,7 +126,7 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
   }
 };
 
-const plugin: Plugin<EssentialsHooks & PackHooks> = {
+const plugin: Plugin = {
   hooks: {
     afterWorkspaceDependencyAddition,
     afterWorkspaceDependencyRemoval,

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1415,6 +1415,9 @@ export class Configuration {
     });
   }
 
+  async triggerHook<U extends Array<any>, V>(get: (hooks: Hooks) => ((...args: U) => V) | undefined, ...args: U): Promise<void>;
+  /** @deprecated Use the version without HooksDefinition generic parameter */
+  async triggerHook<U extends Array<any>, V, HooksDefinition>(get: (hooks: HooksDefinition) => ((...args: U) => V) | undefined, ...args: U): Promise<void>;
   async triggerHook<U extends Array<any>, V, HooksDefinition = Hooks>(get: (hooks: HooksDefinition) => ((...args: U) => V) | undefined, ...args: U): Promise<void> {
     for (const plugin of this.plugins.values()) {
       const hooks = plugin.hooks as HooksDefinition;
@@ -1429,12 +1432,18 @@ export class Configuration {
     }
   }
 
+  async triggerMultipleHooks<U extends Array<any>, V>(get: (hooks: Hooks) => ((...args: U) => V) | undefined, argsList: Array<U>): Promise<void>;
+  /** @deprecated Use the version without HooksDefinition generic parameter */
+  async triggerMultipleHooks<U extends Array<any>, V, HooksDefinition>(get: (hooks: HooksDefinition) => ((...args: U) => V) | undefined, argsList: Array<U>): Promise<void>;
   async triggerMultipleHooks<U extends Array<any>, V, HooksDefinition = Hooks>(get: (hooks: HooksDefinition) => ((...args: U) => V) | undefined, argsList: Array<U>): Promise<void> {
     for (const args of argsList) {
       await this.triggerHook(get, ...args);
     }
   }
 
+  async reduceHook<U extends Array<any>, V>(get: (hooks: Hooks) => ((reduced: V, ...args: U) => Promise<V>) | undefined, initialValue: V, ...args: U): Promise<V>;
+  /** @deprecated Use the version without HooksDefinition generic parameter */
+  async reduceHook<U extends Array<any>, V, HooksDefinition>(get: (hooks: HooksDefinition) => ((reduced: V, ...args: U) => Promise<V>) | undefined, initialValue: V, ...args: U): Promise<V>;
   async reduceHook<U extends Array<any>, V, HooksDefinition = Hooks>(get: (hooks: HooksDefinition) => ((reduced: V, ...args: U) => Promise<V>) | undefined, initialValue: V, ...args: U): Promise<V> {
     let value = initialValue;
 
@@ -1453,6 +1462,9 @@ export class Configuration {
     return value;
   }
 
+  async firstHook<U extends Array<any>, V>(get: (hooks: Hooks) => ((...args: U) => Promise<V>) | undefined, ...args: U): Promise<Exclude<V, void> | null>;
+  /** @deprecated Use the version without HooksDefinition generic parameter */
+  async firstHook<U extends Array<any>, V, HooksDefinition>(get: (hooks: HooksDefinition) => ((...args: U) => Promise<V>) | undefined, ...args: U): Promise<Exclude<V, void> | null>;
   async firstHook<U extends Array<any>, V, HooksDefinition = Hooks>(get: (hooks: HooksDefinition) => ((...args: U) => Promise<V>) | undefined, ...args: U): Promise<Exclude<V, void> | null> {
     for (const plugin of this.plugins.values()) {
       const hooks = plugin.hooks as HooksDefinition;

--- a/packages/yarnpkg-core/sources/CorePlugin.ts
+++ b/packages/yarnpkg-core/sources/CorePlugin.ts
@@ -8,7 +8,7 @@ import {Descriptor, Locator}      from './types';
 
 export const CorePlugin: Plugin = {
   hooks: {
-    reduceDependency: (dependency: Descriptor, project: Project, locator: Locator, initialDependency: Descriptor, {resolver, resolveOptions}: {resolver: Resolver, resolveOptions: ResolveOptions}) => {
+    reduceDependency: async (dependency: Descriptor, project: Project, locator: Locator, initialDependency: Descriptor, {resolver, resolveOptions}: {resolver: Resolver, resolveOptions: ResolveOptions}) => {
       for (const {pattern, reference} of project.topLevelWorkspace.manifest.resolutions) {
         if (pattern.from && pattern.from.fullName !== structUtils.requirableIdent(locator))
           continue;

--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -34,7 +34,7 @@ export interface ResolverPlugin {
   new(): Resolver;
 }
 
-export type Hooks = {
+export interface Hooks {
   // Called when the package extensions are setup. Can be used to inject new
   // ones (for example, that's what the compat plugin uses to workaround
   // metadata problems).
@@ -117,9 +117,9 @@ export type Hooks = {
     project: Project,
     definePath: (path: PortablePath | null) => void,
   ) => Promise<void>,
-};
+}
 
-export type Plugin<PluginHooks = any> = {
+export type Plugin<PluginHooks = Hooks> = {
   configuration?: Partial<ConfigurationDefinitionMap>,
   commands?: Array<CommandClass<CommandContext>>,
   fetchers?: Array<FetcherPlugin>,


### PR DESCRIPTION
PR shows what could be done and allows discussion.
It currently doesn't work due to babel not supporting interpolated literal string types yet.

It'll work once babel supports this new feature. I've verified that it works with tsc via:

```bash
git stash
yarn unplug typescript
git stash pop
node -r ./.pnp.js .yarn/unplugged/typescript-patch-73b6585552/node_modules/typescript/bin/tsc --noEmit
# no errors are logged
```

because `yarn tsc` doesn't work thanks to babel compilation.

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Hooks are typed but these types don't account for multiple plugins defining hooks with the same name but an incompatible interface.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Apply the same idea for the configuration typing to hooks

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
