### PR TITLE
refactor(acceptance-tests): change test name to mention "pnpIgnorePatterns" instead of "blacklist"

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -960,7 +960,7 @@ describe(`Plug'n'Play`, () => {
   );
 
   test(
-    `it should not break relative requires for files within a blacklist`,
+    `it should not break relative requires for files matching pnpIgnorePatterns`,
     makeTemporaryEnv(
       {},
       {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Partially addresses #2002

Part of continuous effort to get rid of non-inclusive terms like "whitelist" and "blacklist" implying that white = good and black = bad.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Simple test rename.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
