### PR TITLE
fix(gatsby/typedoc): use root tsconfig.json

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -9008,6 +9008,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-scroll-into-view-if-needed", "npm:2.1.0"],
             ["@types/react-select", "npm:3.0.11"],
             ["@types/tinycolor2", "npm:1.4.2"],
+            ["@yarnpkg/monorepo", "workspace:."],
             ["algoliasearch", "npm:4.2.0"],
             ["ansi-html", "npm:0.0.7"],
             ["buffer", "npm:5.6.0"],

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -17,6 +17,7 @@
     "@types/marked": "^1.1.0",
     "@types/react": "^16.8.0",
     "@types/react-helmet": "^6.1.0",
+    "@yarnpkg/monorepo": "workspace:0.0.0",
     "algoliasearch": "^4.2.0",
     "ansi-html": "^0.0.7",
     "buffer": "^5.6.0",

--- a/packages/gatsby/tsconfig.json
+++ b/packages/gatsby/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "lib": ["DOM", "ESNext"],
+    "noEmit": true
   },
   "exclude": []
 }

--- a/packages/gatsby/typedoc.js
+++ b/packages/gatsby/typedoc.js
@@ -1,7 +1,9 @@
 const path = require(`path`);
 
+/** @type {import('typedoc').TypeDocOptions} */
 module.exports = {
   name: `Yarn API`,
+  tsconfig: require.resolve(`@yarnpkg/monorepo/tsconfig.json`),
   inputFiles: [`../.`],
   mode: `modules`,
   out: `./static/api`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5595,6 +5595,7 @@ __metadata:
     "@types/react-scroll-into-view-if-needed": ^2
     "@types/react-select": 3.0.11
     "@types/tinycolor2": 1.4.2
+    "@yarnpkg/monorepo": "workspace:0.0.0"
     algoliasearch: ^4.2.0
     ansi-html: ^0.0.7
     buffer: ^5.6.0


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I've introduced a new `tsconfig.json` file for the website in https://github.com/yarnpkg/berry/pull/1785, which caused TypeDoc to use the wrong `tsconfig.json` file when looking up which files to include, which caused the gatsby workspace to be included instead of the other ones.

I've made this change a few days ago and intended to do it in another PR, but since I have to postpone that PR, I've decided to open this PR with the change.

Fixes #2038.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

We now pass the path to the root tsconfig inside the TypeDoc configuration options.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
