### PR TITLE
Implements --skip-builds

### DIFF
--- a/.yarn/versions/fb2c8f98.yml
+++ b/.yarn/versions/fb2c8f98.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -37,6 +37,18 @@ exports[`Commands install it should print the logs to the standard output when u
 "
 `;
 
+exports[`Commands install it should skip build scripts when using --skip-builds 1`] = `
+"➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0013: │ no-deps-scripted@npm:1.0.0 can't be found in the cache and will be fetched from the remote registry
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: Done
+"
+`;
+
 exports[`Commands install reports warning if published binary field is a path but no package name is set 1`] = `
 Object {
   "code": 0,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -1,4 +1,4 @@
-import {xfs, ppath} from '@yarnpkg/fslib';
+import {Filename, xfs, ppath} from '@yarnpkg/fslib';
 
 const {
   fs: {writeJson},
@@ -16,6 +16,40 @@ describe(`Commands`, () => {
         const {stdout} = await run(`install`, `--inline-builds`);
 
         await expect(stdout).toMatchSnapshot();
+      }),
+    );
+
+    test(
+      `it should skip build scripts when using --skip-builds`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-scripted`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        const {stdout} = await run(`install`, `--inline-builds`, `--skip-builds`);
+
+        await expect(stdout).toMatchSnapshot();
+      }),
+    );
+
+    test(
+      `it shouldn't impact how artifacts are generated when using --skip-builds`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-scripted`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        const pnpPath = ppath.join(path, Filename.pnpJs);
+
+        await run(`install`);
+        const pnpFileWithBuilds = await xfs.readFilePromise(pnpPath);
+
+        await xfs.removePromise(pnpPath);
+
+        await run(`install`, `--skip-builds`);
+        const pnpFileWithoutBuilds = await xfs.readFilePromise(pnpPath);
+
+        expect(pnpFileWithBuilds).toEqual(pnpFileWithoutBuilds);
       }),
     );
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -40,6 +40,9 @@ export default class YarnCommand extends BaseCommand {
   @Command.Boolean(`--inline-builds`, {description: `Verbosely print the output of the build steps of dependencies`})
   inlineBuilds?: boolean;
 
+  @Command.Boolean(`--skip-builds`, {description: `Skip the build step altogether`})
+  skipBuilds?: boolean = false;
+
   @Command.String(`--cache-folder`, {hidden: true})
   cacheFolder?: string;
 
@@ -68,6 +71,8 @@ export default class YarnCommand extends BaseCommand {
       If the \`--check-cache\` option is set, Yarn will always refetch the packages and will ensure that their checksum matches what's 1/ described in the lockfile 2/ inside the existing cache files (if present). This is recommended as part of your CI workflow if you're both following the Zero-Installs model and accepting PRs from third-parties, as they'd otherwise have the ability to alter the checked-in packages before submitting them.
 
       If the \`--inline-builds\` option is set, Yarn will verbosely print the output of the build steps of your dependencies (instead of writing them into individual files). This is likely useful mostly for debug purposes only when using Docker-like environments.
+
+      If the \`--skip-builds\` option is set, Yarn will not run the build scripts at all. Note that this is different from setting \`enableScripts\` to false because the later will disable build scripts, and thus affect the content of the artifacts generated on disk, whereas the former will just disable the build step - but not the scripts themselves, which just won't run.
     `,
     examples: [[
       `Install the project`,
@@ -277,7 +282,7 @@ export default class YarnCommand extends BaseCommand {
       stdout: this.context.stdout,
       includeLogs: true,
     }, async (report: StreamReport) => {
-      await project.install({cache, report, immutable});
+      await project.install({cache, report, immutable, skipBuild: this.skipBuilds});
     });
 
     return report.exitCode();

--- a/packages/plugin-essentials/sources/dedupeUtils.ts
+++ b/packages/plugin-essentials/sources/dedupeUtils.ts
@@ -1,0 +1,188 @@
+
+import {Project, ResolveOptions, ThrowReport, Resolver, miscUtils, Descriptor, Package, Report, Cache} from '@yarnpkg/core';
+import {formatUtils, structUtils, IdentHash, LocatorHash, MessageName, Fetcher, FetchOptions}          from '@yarnpkg/core';
+import micromatch                                                                                      from 'micromatch';
+
+export type Algorithm = (project: Project, patterns: Array<string>, opts: {
+  resolver: Resolver,
+  resolveOptions: ResolveOptions,
+  fetcher: Fetcher,
+  fetchOptions: FetchOptions,
+}) => Promise<Array<Promise<{
+  descriptor: Descriptor,
+  currentPackage: Package,
+  updatedPackage: Package,
+} | null>>>;
+
+export enum Strategy {
+  /**
+   * This strategy dedupes a locator to the best candidate already installed in the project.
+   *
+   * Because of this, it's guaranteed that:
+   * - it never takes more than a single pass to dedupe all dependencies
+   * - dependencies are never downgraded
+   */
+  HIGHEST = `highest`,
+}
+
+export const acceptedStrategies = new Set(Object.values(Strategy));
+
+const DEDUPE_ALGORITHMS: Record<Strategy, Algorithm> = {
+  highest: async (project, patterns, {resolver, fetcher, resolveOptions, fetchOptions}) => {
+    const locatorsByIdent = new Map<IdentHash, Set<LocatorHash>>();
+    for (const [descriptorHash, locatorHash] of project.storedResolutions) {
+      const descriptor = project.storedDescriptors.get(descriptorHash);
+      if (typeof descriptor === `undefined`)
+        throw new Error(`Assertion failed: The descriptor (${descriptorHash}) should have been registered`);
+
+      miscUtils.getSetWithDefault(locatorsByIdent, descriptor.identHash).add(locatorHash);
+    }
+
+    return Array.from(project.storedDescriptors.values(), async descriptor => {
+      if (patterns.length && !micromatch.isMatch(structUtils.stringifyIdent(descriptor), patterns))
+        return null;
+
+      const currentResolution = project.storedResolutions.get(descriptor.descriptorHash);
+      if (typeof currentResolution === `undefined`)
+        throw new Error(`Assertion failed: The resolution (${descriptor.descriptorHash}) should have been registered`);
+
+      // We only care about resolutions that are stored in the lockfile
+      // (we shouldn't accidentally try deduping virtual packages)
+      const currentPackage = project.originalPackages.get(currentResolution);
+      if (typeof currentPackage === `undefined`)
+        return null;
+
+      // No need to try deduping packages that are not persisted,
+      // they will be resolved again anyways
+      if (!resolver.shouldPersistResolution(currentPackage, resolveOptions))
+        return null;
+
+      const locators = locatorsByIdent.get(descriptor.identHash);
+      if (typeof locators === `undefined`)
+        throw new Error(`Assertion failed: The resolutions (${descriptor.identHash}) should have been registered`);
+
+      // No need to choose when there's only one possibility
+      if (locators.size === 1)
+        return null;
+
+      const references = [...locators].map(locatorHash => {
+        const pkg = project.originalPackages.get(locatorHash);
+        if (typeof pkg === `undefined`)
+          throw new Error(`Assertion failed: The package (${locatorHash}) should have been registered`);
+
+        return pkg.reference;
+      });
+
+      const candidates = await resolver.getSatisfying(descriptor, references, resolveOptions);
+
+      const bestCandidate = candidates?.[0];
+      if (typeof bestCandidate === `undefined`)
+        return null;
+
+      const updatedResolution = bestCandidate.locatorHash;
+
+      const updatedPackage = project.originalPackages.get(updatedResolution);
+      if (typeof updatedPackage === `undefined`)
+        throw new Error(`Assertion failed: The package (${updatedResolution}) should have been registered`);
+
+      if (updatedResolution === currentResolution)
+        return null;
+
+      return {descriptor, currentPackage, updatedPackage};
+    });
+  },
+};
+
+export type DedupeOptions = {
+  strategy: Strategy,
+  patterns: Array<string>,
+  cache: Cache,
+  report: Report,
+};
+
+export async function dedupe(project: Project, {strategy, patterns, cache, report}: DedupeOptions) {
+  const {configuration} = project;
+  const throwReport = new ThrowReport();
+
+  const resolver = configuration.makeResolver();
+  const fetcher = configuration.makeFetcher();
+
+  const fetchOptions: FetchOptions = {
+    cache,
+    checksums: project.storedChecksums,
+    fetcher,
+    project,
+    report: throwReport,
+    skipIntegrityCheck: true,
+  };
+  const resolveOptions: ResolveOptions = {
+    project,
+    resolver,
+    report: throwReport,
+    fetchOptions,
+  };
+
+  return await report.startTimerPromise(`Deduplication step`, async () => {
+    const algorithm = DEDUPE_ALGORITHMS[strategy];
+    const dedupePromises = await algorithm(project, patterns, {resolver, resolveOptions, fetcher, fetchOptions});
+
+    const progress = Report.progressViaCounter(dedupePromises.length);
+    report.reportProgress(progress);
+
+    let dedupedPackageCount = 0;
+
+    await Promise.all(
+      dedupePromises.map(dedupePromise =>
+        dedupePromise
+          .then(dedupe => {
+            if (dedupe === null)
+              return;
+
+            dedupedPackageCount++;
+
+            const {descriptor, currentPackage, updatedPackage} = dedupe;
+
+            report.reportInfo(
+              MessageName.UNNAMED,
+              `${
+                structUtils.prettyDescriptor(configuration, descriptor)
+              } can be deduped from ${
+                structUtils.prettyLocator(configuration, currentPackage)
+              } to ${
+                structUtils.prettyLocator(configuration, updatedPackage)
+              }`
+            );
+
+            report.reportJson({
+              descriptor: structUtils.stringifyDescriptor(descriptor),
+              currentResolution: structUtils.stringifyLocator(currentPackage),
+              updatedResolution: structUtils.stringifyLocator(updatedPackage),
+            });
+
+            project.storedResolutions.set(descriptor.descriptorHash, updatedPackage.locatorHash);
+          })
+          .finally(() => progress.tick())
+      )
+    );
+
+    let packages: string;
+    switch (dedupedPackageCount) {
+      case 0: {
+        packages = `No packages`;
+      } break;
+
+      case 1: {
+        packages = `One package`;
+      } break;
+
+      default: {
+        packages = `${dedupedPackageCount} packages`;
+      }
+    }
+
+    const prettyStrategy = formatUtils.pretty(configuration, strategy, formatUtils.Type.CODE);
+    report.reportInfo(MessageName.UNNAMED, `${packages} can be deduped using the ${prettyStrategy} strategy`);
+
+    return dedupedPackageCount;
+  });
+}

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -33,9 +33,13 @@ import up                                                       from './commands
 import why                                                      from './commands/why';
 import listWorkspaces                                           from './commands/workspaces/list';
 import workspace                                                from './commands/workspace';
+import * as dedupeUtils                                         from './suggestUtils';
 import * as suggestUtils                                        from './suggestUtils';
 
-export {suggestUtils};
+export {
+  dedupeUtils,
+  suggestUtils,
+};
 
 export interface Hooks {
   afterWorkspaceDependencyAddition?: (

--- a/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
+++ b/packages/plugin-pnp/sources/AbstractPnpInstaller.ts
@@ -61,6 +61,7 @@ export abstract class AbstractPnpInstaller implements Installer {
     const manifest = !hasVirtualInstances || this.opts.skipIncompatiblePackageLinking
       ? await Manifest.tryFind(fetchResult.prefixPath, {baseFs: fetchResult.packageFs})
       : null;
+
     const isManifestCompatible = this.checkAndReportManifestIncompatibility(manifest, pkg);
     if (this.opts.skipIncompatiblePackageLinking && !isManifestCompatible)
       return {packageLocation: null, buildDirective: null};

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -63,6 +63,7 @@ export type InstallOptions = {
   immutable?: boolean,
   lockfileOnly?: boolean,
   persistProject?: boolean,
+  skipBuild?: boolean,
 };
 
 export class Project {
@@ -1040,7 +1041,7 @@ export class Project {
     }
   }
 
-  async linkEverything({cache, report, fetcher: optFetcher}: InstallOptions) {
+  async linkEverything({cache, report, fetcher: optFetcher, skipBuild}: InstallOptions) {
     const fetcher = optFetcher || this.configuration.makeFetcher();
     const fetcherOptions = {checksums: this.storedChecksums, project: this, cache, fetcher, report, skipIntegrityCheck: true};
 
@@ -1222,6 +1223,9 @@ export class Project {
     }
 
     // Step 4: Build the packages in multiple steps
+
+    if (skipBuild)
+      return;
 
     const readyPackages = new Set(this.storedPackages.keys());
     const buildablePackages = new Set(packageBuildDirectives.keys());

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -56,13 +56,59 @@ const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 
 export type InstallOptions = {
+  /**
+   * Instance of the cache that the project will use when packages have to be
+   * fetched. Some fetches may occur even during the resolution, for example
+   * when resolving git packages.
+   */
   cache: Cache,
+
+  /**
+   * An optional override for the default fetching pipeline. This is for
+   * overrides only - if you need to _add_ resolvers, prefer adding them
+   * through regular plugins instead.
+   */
   fetcher?: Fetcher,
+
+  /**
+   * An optional override for the default resolution pipeline. This is for
+   * overrides only - if you need to _add_ resolvers, prefer adding them
+   * through regular plugins instead.
+   */
   resolver?: Resolver
+
+  /**
+   * Provide a report instance that'll be use to store the information emitted
+   * during the install process.
+   */
   report: Report,
+
+  /**
+   * If true, Yarn will check that the lockfile won't change after the
+   * resolution step. Additionally, after the link step, Yarn will retrieve
+   * the list of files in `immutablePatterns` and check that they didn't get
+   * modified either.
+   */
   immutable?: boolean,
+
+  /**
+   * If true, Yarn will exclusively use the lockfile metadata. Setting this
+   * flag will cause it to ignore any change in the manifests, and to abort
+   * if any dependency isn't present in the lockfile.
+   */
   lockfileOnly?: boolean,
+
+  /**
+   * If true (the default), Yarn will update the workspace manifests once the
+   * install has completed.
+   */
   persistProject?: boolean,
+
+  /**
+   * If true, Yarn will skip the build step during the install. Contrary to
+   * setting the `enableScripts` setting to false, setting this won't cause
+   * the generated artifacts to change.
+   */
   skipBuild?: boolean,
 };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some third-party tools need to run installs but don't care about actually building the native packages (notably, bots like renovate). We don't support this well at the moment (setting `enableScripts` to false leads to different unplugged packages) and, while it could be hacked via the Linker API, since we're considering moving the build infra back into the core, it would make sense to provide this capability from the CLI.

Closes #2062 

**How did you fix it?**

A `--skip-builds` option will skip the build step but the packages will still be assumed to be unplugged.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
