### PR TITLE
fix(shell): make some errors recoverable

### DIFF
--- a/.yarn/versions/d1e66fa1.yml
+++ b/.yarn/versions/d1e66fa1.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Explicitly disable administrator rights for the native binary jumper on Windows. When a filename contains "install", "setup", "update", or "patch" Windows thinks it's an installer and requires administrator rights to start the binary
 
+### Shell
+
+- Some shell errors (`No matches found`, `Bad file descriptor`, `Unbound variable`, `Unbound argument`) will now be recoverable errors that make the shell continue on to the next command in the chain instead of hard crashes. Fixes cases such as `rm -rf ./inexistentFolder/* || true`.
+
 ## 2.3.1
 
 ### CLI

--- a/packages/yarnpkg-shell/sources/errors.ts
+++ b/packages/yarnpkg-shell/sources/errors.ts
@@ -1,0 +1,14 @@
+export type ShellErrorOptions = {
+  recoverable: boolean;
+};
+
+export class ShellError extends Error {
+  public recoverable: boolean;
+
+  constructor(message: string, {recoverable}: ShellErrorOptions) {
+    super(message);
+
+    this.name = `ShellError`;
+    this.recoverable = recoverable;
+  }
+}

--- a/packages/yarnpkg-shell/sources/errors.ts
+++ b/packages/yarnpkg-shell/sources/errors.ts
@@ -1,14 +1,10 @@
-export type ShellErrorOptions = {
-  recoverable: boolean;
-};
-
+/**
+ * A recoverable shell error.
+ */
 export class ShellError extends Error {
-  public recoverable: boolean;
-
-  constructor(message: string, {recoverable}: ShellErrorOptions) {
+  constructor(message: string) {
     super(message);
 
     this.name = `ShellError`;
-    this.recoverable = recoverable;
   }
 }

--- a/packages/yarnpkg-shell/sources/globUtils.ts
+++ b/packages/yarnpkg-shell/sources/globUtils.ts
@@ -45,3 +45,7 @@ export function match(pattern: string, {cwd, baseFs}: {cwd: PortablePath, baseFs
     fs: extendFs(fs, new PosixFS(baseFs)),
   });
 }
+
+export function isBraceExpansion(pattern: string) {
+  return micromatch.scan(pattern, micromatchOptions).isBrace;
+}

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -693,10 +693,7 @@ async function executeCommandLine(node: CommandLine, opts: ShellOptions, state: 
     try {
       return await executeCommandChain(chain, opts, state);
     } catch (error) {
-      if (!(error instanceof ShellError))
-        throw error;
-
-      if (!error.recoverable)
+      if (!(error instanceof ShellError) || !error.recoverable)
         throw error;
 
       state.stderr.write(`${error.message}\n`);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell didn't have any concept of recoverable errors, which meant that commands like `echo inexistentFolder/* || true` were throwing instead of printing to stderr and continuing on to the next command in the chain.

Fixes #1984.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've created a new `ShellError` class with a `recoverable` property. When executing a command chain, we now check if a recoverable error is thrown and we don't crash in that case - we instead print the error message to stderr and set the exit code to 1, so that we can continue on to the next command in the chain. I've also made a few more errors recoverable (`Bad file descriptor`, `Unbound {variable, argument}`).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
