### PR TITLE
refactor(core): handle cyclic resolution dependencies

### DIFF
--- a/.yarn/versions/abdc39cd.yml
+++ b/.yarn/versions/abdc39cd.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -749,13 +749,17 @@ export class Project {
 
     const scheduleDescriptorResolution = (descriptor: Descriptor, resolutionDependencyAncestors: Array<DescriptorHash>) => {
       if (resolutionDependencyAncestors.includes(descriptor.descriptorHash)) {
-        const cycle = Array.from(resolutionDependencyAncestors, descriptorHash => {
+        const descriptors = Array.from(resolutionDependencyAncestors, descriptorHash => {
           const descriptor = allDescriptors.get(descriptorHash);
           if (!descriptor)
             throw new Error(`Assertion failed: The descriptor should have been registered`);
 
-          return structUtils.prettyDescriptor(this.configuration, descriptor);
-        }).join(`, `);
+          return descriptor;
+        }).concat([descriptor]);
+        const cycle = descriptors
+          .map(descriptor => structUtils.prettyDescriptor(this.configuration, descriptor))
+          .join(`, `);
+
         throw new Error(`Descriptors cannot have cyclic resolution dependencies: ${cycle}`);
       }
 

--- a/packages/yarnpkg-core/tests/Project.test.ts
+++ b/packages/yarnpkg-core/tests/Project.test.ts
@@ -158,7 +158,9 @@ describe(`Project`, () => {
           if (descriptor.name === `foo`)
             return [structUtils.makeDescriptor(structUtils.makeIdent(null, `bar`), `*`)];
           if (descriptor.name === `bar`)
-            return [structUtils.makeDescriptor(structUtils.makeIdent(null, `foo`), `*`)];
+            return [structUtils.makeDescriptor(structUtils.makeIdent(null, `baz`), `*`)];
+          if (descriptor.name === `baz`)
+            return [structUtils.makeDescriptor(structUtils.makeIdent(null, `foo`), `workspace:.`)];
 
           throw new Error(`Unimplemented`);
         }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

#2100 refactored the resolution pipeline to use recursive promise spawners instead of a pass-based system. One problem with this approach is that the entire pipeline hangs indefinitely if cyclic resolution dependencies are encountered, as the parent awaits the children until they finish resolving and the children await the parent until it finishes resolving.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've made it so that we keep track of all resolution dependency ancestors on each spawner branch and throw if a cycle is detected. I've also added a test.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
