### PR TITLE
perf(core): Optimize progress bar rerenders

### DIFF
--- a/.yarn/versions/eedf13e1.yml
+++ b/.yarn/versions/eedf13e1.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (plus any relevant plugin by running `yarn import plugin from sources <name>`).
 
+### Installs
+
+- Progress bars are not rendered more often than at 60 FPS, which makes all installs faster
+
 ### CLI
 
 - Explicitly disable administrator rights for the native binary jumper on Windows. When a filename contains "install", "setup", "update", or "patch" Windows thinks it's an installer and requires administrator rights to start the binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Installs
 
-- Progress bars are not rendered more often than at 60 FPS, which makes all installs faster
+- Progress bars are rendered less often, which makes all installs faster
 
 ### CLI
 

--- a/packages/yarnpkg-core/sources/Report.ts
+++ b/packages/yarnpkg-core/sources/Report.ts
@@ -21,6 +21,8 @@ export function isReportError(error: Error): error is ReportError {
 export type ProgressDefinition = {
   progress: number,
   title?: string,
+  lastScaledSize?: number,
+  lastRenderTime?: number
 };
 
 export abstract class Report {

--- a/packages/yarnpkg-core/sources/Report.ts
+++ b/packages/yarnpkg-core/sources/Report.ts
@@ -21,8 +21,6 @@ export function isReportError(error: Error): error is ReportError {
 export type ProgressDefinition = {
   progress: number,
   title?: string,
-  lastScaledSize?: number,
-  lastRenderTime?: number
 };
 
 export abstract class Report {

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -519,6 +519,7 @@ export class StreamReport extends Report {
     }
 
     this.progressTimeout = setTimeout(() => {
+      this.progressLastScaledSize = -1;
       this.refreshProgress();
     }, 1000 / 60);
   }

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -521,7 +521,7 @@ export class StreamReport extends Report {
     this.progressTimeout = setTimeout(() => {
       this.progressLastScaledSize = -1;
       this.refreshProgress();
-    }, 1000 / 10);
+    }, PROGRESS_INTERVAL);
   }
 
   private refreshProgress(delta: number = 0) {

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -521,7 +521,7 @@ export class StreamReport extends Report {
     this.progressTimeout = setTimeout(() => {
       this.progressLastScaledSize = -1;
       this.refreshProgress();
-    }, 1000 / 60);
+    }, 1000 / 10);
   }
 
   private refreshProgress(delta: number = 0) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We render progress bar on each change now.

Fixes https://github.com/yarnpkg/berry/issues/1815

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The rendering will be skipped now if the reported progress has no changes in the number of okay bars rendered on the screen.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
