### PR TITLE
docs(plugin-workspace-tools): change --private to --no-private

### DIFF
--- a/.yarn/versions/134869e9.yml
+++ b/.yarn/versions/134869e9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": patch

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -97,7 +97,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
   exclude: Array<string> = [];
 
   @Command.Boolean(`--no-private`, {description: `Avoid running the command on private workspaces`})
-  private: boolean = true;
+  publicOnly: boolean = false;
 
   static schema = yup.object().shape({
     jobs: yup.number().min(2),
@@ -184,7 +184,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
       if (this.exclude.length > 0 && micromatch.isMatch(structUtils.stringifyIdent(workspace.locator), this.exclude))
         continue;
 
-      if (this.private === false && workspace.manifest.private === true)
+      if (this.publicOnly && workspace.manifest.private === true)
         continue;
 
       workspaces.push(workspace);

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -96,7 +96,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
   @Command.Array(`--exclude`, {description: `An array of glob pattern idents; matching workspaces won't be traversed`})
   exclude: Array<string> = [];
 
-  @Command.Boolean(`--private`, {description: `Also run the command on private workspaces`})
+  @Command.Boolean(`--no-private`, {description: `Avoid running the command on private workspaces`})
   private: boolean = true;
 
   static schema = yup.object().shape({


### PR DESCRIPTION
**What's the problem this PR addresses?**

The docs for `yarn workspaces foreach` documents the `--private` flag which makes it seem like it's not enabled by default, but it is.

ref https://github.com/yarnpkg/berry/issues/2034#issuecomment-715295553 (cc @vecerek)

**How did you fix it?**

Document the flag as `--no-private` and update the description which makes it clear that it's enabled by default

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.