### PR TITLE
chore(plugin-compat): add extensions for react-bootstrap-table2-paginator and react-draggable

### DIFF
--- a/.yarn/versions/1bf94456.yml
+++ b/.yarn/versions/1bf94456.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -152,14 +152,14 @@ export const packageExtensions: Array<[string, any]> = [
   // https://github.com/react-bootstrap-table/react-bootstrap-table2/pull/1491
   [`react-bootstrap-table2-paginator@*`, {
     dependencies: {
-      "classnames": "^2.2.6"
+      classnames: `^2.2.6`,
     },
   }],
   // https://github.com/STRML/react-draggable/pull/525
-  [`react-draggable@*`, {
+  [`react-draggable@<=4.4.3`, {
     peerDependencies: {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+      react: `>= 16.3.0`,
+      'react-dom': `>= 16.3.0`,
     },
   }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -149,4 +149,17 @@ export const packageExtensions: Array<[string, any]> = [
       "react-dom": `^15.0.0 || ^16.0.0`,
     },
   }],
+  // https://github.com/react-bootstrap-table/react-bootstrap-table2/pull/1491
+  [`react-bootstrap-table2-paginator@*`, {
+    dependencies: {
+      "classnames": "^2.2.6"
+    },
+  }],
+  // https://github.com/STRML/react-draggable/pull/525
+  [`react-draggable@*`, {
+    dependencies: {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -157,7 +157,7 @@ export const packageExtensions: Array<[string, any]> = [
   }],
   // https://github.com/STRML/react-draggable/pull/525
   [`react-draggable@*`, {
-    dependencies: {
+    peerDependencies: {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**

Adding new entries to `plugin-compat database` with the PRs I sent upstream.