### PR TITLE
[node_modules] Take into account peer dependency defaults when inheriting workspace peer dependencies

### DIFF
--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -49,7 +49,7 @@ jobs:
     - name: 'Running node_modules install with self-validation'
       run: |
         source scripts/e2e-setup-ci.sh
-        git clone https://github.com/babel/babel.git -b next-8-dev
+        git clone https://github.com/babel/babel.git
         cd babel
         NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
       shell: bash

--- a/.yarn/versions/8e1db223.yml
+++ b/.yarn/versions/8e1db223.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -770,4 +770,36 @@ describe(`Node_Modules`, () => {
       },
     )
   );
+
+  test(`should respect peerDependencies with defaults in workspaces`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        workspaces: [`foo`],
+        dependencies: {
+          'has-bin-entries': `2.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await writeJson(npath.toPortablePath(`${path}/foo/package.json`), {
+          name: `foo`,
+          peerDependencies: {
+            'has-bin-entries': `*`,
+          },
+          devDependencies: {
+            'has-bin-entries': `1.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        await expect(source(`require('foo/node_modules/has-bin-entries')`)).resolves.toMatchObject({
+          version: `1.0.0`,
+        });
+      },
+    )
+  );
 });

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -257,14 +257,14 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
     if (options.project) {
       const workspace = options.project.workspacesByCwd.get(npath.toPortablePath(pkg.packageLocation.slice(0, -1)));
       if (workspace) {
-        node.peerNames = new Set([
-          ...pkg.packagePeers,
+        const peerCandidates = new Set([
           ...Array.from(workspace.manifest.peerDependencies.values(), x => structUtils.stringifyIdent(x)),
           ...Array.from(workspace.manifest.peerDependenciesMeta.keys()),
         ]);
-        for (const peerName of node.peerNames) {
-          if (!pkg.packagePeers.has(peerName)) {
+        for (const peerName of peerCandidates) {
+          if (!allDependencies.has(peerName)) {
             allDependencies.set(peerName, parentDependencies.get(peerName) || null);
+            node.peerNames.add(peerName);
           }
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

NM linker didn't take into account defaults for workspace peerDependencies, this was a regression.
https://github.com/babel/babel/pull/12134#issuecomment-702715343

CC: @nicolo-ribaudo 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The linker respects the defaults now.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
