### PR TITLE
chore: fix variable name

### DIFF
--- a/scripts/actions/local-yarn-command/entrypoint.sh
+++ b/scripts/actions/local-yarn-command/entrypoint.sh
@@ -8,6 +8,6 @@ export SHARP_IGNORE_GLOBAL_LIBVIPS=1
 
 NONCE="$(cat /proc/sys/kernel/random/uuid | sha256sum | head -c 64)"
 
-echo "::stop-commands::$HASH"
+echo "::stop-commands::$NONCE"
 exec node ./scripts/run-yarn.js "$@"
-echo "::$HASH::"
+echo "::$NONCE::"


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fixes variable name in https://github.com/yarnpkg/berry/commit/2eb28cf6d0377a7986f56cc4a9b0da30c98a8ae5.

Since GitHub now shows an error if these commands are run and disabled updating `NODE_OPTIONS` environment variable, I've opened a pull request.

**How did you fix it?**
Fixed variable name

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
