### PR TITLE
fix(pnpify): Load prettier with in-memory node_modules enabled

### DIFF
--- a/.yarn/versions/848713c4.yml
+++ b/.yarn/versions/848713c4.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": minor
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -10,6 +10,9 @@ export default class SdkCommand extends Command {
   @Command.Rest()
   integrations: Array<string> = [];
 
+  @Command.Array(`--compat`, {description: `SDKs that should use PnPify`})
+  withPnpify: Array<string> = [];
+
   @Command.String(`--cwd`, {description: `The directory to run the command in`})
   cwd: NativePath = process.cwd();
 
@@ -36,6 +39,8 @@ export default class SdkCommand extends Command {
       The supported integrations at this time are: ${[...SUPPORTED_INTEGRATIONS.keys()].map(integration => `\`${integration}\``).join(`, `)}.
 
       **Note:** This command always updates the already-installed SDKs and editor settings, no matter which arguments are passed.
+
+      In cases where an SDK does still not perform as expected, you may want to enable PnPify \`node_modules\` virtualization using the \`--compat\` switch.
     `,
     examples: [[
       `Generate the base SDKs`,
@@ -46,6 +51,9 @@ export default class SdkCommand extends Command {
     ], [
       `Update all generated SDKs and editor settings`,
       `$0 --sdk`,
+    ], [
+      `Generate the base SDKs and use PnPify in prettier`,
+      `$0 --sdk base --compat prettier`,
     ]],
   });
 
@@ -113,6 +121,7 @@ export default class SdkCommand extends Command {
         onlyBase,
         configuration,
         verbose: this.verbose,
+        withPnpify: this.withPnpify,
       });
     });
 

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -121,7 +121,7 @@ export default class SdkCommand extends Command {
         onlyBase,
         configuration,
         verbose: this.verbose,
-        withPnpify: this.compat,
+        compat: this.compat,
       });
     });
 

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -11,7 +11,7 @@ export default class SdkCommand extends Command {
   integrations: Array<string> = [];
 
   @Command.Array(`--compat`, {description: `SDKs that should use PnPify`})
-  withPnpify: Array<string> = [];
+  compat: Array<string> = [];
 
   @Command.String(`--cwd`, {description: `The directory to run the command in`})
   cwd: NativePath = process.cwd();
@@ -121,7 +121,7 @@ export default class SdkCommand extends Command {
         onlyBase,
         configuration,
         verbose: this.verbose,
-        withPnpify: this.withPnpify,
+        withPnpify: this.compat,
       });
     });
 

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -166,7 +166,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   wrapModule ? `module.exports = moduleWrapper(absRequire(\`${module}\`));\n` : `module.exports = absRequire(\`${module}\`);\n`,
 ].join(``);
 
-export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => Promise<Wrapper>;
+export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath, compat: boolean) => Promise<Wrapper>;
 
 export type GenerateIntegrationWrapper = (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => Promise<void>;
 
@@ -264,7 +264,7 @@ type AllIntegrations = {
   preexistingIntegrations: Set<SupportedIntegration>;
 };
 
-export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, withPnpify, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, withPnpify: Array<string>, configuration: Configuration}): Promise<void> => {
+export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, compat, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, compat: Array<string>, configuration: Configuration}): Promise<void> => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
   const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
 
@@ -315,7 +315,7 @@ export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexi
 
       if (topLevelInformation.packageDependencies.has(pkgName)) {
         report.reportInfo(MessageName.UNNAMED, `${chalk.green(`✓`)} ${displayName}`);
-        const wrapper = await generateBaseWrapper(pnpApi, targetFolder, withPnpify.includes(pkgName));
+        const wrapper = await generateBaseWrapper(pnpApi, targetFolder, compat.includes(pkgName));
 
         for (const sdks of integrationSdks) {
           const sdk = sdks.find(sdk => sdk[0] === pkgName);

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -121,7 +121,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   `\n`,
   `const {existsSync} = require(\`fs\`);\n`,
   `const {createRequire, createRequireFromPath} = require(\`module\`);\n`,
-  `const {resolve, dirname} = require(\`path\`);\n`,
+  `const {resolve} = require(\`path\`);\n`,
   `\n`,
   `const relPnpApiPath = ${JSON.stringify(npath.fromPortablePath(relPnpApiPath))};\n`,
   `\n`,
@@ -148,7 +148,9 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   ] : []),
   ...(usePnpify ? [
     `\n`,
+    `  const {dirname} = require(\`path\`);\n`,
     `  const pnpifyResolution = require.resolve(\`@yarnpkg/pnpify\`, {paths: [dirname(absPnpApiPath)]});\n`,
+    `\n`,
     `  if (typeof global[\`__yarnpkg_sdk_is_using_pnpify__\`] === \`undefined\`) {\n`,
     `    Object.defineProperty(global, \`__yarnpkg_sdk_is_using_pnpify__\`, {configurable: true, value: true});\n`,
     `\n`,

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -164,7 +164,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   wrapModule ? `module.exports = moduleWrapper(absRequire(\`${module}\`));\n` : `module.exports = absRequire(\`${module}\`);\n`,
 ].join(``);
 
-export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath) => Promise<Wrapper>;
+export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => Promise<Wrapper>;
 
 export type GenerateIntegrationWrapper = (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => Promise<void>;
 
@@ -262,7 +262,7 @@ type AllIntegrations = {
   preexistingIntegrations: Set<SupportedIntegration>;
 };
 
-export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, configuration: Configuration}): Promise<void> => {
+export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, withPnpify, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, withPnpify: Array<string>, configuration: Configuration}): Promise<void> => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
   const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
 
@@ -313,7 +313,7 @@ export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexi
 
       if (topLevelInformation.packageDependencies.has(pkgName)) {
         report.reportInfo(MessageName.UNNAMED, `${chalk.green(`✓`)} ${displayName}`);
-        const wrapper = await generateBaseWrapper(pnpApi, targetFolder);
+        const wrapper = await generateBaseWrapper(pnpApi, targetFolder, withPnpify.includes(pkgName));
 
         for (const sdks of integrationSdks) {
           const sdk = sdks.find(sdk => sdk[0] === pkgName);

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -3,38 +3,38 @@ import {PnpApi}                                 from '@yarnpkg/pnp';
 
 import {Wrapper, GenerateBaseWrapper, BaseSdks} from '../generateSdk';
 
-export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
-  await wrapper.writeFile(`lib/api.js` as PortablePath);
+  await wrapper.writeBinary(`bin/eslint.js` as PortablePath, {usePnpify});
+  await wrapper.writeFile(`lib/api.js` as PortablePath, {usePnpify});
 
   return wrapper;
 };
 
-export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`index.js` as PortablePath);
+  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify});
 
   return wrapper;
 };
 
-export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`lib/cli.js` as PortablePath);
+  await wrapper.writeBinary(`lib/cli.js` as PortablePath, {usePnpify});
 
   return wrapper;
 };
 
-export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const tsServerMonkeyPatch = `
     tsserver => {
       // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
@@ -98,43 +98,45 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/tsc` as PortablePath);
-  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
+  await wrapper.writeBinary(`bin/tsc` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`bin/tsserver` as PortablePath, {usePnpify});
 
-  await wrapper.writeFile(`lib/tsc.js` as PortablePath);
-  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
-  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
+  await wrapper.writeFile(`lib/tsc.js` as PortablePath, {usePnpify});
+  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch, usePnpify});
+  await wrapper.writeFile(`lib/typescript.js` as PortablePath, {
+    usePnpify,
+  });
 
   return wrapper;
 };
 
-export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const wrapper = new Wrapper(`stylelint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath);
-  await wrapper.writeFile(`lib/index.js` as PortablePath);
+  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath, {usePnpify});
+  await wrapper.writeFile(`lib/index.js` as PortablePath, {usePnpify});
 
   return wrapper;
 };
 
-export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const wrapper = new Wrapper(`svelte-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/server.js` as PortablePath);
+  await wrapper.writeBinary(`bin/server.js` as PortablePath, {usePnpify});
 
   return wrapper;
 };
 
-export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
   const wrapper = new Wrapper(`flow-bin` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`cli.js` as PortablePath);
+  await wrapper.writeBinary(`cli.js` as PortablePath, {usePnpify});
 
   return wrapper;
 };

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -3,38 +3,38 @@ import {PnpApi}                                 from '@yarnpkg/pnp';
 
 import {Wrapper, GenerateBaseWrapper, BaseSdks} from '../generateSdk';
 
-export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/eslint.js` as PortablePath, {usePnpify});
-  await wrapper.writeFile(`lib/api.js` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`bin/eslint.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/api.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`lib/cli.js` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`lib/cli.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const tsServerMonkeyPatch = `
     tsserver => {
       // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
@@ -98,45 +98,43 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/tsc` as PortablePath, {usePnpify});
-  await wrapper.writeBinary(`bin/tsserver` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`bin/tsc` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`bin/tsserver` as PortablePath, {usePnpify: compat});
 
-  await wrapper.writeFile(`lib/tsc.js` as PortablePath, {usePnpify});
-  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch, usePnpify});
-  await wrapper.writeFile(`lib/typescript.js` as PortablePath, {
-    usePnpify,
-  });
+  await wrapper.writeFile(`lib/tsc.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch, usePnpify:compat});
+  await wrapper.writeFile(`lib/typescript.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`stylelint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath, {usePnpify});
-  await wrapper.writeFile(`lib/index.js` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/index.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`svelte-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/server.js` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`bin/server.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, usePnpify: boolean) => {
+export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`flow-bin` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`cli.js` as PortablePath, {usePnpify});
+  await wrapper.writeBinary(`cli.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**
Using `--compat prettier,eslint`, the user can have the PnPify filesystem virtualization enabled in an SDK wrapper. This will allow users to get around packages (like `prettier`) that heavily rely on a `node_modules` file system layout to auto-load their plugins.

Fixes #1903

**How did you fix it?**
The template used for the wrapper, already has an argument to have the PnPify virtualization enabled. So far it appeares unused.

In the SDK generation path, I accept the same argument to have this virtualization enabled if requested from upstream.

I accept a new argument `--compat eslint,prettier,whatever` and when a base SDK name matches any of the given arguments, it will have the `usePnpify` option enabled.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
