### PR TITLE
Only iterates the first level of info by default

### DIFF
--- a/.yarn/versions/d8eb7046.yml
+++ b/.yarn/versions/d8eb7046.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/info.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/info.test.ts
@@ -1,10 +1,4 @@
-// We need this to silence the TS warning about isolatedModule, since there's no import
-
-import {Filename, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
-import {fs}                                 from 'pkg-tests-core';
-
-// eslint-disable-next-line
-export default null;
+import {PortablePath, ppath, xfs} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
   describe(`info`, () => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/info.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/info.test.ts
@@ -1,4 +1,8 @@
 // We need this to silence the TS warning about isolatedModule, since there's no import
+
+import {Filename, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
+import {fs}                                 from 'pkg-tests-core';
+
 // eslint-disable-next-line
 export default null;
 
@@ -14,6 +18,92 @@ describe(`Commands`, () => {
         await run(`install`);
 
         const {stdout} = await run(`info`, `no-deps`, `--json`);
+        const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
+
+        expect(data).toHaveLength(1);
+
+        expect(data[0]).toMatchObject({
+          value: `no-deps@npm:1.0.0`,
+          children: {
+            Version: `1.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it shouldn't print info for the transitive dependencies by default`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(run(`info`, `no-deps`, `--json`)).rejects.toThrow();
+      }),
+    );
+
+    test(
+      `it should print info for the transitive dependencies if -R,--recursive is set`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        const {stdout} = await run(`info`, `no-deps`, `--recursive`, `--json`);
+        const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
+
+        expect(data).toHaveLength(1);
+
+        expect(data[0]).toMatchObject({
+          value: `no-deps@npm:1.0.0`,
+          children: {
+            Version: `1.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it shouldn't print info for other workspaces by default`,
+      makeTemporaryEnv({
+        workspaces: [
+          `workspace`,
+        ],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(ppath.join(path, `workspace` as PortablePath));
+        await xfs.writeJsonPromise(ppath.join(path, `workspace/package.json` as PortablePath), {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        await expect(run(`info`, `no-deps`, `--json`)).rejects.toThrow();
+      }),
+    );
+
+    test(
+      `it should print info for other workspaces if -A,--all is set`,
+      makeTemporaryEnv({
+        workspaces: [
+          `workspace`,
+        ],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(ppath.join(path, `workspace` as PortablePath));
+        await xfs.writeJsonPromise(ppath.join(path, `workspace/package.json` as PortablePath), {
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        const {stdout} = await run(`info`, `no-deps`, `--all`, `--json`);
         const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
 
         expect(data).toHaveLength(1);
@@ -47,7 +137,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        const {stdout} = await run(`info`, `no-deps`, `--json`);
+        const {stdout} = await run(`info`, `no-deps`, `--recursive`, `--json`);
         const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
 
         expect(data).toHaveLength(2);
@@ -78,7 +168,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        const {stdout} = await run(`info`, `no-deps@npm:2.0.0`, `--json`);
+        const {stdout} = await run(`info`, `no-deps@npm:2.0.0`, `--recursive`, `--json`);
         const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
 
         expect(data).toHaveLength(1);
@@ -102,7 +192,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        const {stdout} = await run(`info`, `no-*`, `--json`);
+        const {stdout} = await run(`info`, `no-*`, `--recursive`, `--json`);
         const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
 
         expect(data).toHaveLength(2);
@@ -133,7 +223,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        const {stdout} = await run(`info`, `*@npm:2.0.0`, `--json`);
+        const {stdout} = await run(`info`, `*@npm:2.0.0`, `--recursive`, `--json`);
         const data = stdout.match(/.*\n/g)!.map(line => JSON.parse(line));
 
         expect(data).toHaveLength(2);

--- a/packages/plugin-essentials/sources/commands/info.ts
+++ b/packages/plugin-essentials/sources/commands/info.ts
@@ -2,6 +2,7 @@ import {BaseCommand, WorkspaceRequiredError}                                    
 import {Configuration, Project, structUtils, Workspace, LocatorHash, Package, formatUtils, miscUtils, Locator, Cache, FetchOptions, ThrowReport, Manifest, treeUtils} from '@yarnpkg/core';
 import {xfs}                                                                                                                                                          from '@yarnpkg/fslib';
 import {Command, Usage, UsageError}                                                                                                                                   from 'clipanion';
+import {initial}                                                                                                                                                      from 'lodash';
 import mm                                                                                                                                                             from 'micromatch';
 
 import {Hooks}                                                                                                                                                        from '..';
@@ -10,6 +11,9 @@ import {Hooks}                                                                  
 export default class InfoCommand extends BaseCommand {
   @Command.Boolean(`-A,--all`, {description: `Print versions of a package from the whole project`})
   all: boolean = false;
+
+  @Command.Boolean(`-R,--recursive`, {description: `Print information for all packages, including transitive dependencies`})
+  recursive: boolean = false;
 
   @Command.Array(`-X,--extra`, {description: `An array of requests of extra data provided by plugins`})
   extra: Array<string> = [];
@@ -37,7 +41,7 @@ export default class InfoCommand extends BaseCommand {
     details: `
       This command prints various information related to the specified packages, accepting glob patterns.
 
-      By default, if the locator reference is missing, Yarn will default to print the information about all versions of the package in the active workspace dependency tree. To instead print all versions of the package in the whole project, use the \`-A,--all\` flag.
+      By default, if the locator reference is missing, Yarn will default to print the information about all the matching direct dependencies of the package for the active workspace. To instead print all versions of the package that are direct dependencies of any of your workspaces, use the \`-A,--all\` flag. Adding the \`-R,--recursive\` flag will also report transitive dependencies.
 
       Some fields will be hidden by default in order to keep the output readable, but can be selectively displayed by using additional options (\`--dependents\`, \`--manifest\`, \`--virtuals\`, ...) described in the option descriptions.
 
@@ -68,9 +72,11 @@ export default class InfoCommand extends BaseCommand {
     if (this.manifest)
       extraSet.add(`manifest`);
 
-    const traverse = (workspace: Workspace) => {
+    const traverseWorkspace = (workspace: Workspace, {recursive}: {recursive: boolean}) => {
+      const initialHash = workspace.anchoredLocator.locatorHash;
+
       const seen = new Map<LocatorHash, Package>();
-      const pass = [workspace.anchoredLocator.locatorHash];
+      const pass = [initialHash];
 
       while (pass.length > 0) {
         const hash = pass.shift()!;
@@ -86,6 +92,9 @@ export default class InfoCommand extends BaseCommand {
         if (structUtils.isVirtualLocator(pkg))
           pass.push(structUtils.devirtualizeLocator(pkg).locatorHash);
 
+        if (!recursive && hash !== initialHash)
+          continue;
+
         for (const dependency of pkg.dependencies.values()) {
           const resolution = project.storedResolutions.get(dependency.descriptorHash);
           if (typeof resolution === `undefined`)
@@ -98,10 +107,31 @@ export default class InfoCommand extends BaseCommand {
       return seen.values();
     };
 
-    const findSelectedSet = ({all}: {all: boolean}) => {
-      const lookupSet = all
-        ? project.storedPackages.values()
-        : traverse(workspace!);
+    const traverseAllWorkspaces = ({recursive}: {recursive: boolean}) => {
+      const aggregate = new Map<LocatorHash, Package>();
+
+      for (const workspace of project.workspaces)
+        for (const pkg of traverseWorkspace(workspace, {recursive}))
+          aggregate.set(pkg.locatorHash, pkg);
+
+      return aggregate.values();
+    };
+
+    const getLookupSet = ({all, recursive}: {all: boolean, recursive: boolean}) => {
+      // Optimization: if both -A and -R are set, it means we care about the
+      // whole set of packages, no need for filtering
+      if (all && recursive)
+        return project.storedPackages.values();
+
+      if (all) {
+        return traverseAllWorkspaces({recursive});
+      } else {
+        return traverseWorkspace(workspace!, {recursive});
+      }
+    };
+
+    const findSelectedSet = ({all, recursive}: {all: boolean, recursive: boolean}) => {
+      const lookupSet = getLookupSet({all, recursive});
 
       const matchers = this.patterns.map(pattern => {
         const patternLocator = structUtils.parseLocator(pattern);
@@ -150,15 +180,11 @@ export default class InfoCommand extends BaseCommand {
 
     const {selection, sortedLookup} = findSelectedSet({
       all: this.all,
+      recursive: this.recursive,
     });
 
-    if (selection.length === 0) {
-      if (this.all || findSelectedSet({all: true}).selection.length === 0) {
-        throw new UsageError(`No package matched your request`);
-      } else {
-        throw new UsageError(`No package matched your request in this workspace, but some matches were found elsewhere - run the command again with -A,--all to see them all`);
-      }
-    }
+    if (selection.length === 0)
+      throw new UsageError(`No package matched your request`);
 
     const dependentMap = new Map<LocatorHash, Array<Locator>>();
 

--- a/packages/plugin-essentials/sources/commands/info.ts
+++ b/packages/plugin-essentials/sources/commands/info.ts
@@ -26,6 +26,9 @@ export default class InfoCommand extends BaseCommand {
   @Command.Boolean(`--manifest`, {description: `Print data obtained by looking at the package archive (license, homepage, ...)`})
   manifest: boolean = false;
 
+  @Command.Boolean(`--name-only`, {description: `Only print the name for the matching packages`})
+  nameOnly: boolean = false;
+
   @Command.Boolean(`--virtuals`, {description: `Print each instance of the virtual packages`})
   virtuals: boolean = false;
 
@@ -276,6 +279,11 @@ export default class InfoCommand extends BaseCommand {
 
       infoTreeChildren[structUtils.stringifyLocator(pkg)] = node;
 
+      if (this.nameOnly) {
+        delete node.children;
+        continue;
+      }
+
       const instances = allInstances.get(pkg.locatorHash);
       if (typeof instances !== `undefined`) {
         nodeChildren.Instances = {
@@ -372,7 +380,7 @@ export default class InfoCommand extends BaseCommand {
       configuration,
       json: this.json,
       stdout: this.context.stdout,
-      separators: 2,
+      separators: this.nameOnly ? 0 : 2,
     });
   }
 }

--- a/packages/plugin-essentials/sources/commands/info.ts
+++ b/packages/plugin-essentials/sources/commands/info.ts
@@ -2,7 +2,6 @@ import {BaseCommand, WorkspaceRequiredError}                                    
 import {Configuration, Project, structUtils, Workspace, LocatorHash, Package, formatUtils, miscUtils, Locator, Cache, FetchOptions, ThrowReport, Manifest, treeUtils} from '@yarnpkg/core';
 import {xfs}                                                                                                                                                          from '@yarnpkg/fslib';
 import {Command, Usage, UsageError}                                                                                                                                   from 'clipanion';
-import {initial}                                                                                                                                                      from 'lodash';
 import mm                                                                                                                                                             from 'micromatch';
 
 import {Hooks}                                                                                                                                                        from '..';


### PR DESCRIPTION
**What's the problem this PR addresses?**
Info is currently inconsistent with how we want Yarn commands to behave: direct dependencies by default, other workspaces with `-A,--all`, and transitive dependencies with `-R,--recursive`.

**How did you fix it?**
Fixed the behaviour to follow the logic I mentioned.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
