### PR TITLE
feat(core): per hostname CA file support

### DIFF
--- a/.yarn/versions/b0e1ca97.yml
+++ b/.yarn/versions/b0e1ca97.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/https.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/https.test.js
@@ -95,7 +95,9 @@ describe(`Https tests`, () => {
       },
       async ({path, run}) => {
         const url = await startPackageServer({type: `https`});
+        const certs = await getHttpsCertificates();
 
+        await writeFile(`${path}/rootCA.crt`, certs.ca.certificate);
         await writeFile(`${path}/.yarnrc.yml`, [
           `caFilePath:`,
           `  "foo": ${path}/rootCA.crt`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/https.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/https.test.js
@@ -112,6 +112,28 @@ describe(`Https tests`, () => {
     ),
   );
 
+  test(
+    `it should throw error if CA cert file does not exist`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`@private/package`]: `1.0.0`},
+      },
+      async ({path, run}) => {
+        const url = await startPackageServer({type: `https`});
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `caFilePath:`,
+          `  "localhost": ${path}/missing.crt`,
+          `npmScopes:`,
+          `  private:`,
+          `    npmRegistryServer: "${url}"`,
+          `    npmAuthToken: ${AUTH_TOKEN}`,
+        ].join(`\n`));
+
+        await expect(run(`install`)).rejects.toThrow(`ENOENT: no such file or directory`);
+      },
+    ),
+  );
 
   test(
     `it should allow bypassing ssl certificate errors`,

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -17,20 +17,10 @@
       "default": "./.yarn/cache"
     },
     "caFilePath": {
-      "description": "Map of hostnames to files containing one or multiple Certificate Authority signing certificates. Glob patterns are supported.",
-      "type": "object",
-      "patternProperties": {
-        "^(.+)$": {
-          "description": "Path to file containing one or multiple Certificate Authority signing certificates",
-          "format": "uri-reference",
-          "default": "./exampleCA.pem"
-        }
-      },
-      "default": {
-        "example.com": {},
-        "*.example.com": {},
-        "*": {}
-      }
+      "description": "Path to file containing one or multiple Certificate Authority signing certificates",
+      "type": "string",
+      "format": "uri-reference",
+      "default": "./exampleCA.pem"
     },
     "changesetBaseRefs": {
       "description": "The base git refs that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, and upstream/master. Supports git branches, tags, and commits.",
@@ -241,6 +231,30 @@
       "description": "Defines how many requests are allowed to run at the same time. By default Yarn doesn't put limits on it, but it may sometimes be required when working behind proxies that don't handle too well large amount of requests.",
       "type": "number",
       "default": 8
+    },
+    "networkSettings": {
+      "description": "Additional network settings, per hostname",
+      "type": "object",
+      "patternProperties": {
+        "^(.+)$": {
+          "description": "The hostname to override settings for (glob patterns are supported)",
+          "type": "object",
+          "properties": {
+            "caFilePath": {
+              "$ref": "#/properties/caFilePath",
+              "$comment": "{ \"anchor\": \"npmRegistries.caFilePath\" }"
+            }
+          },
+          "default": {
+            "caFilePath": {}
+          }
+        }
+      },
+      "default": {
+        "example.com": {},
+        "*.example.com": {},
+        "*": {}
+      }
     },
     "nmHoistingLimits": {
       "description": "Defines the highest point where packages can be hoisted. One of `workspaces` (don't hoist packages past the workspace that depends on them), `dependencies` (packages aren't hoisted past the direct dependencies for each workspace), or `none` (the default, packages are hoisted as much as possible). This setting can be overriden per-workspace through the [`installConfig.hoistingLimits` field](/configuration/manifest#installConfig.hoistingLimits).",

--- a/packages/gatsby/src/pages/configuration/yarnrc.json
+++ b/packages/gatsby/src/pages/configuration/yarnrc.json
@@ -16,6 +16,22 @@
       "format": "uri-reference",
       "default": "./.yarn/cache"
     },
+    "caFilePath": {
+      "description": "Map of hostnames to files containing one or multiple Certificate Authority signing certificates. Glob patterns are supported.",
+      "type": "object",
+      "patternProperties": {
+        "^(.+)$": {
+          "description": "Path to file containing one or multiple Certificate Authority signing certificates",
+          "format": "uri-reference",
+          "default": "./exampleCA.pem"
+        }
+      },
+      "default": {
+        "example.com": {},
+        "*.example.com": {},
+        "*": {}
+      }
+    },
     "changesetBaseRefs": {
       "description": "The base git refs that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, and upstream/master. Supports git branches, tags, and commits.",
       "type": "array",
@@ -124,6 +140,11 @@
       "type": "boolean",
       "default": true
     },
+    "enableStrictSsl": {
+      "description": "If false, SSL certificate errors will be ignored",
+      "type": "boolean",
+      "default": true
+    },
     "enableTelemetry": {
       "description": "If true (the default outside of CI environments), Yarn will periodically send anonymous data to our servers tracking some usage information such as the number of dependency in your project, how many install you ran, etc. Consult the [Telemetry](/telemetry) page for more details about it.",
       "type": "boolean",
@@ -226,7 +247,7 @@
       "type": "string",
       "enum": ["workspaces", "dependencies", "none"],
       "default": "none"
-  },
+    },
     "nodeLinker": {
       "description": "Defines what linker should be used for installing Node packages (useful to enable the node-modules plugin), one of: `pnp`, `node-modules`.",
       "type": "string",

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -331,9 +331,12 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     default: Infinity,
   },
   caFilePath: {
-    description: `A path to a file containing one or multiple Certificate Authority signing certificates`,
-    type: SettingsType.ABSOLUTE_PATH,
-    default: null,
+    description: `Map of hostnames to files containing one or multiple Certificate Authority signing certificates. Glob patterns are supported.`,
+    type: SettingsType.MAP,
+    valueDefinition: {
+      description: `Path to file containing one or multiple Certificate Authority signing certificates`,
+      type: SettingsType.ABSOLUTE_PATH,
+    },
   },
   enableStrictSsl: {
     description: `If false, SSL certificate errors will be ignored`,
@@ -432,7 +435,7 @@ export interface ConfigurationValueMap {
   httpTimeout: number;
   httpRetry: number;
   networkConcurrency: number;
-  caFilePath: PortablePath;
+  caFilePath: Map<string, PortablePath>;
   enableStrictSsl: boolean;
 
   // Settings related to telemetry

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -330,13 +330,25 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.NUMBER,
     default: Infinity,
   },
-  caFilePath: {
-    description: `Map of hostnames to files containing one or multiple Certificate Authority signing certificates. Glob patterns are supported.`,
+  networkSettings: {
+    description: `Network settings per hostname (glob patterns are supported)`,
     type: SettingsType.MAP,
     valueDefinition: {
-      description: `Path to file containing one or multiple Certificate Authority signing certificates`,
-      type: SettingsType.ABSOLUTE_PATH,
+      description: ``,
+      type: SettingsType.SHAPE,
+      properties: {
+        caFilePath: {
+          description: `Path to file containing one or multiple Certificate Authority signing certificates`,
+          type: SettingsType.ABSOLUTE_PATH,
+          default: null,
+        },
+      },
     },
+  },
+  caFilePath: {
+    description: `A path to a file containing one or multiple Certificate Authority signing certificates`,
+    type: SettingsType.ABSOLUTE_PATH,
+    default: null,
   },
   enableStrictSsl: {
     description: `If false, SSL certificate errors will be ignored`,
@@ -435,7 +447,8 @@ export interface ConfigurationValueMap {
   httpTimeout: number;
   httpRetry: number;
   networkConcurrency: number;
-  caFilePath: Map<string, PortablePath>;
+  networkSettings: Map<string, MapConfigurationValue<{ caFilePath: PortablePath }>>;
+  caFilePath: PortablePath;
   enableStrictSsl: boolean;
 
   // Settings related to telemetry

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -100,7 +100,10 @@ export async function request(target: string, body: Body, {configuration, header
         certCache.set(path, entry);
       }
 
-      extraHttpsOptions.certificateAuthority = await entry;
+      if (Buffer.isBuffer(entry) === false)
+        entry = await entry;
+
+      extraHttpsOptions.certificateAuthority = entry;
       break;
     }
   }

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -35,7 +35,7 @@ async function getCachedCertificate(caFilePath: PortablePath) {
     certCache.set(caFilePath, certificate);
   }
 
-  return Buffer.isBuffer(certificate) ? certificate : await certificate;
+  return certificate;
 }
 
 export type Body = (

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -35,7 +35,7 @@ async function getCachedCertificate(caFilePath: PortablePath) {
     certCache.set(caFilePath, certificate);
   }
 
-  return Buffer.isBuffer(certificate) ? certificate : await certificate;;
+  return Buffer.isBuffer(certificate) ? certificate : await certificate;
 }
 
 export type Body = (
@@ -108,14 +108,14 @@ export async function request(target: string, body: Body, {configuration, header
 
   for (const [glob, scopeConfig] of configuration.get(`networkSettings`)) {
     if (micromatch.isMatch(url.hostname, glob)) {
-      extraHttpsOptions.certificateAuthority = await getCachedCertificate(scopeConfig.get("caFilePath"));
+      extraHttpsOptions.certificateAuthority = await getCachedCertificate(scopeConfig.get(`caFilePath`));
       break;
     }
   }
 
-  if (!extraHttpsOptions.certificateAuthority && globalCaFilePath) {
+  if (!extraHttpsOptions.certificateAuthority && globalCaFilePath)
     extraHttpsOptions.certificateAuthority = await getCachedCertificate(globalCaFilePath);
-  }
+
 
   const gotClient = got.extend({
     timeout: {

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -104,7 +104,6 @@ export async function request(target: string, body: Body, {configuration, header
       }
 
       extraHttpsOptions.certificateAuthority = Buffer.isBuffer(entry) ? entry : await entry;
-
       break;
     }
   }

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -89,7 +89,7 @@ export async function request(target: string, body: Body, {configuration, header
 
   const {default: got} = await import(`got`);
 
-  let extraHttpsOptions: HTTPSOptions = {};
+  const extraHttpsOptions: HTTPSOptions = {};
 
   for (const [glob, path] of configuration.get(`caFilePath`)) {
     if (micromatch.isMatch(url.hostname, glob)) {

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -96,14 +96,15 @@ export async function request(target: string, body: Body, {configuration, header
       let entry = certCache.get(path);
 
       if (!entry) {
-        entry = xfs.readFilePromise(path);
+        entry = xfs.readFilePromise(path).then(cert => {
+          certCache.set(path, cert);
+          return cert;
+        });
         certCache.set(path, entry);
       }
 
-      if (Buffer.isBuffer(entry) === false)
-        entry = await entry;
+      extraHttpsOptions.certificateAuthority = Buffer.isBuffer(entry) ? entry : await entry;
 
-      extraHttpsOptions.certificateAuthority = entry;
       break;
     }
   }

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -92,7 +92,7 @@ export async function request(target: string, body: Body, {configuration, header
 
   for (const [glob, path] of configuration.get(`caFilePath`)) {
     if (micromatch.isMatch(url.hostname, glob)) {
-      extraHttpsOptions = {certificateAuthority: await xfs.readFilePromise(path)};
+      extraHttpsOptions.certificateAuthority = await xfs.readFilePromise(path);
       break;
     }
   }

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -96,7 +96,7 @@ export async function request(target: string, body: Body, {configuration, header
       let entry = certCache.get(path);
 
       if (!entry) {
-        entry = await xfs.readFilePromise(path);
+        entry = xfs.readFilePromise(path);
         certCache.set(path, entry);
       }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Fixes https://github.com/yarnpkg/berry/issues/798#issuecomment-705155101

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Enables overriding the `caFilePath` per hostname. Example:

```yml
networkSettings:
  "github.com":
    caFilePath: <path>
# root caFilePath setting still works:
caFilePath: <path>
```

Also updated the documentation and added additional tests.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
