### PR TITLE
Fixes how the lockfile interacts with installs

### DIFF
--- a/.yarn/versions/574496f6.yml
+++ b/.yarn/versions/574496f6.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -98,7 +98,7 @@ export default class AddCommand extends BaseCommand {
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.restoreInstallState({
-      lightResolutionFallback: false,
+      restoreResolutions: false,
     });
 
     const interactive = this.interactive ?? configuration.get(`preferInteractive`);

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -269,7 +269,7 @@ export default class YarnCommand extends BaseCommand {
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.restoreInstallState({
-      lightResolutionFallback: false,
+      restoreResolutions: false,
     });
 
     // Important: Because other commands also need to run installs, if you

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -51,7 +51,7 @@ export default class RemoveCommand extends BaseCommand {
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     await project.restoreInstallState({
-      lightResolutionFallback: false,
+      restoreResolutions: false,
     });
 
     const affectedWorkspaces = this.all

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -3,6 +3,7 @@ import {parseSyml, stringifySyml}                                 from '@yarnpkg
 import {UsageError}                                               from 'clipanion';
 import {createHash}                                               from 'crypto';
 import {structuredPatch}                                          from 'diff';
+import {pick}                                                     from 'lodash';
 // @ts-expect-error
 import Logic                                                      from 'logic-solver';
 import pLimit                                                     from 'p-limit';
@@ -111,6 +112,28 @@ export type InstallOptions = {
    */
   skipBuild?: boolean,
 };
+
+const INSTALL_STATE_FIELDS = {
+  restoreInstallersCustomData: [
+    `installersCustomData`,
+  ] as const,
+
+  restoreResolutions: [
+    `accessibleLocators`,
+    `optionalBuilds`,
+    `storedDescriptors`,
+    `storedResolutions`,
+    `storedPackages`,
+    `lockFileChecksum`,
+  ] as const,
+};
+
+type RestoreInstallStateOpts = {
+  [key in keyof typeof INSTALL_STATE_FIELDS]?: boolean;
+};
+
+// Just a type that's the union of all the fields declared in `INSTALL_STATE_FIELDS`
+type InstallState = Pick<Project, typeof INSTALL_STATE_FIELDS[keyof typeof INSTALL_STATE_FIELDS][number]>;
 
 export class Project {
   public readonly configuration: Configuration;
@@ -1766,8 +1789,11 @@ export class Project {
   }
 
   async persistInstallStateFile() {
-    const {accessibleLocators, optionalBuilds, storedDescriptors, storedResolutions, storedPackages, installersCustomData, lockFileChecksum} = this;
-    const installState = {accessibleLocators, optionalBuilds, storedDescriptors, storedResolutions, storedPackages, installersCustomData, lockFileChecksum};
+    const fields = [];
+    for (const category of Object.values(INSTALL_STATE_FIELDS))
+      fields.push(...category);
+
+    const installState = pick(this, fields) as InstallState;
     const serializedState = await gzip(v8.serialize(installState));
 
     const installStatePath = this.configuration.get(`installStatePath`);
@@ -1776,29 +1802,29 @@ export class Project {
     await xfs.changeFilePromise(installStatePath, serializedState as Buffer);
   }
 
-  async restoreInstallState({lightResolutionFallback = true}: {lightResolutionFallback?: boolean} = {}) {
+  async restoreInstallState({restoreInstallersCustomData = true, restoreResolutions = true}: RestoreInstallStateOpts = {}) {
     const installStatePath = this.configuration.get(`installStatePath`);
     if (!xfs.existsSync(installStatePath)) {
-      if (lightResolutionFallback)
+      if (restoreResolutions)
         await this.applyLightResolution();
       return;
     }
 
     const serializedState = await xfs.readFilePromise(installStatePath);
-    const installState = v8.deserialize(await gunzip(serializedState) as Buffer);
+    const installState: InstallState = v8.deserialize(await gunzip(serializedState) as Buffer);
 
-    if (typeof installState.installersCustomData !== `undefined`)
-      this.installersCustomData = installState.installersCustomData;
+    if (restoreInstallersCustomData)
+      if (typeof installState.installersCustomData !== `undefined`)
+        this.installersCustomData = installState.installersCustomData;
 
-    if (installState.lockFileChecksum !== this.lockFileChecksum) {
-      if (lightResolutionFallback)
+    if (restoreResolutions) {
+      if (installState.lockFileChecksum !== this.lockFileChecksum)
+        Object.assign(this, pick(installState, INSTALL_STATE_FIELDS.restoreResolutions));
+      else
         await this.applyLightResolution();
-      return;
+
+      this.refreshWorkspaceDependencies();
     }
-
-    Object.assign(this, installState);
-
-    this.refreshWorkspaceDependencies();
   }
 
   async applyLightResolution() {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1818,12 +1818,12 @@ export class Project {
         this.installersCustomData = installState.installersCustomData;
 
     if (restoreResolutions) {
-      if (installState.lockFileChecksum !== this.lockFileChecksum)
+      if (installState.lockFileChecksum === this.lockFileChecksum) {
         Object.assign(this, pick(installState, INSTALL_STATE_FIELDS.restoreResolutions));
-      else
+        this.refreshWorkspaceDependencies();
+      } else {
         await this.applyLightResolution();
-
-      this.refreshWorkspaceDependencies();
+      }
     }
   }
 

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -3,7 +3,7 @@ import {parseSyml, stringifySyml}                                 from '@yarnpkg
 import {UsageError}                                               from 'clipanion';
 import {createHash}                                               from 'crypto';
 import {structuredPatch}                                          from 'diff';
-import {pick}                                                     from 'lodash';
+import pick                                                       from 'lodash/pick';
 // @ts-expect-error
 import Logic                                                      from 'logic-solver';
 import pLimit                                                     from 'p-limit';


### PR DESCRIPTION
**What's the problem this PR addresses?**

I've noticed that the `restoreInstallState` call before installs (due to #2093) causes the lockfile data to be ignored (the install state overwrites the data structures). It's not clear under which situations this could cause a problem (hence no test), but it wasn't intended.

**How did you fix it?**

I improved `restoreInstallState` to allow to explicitly restore parts of the install state (unfortunately you currently opt-out; I'd prefer that to be opt-in, but it would be too much of a breaking change). I've also cleaned the typings around the install state to avoid desyncs.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
