### PR TITLE
[doctor] Don't warn about scripts named "prettier"

### DIFF
--- a/.yarn/versions/a09d2933.yml
+++ b/.yarn/versions/a09d2933.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": patch

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -293,7 +293,7 @@ async function processWorkspace(workspace: Workspace, {configuration, fileList, 
   const reportedProgress = report.reportProgress(progress);
 
   for (const scriptName of workspace.manifest.scripts.keys())
-    if (scriptName.match(/^(pre|post)(?!(install|pack)$)/))
+    if (scriptName.match(/^(pre|post)(?!(install|pack)$)/) && !scriptName.includes("prettier"))
       report.reportWarning(MessageName.UNNAMED, `User scripts prefixed with "pre" or "post" (like "${scriptName}") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly`);
 
   for (const p of fileList) {

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -293,7 +293,7 @@ async function processWorkspace(workspace: Workspace, {configuration, fileList, 
   const reportedProgress = report.reportProgress(progress);
 
   for (const scriptName of workspace.manifest.scripts.keys())
-    if (scriptName.match(/^(pre|post)(?!(install|pack)$)/) && !scriptName.includes("prettier"))
+    if (scriptName.match(/^(pre|post)(?!(install|pack)$)/) && !scriptName.match(/^prettier/))
       report.reportWarning(MessageName.UNNAMED, `User scripts prefixed with "pre" or "post" (like "${scriptName}") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly`);
 
   for (const p of fileList) {


### PR DESCRIPTION
Signed-off-by: Reece Dunham <me@rdil.rocks>

**What's the problem this PR addresses?**
This fixes the doctor package warning about pre/post scripts with a script named `prettier`, typically used for [Prettier](https://prettier.io).  It isn't a pre/post command, so it shouldn't warn about it.  

**How did you fix it?**
Just added a bit of extra regex.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
