### PR TITLE
fix(node-modules): allow running binaries and scripts while depending on an incompatible package with binaries

### DIFF
--- a/.yarn/versions/33c02888.yml
+++ b/.yarn/versions/33c02888.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-dlx": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1,4 +1,4 @@
-import {xfs, npath, PortablePath} from '@yarnpkg/fslib';
+import {xfs, npath, PortablePath, ppath, Filename} from '@yarnpkg/fslib';
 
 const {
   fs: {readJson, writeFile, writeJson},
@@ -801,5 +801,40 @@ describe(`Node_Modules`, () => {
         });
       },
     )
+  );
+
+  it(`should allow running binaries unrelated to incompatible package`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        dependencies: {
+          dep: `file:./dep`,
+          dep2: `file:./dep2`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run}) => {
+        await writeJson(ppath.resolve(path, `dep/package.json` as Filename), {
+          name: `dep`,
+          version: `1.0.0`,
+          os: [`!${process.platform}`],
+          bin: `./noop.js`,
+        });
+        await xfs.writeFilePromise(ppath.resolve(path, `dep/noop.js` as Filename), ``);
+
+        await writeJson(ppath.resolve(path, `dep2/package.json` as Filename), {
+          name: `dep2`,
+          version: `1.0.0`,
+          bin: `./echo.js`,
+        });
+        await xfs.writeFilePromise(ppath.resolve(path, `dep2/echo.js` as Filename), `console.log('echo')`);
+
+        await run(`install`);
+
+        await expect(run(`dep2`)).resolves.toMatchObject({stdout: `echo\n`});
+      },
+    ),
   );
 });

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -38,8 +38,11 @@ export class NodeModulesLinker implements Linker {
       throw new UsageError(`Couldn't find the node_modules state file - running an install might help (findPackageLocation)`);
 
     const locatorInfo = installState.locatorMap.get(structUtils.stringifyLocator(locator));
-    if (!locatorInfo)
-      throw new UsageError(`Couldn't find ${structUtils.prettyLocator(opts.project.configuration, locator)} in the currently installed node_modules map - running an install might help`);
+    if (!locatorInfo) {
+      const err = new UsageError(`Couldn't find ${structUtils.prettyLocator(opts.project.configuration, locator)} in the currently installed node_modules map - running an install might help`);
+      (err as any).code = `LOCATOR_NOT_INSTALLED`;
+      throw err;
+    }
 
     return locatorInfo.locations[0];
   }

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -467,6 +467,8 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project}: 
     try {
       packageLocation = await linker.findPackageLocation(dependency, linkerOptions);
     } catch (err) {
+      // Some packages may not be installed when they are incompatible
+      // with the current system.
       if (err.code === `LOCATOR_NOT_INSTALLED`) {
         continue;
       } else {

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -463,7 +463,16 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project}: 
     if (!linker)
       continue;
 
-    const packageLocation = await linker.findPackageLocation(dependency, linkerOptions);
+    let packageLocation: PortablePath | null = null;
+    try {
+      packageLocation = await linker.findPackageLocation(dependency, linkerOptions);
+    } catch (err) {
+      if (err.code === `LOCATOR_NOT_INSTALLED`) {
+        continue;
+      } else {
+        throw err;
+      }
+    }
 
     for (const [name, target] of dependency.bin) {
       binaries.set(name, [dependency, npath.fromPortablePath(ppath.resolve(packageLocation, target))]);


### PR DESCRIPTION
**What's the problem this PR addresses?**

When using the `node-modules` linker and depending on any incompatible package with binaries, it's impossible to run unrelated binaries and scripts

Fixes https://github.com/yarnpkg/berry/issues/1891

**How did you fix it?**

Ignore locators that aren't installed when asking for them in `getPackageAccessibleBinaries`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.