### PR TITLE
fix(pnpify): Load prettier with in-memory node_modules enabled

### DIFF
--- a/.yarn/versions/848713c4.yml
+++ b/.yarn/versions/848713c4.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/pnpify": minor
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -10,9 +10,6 @@ export default class SdkCommand extends Command {
   @Command.Rest()
   integrations: Array<string> = [];
 
-  @Command.Array(`--compat`, {description: `SDKs that should use PnPify`})
-  compat: Array<string> = [];
-
   @Command.String(`--cwd`, {description: `The directory to run the command in`})
   cwd: NativePath = process.cwd();
 
@@ -39,8 +36,6 @@ export default class SdkCommand extends Command {
       The supported integrations at this time are: ${[...SUPPORTED_INTEGRATIONS.keys()].map(integration => `\`${integration}\``).join(`, `)}.
 
       **Note:** This command always updates the already-installed SDKs and editor settings, no matter which arguments are passed.
-
-      In cases where an SDK does still not perform as expected, you may want to enable PnPify \`node_modules\` virtualization using the \`--compat\` switch.
     `,
     examples: [[
       `Generate the base SDKs`,
@@ -51,9 +46,6 @@ export default class SdkCommand extends Command {
     ], [
       `Update all generated SDKs and editor settings`,
       `$0 --sdk`,
-    ], [
-      `Generate the base SDKs and use PnPify in prettier`,
-      `$0 --sdk base --compat prettier`,
     ]],
   });
 
@@ -121,7 +113,6 @@ export default class SdkCommand extends Command {
         onlyBase,
         configuration,
         verbose: this.verbose,
-        compat: this.compat,
       });
     });
 

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -10,6 +10,9 @@ export default class SdkCommand extends Command {
   @Command.Rest()
   integrations: Array<string> = [];
 
+  @Command.Array(`--compat`, {description: `SDKs that should use PnPify`})
+  compat: Array<string> = [];
+
   @Command.String(`--cwd`, {description: `The directory to run the command in`})
   cwd: NativePath = process.cwd();
 
@@ -36,6 +39,8 @@ export default class SdkCommand extends Command {
       The supported integrations at this time are: ${[...SUPPORTED_INTEGRATIONS.keys()].map(integration => `\`${integration}\``).join(`, `)}.
 
       **Note:** This command always updates the already-installed SDKs and editor settings, no matter which arguments are passed.
+
+      In cases where an SDK does still not perform as expected, you may want to enable PnPify \`node_modules\` virtualization using the \`--compat\` switch.
     `,
     examples: [[
       `Generate the base SDKs`,
@@ -46,6 +51,9 @@ export default class SdkCommand extends Command {
     ], [
       `Update all generated SDKs and editor settings`,
       `$0 --sdk`,
+    ], [
+      `Generate the base SDKs and use PnPify in prettier`,
+      `$0 --sdk base --compat prettier`,
     ]],
   });
 
@@ -113,6 +121,7 @@ export default class SdkCommand extends Command {
         onlyBase,
         configuration,
         verbose: this.verbose,
+        compat: this.compat,
       });
     });
 

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -121,7 +121,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   `\n`,
   `const {existsSync} = require(\`fs\`);\n`,
   `const {createRequire, createRequireFromPath} = require(\`module\`);\n`,
-  `const {resolve, dirname} = require(\`path\`);\n`,
+  `const {resolve} = require(\`path\`);\n`,
   `\n`,
   `const relPnpApiPath = ${JSON.stringify(npath.fromPortablePath(relPnpApiPath))};\n`,
   `\n`,
@@ -148,7 +148,9 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   ] : []),
   ...(usePnpify ? [
     `\n`,
+    `  const {dirname} = require(\`path\`);\n`,
     `  const pnpifyResolution = require.resolve(\`@yarnpkg/pnpify\`, {paths: [dirname(absPnpApiPath)]});\n`,
+    `\n`,
     `  if (typeof global[\`__yarnpkg_sdk_is_using_pnpify__\`] === \`undefined\`) {\n`,
     `    Object.defineProperty(global, \`__yarnpkg_sdk_is_using_pnpify__\`, {configurable: true, value: true});\n`,
     `\n`,
@@ -164,7 +166,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   wrapModule ? `module.exports = moduleWrapper(absRequire(\`${module}\`));\n` : `module.exports = absRequire(\`${module}\`);\n`,
 ].join(``);
 
-export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath) => Promise<Wrapper>;
+export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath, compat: boolean) => Promise<Wrapper>;
 
 export type GenerateIntegrationWrapper = (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => Promise<void>;
 
@@ -262,7 +264,7 @@ type AllIntegrations = {
   preexistingIntegrations: Set<SupportedIntegration>;
 };
 
-export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, configuration: Configuration}): Promise<void> => {
+export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, compat, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, compat: Array<string>, configuration: Configuration}): Promise<void> => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
   const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
 
@@ -313,7 +315,7 @@ export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexi
 
       if (topLevelInformation.packageDependencies.has(pkgName)) {
         report.reportInfo(MessageName.UNNAMED, `${chalk.green(`✓`)} ${displayName}`);
-        const wrapper = await generateBaseWrapper(pnpApi, targetFolder);
+        const wrapper = await generateBaseWrapper(pnpApi, targetFolder, compat.includes(pkgName));
 
         for (const sdks of integrationSdks) {
           const sdk = sdks.find(sdk => sdk[0] === pkgName);

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -121,7 +121,11 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   `\n`,
   `const {existsSync} = require(\`fs\`);\n`,
   `const {createRequire, createRequireFromPath} = require(\`module\`);\n`,
-  `const {resolve} = require(\`path\`);\n`,
+  ...(usePnpify ? [
+    `const {resolve, dirname} = require(\`path\`);\n`,
+  ] : [
+    `const {resolve} = require(\`path\`);\n`,
+  ]),
   `\n`,
   `const relPnpApiPath = ${JSON.stringify(npath.fromPortablePath(relPnpApiPath))};\n`,
   `\n`,
@@ -148,9 +152,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   ] : []),
   ...(usePnpify ? [
     `\n`,
-    `  const {dirname} = require(\`path\`);\n`,
     `  const pnpifyResolution = require.resolve(\`@yarnpkg/pnpify\`, {paths: [dirname(absPnpApiPath)]});\n`,
-    `\n`,
     `  if (typeof global[\`__yarnpkg_sdk_is_using_pnpify__\`] === \`undefined\`) {\n`,
     `    Object.defineProperty(global, \`__yarnpkg_sdk_is_using_pnpify__\`, {configurable: true, value: true});\n`,
     `\n`,
@@ -166,7 +168,7 @@ const TEMPLATE = (relPnpApiPath: PortablePath, module: string, {setupEnv = false
   wrapModule ? `module.exports = moduleWrapper(absRequire(\`${module}\`));\n` : `module.exports = absRequire(\`${module}\`);\n`,
 ].join(``);
 
-export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath, compat: boolean) => Promise<Wrapper>;
+export type GenerateBaseWrapper = (pnpApi: PnpApi, target: PortablePath) => Promise<Wrapper>;
 
 export type GenerateIntegrationWrapper = (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => Promise<void>;
 
@@ -264,7 +266,7 @@ type AllIntegrations = {
   preexistingIntegrations: Set<SupportedIntegration>;
 };
 
-export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, compat, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, compat: Array<string>, configuration: Configuration}): Promise<void> => {
+export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexistingIntegrations}: AllIntegrations, {report, onlyBase, verbose, configuration}: {report: Report, onlyBase: boolean, verbose: boolean, configuration: Configuration}): Promise<void> => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
   const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
 
@@ -315,7 +317,7 @@ export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexi
 
       if (topLevelInformation.packageDependencies.has(pkgName)) {
         report.reportInfo(MessageName.UNNAMED, `${chalk.green(`✓`)} ${displayName}`);
-        const wrapper = await generateBaseWrapper(pnpApi, targetFolder, compat.includes(pkgName));
+        const wrapper = await generateBaseWrapper(pnpApi, targetFolder);
 
         for (const sdks of integrationSdks) {
           const sdk = sdks.find(sdk => sdk[0] === pkgName);

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -3,38 +3,38 @@ import {PnpApi}                                 from '@yarnpkg/pnp';
 
 import {Wrapper, GenerateBaseWrapper, BaseSdks} from '../generateSdk';
 
-export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/eslint.js` as PortablePath, {usePnpify: compat});
-  await wrapper.writeFile(`lib/api.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
+  await wrapper.writeFile(`lib/api.js` as PortablePath);
 
   return wrapper;
 };
 
-export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify: true});
 
   return wrapper;
 };
 
-export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`lib/cli.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`lib/cli.js` as PortablePath);
 
   return wrapper;
 };
 
-export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const tsServerMonkeyPatch = `
     tsserver => {
       // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
@@ -98,43 +98,43 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/tsc` as PortablePath, {usePnpify: compat});
-  await wrapper.writeBinary(`bin/tsserver` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`bin/tsc` as PortablePath);
+  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
 
-  await wrapper.writeFile(`lib/tsc.js` as PortablePath, {usePnpify: compat});
-  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch, usePnpify:compat});
-  await wrapper.writeFile(`lib/typescript.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/tsc.js` as PortablePath);
+  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
+  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
 
   return wrapper;
 };
 
-export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`stylelint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath, {usePnpify: compat});
-  await wrapper.writeFile(`lib/index.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath);
+  await wrapper.writeFile(`lib/index.js` as PortablePath);
 
   return wrapper;
 };
 
-export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`svelte-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/server.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`bin/server.js` as PortablePath);
 
   return wrapper;
 };
 
-export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
+export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`flow-bin` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`cli.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`cli.js` as PortablePath);
 
   return wrapper;
 };

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -3,38 +3,38 @@ import {PnpApi}                                 from '@yarnpkg/pnp';
 
 import {Wrapper, GenerateBaseWrapper, BaseSdks} from '../generateSdk';
 
-export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
-  await wrapper.writeFile(`lib/api.js` as PortablePath);
+  await wrapper.writeBinary(`bin/eslint.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/api.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`index.js` as PortablePath);
+  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`lib/cli.js` as PortablePath);
+  await wrapper.writeBinary(`lib/cli.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const tsServerMonkeyPatch = `
     tsserver => {
       // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
@@ -98,43 +98,43 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/tsc` as PortablePath);
-  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
+  await wrapper.writeBinary(`bin/tsc` as PortablePath, {usePnpify: compat});
+  await wrapper.writeBinary(`bin/tsserver` as PortablePath, {usePnpify: compat});
 
-  await wrapper.writeFile(`lib/tsc.js` as PortablePath);
-  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
-  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
+  await wrapper.writeFile(`lib/tsc.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch, usePnpify:compat});
+  await wrapper.writeFile(`lib/typescript.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`stylelint` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath);
-  await wrapper.writeFile(`lib/index.js` as PortablePath);
+  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath, {usePnpify: compat});
+  await wrapper.writeFile(`lib/index.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`svelte-language-server` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`bin/server.js` as PortablePath);
+  await wrapper.writeBinary(`bin/server.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };
 
-export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath, compat: boolean) => {
   const wrapper = new Wrapper(`flow-bin` as PortablePath, {pnpApi, target});
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`cli.js` as PortablePath);
+  await wrapper.writeBinary(`cli.js` as PortablePath, {usePnpify: compat});
 
   return wrapper;
 };


### PR DESCRIPTION
Loads prettier with in-memory node_modules enabled

Fixes #1903

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Prettier cannot find plugins in PnP environment

**How did you fix it?**
<!-- A detailed description of your implementation. -->

In-memory node_modules is enabled for prettier, so that it can find plugins. 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
