### PR TITLE
Removes extraneous script warnings

### DIFF
--- a/.yarn/versions/c0cc9126.yml
+++ b/.yarn/versions/c0cc9126.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/jsInstallUtils.ts
+++ b/packages/plugin-pnp/sources/jsInstallUtils.ts
@@ -37,6 +37,9 @@ export function extractBuildScripts(pkg: Package, requirements: ExtractBuildScri
   if (!requirements.manifest.scripts.has(`install`) && requirements.misc.hasBindingGyp)
     buildScripts.push([BuildType.SHELLCODE, `node-gyp rebuild`]);
 
+  if (buildScripts.length === 0)
+    return [];
+
   if (!configuration.get(`enableScripts`) && !dependencyMeta.built) {
     report?.reportWarningOnce(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(configuration, pkg)} lists build scripts, but all build scripts have been disabled.`);
     return [];


### PR DESCRIPTION
**What's the problem this PR addresses?**

We always print the `scripts are disabled` warning, even when the packages don't actually have scripts 😅

**How did you fix it?**

Early return when needed.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
