### PR TITLE
fix(core): make lockfile if it's missing in prepareExternalProject

### DIFF
--- a/.yarn/versions/cd65a831.yml
+++ b/.yarn/versions/cd65a831.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -191,6 +191,14 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
             // read a logfile telling them to open another logfile
             env.YARN_ENABLE_INLINE_BUILDS = `1`;
 
+            // If a lockfile doesn't exist we create a empty one to
+            // prevent the project root detection from thinking it's in an
+            // undeclared workspace when the user has a lockfile in their home
+            // directory on Windows
+            const lockfilePath = ppath.join(cwd, Filename.lockfile);
+            if (!(await xfs.existsPromise(lockfilePath)))
+              await xfs.writeFilePromise(lockfilePath, ``);
+
             // Yarn 2 supports doing the install and the pack in a single command,
             // so we leverage that. We also don't need the "set version" call since
             // we're already operating within a Yarn 2 context (plus people should


### PR DESCRIPTION
**What's the problem this PR addresses?**

When installing a git repo without a lockfile as a dependency on Windows when you have a `package.json` and/or a `yarn.lock` in the home folder, the project root detection thinks `C:\Users\<username>\AppData\Local\Temp\xfs-12345678` is an undeclared workspace of `C:\Users\<username>` and refuses to pack it.

Fixes https://github.com/yarnpkg/berry/issues/2017

**How did you fix it?**

Write a empty `yarn.lock` before telling Yarn to pack the external project

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.