### PR TITLE
use chalk to emit smooth baseline text

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -9636,7 +9636,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/libui", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-libui"],
             ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
             ["algoliasearch", "npm:4.2.0"],
-            ["chalk", "npm:3.0.0"],
             ["clipanion", "npm:2.6.2"],
             ["diff", "npm:4.0.1"],
             ["ink", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#npm:3.0.7"],

--- a/.pnp.js
+++ b/.pnp.js
@@ -9097,6 +9097,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/libui", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-libui"],
             ["@types/ink", null],
             ["@types/react", "npm:16.9.2"],
+            ["chalk", "npm:3.0.0"],
             ["ink", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#npm:3.0.7"],
             ["react", "npm:16.13.1"],
             ["redux", "npm:4.0.5"],
@@ -9115,6 +9116,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/libui", "workspace:packages/yarnpkg-libui"],
             ["@types/react", "npm:16.9.2"],
+            ["chalk", "npm:3.0.0"],
             ["ink", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#npm:3.0.7"],
             ["react", "npm:16.13.1"],
             ["redux", "npm:4.0.5"],
@@ -9634,6 +9636,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/libui", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-libui"],
             ["@yarnpkg/plugin-essentials", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-essentials"],
             ["algoliasearch", "npm:4.2.0"],
+            ["chalk", "npm:3.0.0"],
             ["clipanion", "npm:2.6.2"],
             ["diff", "npm:4.0.1"],
             ["ink", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#npm:3.0.7"],

--- a/.yarn/versions/9b987adf.yml
+++ b/.yarn/versions/9b987adf.yml
@@ -1,0 +1,4 @@
+releases:
+  "@yarnpkg/libui": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@yarnpkg/libui": "workspace:^2.1.0",
     "algoliasearch": "^4.2.0",
+    "chalk": "^3.0.0",
     "clipanion": "^2.6.2",
     "diff": "^4.0.1",
     "ink": "^3.0.7",

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@yarnpkg/libui": "workspace:^2.1.0",
     "algoliasearch": "^4.2.0",
-    "chalk": "^3.0.0",
     "clipanion": "^2.6.2",
     "diff": "^4.0.1",
     "ink": "^3.0.7",

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -1,6 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}                                                                                            from '@yarnpkg/cli';
 import {Cache, Configuration, Project, HardDependencies, formatUtils, miscUtils, structUtils, Descriptor, DescriptorHash, StreamReport} from '@yarnpkg/core';
 import {ItemOptions}                                                                                                                    from '@yarnpkg/libui/sources/components/ItemOptions';
+import {Pad}                                                                                                                            from '@yarnpkg/libui/sources/components/Pad';
 import {ScrollableItems}                                                                                                                from '@yarnpkg/libui/sources/components/ScrollableItems';
 import {useMinistore}                                                                                                                   from '@yarnpkg/libui/sources/hooks/useMinistore';
 import {renderForm, SubmitInjectedComponent}                                                                                            from '@yarnpkg/libui/sources/misc/renderForm';
@@ -199,15 +200,12 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       ]);
       const packageIdentifier = structUtils.stringifyIdent(descriptor);
       const padLength = Math.max(0, 45 - packageIdentifier.length);
-
       return <Box>
         <Box width={45}>
           <Text bold>
             {structUtils.prettyIdent(configuration, descriptor)}
           </Text>
-          <Text dimColor={!active}>
-            {` `.padEnd(padLength, `_`)}
-          </Text>
+          <Pad active={active} length={padLength}/>
         </Box>
         {suggestions !== null
           ? <ItemOptions active={active} options={suggestions} value={action} skewer={true} onChange={setAction} sizes={[17, 17, 17]} />

--- a/packages/yarnpkg-libui/package.json
+++ b/packages/yarnpkg-libui/package.json
@@ -17,6 +17,7 @@
     "url": "ssh://git@github.com/yarnpkg/berry.git"
   },
   "dependencies": {
+    "chalk": "^3.0.0",
     "redux": "^4.0.0",
     "tslib": "^1.13.0"
   },

--- a/packages/yarnpkg-libui/sources/components/Gem.tsx
+++ b/packages/yarnpkg-libui/sources/components/Gem.tsx
@@ -1,10 +1,11 @@
-import {Text}        from 'ink';
-import React, {memo} from 'react';
+import {Text}                 from 'ink';
+import React, {memo, useMemo} from 'react';
 
 export interface GemProps {
   active: boolean
 }
 export const Gem: React.FC<GemProps> = memo(({active}) => {
-  return active ? <Text color="green">{`◉`}</Text>
-    :  <Text color="yellow">{`◯`}</Text>;
+  const text = useMemo(() => active ? `◉` : `◯`, [active]);
+  const color = useMemo(() => active ? `green` : `yellow`, [active]);
+  return <Text color={color}>{text}</Text>;
 });

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -1,9 +1,11 @@
+import chalk          from 'chalk';
 import {Box, Text}    from 'ink';
 import React          from 'react';
 
 import {useListInput} from '../hooks/useListInput';
 
 import {Gem}          from './Gem';
+import {Pad}          from './Pad';
 
 export const ItemOptions = function <T>({
   active,
@@ -40,14 +42,12 @@ export const ItemOptions = function <T>({
         .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ``);
 
       const padWidth = Math.max(0, boxWidth - (simpleLabel).length - 2);
-      const padText = skewer ? ` `.padEnd(padWidth, `_`) : ``;
-
       return (
         <Box key={label} width={boxWidth} marginLeft={1}>
           <Text wrap="truncate">
-            <Gem active={isGemActive} /> {label}
+            <Gem active={isGemActive} />{` `}{label}
           </Text>
-          <Text dimColor={!active}>{padText}</Text>
+          { skewer ? <Pad active={active} length={padWidth}/> : null }
         </Box>
       );
     })}

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -1,4 +1,3 @@
-import chalk          from 'chalk';
 import {Box, Text}    from 'ink';
 import React          from 'react';
 

--- a/packages/yarnpkg-libui/sources/components/Pad.tsx
+++ b/packages/yarnpkg-libui/sources/components/Pad.tsx
@@ -6,7 +6,14 @@ export interface PadProps {
   length: number
   active: boolean
 }
-export const Pad = memo(({length, active}: PadProps) => {
-  const text = useMemo(() => chalk.underline(` `.padEnd(length, ` `)), [length, active]);
+
+export const Pad = ({length, active}: PadProps) => {
+  if (length === 0)
+    return null;
+
+  const text = length > 1
+    ? ` ${chalk.underline(` `.repeat(length - 1))}`
+    : ` `;
+
   return <Text dimColor={!active}>{text}</Text>;
-});
+};

--- a/packages/yarnpkg-libui/sources/components/Pad.tsx
+++ b/packages/yarnpkg-libui/sources/components/Pad.tsx
@@ -1,0 +1,12 @@
+import chalk                  from 'chalk';
+import {Text}                 from 'ink';
+import React, {memo, useMemo} from 'react';
+
+export interface PadProps {
+  length: number
+  active: boolean
+}
+export const Pad = memo(({length, active}: PadProps) => {
+  const text = useMemo(() => chalk.underline(` `.padEnd(length, ` `)), [length, active]);
+  return <Text dimColor={!active}>{text}</Text>;
+});

--- a/packages/yarnpkg-libui/sources/components/Pad.tsx
+++ b/packages/yarnpkg-libui/sources/components/Pad.tsx
@@ -1,6 +1,6 @@
-import chalk                  from 'chalk';
-import {Text}                 from 'ink';
-import React, {memo, useMemo} from 'react';
+import chalk  from 'chalk';
+import {Text} from 'ink';
+import React  from 'react';
 
 export interface PadProps {
   length: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -5952,7 +5952,6 @@ __metadata:
     "@yarnpkg/libui": "workspace:^2.1.0"
     "@yarnpkg/plugin-essentials": "workspace:^2.3.2"
     algoliasearch: ^4.2.0
-    chalk: ^3.0.0
     clipanion: ^2.6.2
     diff: ^4.0.1
     ink: ^3.0.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -5679,6 +5679,7 @@ __metadata:
   resolution: "@yarnpkg/libui@workspace:packages/yarnpkg-libui"
   dependencies:
     "@types/react": ^16.8.0
+    chalk: ^3.0.0
     ink: ^3.0.7
     react: ^16.13.1
     redux: ^4.0.0
@@ -5951,6 +5952,7 @@ __metadata:
     "@yarnpkg/libui": "workspace:^2.1.0"
     "@yarnpkg/plugin-essentials": "workspace:^2.3.2"
     algoliasearch: ^4.2.0
+    chalk: ^3.0.0
     clipanion: ^2.6.2
     diff: ^4.0.1
     ink: ^3.0.7


### PR DESCRIPTION
**What's the problem this PR addresses?**
The current baseline indicators use a simple underscore character pad. This can be improved by using a underline style over spaces.

Expands on #1980, #2029 

**How did you fix it?**
Instead of underscore characters, use space characters styled with `chalk.underline`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
