### PR TITLE
fix(plugin-version): rename duplicate command identifier to VersionCh…

### DIFF
--- a/.yarn/versions/a5698a22.yml
+++ b/.yarn/versions/a5698a22.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -15,7 +15,7 @@ import * as versionUtils                                                        
 type Releases = Map<Workspace, Exclude<versionUtils.Decision, versionUtils.Decision.UNDECIDED>>;
 
 // eslint-disable-next-line arca/no-default-export
-export default class VersionApplyCommand extends Command<CommandContext> {
+export default class VersionCheckCommand extends Command<CommandContext> {
   @Command.Boolean(`-i,--interactive`, {description: `Open an interactive interface used to set version bumps`})
   interactive?: boolean;
 


### PR DESCRIPTION
…eckCommand

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
Rename duplicate identifier VersionApplyCommand to VersionCheckCommand. The refactoring provides semantic value only. The duplicate identifier is not referenced elsewhere due to the command being a default export.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
#2008 
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
I renamed the command using the webstorm rename refactoring tool.
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ x ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ x ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ x ] I will check that all automated PR checks pass before the PR gets reviewed.
