### PR TITLE
feat(vscode-zipfs): register yaml schema

### DIFF
--- a/.yarn/versions/5964334c.yml
+++ b/.yarn/versions/5964334c.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: minor

--- a/packages/vscode-zipfs/package.json
+++ b/packages/vscode-zipfs/package.json
@@ -17,7 +17,11 @@
   "activationEvents": [
     "workspaceContains:**/*.zip",
     "onLanguage:zip",
-    "onFileSystem:zip"
+    "onFileSystem:zip",
+    "onLanguage:yaml"
+  ],
+  "extensionDependencies": [
+    "redhat.vscode-yaml"
   ],
   "main": "./build/index.js",
   "sideEffects": false,

--- a/packages/vscode-zipfs/sources/YamlSchema.ts
+++ b/packages/vscode-zipfs/sources/YamlSchema.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+
+interface YamlExtension {
+  registerContributor(
+    schema: string,
+    requestSchema: (resource: string) => string | undefined,
+  ): void;
+}
+
+async function activateYamlExtension(): Promise<YamlExtension | undefined> {
+  const extension = vscode.extensions.getExtension(`redhat.vscode-yaml`);
+  if (!extension)
+    return undefined;
+
+  const extensionAPI = await extension.activate();
+  if (!extensionAPI || !extensionAPI.registerContributor)
+    return undefined;
+
+  return extensionAPI;
+}
+
+export async function registerYamlSchema() {
+  const yamlPlugin = await activateYamlExtension();
+  yamlPlugin?.registerContributor(
+    `yarnrc`,
+    resource => {
+      if (resource.endsWith(`.yarnrc.yml`))
+        return `https://raw.githubusercontent.com/yarnpkg/berry/master/packages/gatsby/src/pages/configuration/yarnrc.json`;
+
+      return undefined;
+    },
+  );
+}

--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -1,7 +1,8 @@
-import {npath}         from '@yarnpkg/fslib';
-import * as vscode     from 'vscode';
+import {npath}              from '@yarnpkg/fslib';
+import * as vscode          from 'vscode';
 
-import {ZipFSProvider} from './ZipFSProvider';
+import {registerYamlSchema} from './YamlSchema';
+import {ZipFSProvider}      from './ZipFSProvider';
 
 function mount(uri: vscode.Uri) {
   const zipUri = vscode.Uri.parse(`zip:${uri.fsPath}`);
@@ -14,7 +15,7 @@ function mount(uri: vscode.Uri) {
   }
 }
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.workspace.registerFileSystemProvider(`zip`, new ZipFSProvider(), {
     isCaseSensitive: true,
   }));
@@ -26,4 +27,6 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(`zipfs.mountZipEditor`, () => {
     mount(vscode.window.activeTextEditor!.document.uri);
   }));
+
+  await registerYamlSchema();
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Users currently have to manually update their yaml schema config to get autocomplete in `.yarnrc.yml` files

**How did you fix it?**

Make `vscode-zipfs` register the schema automatically

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
