### PR TITLE
feat(upgrade-interactive): Only show packages with upgrades available

### DIFF
--- a/.yarn/versions/8aa8cfef.yml
+++ b/.yarn/versions/8aa8cfef.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-interactive-tools": minor

--- a/packages/plugin-interactive-tools/README.md
+++ b/packages/plugin-interactive-tools/README.md
@@ -10,4 +10,5 @@ yarn plugin import interactive-tools
 
 ## Commands
 
+- [`yarn search`](https://yarnpkg.com/cli/search)
 - [`yarn upgrade-interactive`](https://yarnpkg.com/cli/upgrade-interactive)

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -203,14 +203,14 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     };
 
     const UpgradeEntries = ({dependencies}: { dependencies: Array<Descriptor> }) => {
-      const [suggestions, setSuggestions] = useState<Array<[Descriptor, UpgradeSuggestions]>|null>(null);
+      const [suggestions, setSuggestions] = useState<Array<readonly [Descriptor, UpgradeSuggestions]>|null>(null);
 
       useEffect(() => {
         Promise.all(dependencies.map(descriptor => fetchSuggestions(descriptor)))
           .then(allSuggestions => {
             const mappedToSuggestions = dependencies.map((descriptor, i) => {
               const suggestionsForDescriptor = allSuggestions[i];
-              return [descriptor, suggestionsForDescriptor] as [Descriptor, UpgradeSuggestions];
+              return [descriptor, suggestionsForDescriptor] as const;
             }).filter(([_, suggestions]) => suggestions.length > 1);
 
             setSuggestions(mappedToSuggestions);

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -24,7 +24,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     category: `Interactive commands`,
     description: `open the upgrade interface`,
     details: `
-      This command opens a fullscreen terminal interface where you can see the packages used by your application, their status compared to the latest versions available on the remote registry, and let you upgrade.
+      This command opens a fullscreen terminal interface where you can see any out of date packages used by your application, their status compared to the latest versions available on the remote registry, and select packages to upgrade.
     `,
     examples: [[
       `Open the upgrade window`,

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -109,7 +109,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         ? `^${descriptor.range}`
         : descriptor.range;
 
-      const [resolution, dependency] = await Promise.all([
+      const [resolution, latest] = await Promise.all([
         fetchUpdatedDescriptor(descriptor, descriptor.range, referenceRange).catch(() => null),
         fetchUpdatedDescriptor(descriptor, descriptor.range, `latest`).catch(() => null),
       ]);
@@ -126,10 +126,10 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         });
       }
 
-      if (dependency && dependency !== resolution && dependency !== descriptor.range) {
+      if (latest && latest !== resolution && latest !== descriptor.range) {
         suggestions.push({
-          value: dependency,
-          label: colorizeVersionDiff(descriptor.range, dependency),
+          value: latest,
+          label: colorizeVersionDiff(descriptor.range, latest),
         });
       }
 
@@ -176,7 +176,8 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
             </Text>
           </Box>
           <Box width={17}><Text bold underline color="gray">Current</Text></Box>
-          <Box width={17}><Text bold underline color="gray">Range/Latest</Text></Box>
+          <Box width={17}><Text bold underline color="gray">Range</Text></Box>
+          <Box width={17}><Text bold underline color="gray">Latest</Text></Box>
         </Box>
       );
     };

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -9,7 +9,7 @@ import {suggestUtils}                                                           
 import {Command, Usage}                                                                                                                 from 'clipanion';
 import {diffWords}                                                                                                                      from 'diff';
 import {Box, Text}                                                                                                                      from 'ink';
-import React, {useEffect, useState, useRef}                                                                                             from 'react';
+import React, {useEffect, useState}                                                                                                     from 'react';
 import semver                                                                                                                           from 'semver';
 
 const SIMPLE_SEMVER = /^((?:[\^~]|>=?)?)([0-9]+)(\.[0-9]+)(\.[0-9]+)((?:-\S+)?)$/;

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -9,7 +9,7 @@ import {suggestUtils}                                                           
 import {Command, Usage}                                                                                                                 from 'clipanion';
 import {diffWords}                                                                                                                      from 'diff';
 import {Box, Text}                                                                                                                      from 'ink';
-import React, {useEffect, useState}                                                                                                     from 'react';
+import React, {useEffect, useRef, useState}                                                                                             from 'react';
 import semver                                                                                                                           from 'semver';
 
 const SIMPLE_SEMVER = /^((?:[\^~]|>=?)?)([0-9]+)(\.[0-9]+)(\.[0-9]+)((?:-\S+)?)$/;
@@ -205,6 +205,13 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
 
     const UpgradeEntries = ({dependencies}: { dependencies: Array<Descriptor> }) => {
       const [suggestions, setSuggestions] = useState<Array<readonly [Descriptor, UpgradeSuggestions]>|null>(null);
+      const mountedRef = useRef<boolean>(true);
+
+      useEffect(() => {
+        return () => {
+          mountedRef.current = false;
+        };
+      });
 
       useEffect(() => {
         Promise.all(dependencies.map(descriptor => fetchSuggestions(descriptor)))
@@ -214,7 +221,9 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
               return [descriptor, suggestionsForDescriptor] as const;
             }).filter(([_, suggestions]) => suggestions.length > 1);
 
-            setSuggestions(mappedToSuggestions);
+            if (mountedRef.current) {
+              setSuggestions(mappedToSuggestions);
+            }
           });
       }, []);
 


### PR DESCRIPTION
Currently when running yarn upgrade-interactive it lists all installed packages and lazily displays new packages. When working on a project that has many dependencies (>20) this can get out of hand easily where you're scrolling for a while until you've "found" the first package with a new available version.

Fixes #1673 

...

**How did you fix it?**
To keep it simple since this is the first time I've attempted to make changes to the codebase, this looks for the presence of the new `--new-only` flag for `upgrade-interactive`, and renders a different component to the usual flow. On mounting the new component, all of the dependencies are checked for available updates. Any that don't return any update options are removed from the list to be displayed.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
