### PR TITLE
test(pnp): pnpapi isn't lost on virtual path portals

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -606,7 +606,7 @@ export const generatePkgDriver = ({
         try {
           await fn!({path, run, source});
         } catch (error) {
-          error.message = `Temporary fixture folder: ${path}\n\n${error.message}`;
+          error.message = `Temporary fixture folder: ${npath.fromPortablePath(path)}\n\n${error.message}`;
           throw error;
         }
       });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/__snapshots__/pnp.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/__snapshots__/pnp.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Plug'n'Play it should not loose the pnpapi on portals with virtual paths 1`] = `"../../../peer-deps-fixed-virtual-5906ff95f0/0/cache/peer-deps-fixed-npm-1.0.0-030dcb4b1c-61770e5840.zip/node_modules/peer-deps-fixed/index.js"`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/__snapshots__/pnp.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/__snapshots__/pnp.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Plug'n'Play it should not loose the pnpapi on portals with virtual paths 1`] = `"../../../peer-deps-fixed-virtual-5906ff95f0/0/cache/peer-deps-fixed-npm-1.0.0-030dcb4b1c-61770e5840.zip/node_modules/peer-deps-fixed/index.js"`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1711,7 +1711,7 @@ describe(`Plug'n'Play`, () => {
 
         await xfs.writeFilePromise(
           `${portalTarget}/index.js`,
-          `module.exports = require('path').relative(__dirname, require.resolve('peer-deps-fixed', {paths: [__dirname]})).replace(/\\\\/g, '/')`
+          `module.exports = require.resolve('peer-deps-fixed', {paths: [__dirname]})`
         );
 
         await xfs.writeJsonPromise(`${path}/package.json`, {
@@ -1722,7 +1722,7 @@ describe(`Plug'n'Play`, () => {
 
         await run(`install`);
 
-        await expect(source(`require('portal')`)).resolves.toMatchSnapshot();
+        await expect(source(`require('portal')`)).resolves.toMatch(`peer-deps-fixed-virtual-`);
       });
     })
   );


### PR DESCRIPTION
**What's the problem this PR addresses?**

When I opened https://github.com/yarnpkg/berry/pull/1851 I didn't add a test

Fixes https://github.com/yarnpkg/berry/pull/1851#issuecomment-701386323

**How did you fix it?**

Added a test

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.