### PR TITLE
perf(core) Recurrent installs optimization

### DIFF
--- a/.yarn/versions/d848165f.yml
+++ b/.yarn/versions/d848165f.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/fslib": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Installs
 
 - Progress bars are rendered less often, which makes all installs faster
+- Recurrent installs are faster due to better manifest info caching
 
 ### CLI
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -114,7 +114,7 @@ describe(`Node_Modules`, () => {
           },
         });
 
-        await expect(run(`install`)).resolves.toBeTruthy();
+        await expect(run(`install`, `--inline-builds`)).resolves.toBeTruthy();
       },
     ),
   );

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -172,7 +172,7 @@ class NodeModulesInstaller extends AbstractPnpInstaller {
       if (!packageMeta)
         throw new Error(`Assertion failed: Expected the package to have package meta (${structUtils.prettyLocator(this.opts.project.configuration, locator)})`);
 
-      const buildScripts = packageMeta.nmBuildScripts;
+      const buildScripts = [...packageMeta.nmBuildScripts];
 
       if (buildScripts.length > 0 && !this.opts.project.configuration.get(`enableScripts`)) {
         this.opts.report.reportWarningOnce(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(this.opts.project.configuration, locator)} lists build scripts, but all build scripts have been disabled.`);

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -60,9 +60,7 @@ export abstract class AbstractPnpInstaller implements Installer {
     const key1 = structUtils.requirableIdent(pkg);
     const key2 = pkg.reference;
 
-    const {isManifestCompatible, buildScripts} = packageMeta;
-
-    if (this.opts.skipIncompatiblePackageLinking && !isManifestCompatible)
+    if (this.opts.skipIncompatiblePackageLinking && !packageMeta.isManifestCompatible)
       return {packageLocation: null, buildDirective: null};
 
     const hasVirtualInstances =
@@ -71,6 +69,7 @@ export abstract class AbstractPnpInstaller implements Installer {
       !this.opts.project.tryWorkspaceByLocator(pkg);
 
     const dependencyMeta = this.opts.project.getDependencyMeta(pkg, pkg.version);
+    const buildScripts = [...packageMeta.buildScripts];
 
     if (buildScripts.length > 0 && !this.opts.project.configuration.get(`enableScripts`) && !dependencyMeta.built) {
       this.opts.report.reportWarningOnce(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(this.opts.project.configuration, pkg)} lists build scripts, but all build scripts have been disabled.`);
@@ -124,7 +123,7 @@ export abstract class AbstractPnpInstaller implements Installer {
 
     return {
       packageLocation: packageRawLocation,
-      buildDirective: buildScripts.length > 0 && isManifestCompatible ? buildScripts as Array<BuildDirective> : null,
+      buildDirective: buildScripts.length > 0 && packageMeta.isManifestCompatible ? buildScripts as Array<BuildDirective> : null,
     };
   }
 

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -226,10 +226,8 @@ export class PnpInstaller extends AbstractPnpInstaller {
     const unplugPath = pnpUtils.getUnpluggedPath(locator, {configuration: this.opts.project.configuration});
     this.unpluggedPaths.add(unplugPath);
 
-    if (!await xfs.existsPromise(unplugPath)) {
-      await xfs.mkdirPromise(unplugPath, {recursive: true});
-      await xfs.copyPromise(unplugPath, PortablePath.dot, {baseFs: packageFs, overwrite: false});
-    }
+    await xfs.mkdirPromise(unplugPath, {recursive: true});
+    await xfs.copyPromise(unplugPath, PortablePath.dot, {baseFs: packageFs, overwrite: false});
 
     return new CwdFS(unplugPath);
   }

--- a/packages/yarnpkg-core/sources/Installer.ts
+++ b/packages/yarnpkg-core/sources/Installer.ts
@@ -21,7 +21,30 @@ export type FinalizeInstallStatus = {
   buildDirective: Array<BuildDirective>,
 };
 
+export type PackageMeta = Record<any, any>;
+
 export interface Installer {
+  /**
+   * Returns cache key used to store package meta information.
+   *
+   * The key should be unique to the linker, the package and the meta format version used.
+   *
+   * @param pkg The package being installed
+   */
+  getPackageMetaKey?(pkg: Package): string;
+
+  /**
+   * Retrieves serializable meta information from the fetched information about the package.
+   *
+   * This meta information will be cached by the core.
+   * Installer can use the package meta information to skip accessing `fetchResult`
+   * in `installPackage` implementation.
+   *
+   * @param pkg The package being installed
+   * @param fetchResult The fetched information about the package
+   */
+  fetchPackageMeta?(pkg: Package, fetchResult: FetchResult): Promise<PackageMeta>;
+
   /**
    * Install a package on the disk.
    *
@@ -37,8 +60,9 @@ export interface Installer {
    *
    * @param pkg The package being installed
    * @param fetchResult The fetched information about the package
+   * @param packageMeta The meta information about the package
    */
-  installPackage(pkg: Package, fetchResult: FetchResult): Promise<InstallStatus>;
+  installPackage(pkg: Package, fetchResult: FetchResult, packageMeta?: PackageMeta): Promise<InstallStatus>;
 
   /**
    * Link a package and its internal (same-linker) dependencies.

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -18,6 +18,7 @@ export type {ConfigurationValueMap, ConfigurationDefinitionMap}                 
 export type {Fetcher, FetchOptions, FetchResult, MinimalFetchOptions}               from './Fetcher';
 export {BuildType}                                                                  from './Installer';
 export type {Installer, BuildDirective, InstallStatus, FinalizeInstallStatus}       from './Installer';
+export type {PackageMeta}                                                           from './Installer';
 export {LightReport}                                                                from './LightReport';
 export type {Linker, LinkOptions, MinimalLinkOptions}                               from './Linker';
 export {Manifest}                                                                   from './Manifest';


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR speed ups recurrent installs

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Each linker can cache usage of `fetchResult.packageFs` now  (it is an expensive operation) through new interface functions. The core will cache package meta produced by linkers and store it inside `install-state` and will pass it on to the linker on next recurrent install, so that linker can avoid accessing `fetchResult.packageFs`.

| | before | after |
|--|--|--|
| Recurrent Gatsby PnP Linker benchmark | 5.379s | 2.394s |
| Recurrent Gatsby NM Linker benchmark |  5.829s | 3.845s |

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
