### PR TITLE
perf(core): enable http2

### DIFF
--- a/.yarn/versions/2a3515c7.yml
+++ b/.yarn/versions/2a3515c7.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -471,8 +471,8 @@ export interface ConfigurationValueMap {
 
   enableMirror: boolean;
   enableNetwork: boolean;
-  httpProxy: string;
-  httpsProxy: string;
+  httpProxy: string | null;
+  httpsProxy: string | null;
   unsafeHttpWhitelist: Array<string>;
   httpTimeout: number;
   httpRetry: number;

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -149,6 +149,7 @@ export async function request(target: string, body: Body, {configuration, header
       socket: socketTimeout,
     },
     retry,
+    http2: !httpsProxy,
     https: {
       rejectUnauthorized,
       certificateAuthority,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The resolution step is a bit slow.

**How did you ~~fix~~ improve it?**

Enable the Http/2 protocol when no `httpsProxy` is provided.

**Result**

Testing on the gatsby benchmark, the resolution step goes from ~27 seconds to ~17 seconds.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.