### PR TITLE
fix(plugin-workspace-tools): Remove scripts from workspaces during focus

### DIFF
--- a/.yarn/versions/db8a6d56.yml
+++ b/.yarn/versions/db8a6d56.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -149,22 +149,12 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupProject(path);
 
-          await run(`install`);
-
-          await xfs.removePromise(ppath.join(path, `.yarn/cache`));
-          await xfs.removePromise(ppath.join(path, `.yarn/build-state.yml`));
-
-          const fooPostinstallPath = ppath.join(path, `packages/foo/postinstall.log`);
-          const quxPostinstallPath = ppath.join(path, `packages/qux/postinstall.log`);
-          await xfs.removePromise(fooPostinstallPath);
-          await xfs.removePromise(quxPostinstallPath);
-
           await run(`workspaces`, `focus`, `foo`, `bar`, {
             cwd: ppath.join(path, `packages/foo`),
           });
 
-          await expect(xfs.existsSync(fooPostinstallPath)).toBeTruthy();
-          await expect(xfs.existsSync(quxPostinstallPath)).toBeFalsy();
+          await expect(xfs.existsSync(ppath.join(path, `packages/foo/postinstall.log`))).toBeTruthy();
+          await expect(xfs.existsSync(ppath.join(path, `packages/qux/postinstall.log`))).toBeFalsy();
         }
       )
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -138,19 +138,49 @@ describe(`Commands`, () => {
         }
       )
     );
+
+    test(
+      `should not execute postinstall scripts of unspecified workspace`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          await xfs.removePromise(ppath.join(path, `.yarn/cache`));
+          await xfs.removePromise(ppath.join(path, `.yarn/build-state.yml`));
+
+          const fooPostinstallPath = ppath.join(path, `packages/foo/postinstall.log`);
+          const quxPostinstallPath = ppath.join(path, `packages/qux/postinstall.log`);
+          await xfs.removePromise(fooPostinstallPath);
+          await xfs.removePromise(quxPostinstallPath);
+
+          await run(`workspaces`, `focus`, `foo`, `bar`, {
+            cwd: ppath.join(path, `packages/foo`),
+          });
+
+          await expect(xfs.existsSync(fooPostinstallPath)).toBeTruthy();
+          await expect(xfs.existsSync(quxPostinstallPath)).toBeFalsy();
+        }
+      )
+    );
   });
 });
 
 async function setupProject(path) {
   await xfs.writeFilePromise(ppath.join(path, `.yarnrc.yml`), `plugins:\n  - ${JSON.stringify(require.resolve(`@yarnpkg/monorepo/scripts/plugin-workspace-tools.js`))}\n`);
 
-  const pkg = async (name, dependencies, devDependencies) => {
+  const pkg = async (name, dependencies, devDependencies, scripts) => {
     await xfs.mkdirpPromise(ppath.join(path, `packages/${name}`));
-    await xfs.writeJsonPromise(ppath.join(path, `packages/${name}/package.json`), {name, dependencies, devDependencies});
+    await xfs.writeJsonPromise(ppath.join(path, `packages/${name}/package.json`), {name, dependencies, devDependencies, scripts});
   };
 
-  await pkg(`foo`, {[`no-deps`]: `1.0.0`});
+  await pkg(`foo`, {[`no-deps`]: `1.0.0`}, {},{postinstall: `echo 'postinstall' > postinstall.log`});
   await pkg(`bar`, {[`no-deps`]: `2.0.0`});
   await pkg(`baz`, {[`bar`]: `workspace:*`});
-  await pkg(`qux`, {[`no-deps`]: `1.0.0`}, {[`no-deps-bins`]: `1.0.0`});
+  await pkg(`qux`, {[`no-deps`]: `1.0.0`}, {[`no-deps-bins`]: `1.0.0`}, {postinstall: `echo 'postinstall' > postinstall.log`});
 }

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,21 +1,21 @@
-import { BaseCommand, WorkspaceRequiredError } from '@yarnpkg/cli';
-import { Cache, Configuration, DependencyMeta, Manifest, Project, StreamReport, Workspace } from '@yarnpkg/core';
-import { structUtils } from '@yarnpkg/core';
-import { Command, Usage } from 'clipanion';
-import * as yup from 'yup';
+import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
+import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
+import {structUtils}                                                      from '@yarnpkg/core';
+import {Command, Usage}                                                   from 'clipanion';
+import * as yup                                                           from 'yup';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
   @Command.Rest()
   workspaces: Array<string> = [];
 
-  @Command.Boolean(`--json`, { description: `Format the output as an NDJSON stream` })
+  @Command.Boolean(`--json`, {description: `Format the output as an NDJSON stream`})
   json: boolean = false;
 
-  @Command.Boolean(`--production`, { description: `Only install regular dependencies by omitting dev dependencies` })
+  @Command.Boolean(`--production`, {description: `Only install regular dependencies by omitting dev dependencies`})
   production: boolean = false;
 
-  @Command.Boolean(`-A,--all`, { description: `Install the entire project` })
+  @Command.Boolean(`-A,--all`, {description: `Install the entire project`})
   all: boolean = false;
 
   static usage: Usage = Command.Usage({
@@ -42,7 +42,7 @@ export default class WorkspacesFocus extends BaseCommand {
   @Command.Path(`workspaces`, `focus`)
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const { project, workspace } = await Project.find(configuration, this.context.cwd);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
     let requiredWorkspaces: Set<Workspace>;
@@ -80,6 +80,7 @@ export default class WorkspacesFocus extends BaseCommand {
 
     // Then we go over each workspace that didn't get selected, and remove all
     // their dependencies.
+
     for (const workspace of project.workspaces) {
       if (requiredWorkspaces.has(workspace)) {
         if (this.production) {
@@ -103,7 +104,7 @@ export default class WorkspacesFocus extends BaseCommand {
       stdout: this.context.stdout,
       includeLogs: true,
     }, async (report: StreamReport) => {
-      await project.install({ cache, report, persistProject: false });
+      await project.install({cache, report, persistProject: false});
       // Virtual package references may have changed so persist just the install state.
       await project.persistInstallStateFile();
     });

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,21 +1,21 @@
-import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
-import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
-import {structUtils}                                                      from '@yarnpkg/core';
-import {Command, Usage}                                                   from 'clipanion';
-import * as yup                                                           from 'yup';
+import { BaseCommand, WorkspaceRequiredError } from '@yarnpkg/cli';
+import { Cache, Configuration, DependencyMeta, Manifest, Project, StreamReport, Workspace } from '@yarnpkg/core';
+import { structUtils } from '@yarnpkg/core';
+import { Command, Usage } from 'clipanion';
+import * as yup from 'yup';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
   @Command.Rest()
   workspaces: Array<string> = [];
 
-  @Command.Boolean(`--json`, {description: `Format the output as an NDJSON stream`})
+  @Command.Boolean(`--json`, { description: `Format the output as an NDJSON stream` })
   json: boolean = false;
 
-  @Command.Boolean(`--production`, {description: `Only install regular dependencies by omitting dev dependencies`})
+  @Command.Boolean(`--production`, { description: `Only install regular dependencies by omitting dev dependencies` })
   production: boolean = false;
 
-  @Command.Boolean(`-A,--all`, {description: `Install the entire project`})
+  @Command.Boolean(`-A,--all`, { description: `Install the entire project` })
   all: boolean = false;
 
   static usage: Usage = Command.Usage({
@@ -42,7 +42,7 @@ export default class WorkspacesFocus extends BaseCommand {
   @Command.Path(`workspaces`, `focus`)
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
+    const { project, workspace } = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
     let requiredWorkspaces: Set<Workspace>;
@@ -67,7 +67,7 @@ export default class WorkspacesFocus extends BaseCommand {
 
     for (const workspace of requiredWorkspaces) {
       for (const dependencyType of Manifest.hardDependencies) {
-        for (const descriptor  of workspace.manifest.getForScope(dependencyType).values()) {
+        for (const descriptor of workspace.manifest.getForScope(dependencyType).values()) {
           const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
 
           if (matchingWorkspace === null)
@@ -80,7 +80,6 @@ export default class WorkspacesFocus extends BaseCommand {
 
     // Then we go over each workspace that didn't get selected, and remove all
     // their dependencies.
-
     for (const workspace of project.workspaces) {
       if (requiredWorkspaces.has(workspace)) {
         if (this.production) {
@@ -90,6 +89,7 @@ export default class WorkspacesFocus extends BaseCommand {
         workspace.manifest.dependencies.clear();
         workspace.manifest.devDependencies.clear();
         workspace.manifest.peerDependencies.clear();
+        workspace.manifest.scripts.clear();
       }
     }
 
@@ -103,7 +103,7 @@ export default class WorkspacesFocus extends BaseCommand {
       stdout: this.context.stdout,
       includeLogs: true,
     }, async (report: StreamReport) => {
-      await project.install({cache, report, persistProject: false});
+      await project.install({ cache, report, persistProject: false });
       // Virtual package references may have changed so persist just the install state.
       await project.persistInstallStateFile();
     });

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1115,7 +1115,7 @@ export class Project {
 
       if (workspace !== null) {
         const buildScripts: Array<BuildDirective> = [];
-        const {scripts} = await workspace.manifest;
+        const {scripts} = workspace.manifest;
 
         for (const scriptName of [`preinstall`, `install`, `postinstall`])
           if (scripts.has(scriptName))

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1111,9 +1111,11 @@ export class Project {
 
       const fetchResult = await fetcher.fetch(pkg, fetcherOptions);
 
-      if (this.tryWorkspaceByLocator(pkg) !== null) {
+      const workspace = this.tryWorkspaceByLocator(pkg);
+
+      if (workspace !== null) {
         const buildScripts: Array<BuildDirective> = [];
-        const {scripts} = await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs});
+        const {scripts} = await workspace.manifest;
 
         for (const scriptName of [`preinstall`, `install`, `postinstall`])
           if (scripts.has(scriptName))


### PR DESCRIPTION
**What's the problem this PR addresses?**

~unspecified workspaces were not removed from the project during focus install. Unspecified workspaces were kept inside `node_modules` and so, was accessible by others.~

This PR fixes the `yarn workspaces focus <workspace>` command. `postinstall` scripts from unfocus workspaces were executed.


**How did you fix it?**

We clear scripts from unfocused workspaces manifests.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
