### PR TITLE
fix(vscode-zipfs): use buffer.from instead of the deprecated constructor

### DIFF
--- a/.yarn/versions/6e8fed5d.yml
+++ b/.yarn/versions/6e8fed5d.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: patch

--- a/packages/vscode-zipfs/sources/ZipFSProvider.ts
+++ b/packages/vscode-zipfs/sources/ZipFSProvider.ts
@@ -57,7 +57,7 @@ export class ZipFSProvider implements vscode.FileSystemProvider {
     if (options.create && !options.overwrite && this.fs.existsSync(uri.fsPath))
       throw vscode.FileSystemError.FileExists(uri);
 
-    this.fs.writeFileSync(uri.fsPath, new Buffer(content));
+    this.fs.writeFileSync(uri.fsPath, Buffer.from(content));
   }
 
   rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean }): void {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The devtools in VSCode logs an error from the vscode-zipfs extension due to it's usage of `new Buffer`

**How did you fix it?**

Replace the use of the deprecated constructor with `Buffer.from`

**Checklist**

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
