### PR TITLE
feat(core): merge multiple logFilter configurations

### DIFF
--- a/.yarn/versions/556f99e6.yml
+++ b/.yarn/versions/556f99e6.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/tests/Configuration.test.ts
+++ b/packages/yarnpkg-core/tests/Configuration.test.ts
@@ -182,5 +182,85 @@ describe(`Configuration`, () => {
         expect(scopeConfiguration.get(`bar`)?.get(`npmAlwaysAuth`)).toBe(true);
       });
     });
+
+    it(`should merge mergeable array properties`, async () => {
+      await initializeConfiguration({
+        logFilters: [
+          {
+            code: `YN0005`,
+            level: `info`,
+          },
+        ],
+
+        unsafeHttpWhitelist: [
+          `example.com`,
+        ],
+      }, async dir => {
+        const configuration = await Configuration.find(dir, null);
+
+        configuration.useWithSource(`second file`, {
+          logFilters: [
+            {
+              code: `YN0027`,
+              level: `error`,
+            },
+          ],
+
+          unsafeHttpWhitelist: [
+            `evil.com`,
+          ],
+        }, dir);
+
+        expect(configuration.get(`logFilters`)).toEqual([
+          new Map(Object.entries({
+            code: `YN0027`,
+            text: undefined,
+            level: `error`,
+          })),
+          new Map(Object.entries({
+            code: `YN0005`,
+            text: undefined,
+            level: `info`,
+          })),
+        ]);
+        expect(configuration.get(`unsafeHttpWhitelist`)).toEqual([
+          `example.com`,
+        ]);
+
+        configuration.useWithSource(`override file`, {
+          logFilters: [
+            {
+              code: `YN0066`,
+              level: `warning`,
+            },
+          ],
+
+          unsafeHttpWhitelist: [
+            `yarnpkg.com`,
+          ],
+        }, dir, {overwrite: true});
+
+        expect(configuration.get(`logFilters`)).toEqual([
+          new Map(Object.entries({
+            code: `YN0027`,
+            text: undefined,
+            level: `error`,
+          })),
+          new Map(Object.entries({
+            code: `YN0005`,
+            text: undefined,
+            level: `info`,
+          })),
+          new Map(Object.entries({
+            code: `YN0066`,
+            text: undefined,
+            level: `warning`,
+          })),
+        ]);
+        expect(configuration.get(`unsafeHttpWhitelist`)).toEqual([
+          `yarnpkg.com`,
+        ]);
+      });
+    });
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

Log filters are defined as array, but arrays aren't merged in the configuration.

**How did you fix it?**

Make it possible to define arrays in the configuration that should get concatenated instead of replaced when multiple values are passed.

This implementations makes the assumption that either

- elements in the array overrule earlier elements (e.g. the case for `logFilters`), or that
- the order of elements in the array doesn't matter.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
