### PR TITLE
docs: add DT link when TypeScript support is "definitely-typed"

### DIFF
--- a/packages/gatsby/src/components/details/Header.js
+++ b/packages/gatsby/src/components/details/Header.js
@@ -1,9 +1,9 @@
-import styled                                  from '@emotion/styled';
-import React                                   from 'react';
+import styled                                              from '@emotion/styled';
+import React                                               from 'react';
 
+import IcoSnyk                                             from '../../images/detail/ico-snyk.svg';
 import {License, Deprecated, Owner, Downloads, TypeScript} from '../hit';
-import {Keywords, safeMarkdown}                from '../util';
-import IcoSnyk                                 from '../../images/detail/ico-snyk.svg';
+import {Keywords, safeMarkdown}                            from '../util';
 
 const DescriptionText = styled.p`
   font-size: 1.25rem;
@@ -94,7 +94,7 @@ export const Header = ({
       <License type={license} />
       <Deprecated deprecated={deprecated} />
       <span>{version}</span>
-      <TypeScript ts={types.ts} />
+      <TypeScript name={name} ts={types.ts} />
       <Vulnerabilities vulns={vulns} url={vulnsUrl} />
     </PackageInfo>
     <Description description={description} deprecated={deprecated} />

--- a/packages/gatsby/src/components/hit/index.js
+++ b/packages/gatsby/src/components/hit/index.js
@@ -130,7 +130,7 @@ const HitPopular = styled.span`
 export const Downloads = ({downloads = 0, humanDownloads}) => (
   <HitPopular
     className={`${getDownloadBucket(downloads)}`}
-    title={`${downloads.toLocaleString('en')} downloads in the last 30 days`}
+    title={`${downloads.toLocaleString(`en`)} downloads in the last 30 days`}
   >
     {humanDownloads}
   </HitPopular>
@@ -178,7 +178,7 @@ const HitRepoLink = styled(HitLink)`
 `;
 
 const Repository = ({repository, name}) => {
-  const [provider] = repository.host.split('.');
+  const [provider] = repository.host.split(`.`);
 
   return (
     <HitRepoLink
@@ -186,7 +186,7 @@ const Repository = ({repository, name}) => {
       title={`${provider} repository of ${name}`}
       href={`https://${repository.host}/${encode(repository.user)}/${encode(
         repository.project
-      )}${repository.path || ''}`}
+      )}${repository.path || ``}`}
     >
       {provider}
     </HitRepoLink>
@@ -254,14 +254,31 @@ const IconTypeScript = styled.img`
   vertical-align: baseline;
 `;
 
-export const TypeScript = ({ts}) =>
-  ts !== false ? (
-    <IconTypeScript
-      src={IcoTypeScript}
-      alt={`TypeScript support: ${ts}`}
-      title={`TypeScript support: ${ts}`}
-    />
-  ) : null;
+export const TypeScript = ({name, ts}) => {
+  if (ts === false)
+    return null;
+
+  const iconTypescript = <IconTypeScript
+    src={IcoTypeScript}
+    alt={`TypeScript support: ${ts}`}
+    title={`TypeScript support: ${ts}`}
+  />;
+
+  if (ts !== `definitely-typed`)
+    return iconTypescript;
+
+  const [, identScope, indentName] = /^(?:@([^/]+?)\/)?([^/]+)$/.exec(name);
+
+  const typesIdentName = identScope
+    ? `${identScope}__${indentName}`
+    : indentName;
+
+  return (
+    <a href={`/package/@types/${typesIdentName}`}>
+      {iconTypescript}
+    </a>
+  );
+};
 
 const HitDescription = styled.p`
   font-size: 0.875rem;
@@ -296,7 +313,7 @@ export const Hit = ({hit, onTagClick, onOwnerClick, searchState}) => (
     <License type={hit.license} />
     <Deprecated deprecated={hit.deprecated} />
     <HitVersion>{hit.version}</HitVersion>
-    <TypeScript ts={hit.types.ts} />
+    <TypeScript name={hit.name} ts={hit.types.ts} />
     <HitDescription>
       {hit.deprecated ? (
         hit.deprecated
@@ -306,10 +323,10 @@ export const Hit = ({hit, onTagClick, onOwnerClick, searchState}) => (
     </HitDescription>
     <Owner {...hit.owner} onClick={onOwnerClick} />
     <HitLastUpdate
-      title={`last updated ${new Date(hit.modified).toLocaleDateString('en')}`}
+      title={`last updated ${new Date(hit.modified).toLocaleDateString(`en`)}`}
     >
-      {'{time_distance} ago'.replace(
-        '{time_distance}',
+      {`{time_distance} ago`.replace(
+        `{time_distance}`,
         formatDistance(new Date(hit.modified), new Date())
       )}
     </HitLastUpdate>


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The TypeScript support icon on the package details page on the website didn't link to the DT entry when TypeScript support is `definitely-typed`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

With a keyboard.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
