### PR TITLE
fix(zipfs): allow extension activation via menu commands

### DIFF
--- a/.yarn/versions/613aace9.yml
+++ b/.yarn/versions/613aace9.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: patch

--- a/packages/vscode-zipfs/package.json
+++ b/packages/vscode-zipfs/package.json
@@ -17,7 +17,9 @@
   "activationEvents": [
     "workspaceContains:**/*.zip",
     "onLanguage:zip",
-    "onFileSystem:zip"
+    "onFileSystem:zip",
+    "onCommand:zipfs.mountZipFile",
+    "onCommand:zipfs.mountZipEditor"
   ],
   "main": "./build/index.js",
   "sideEffects": false,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

If all `zip` files were excluded via the `search.exclude` setting in `.vscode/settings.json`, the extension would never activate.

This meant that `Mount as Zip` wouldn't do anything.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added new activation events. Credits @merceyz: https://discordapp.com/channels/226791405589233664/226793713722982400/770640828438937620


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
