### PR TITLE
Restores the catch details

### DIFF
--- a/.yarn/versions/5badbc1c.yml
+++ b/.yarn/versions/5badbc1c.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -738,8 +738,15 @@ export class Project {
         return [dependency.descriptorHash, await scheduleDescriptorResolution(dependency)] as const;
       })));
 
-      const candidateResolutions = await resolver.getCandidates(descriptor, resolvedDependencies, resolveOptions);
+      const candidateResolutions = await miscUtils.prettifyAsyncErrors(async () => {
+        return await resolver.getCandidates(descriptor, resolvedDependencies, resolveOptions);
+      }, message => {
+        return `${structUtils.prettyDescriptor(this.configuration, descriptor)}: ${message}`;
+      });
+
       const finalResolution = candidateResolutions[0];
+      if (typeof finalResolution === `undefined`)
+        throw new Error(`${structUtils.prettyDescriptor(this.configuration, descriptor)}: No candidates found`);
 
       allDescriptors.set(descriptor.descriptorHash, descriptor);
       allResolutions.set(descriptor.descriptorHash, finalResolution.locatorHash);


### PR DESCRIPTION
**What's the problem this PR addresses?**

#2100 accidentally removed a few guards made to provide better error messages.

**How did you fix it?**

Adds them back. Note that HTTP errors still don't have the right prefix, probably because of Got doing some [magic](https://github.com/sindresorhus/got/blob/49c16ee54fb19ea7aa77e24ac8c2b602f0aad265/source/core/index.ts#L1187). I'll address that later by trying out Axios instead of Got.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
