### PR TITLE
fix(core): ignore flock files in cache

### DIFF
--- a/.yarn/versions/d341da35.yml
+++ b/.yarn/versions/d341da35.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -125,7 +125,7 @@ export class Cache {
 
       const gitignorePath = ppath.resolve(this.cwd, `.gitignore` as Filename);
 
-      await xfs.changeFilePromise(gitignorePath, `/.gitignore\n*.lock\n*.flock\n`);
+      await xfs.changeFilePromise(gitignorePath, `/.gitignore\n*.flock\n`);
     }
   }
 

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -127,7 +127,7 @@ export class Cache {
       const gitignoreExists = await xfs.existsPromise(gitignorePath);
 
       if (!gitignoreExists) {
-        await xfs.writeFilePromise(gitignorePath, `/.gitignore\n*.lock\n`);
+        await xfs.writeFilePromise(gitignorePath, `/.gitignore\n*.lock\n*.flock\n`);
       }
     }
   }

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -124,11 +124,8 @@ export class Cache {
       await xfs.mkdirPromise(this.cwd, {recursive: true});
 
       const gitignorePath = ppath.resolve(this.cwd, `.gitignore` as Filename);
-      const gitignoreExists = await xfs.existsPromise(gitignorePath);
 
-      if (!gitignoreExists) {
-        await xfs.writeFilePromise(gitignorePath, `/.gitignore\n*.lock\n*.flock\n`);
-      }
+      await xfs.changeFilePromise(gitignorePath, `/.gitignore\n*.lock\n*.flock\n`);
     }
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `.gitignore` file we write to `.yarn/cache` doesn't ignore the flock files we create

**How did you fix it?**

Added `.flock` to the list of ignored files

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.