### PR TITLE
fix(plugin-essentials): correctly log deep properties getting set

### DIFF
--- a/.yarn/versions/e92383f8.yml
+++ b/.yarn/versions/e92383f8.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.js
@@ -1,0 +1,46 @@
+import {xfs} from '@yarnpkg/fslib';
+
+describe(`Commands`, () => {
+  describe(`config set`, () => {
+    test(
+      `it should print the configured value for the current directory`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await expect(run(`config`, `set`, `pnpShebang`, `#!/usr/bin/env iojs\n`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`#!/usr/bin/env iojs\\n`),
+        });
+
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`pnpShebang`);
+      }),
+    );
+
+    test(
+      `it shouldn't print secrets`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const {stdout} = await run(`config`, `set`, `npmAuthToken`, `foobar`);
+
+        expect(stdout).not.toContain(`foobar`);
+        expect(stdout).toContain(`********`);
+
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`npmAuthToken: foobar`);
+      }),
+    );
+
+    test(
+      `it should support setting JSON values`,
+      makeTemporaryEnv({enableColors: false}, async({path, run, source}) => {
+        const {stdout} = await run(`config`, `set`, `npmScopes.yarnpkg`, `--json`, JSON.stringify({
+          npmAlwaysAuth: false,
+        }));
+
+        expect(stdout).toContain(`npmScopes.yarnpkg`);
+        expect(stdout).toContain(`npmAlwaysAuth: false`);
+
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(
+          `npmScopes:\n` +
+          `  yarnpkg:\n` +
+          `    npmAlwaysAuth: false`,
+        );
+      }),
+    );
+  });
+});

--- a/packages/plugin-essentials/sources/commands/config/get.ts
+++ b/packages/plugin-essentials/sources/commands/config/get.ts
@@ -81,7 +81,7 @@ export default class ConfigSetCommand extends BaseCommand {
 
       this.context.stdout.write(`${inspect(requestedObject, {
         depth: Infinity,
-        colors: true,
+        colors: configuration.get(`enableColors`),
         compact: false,
       })}\n`);
     }

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -102,7 +102,7 @@ export default class ConfigSetCommand extends BaseCommand {
 
       report.reportInfo(MessageName.UNNAMED, `Successfully set ${this.name} to ${inspect(requestedObject, {
         depth: Infinity,
-        colors: true,
+        colors: configuration.get(`enableColors`),
         compact: false,
       })}`);
     });

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -53,7 +53,7 @@ export default class ConfigSetCommand extends BaseCommand {
       throw new UsageError(`This command must be run from within a project folder`);
 
     const name = this.name.replace(/[.[].*$/, ``);
-    const path = this.name.replace(/^[^.[]*/, ``);
+    const path = this.name.replace(/^[^.[]*\.?/, ``);
 
     const setting = configuration.settings.get(name);
     if (typeof setting === `undefined`)


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Setting deep configuration values sometimes logged undefined:

```
$ yarn config set "npmScopes.angular.npmAlwaysAuth" false
➤ YN0000: Successfully set npmScopes.angular.npmAlwaysAuth to undefined

$ yarn config set "npmScopes['angular'].npmAlwaysAuth" false
➤ YN0000: Successfully set npmScopes['angular'].npmAlwaysAuth to false
```

**How did you fix it?**

Consume the `.` in the path. This changes the path from `.angular.npmAlwaysAuth` to `angular.npmAlwaysAuth`, which matches what lodash.get expects.

I also added tests for `yarn config set`, and changed config get/set so these respsect the `enableColors` configuration value, which I needed to write the tests in set.test.js.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
