### PR TITLE
Use React.memo on function components

### DIFF
--- a/.yarn/versions/e75d20cf.yml
+++ b/.yarn/versions/e75d20cf.yml
@@ -1,0 +1,4 @@
+releases:
+  "@yarnpkg/libui": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-interactive-tools/sources/commands/search.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/search.tsx
@@ -9,7 +9,7 @@ import {Command, Usage}                      from 'clipanion';
 import InkTextInput                          from 'ink-text-input';
 import {Box, Text}                           from 'ink';
 
-import React, {useEffect, useState}          from 'react';
+import React, {memo, useEffect, useState}    from 'react';
 
 import {AlgoliaPackage, search}              from '../algolia';
 
@@ -33,55 +33,53 @@ export default class SearchCommand extends BaseCommand {
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
-    const Prompt = () => {
-      return (
-        <Box flexDirection="row">
-          <Box flexDirection="column" width={48}>
-            <Box>
-              <Text>
+    const Prompt = memo(() => (
+      <Box flexDirection="row">
+        <Box flexDirection="column" width={48}>
+          <Box>
+            <Text>
                 Press <Text bold color="cyanBright">{`<up>`}</Text>/<Text bold color="cyanBright">{`<down>`}</Text> to move between packages.
-              </Text>
-            </Box>
-            <Box>
-              <Text>
-                Press <Text bold color="cyanBright">{`<space>`}</Text> to select a package.
-              </Text>
-            </Box>
-            <Box>
-              <Text>
-                Press <Text bold color="cyanBright">{`<space>`}</Text> again to change the target.
-              </Text>
-            </Box>
+            </Text>
           </Box>
-          <Box flexDirection="column">
-            <Box marginLeft={1}>
-              <Text>
-                Press <Text bold color="cyanBright">{`<enter>`}</Text> to install the selected packages.
-              </Text>
-            </Box>
-            <Box marginLeft={1}>
-              <Text>
-                Press <Text bold color="cyanBright">{`<ctrl+c>`}</Text> to abort.
-              </Text>
-            </Box>
+          <Box>
+            <Text>
+                Press <Text bold color="cyanBright">{`<space>`}</Text> to select a package.
+            </Text>
+          </Box>
+          <Box>
+            <Text>
+                Press <Text bold color="cyanBright">{`<space>`}</Text> again to change the target.
+            </Text>
           </Box>
         </Box>
-      );
-    };
+        <Box flexDirection="column">
+          <Box marginLeft={1}>
+            <Text>
+                Press <Text bold color="cyanBright">{`<enter>`}</Text> to install the selected packages.
+            </Text>
+          </Box>
+          <Box marginLeft={1}>
+            <Text>
+                Press <Text bold color="cyanBright">{`<ctrl+c>`}</Text> to abort.
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    ));
 
-    const SearchColumnNames = () => {
-      return <>
+    const SearchColumnNames = memo(() => (
+      <>
         <Box width={15}><Text bold underline color="gray">Owner</Text></Box>
         <Box width={11}><Text bold underline color="gray">Version</Text></Box>
         <Box width={10}><Text bold underline color="gray">Downloads</Text></Box>
-      </>;
-    };
+      </>
+    ));
 
-    const SelectedColumnNames = () => {
-      return <Box width={17}><Text bold underline color="gray">Target</Text></Box>;
-    };
+    const SelectedColumnNames = memo(() => (
+      <Box width={17}><Text bold underline color="gray">Target</Text></Box>
+    ));
 
-    const HitEntry = ({hit, active}: {hit: AlgoliaPackage, active: boolean}) => {
+    const HitEntry = memo(({hit, active}: {hit: AlgoliaPackage, active: boolean}) => {
       const [action, setAction] = useMinistore<string | null>(hit.name, null);
 
       useKeypress({active}, (ch, key) => {
@@ -131,9 +129,9 @@ export default class SearchCommand extends BaseCommand {
           </Box>
         </Box>
       );
-    };
+    });
 
-    const SelectedEntry = ({name, active}: {name: string, active: boolean}) => {
+    const SelectedEntry = memo(({name, active}: {name: string, active: boolean}) => {
       const [action] = useMinistore<string | null>(name, null);
 
       const ident = structUtils.parseIdent(name);
@@ -154,15 +152,15 @@ export default class SearchCommand extends BaseCommand {
             </Box>
         )}
       </Box>;
-    };
+    });
 
-    const PoweredByAlgolia = () => (
+    const PoweredByAlgolia = memo(() => (
       <Box marginTop={1}>
         <Text>Powered by Algolia.</Text>
       </Box>
-    );
+    ));
 
-    const SearchApp: SubmitInjectedComponent<Map<string, unknown>> = ({useSubmit}) => {
+    const SearchApp: SubmitInjectedComponent<Map<string, unknown>> = memo(({useSubmit}) => {
       const selectionMap = useMinistore();
       useSubmit(selectionMap);
 
@@ -244,7 +242,7 @@ export default class SearchCommand extends BaseCommand {
           <PoweredByAlgolia />
         </Box>
       );
-    };
+    });
 
     const installRequests = await renderForm(SearchApp, {});
     if (typeof installRequests === `undefined`)

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -210,7 +210,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           </Text>
         </Box>
         {suggestions !== null
-          ? <ItemOptions active={active} options={suggestions} value={action} skewer={true} onChange={setAction} sizes={[17, 17, 17]} />
+          ? <ItemOptions<string|null> active={active} options={suggestions} value={action} skewer={true} onChange={setAction} sizes={[17, 17, 17]} />
           : <Box marginLeft={2}><Text color="gray">Fetching suggestions...</Text></Box>
         }
       </Box>;

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -8,7 +8,7 @@ import {suggestUtils}                                                           
 import {Command, Usage}                                                                                                                 from 'clipanion';
 import {diffWords}                                                                                                                      from 'diff';
 import {Box, Text}                                                                                                                      from 'ink';
-import React, {useEffect, useState, useRef}                                                                                             from 'react';
+import React, {memo, useEffect, useState, useRef}                                                                                       from 'react';
 import semver                                                                                                                           from 'semver';
 
 const SIMPLE_SEMVER = /^((?:[\^~]|>=?)?)([0-9]+)(\.[0-9]+)(\.[0-9]+)((?:-\S+)?)$/;
@@ -131,7 +131,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       return suggestions;
     };
 
-    const Prompt = () => {
+    const Prompt = memo(() => {
       return (
         <Box flexDirection="row">
           <Box flexDirection="column" width={49}>
@@ -160,9 +160,9 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           </Box>
         </Box>
       );
-    };
+    });
 
-    const Header = () => {
+    const Header = memo(() => {
       return (
         <Box flexDirection="row" paddingTop={1} paddingBottom={1}>
           <Box width={50}>
@@ -174,9 +174,9 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           <Box width={17}><Text bold underline color="gray">Range/Latest</Text></Box>
         </Box>
       );
-    };
+    });
 
-    const UpgradeEntry = ({active, descriptor}: {active: boolean, descriptor: Descriptor}) => {
+    const UpgradeEntry = memo(({active, descriptor}: {active: boolean, descriptor: Descriptor}) => {
       const [action, setAction] = useMinistore<string | null>(descriptor.descriptorHash, null);
       const [suggestions, setSuggestions] = useState<Array<{value: string | null, label: string}> | null>(null);
 
@@ -214,9 +214,9 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           : <Box marginLeft={2}><Text color="gray">Fetching suggestions...</Text></Box>
         }
       </Box>;
-    };
+    });
 
-    const GlobalListApp: SubmitInjectedComponent<Map<string, string | null>> = ({useSubmit}) => {
+    const GlobalListApp: SubmitInjectedComponent<Map<string, string | null>> = memo(({useSubmit}) => {
       useSubmit(useMinistore());
 
       const allDependencies = new Map<DescriptorHash, Descriptor>();
@@ -240,7 +240,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           })} />
         </Box>
       </>;
-    };
+    });
 
     const updateRequests = await renderForm(GlobalListApp, {});
     if (typeof updateRequests === `undefined`)

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -8,7 +8,7 @@ import {useListInput}                                                           
 import {renderForm}                                                                                             from '@yarnpkg/libui/sources/misc/renderForm';
 import {Command, Usage, UsageError}                                                                             from 'clipanion';
 import {Box, Text}                                                                                              from 'ink';
-import React, {useCallback, useState}                                                                           from 'react';
+import React, {memo, useCallback, useState}                                                                     from 'react';
 import semver                                                                                                   from 'semver';
 
 import * as versionUtils                                                                                        from '../../versionUtils';
@@ -63,7 +63,7 @@ export default class VersionCheckCommand extends Command<CommandContext> {
     if (versionFile.root === null)
       throw new UsageError(`This command can only be run on Git repositories`);
 
-    const Prompt = () => {
+    const Prompt = memo(() => {
       return (
         <Box flexDirection="row" paddingBottom={1}>
           <Box flexDirection="column" width={60}>
@@ -92,9 +92,9 @@ export default class VersionCheckCommand extends Command<CommandContext> {
           </Box>
         </Box>
       );
-    };
+    });
 
-    const Undecided = ({workspace, active, decision, setDecision}: {workspace: Workspace, active?: boolean, decision: versionUtils.Decision, setDecision: (decision: versionUtils.Decision) => void}) => {
+    const Undecided = memo(({workspace, active, decision, setDecision}: {workspace: Workspace, active?: boolean, decision: versionUtils.Decision, setDecision: (decision: versionUtils.Decision) => void}) => {
       const currentVersion = workspace.manifest.version;
       if (currentVersion === null)
         throw new Error(`Assertion failed: The version should have been set (${structUtils.prettyLocator(configuration, workspace.anchoredLocator)})`);
@@ -137,7 +137,7 @@ export default class VersionCheckCommand extends Command<CommandContext> {
           </Box>
         </Box>
       );
-    };
+    });
 
     const getRelevancy = (releases: Releases) => {
       // Now, starting from all the workspaces that changed, we'll detect
@@ -226,7 +226,7 @@ export default class VersionCheckCommand extends Command<CommandContext> {
       return <Text color="yellow">{parts.join(`, `)}</Text>;
     };
 
-    const App = ({useSubmit}: {useSubmit: (value: Releases) => void}) => {
+    const App = memo(({useSubmit}: {useSubmit: (value: Releases) => void}) => {
       const [releases, setWorkspaceRelease] = useReleases();
       useSubmit(releases);
 
@@ -310,7 +310,7 @@ export default class VersionCheckCommand extends Command<CommandContext> {
           ) : null}
         </Box>
       );
-    };
+    });
 
     const decisions = await renderForm<Releases>(App, {versionFile});
     if (typeof decisions === `undefined`)

--- a/packages/yarnpkg-libui/sources/components/Application.tsx
+++ b/packages/yarnpkg-libui/sources/components/Application.tsx
@@ -1,6 +1,6 @@
-import {useStdin}                            from 'ink';
-import React, {useEffect, useMemo, useState} from 'react';
-import {emitKeypressEvents}                  from 'readline';
+import {useStdin}                                  from 'ink';
+import React, {memo, useEffect, useMemo, useState} from 'react';
+import {emitKeypressEvents}                        from 'readline';
 
 export const MinistoreContext = React.createContext<{
   getAll: () => Map<string, any>,
@@ -8,7 +8,7 @@ export const MinistoreContext = React.createContext<{
   set: (key: string, value: any) => void,
 } | null>(null);
 
-export const Application = ({children}: {children: React.ReactElement}) => {
+export const Application = memo(({children}: {children: React.ReactElement}) => {
   const {stdin, setRawMode} = useStdin();
 
   useEffect(() => {
@@ -25,4 +25,4 @@ export const Application = ({children}: {children: React.ReactElement}) => {
   }), [data, setData]);
 
   return <MinistoreContext.Provider value={ministore} children={children} />;
-};
+});

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -5,21 +5,22 @@ import {useListInput} from '../hooks/useListInput';
 
 import {Gem}          from './Gem';
 
-export const ItemOptions = memo(({
-  active,
-  skewer,
-  options,
-  value,
-  onChange,
-  sizes = [],
-}: {
+export interface ItemOptionsProps<T> {
   active: boolean,
   skewer?: boolean,
   options: Array<{value: T, label: string}>,
   value: T,
   onChange: (value: T) => void,
   sizes?: Array<number>
-}) => {
+}
+function ItemOptionsComponent<T>({
+  active,
+  skewer,
+  options,
+  value,
+  onChange,
+  sizes = [],
+}: ItemOptionsProps<T>) {
   const values = options.map(({value}) => value);
   const selectedIndex = values.indexOf(value);
 
@@ -52,4 +53,6 @@ export const ItemOptions = memo(({
       );
     })}
   </>;
-});
+}
+
+export const ItemOptions = memo(ItemOptionsComponent) as typeof ItemOptionsComponent;

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -1,11 +1,11 @@
 import {Box, Text}    from 'ink';
-import React          from 'react';
+import React, {memo}  from 'react';
 
 import {useListInput} from '../hooks/useListInput';
 
 import {Gem}          from './Gem';
 
-export const ItemOptions = function <T>({
+export const ItemOptions = memo(({
   active,
   skewer,
   options,
@@ -19,7 +19,7 @@ export const ItemOptions = function <T>({
   value: T,
   onChange: (value: T) => void,
   sizes?: Array<number>
-}) {
+}) => {
   const values = options.map(({value}) => value);
   const selectedIndex = values.indexOf(value);
 
@@ -52,4 +52,4 @@ export const ItemOptions = function <T>({
       );
     })}
   </>;
-};
+});

--- a/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
+++ b/packages/yarnpkg-libui/sources/components/ScrollableItems.tsx
@@ -1,12 +1,12 @@
 import {Box, Text}                            from 'ink';
-import React, {useEffect, useState}           from 'react';
+import React, {memo, useEffect, useState}     from 'react';
 
 import {FocusRequestHandler, useFocusRequest} from '../hooks/useFocusRequest';
 import {useListInput}                         from '../hooks/useListInput';
 
 type WillReachEnd = () => void;
 
-export const ScrollableItems = ({active = true, children = [], radius = 10, size = 1, loop = true, onFocusRequest, willReachEnd}: {active?: boolean, children: Array<React.ReactElement>, radius?: number, size?: number, loop?: boolean, onFocusRequest?: FocusRequestHandler, willReachEnd?: WillReachEnd}) => {
+export const ScrollableItems = memo(({active = true, children = [], radius = 10, size = 1, loop = true, onFocusRequest, willReachEnd}: {active?: boolean, children: Array<React.ReactElement>, radius?: number, size?: number, loop?: boolean, onFocusRequest?: FocusRequestHandler, willReachEnd?: WillReachEnd}) => {
   const getKey = (child: React.ReactElement) => {
     if (child.key === null) {
       throw new Error(`Expected all children to have a key`);
@@ -88,4 +88,4 @@ export const ScrollableItems = ({active = true, children = [], radius = 10, size
   return <Box flexDirection={`column`} width={`100%`}>
     {rendered}
   </Box>;
-};
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**
This PR introduces some minor performance improvements that can be gained from using `React.memo` by default on function components. This will prevent these components from re-rendering on every render cycle unless their props change or their hooks fire internally. 

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
