### PR TITLE
fix(core): normalize relative filepaths in Manifest

### DIFF
--- a/.yarn/versions/c8af9c56.yml
+++ b/.yarn/versions/c8af9c56.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -150,13 +150,6 @@ export class Manifest {
     this.indent = getIndent(content);
   }
 
-  /**
-   * Replaces all backslashes with slashes
-   */
-  private normalizeSlashes(str: string) {
-    return str.replace(/\\/g, `/`) as PortablePath;
-  }
-
   load(data: any) {
     if (typeof data !== `object` || data === null)
       throw new Error(`Utterly invalid manifest data (${data})`);
@@ -214,20 +207,20 @@ export class Manifest {
       this.languageName = data.languageName;
 
     if (typeof data.main === `string`)
-      this.main = this.normalizeSlashes(data.main);
+      this.main = normalizeSlashes(data.main);
 
     if (typeof data.module === `string`)
-      this.module = this.normalizeSlashes(data.module);
+      this.module = normalizeSlashes(data.module);
 
     if (data.browser != null) {
       if (typeof data.browser === `string`) {
-        this.browser = this.normalizeSlashes(data.browser);
+        this.browser = normalizeSlashes(data.browser);
       } else {
         this.browser = new Map();
         for (const [key, value] of Object.entries(data.browser)) {
           this.browser.set(
-            this.normalizeSlashes(key) ,
-            typeof value === `string` ? this.normalizeSlashes(value) : (value as boolean)
+            normalizeSlashes(key) ,
+            typeof value === `string` ? normalizeSlashes(value) : (value as boolean)
           );
         }
       }
@@ -235,7 +228,7 @@ export class Manifest {
 
     if (typeof data.bin === `string`) {
       if (this.name !== null) {
-        this.bin = new Map([[this.name.name, this.normalizeSlashes(data.bin)]]);
+        this.bin = new Map([[this.name.name, normalizeSlashes(data.bin)]]);
       } else {
         errors.push(new Error(`String bin field, but no attached package name`));
       }
@@ -246,7 +239,7 @@ export class Manifest {
           continue;
         }
 
-        this.bin.set(key, this.normalizeSlashes(value));
+        this.bin.set(key, normalizeSlashes(value));
       }
     }
 
@@ -405,20 +398,20 @@ export class Manifest {
         this.publishConfig.access = data.publishConfig.access;
 
       if (typeof data.publishConfig.main === `string`)
-        this.publishConfig.main = this.normalizeSlashes(data.publishConfig.main);
+        this.publishConfig.main = normalizeSlashes(data.publishConfig.main);
 
       if (typeof data.publishConfig.module === `string`)
-        this.publishConfig.module = this.normalizeSlashes(data.publishConfig.module);
+        this.publishConfig.module = normalizeSlashes(data.publishConfig.module);
 
       if (data.publishConfig.browser != null) {
         if (typeof data.publishConfig.browser === `string`) {
-          this.publishConfig.browser = this.normalizeSlashes(data.publishConfig.browser);
+          this.publishConfig.browser = normalizeSlashes(data.publishConfig.browser);
         } else {
           this.publishConfig.browser = new Map();
           for (const [key, value] of Object.entries(data.publishConfig.browser)) {
             this.publishConfig.browser.set(
-              this.normalizeSlashes(key) ,
-              typeof value === `string` ? this.normalizeSlashes(value) : (value as boolean)
+              normalizeSlashes(key) ,
+              typeof value === `string` ? normalizeSlashes(value) : (value as boolean)
             );
           }
         }
@@ -429,7 +422,7 @@ export class Manifest {
 
       if (typeof data.publishConfig.bin === `string`) {
         if (this.name !== null) {
-          this.publishConfig.bin = new Map([[this.name.name, this.normalizeSlashes(data.publishConfig.bin)]]);
+          this.publishConfig.bin = new Map([[this.name.name, normalizeSlashes(data.publishConfig.bin)]]);
         } else {
           errors.push(new Error(`String bin field, but no attached package name`));
         }
@@ -442,7 +435,7 @@ export class Manifest {
             continue;
           }
 
-          this.publishConfig.bin.set(key, this.normalizeSlashes(value));
+          this.publishConfig.bin.set(key, normalizeSlashes(value));
         }
       }
 
@@ -455,7 +448,7 @@ export class Manifest {
             continue;
           }
 
-          this.publishConfig.executableFiles.add(this.normalizeSlashes(value));
+          this.publishConfig.executableFiles.add(normalizeSlashes(value));
         }
       }
     }
@@ -876,4 +869,8 @@ function isManifestFieldCompatible(rules: Array<string>, actual: string) {
 
   // Denylists with allowlisted items should be treated as allowlists for `os` and `cpu` in `package.json`
   return isOnDenylist && isNotOnAllowlist;
+}
+
+function normalizeSlashes(str: string) {
+  return str.replace(/\\/g, `/`) as PortablePath;
 }

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -410,11 +410,19 @@ export class Manifest {
       if (typeof data.publishConfig.module === `string`)
         this.publishConfig.module = this.normalizeSlashes(data.publishConfig.module);
 
-      if (typeof data.publishConfig.browser === `string`)
-        this.publishConfig.browser = this.normalizeSlashes(data.publishConfig.browser);
-
-      if (typeof data.publishConfig.browser === `object` && data.publishConfig.browser !== null)
-        this.publishConfig.browser = new Map(Object.entries(data.publishConfig.browser) as Iterable<[PortablePath, PortablePath | boolean]>);
+      if (data.publishConfig.browser != null) {
+        if (typeof data.publishConfig.browser === `string`) {
+          this.publishConfig.browser = this.normalizeSlashes(data.publishConfig.browser);
+        } else {
+          this.publishConfig.browser = new Map();
+          for (const [key, value] of Object.entries(data.publishConfig.browser)) {
+            this.publishConfig.browser.set(
+              this.normalizeSlashes(key) ,
+              typeof value === `string` ? this.normalizeSlashes(value) : (value as boolean)
+            );
+          }
+        }
+      }
 
       if (typeof data.publishConfig.registry === `string`)
         this.publishConfig.registry = data.publishConfig.registry;

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -150,6 +150,13 @@ export class Manifest {
     this.indent = getIndent(content);
   }
 
+  /**
+   * Replaces all backslashes with slashes
+   */
+  private normalizeSlashes(str: string) {
+    return str.replace(/\\/g, `/`) as PortablePath;
+  }
+
   load(data: any) {
     if (typeof data !== `object` || data === null)
       throw new Error(`Utterly invalid manifest data (${data})`);
@@ -207,20 +214,20 @@ export class Manifest {
       this.languageName = data.languageName;
 
     if (typeof data.main === `string`)
-      this.main = data.main.replace(/\\/g, `/`);
+      this.main = this.normalizeSlashes(data.main);
 
     if (typeof data.module === `string`)
-      this.module = data.module.replace(/\\/g, `/`);
+      this.module = this.normalizeSlashes(data.module);
 
     if (data.browser != null) {
       if (typeof data.browser === `string`) {
-        this.browser = data.browser.replace(/\\/g, `/`);
+        this.browser = this.normalizeSlashes(data.browser);
       } else {
         this.browser = new Map();
         for (const [key, value] of Object.entries(data.browser)) {
           this.browser.set(
-            key.replace(/\\/g, `/`) as PortablePath,
-            typeof value === `string` ? (value.replace(/\\/g, `/`) as PortablePath) : (value as boolean)
+            this.normalizeSlashes(key) ,
+            typeof value === `string` ? this.normalizeSlashes(value) : (value as boolean)
           );
         }
       }
@@ -228,7 +235,7 @@ export class Manifest {
 
     if (typeof data.bin === `string`) {
       if (this.name !== null) {
-        this.bin = new Map([[this.name.name, data.bin.replace(/\\/g, `/`)]]);
+        this.bin = new Map([[this.name.name, this.normalizeSlashes(data.bin)]]);
       } else {
         errors.push(new Error(`String bin field, but no attached package name`));
       }
@@ -239,7 +246,7 @@ export class Manifest {
           continue;
         }
 
-        this.bin.set(key, value.replace(/\\/g, `/`) as PortablePath);
+        this.bin.set(key, this.normalizeSlashes(value));
       }
     }
 
@@ -398,13 +405,13 @@ export class Manifest {
         this.publishConfig.access = data.publishConfig.access;
 
       if (typeof data.publishConfig.main === `string`)
-        this.publishConfig.main = data.publishConfig.main.replace(/\\/g, `/`);
+        this.publishConfig.main = this.normalizeSlashes(data.publishConfig.main);
 
       if (typeof data.publishConfig.module === `string`)
-        this.publishConfig.module = data.publishConfig.module.replace(/\\/g, `/`);
+        this.publishConfig.module = this.normalizeSlashes(data.publishConfig.module);
 
       if (typeof data.publishConfig.browser === `string`)
-        this.publishConfig.browser = data.publishConfig.browser.replace(/\\/g, `/`);
+        this.publishConfig.browser = this.normalizeSlashes(data.publishConfig.browser);
 
       if (typeof data.publishConfig.browser === `object` && data.publishConfig.browser !== null)
         this.publishConfig.browser = new Map(Object.entries(data.publishConfig.browser) as Iterable<[PortablePath, PortablePath | boolean]>);
@@ -414,7 +421,7 @@ export class Manifest {
 
       if (typeof data.publishConfig.bin === `string`) {
         if (this.name !== null) {
-          this.publishConfig.bin = new Map([[this.name.name, data.publishConfig.bin.replace(/\\/g, `/`)]]);
+          this.publishConfig.bin = new Map([[this.name.name, this.normalizeSlashes(data.publishConfig.bin)]]);
         } else {
           errors.push(new Error(`String bin field, but no attached package name`));
         }
@@ -427,7 +434,7 @@ export class Manifest {
             continue;
           }
 
-          this.publishConfig.bin.set(key, value.replace(/\\/g, `/`) as PortablePath);
+          this.publishConfig.bin.set(key, this.normalizeSlashes(value));
         }
       }
 
@@ -440,7 +447,7 @@ export class Manifest {
             continue;
           }
 
-          this.publishConfig.executableFiles.add(npath.toPortablePath(value.replace(/\\/g, `/`)));
+          this.publishConfig.executableFiles.add(this.normalizeSlashes(value));
         }
       }
     }

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -1,12 +1,12 @@
-import {FakeFS, Filename, NodeFS, PortablePath, npath, ppath} from '@yarnpkg/fslib';
-import {Resolution, parseResolution, stringifyResolution}     from '@yarnpkg/parsers';
-import semver                                                 from 'semver';
+import {FakeFS, Filename, NodeFS, PortablePath, ppath}    from '@yarnpkg/fslib';
+import {Resolution, parseResolution, stringifyResolution} from '@yarnpkg/parsers';
+import semver                                             from 'semver';
 
-import * as miscUtils                                         from './miscUtils';
-import * as semverUtils                                       from './semverUtils';
-import * as structUtils                                       from './structUtils';
-import {IdentHash}                                            from './types';
-import {Ident, Descriptor}                                    from './types';
+import * as miscUtils                                     from './miscUtils';
+import * as semverUtils                                   from './semverUtils';
+import * as structUtils                                   from './structUtils';
+import {IdentHash}                                        from './types';
+import {Ident, Descriptor}                                from './types';
 
 export type AllDependencies = 'dependencies' | 'devDependencies' | 'peerDependencies';
 export type HardDependencies = 'dependencies' | 'devDependencies';

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -207,22 +207,28 @@ export class Manifest {
       this.languageName = data.languageName;
 
     if (typeof data.main === `string`)
-      this.main = data.main;
+      this.main = data.main.replace(/\\/g, `/`);
 
     if (typeof data.module === `string`)
-      this.module = data.module;
+      this.module = data.module.replace(/\\/g, `/`);
 
     if (data.browser != null) {
       if (typeof data.browser === `string`) {
-        this.browser = data.browser;
+        this.browser = data.browser.replace(/\\/g, `/`);
       } else {
-        this.browser = new Map(Object.entries(data.browser) as Iterable<[PortablePath, PortablePath | boolean]>);
+        this.browser = new Map();
+        for (const [key, value] of Object.entries(data.browser)) {
+          this.browser.set(
+            key.replace(/\\/g, `/`) as PortablePath,
+            typeof value === `string` ? (value.replace(/\\/g, `/`) as PortablePath) : (value as boolean)
+          );
+        }
       }
     }
 
     if (typeof data.bin === `string`) {
       if (this.name !== null) {
-        this.bin = new Map([[this.name.name, data.bin]]);
+        this.bin = new Map([[this.name.name, data.bin.replace(/\\/g, `/`)]]);
       } else {
         errors.push(new Error(`String bin field, but no attached package name`));
       }
@@ -233,7 +239,7 @@ export class Manifest {
           continue;
         }
 
-        this.bin.set(key, value as PortablePath);
+        this.bin.set(key, value.replace(/\\/g, `/`) as PortablePath);
       }
     }
 
@@ -392,13 +398,13 @@ export class Manifest {
         this.publishConfig.access = data.publishConfig.access;
 
       if (typeof data.publishConfig.main === `string`)
-        this.publishConfig.main = data.publishConfig.main;
+        this.publishConfig.main = data.publishConfig.main.replace(/\\/g, `/`);
 
       if (typeof data.publishConfig.module === `string`)
-        this.publishConfig.module = data.publishConfig.module;
+        this.publishConfig.module = data.publishConfig.module.replace(/\\/g, `/`);
 
       if (typeof data.publishConfig.browser === `string`)
-        this.publishConfig.browser = data.publishConfig.browser;
+        this.publishConfig.browser = data.publishConfig.browser.replace(/\\/g, `/`);
 
       if (typeof data.publishConfig.browser === `object` && data.publishConfig.browser !== null)
         this.publishConfig.browser = new Map(Object.entries(data.publishConfig.browser) as Iterable<[PortablePath, PortablePath | boolean]>);
@@ -408,7 +414,7 @@ export class Manifest {
 
       if (typeof data.publishConfig.bin === `string`) {
         if (this.name !== null) {
-          this.publishConfig.bin = new Map([[this.name.name, data.publishConfig.bin]]);
+          this.publishConfig.bin = new Map([[this.name.name, data.publishConfig.bin.replace(/\\/g, `/`)]]);
         } else {
           errors.push(new Error(`String bin field, but no attached package name`));
         }
@@ -421,7 +427,7 @@ export class Manifest {
             continue;
           }
 
-          this.publishConfig.bin.set(key, value as PortablePath);
+          this.publishConfig.bin.set(key, value.replace(/\\/g, `/`) as PortablePath);
         }
       }
 
@@ -434,7 +440,7 @@ export class Manifest {
             continue;
           }
 
-          this.publishConfig.executableFiles.add(npath.toPortablePath(value));
+          this.publishConfig.executableFiles.add(npath.toPortablePath(value.replace(/\\/g, `/`)));
         }
       }
     }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Packages can be published using backslash in their fields which breaks on non-Windows systems.

Fixes https://github.com/yarnpkg/berry/issues/2054

**How did you fix it?**

Replace backslash with slash in fields that can contain relative filepaths

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.