### PR TITLE
fix(plugin-version): remove unnecessary await when setting map object

### DIFF
--- a/.yarn/versions/a1d64a58.yml
+++ b/.yarn/versions/a1d64a58.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -116,7 +116,7 @@ export default class VersionCommand extends BaseCommand {
     }
 
     const versionFile = await versionUtils.openVersionFile(project, {allowEmpty: true});
-    await versionFile.releases.set(workspace, releaseStrategy as any);
+    versionFile.releases.set(workspace, releaseStrategy as any);
     await versionFile.saveAll();
 
     if (!deferred) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Cleans up unnecessary await when setting the releases map object.
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
