### PR TITLE
fix(plugin-pack): format output path as a path

### DIFF
--- a/.yarn/versions/ce4b8b98.yml
+++ b/.yarn/versions/ce4b8b98.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -92,7 +92,7 @@ export default class PackCommand extends BaseCommand {
       });
 
       if (!this.dryRun) {
-        report.reportInfo(MessageName.UNNAMED, `Package archive generated in ${formatUtils.pretty(configuration, target, `magenta`)}`);
+        report.reportInfo(MessageName.UNNAMED, `Package archive generated in ${formatUtils.pretty(configuration, target, formatUtils.Type.PATH)}`);
         report.reportJson({output: target});
       }
     });


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn pack` is printing the output path as a `PortablePath`

**How did you fix it?**

Set the format type to `PATH` instead of a hardcoded colour

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
