### PR TITLE
fix(plugin-npm-cli): pass ident to whoami when scope is specified

### DIFF
--- a/.yarn/versions/e687f905.yml
+++ b/.yarn/versions/e687f905.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -57,6 +57,8 @@ const mte = generatePkgDriver({
         [`YARN_PNP_FALLBACK_MODE`]: `none`,
         // Otherwise tests fail on systems where this is globally set to true
         [`YARN_ENABLE_GLOBAL_CACHE`]: `false`,
+        // Older versions of Windows need this set to not have node throw an error
+        [`NODE_SKIP_PLATFORM_CHECK`]: `1`,
         ...rcEnv,
         ...env,
       },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/whoami.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/whoami.test.js.snap
@@ -4,7 +4,7 @@ exports[`Commands npm whoami it should print the npm registry username for a giv
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: testUser
+  "stdout": "➤ YN0000: anotherTestUser
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/whoami.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/whoami.test.js.snap
@@ -4,7 +4,7 @@ exports[`Commands npm whoami it should print the npm registry username for a giv
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: username
+  "stdout": "➤ YN0000: testUser
 ➤ YN0000: Done
 ",
 }
@@ -24,7 +24,7 @@ exports[`Commands npm whoami it should print the npm registry username when conf
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: username
+  "stdout": "➤ YN0000: testUser
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
@@ -4,6 +4,7 @@ const {
 } = require(`pkg-tests-core`);
 
 const AUTH_TOKEN = `686159dc-64b3-413e-a244-2de2b8d1c36f`;
+const AUTH_TOKEN2 = `316158de-64b3-413e-a244-2de2b8d1c80f`;
 const AUTH_IDENT = `dXNlcm5hbWU6YSB2ZXJ5IHNlY3VyZSBwYXNzd29yZA==`;
 
 const INVALID_AUTH_TOKEN = `a24cb960-e6a5-45fc-b9ab-0f9fe0aaae57`;
@@ -55,12 +56,12 @@ describe(`Commands`, () => {
         const url = await startPackageServer();
 
         await writeFile(`${path}/.yarnrc.yml`, [
+          `npmRegistryServer: "${url}"\n`,
+          `npmAuthToken: "${AUTH_TOKEN}"\n`,
           `npmScopes:\n`,
           `  testScope:\n`,
+          `    npmAuthToken: ${AUTH_TOKEN2}\n`,
           `    npmRegistryServer: "${url}"\n`,
-          `npmRegistries:\n`,
-          `  "${url}":\n`,
-          `    npmAuthToken: ${AUTH_TOKEN}`,
         ].join(``));
 
         let code;

--- a/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
@@ -1,6 +1,6 @@
 import {BaseCommand, openWorkspace}   from '@yarnpkg/cli';
 import {Configuration, MessageName}   from '@yarnpkg/core';
-import {StreamReport}                 from '@yarnpkg/core';
+import {StreamReport, structUtils}    from '@yarnpkg/core';
 import {npmConfigUtils, npmHttpUtils} from '@yarnpkg/plugin-npm';
 import {Command, Usage}               from 'clipanion';
 
@@ -55,6 +55,7 @@ export default class NpmWhoamiCommand extends BaseCommand {
           registry,
           authType: npmHttpUtils.AuthType.ALWAYS_AUTH,
           jsonResponse: true,
+          ident: this.scope ? structUtils.makeIdent(this.scope, ``) : undefined,
         });
 
         report.reportInfo(MessageName.UNNAMED, response.username);


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn npm whoami --scope <name>` doesn't work because it doesn't pass the scope to `npmHttpUtils`

**How did you fix it?**

Pass the specified scope to `npmHttpUtils`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
