### PR TITLE
refactor(plugin-npm): improve evaulation of npm auth configuration

### DIFF
--- a/.yarn/versions/48e607c6.yml
+++ b/.yarn/versions/48e607c6.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": minor
+  "@yarnpkg/plugin-npm-cli": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/whoami.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/__snapshots__/whoami.test.js.snap
@@ -1,6 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Commands npm whoami it should print the npm publish registry username for a given scope when npmRegistries config has a valid npmAuthToken  1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: anotherTestUser
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands npm whoami it should print the npm publish registry username when npmRegistries has a valid npmAuthToken 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: anotherTestUser
+➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands npm whoami it should print the npm registry username for a given scope 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: anotherTestUser
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands npm whoami it should print the npm registry username for a given scope when npmRegistries config has a valid npmAuthToken 1`] = `
 Object {
   "code": 0,
   "stderr": "",
@@ -25,6 +55,16 @@ Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: testUser
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands npm whoami it should print the npm registry username when npmRegistries has a valid npmAuthToken 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: anotherTestUser
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/whoami.test.js
@@ -51,6 +51,59 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should print the npm registry username when npmRegistries has a valid npmAuthToken`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmRegistryServer: "${url}"\n`,
+          `npmRegistries:\n`,
+          `  "${url}":\n`,
+          `    npmAuthToken: ${AUTH_TOKEN2}\n`,
+        ].join(``));
+
+        let code;
+        let stdout;
+        let stderr;
+
+        try {
+          ({code, stdout, stderr} = await run(`npm`, `whoami`));
+        } catch (error) {
+          ({code, stdout, stderr} = error);
+        }
+
+        expect({code, stdout, stderr}).toMatchSnapshot();
+      })
+    );
+
+    test(
+      `it should print the npm publish registry username when npmRegistries has a valid npmAuthToken`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmPublishRegistry: "${url}"\n`,
+          `npmAuthToken: ${AUTH_TOKEN}\n`,
+          `npmRegistries:\n`,
+          `  "${url}":\n`,
+          `    npmAuthToken: ${AUTH_TOKEN2}\n`,
+        ].join(``));
+
+        let code;
+        let stdout;
+        let stderr;
+
+        try {
+          ({code, stdout, stderr} = await run(`npm`, `whoami`, `--publish`));
+        } catch (error) {
+          ({code, stdout, stderr} = error);
+        }
+
+        expect({code, stdout, stderr}).toMatchSnapshot();
+      })
+    );
+
+    test(
       `it should print the npm registry username for a given scope`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const url = await startPackageServer();
@@ -70,6 +123,64 @@ describe(`Commands`, () => {
 
         try {
           ({code, stdout, stderr} = await run(`npm`, `whoami`, `--scope`, `testScope`));
+        } catch (error) {
+          ({code, stdout, stderr} = error);
+        }
+
+        expect({code, stdout, stderr}).toMatchSnapshot();
+      })
+    );
+
+    test(
+      `it should print the npm registry username for a given scope when npmRegistries config has a valid npmAuthToken`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmRegistries:\n`,
+          `  "${url}":\n`,
+          `    npmAuthToken: "${AUTH_TOKEN}"\n`,
+          `npmScopes:\n`,
+          `  testScope:\n`,
+          `    npmAuthToken: ${AUTH_TOKEN2}\n`,
+          `    npmRegistryServer: "${url}"\n`,
+        ].join(``));
+
+        let code;
+        let stdout;
+        let stderr;
+
+        try {
+          ({code, stdout, stderr} = await run(`npm`, `whoami`, `--scope`, `testScope`));
+        } catch (error) {
+          ({code, stdout, stderr} = error);
+        }
+
+        expect({code, stdout, stderr}).toMatchSnapshot();
+      })
+    );
+
+    test(
+      `it should print the npm publish registry username for a given scope when npmRegistries config has a valid npmAuthToken `,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const url = await startPackageServer();
+
+        await writeFile(`${path}/.yarnrc.yml`, [
+          `npmRegistries:\n`,
+          `  "${url}":\n`,
+          `    npmAuthToken: "${AUTH_TOKEN}"\n`,
+          `npmScopes:\n`,
+          `  testScope:\n`,
+          `    npmAuthToken: ${AUTH_TOKEN2}\n`,
+          `    npmPublishRegistry: "${url}"\n`,
+        ].join(``));
+
+        let code;
+        let stdout;
+        let stderr;
+
+        try {
+          ({code, stdout, stderr} = await run(`npm`, `whoami`, `--scope`, `testScope`, `--publish`));
         } catch (error) {
           ({code, stdout, stderr} = error);
         }

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -86,7 +86,7 @@ export default class AuditCommand extends BaseCommand {
       dependencies,
     };
 
-    const registry = npmConfigUtils.getPublishRegistry(workspace.manifest, {
+    const registry = npmConfigUtils.getPublishRegistryConfiguration(workspace.manifest, {
       configuration,
     });
 

--- a/packages/plugin-npm-cli/sources/commands/npm/login.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/login.ts
@@ -40,12 +40,13 @@ export default class NpmLoginCommand extends BaseCommand {
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
-    const registry: string = await getRegistry({
+    const registryConfiguration = await getRegistryConfiguration({
       configuration,
       cwd: this.context.cwd,
       publish: this.publish,
       scope: this.scope,
     });
+    const registry = registryConfiguration.get(`npmRegistryServer`);
 
     const report = await StreamReport.start({
       configuration,
@@ -75,17 +76,17 @@ export default class NpmLoginCommand extends BaseCommand {
   }
 }
 
-export async function getRegistry({scope, publish, configuration, cwd}: {scope?: string, publish: boolean, configuration: Configuration, cwd: PortablePath}) {
+export async function getRegistryConfiguration({scope, publish, configuration, cwd}: {scope?: string, publish: boolean, configuration: Configuration, cwd: PortablePath}) {
   if (scope && publish)
-    return npmConfigUtils.getScopeRegistry(scope, {configuration, type: npmConfigUtils.RegistryType.PUBLISH_REGISTRY});
+    return npmConfigUtils.getScopeRegistryConfiguration(scope, {configuration, type: npmConfigUtils.RegistryType.PUBLISH_REGISTRY});
 
   if (scope)
-    return npmConfigUtils.getScopeRegistry(scope, {configuration});
+    return npmConfigUtils.getScopeRegistryConfiguration(scope, {configuration});
 
   if (publish)
-    return npmConfigUtils.getPublishRegistry((await openWorkspace(configuration, cwd)).manifest, {configuration});
+    return npmConfigUtils.getPublishRegistryConfiguration((await openWorkspace(configuration, cwd)).manifest, {configuration});
 
-  return npmConfigUtils.getDefaultRegistry({configuration});
+  return npmConfigUtils.getDefaultRegistryConfiguration({configuration});
 }
 
 async function setAuthToken(registry: string, npmAuthToken: string, {configuration, scope}: {configuration: Configuration, scope?: string}) {

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -50,7 +50,7 @@ export default class NpmPublishCommand extends BaseCommand {
     const ident = workspace.manifest.name;
     const version = workspace.manifest.version;
 
-    const registry = npmConfigUtils.getPublishRegistry(workspace.manifest, {configuration});
+    const registry = npmConfigUtils.getPublishRegistryConfiguration(workspace.manifest, {configuration});
 
     const report = await StreamReport.start({
       configuration,
@@ -96,7 +96,7 @@ export default class NpmPublishCommand extends BaseCommand {
         const body = await npmPublishUtils.makePublishBody(workspace, buffer, {
           access: this.access,
           tag: this.tag,
-          registry,
+          registry: registry.get(`npmRegistryServer`),
         });
 
         try {

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -62,7 +62,6 @@ export default class NpmPublishCommand extends BaseCommand {
           const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(ident), {
             configuration,
             registry,
-            ident,
             jsonResponse: true,
           });
 
@@ -103,7 +102,6 @@ export default class NpmPublishCommand extends BaseCommand {
           await npmHttpUtils.put(npmHttpUtils.getIdentUrl(ident), body, {
             configuration,
             registry,
-            ident,
             jsonResponse: true,
           });
         } catch (error) {

--- a/packages/plugin-npm-cli/sources/commands/npm/tag/add.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/tag/add.ts
@@ -39,7 +39,7 @@ export default class NpmTagAddCommand extends BaseCommand {
     if (!semver.valid(version))
       throw new UsageError(`The range ${formatUtils.pretty(configuration, descriptor.range, formatUtils.Type.RANGE)} must be a valid semver version`);
 
-    const registry = npmConfigUtils.getPublishRegistry(workspace.manifest, {configuration});
+    const registry = npmConfigUtils.getPublishRegistryConfiguration(workspace.manifest, {configuration});
 
     const prettyIdent = formatUtils.pretty(configuration, descriptor, formatUtils.Type.IDENT);
     const prettyVersion = formatUtils.pretty(configuration, version, formatUtils.Type.RANGE);

--- a/packages/plugin-npm-cli/sources/commands/npm/tag/add.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/tag/add.ts
@@ -59,7 +59,6 @@ export default class NpmTagAddCommand extends BaseCommand {
         await npmHttpUtils.put(url, version, {
           configuration,
           registry,
-          ident: descriptor,
           jsonRequest: true,
           jsonResponse: true,
         });

--- a/packages/plugin-npm-cli/sources/commands/npm/tag/remove.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/tag/remove.ts
@@ -41,7 +41,7 @@ export default class NpmTagRemoveCommand extends BaseCommand {
 
     const ident = structUtils.parseIdent(this.package);
 
-    const registry = npmConfigUtils.getPublishRegistry(workspace.manifest, {configuration});
+    const registry = npmConfigUtils.getPublishRegistryConfiguration(workspace.manifest, {configuration});
 
     const prettyTag = formatUtils.pretty(configuration, this.tag, formatUtils.Type.CODE);
     const prettyIdent = formatUtils.pretty(configuration, ident, formatUtils.Type.IDENT);

--- a/packages/plugin-npm-cli/sources/commands/npm/tag/remove.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/tag/remove.ts
@@ -60,7 +60,6 @@ export default class NpmTagRemoveCommand extends BaseCommand {
         await npmHttpUtils.del(url, {
           configuration,
           registry,
-          ident,
           jsonResponse: true,
         });
       } catch (error) {

--- a/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
@@ -1,6 +1,6 @@
 import {BaseCommand}                from '@yarnpkg/cli';
 import {Configuration, MessageName} from '@yarnpkg/core';
-import {StreamReport, structUtils}  from '@yarnpkg/core';
+import {StreamReport}               from '@yarnpkg/core';
 import {npmHttpUtils}               from '@yarnpkg/plugin-npm';
 import {Command, Usage}             from 'clipanion';
 
@@ -54,7 +54,6 @@ export default class NpmWhoamiCommand extends BaseCommand {
           registry,
           authType: npmHttpUtils.AuthType.ALWAYS_AUTH,
           jsonResponse: true,
-          ident: this.scope ? structUtils.makeIdent(this.scope, ``) : undefined,
         });
 
         report.reportInfo(MessageName.UNNAMED, response.username);

--- a/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/whoami.ts
@@ -1,8 +1,10 @@
-import {BaseCommand, openWorkspace}   from '@yarnpkg/cli';
-import {Configuration, MessageName}   from '@yarnpkg/core';
-import {StreamReport, structUtils}    from '@yarnpkg/core';
-import {npmConfigUtils, npmHttpUtils} from '@yarnpkg/plugin-npm';
-import {Command, Usage}               from 'clipanion';
+import {BaseCommand}                from '@yarnpkg/cli';
+import {Configuration, MessageName} from '@yarnpkg/core';
+import {StreamReport, structUtils}  from '@yarnpkg/core';
+import {npmHttpUtils}               from '@yarnpkg/plugin-npm';
+import {Command, Usage}             from 'clipanion';
+
+import {getRegistryConfiguration}   from './login';
 
 // eslint-disable-next-line arca/no-default-export
 export default class NpmWhoamiCommand extends BaseCommand {
@@ -35,15 +37,12 @@ export default class NpmWhoamiCommand extends BaseCommand {
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
-    let registry: string;
-    if (this.scope && this.publish)
-      registry = npmConfigUtils.getScopeRegistry(this.scope, {configuration, type: npmConfigUtils.RegistryType.PUBLISH_REGISTRY});
-    else if (this.scope)
-      registry = npmConfigUtils.getScopeRegistry(this.scope, {configuration});
-    else if (this.publish)
-      registry = npmConfigUtils.getPublishRegistry((await openWorkspace(configuration, this.context.cwd)).manifest, {configuration});
-    else
-      registry = npmConfigUtils.getDefaultRegistry({configuration});
+    const registry = await getRegistryConfiguration({
+      configuration,
+      cwd: this.context.cwd,
+      publish: this.publish,
+      scope: this.scope,
+    });
 
     const report = await StreamReport.start({
       configuration,

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -18,7 +18,7 @@ const authSettings = {
   npmAlwaysAuth: {
     description: `URL of the selected npm registry (note: npm enterprise isn't supported)`,
     type: SettingsType.BOOLEAN as const,
-    default: false,
+    default: null,
   },
   npmAuthIdent: {
     description: `Authentication identity for the npm registry (_auth in npm and yarn v1)`,
@@ -47,7 +47,7 @@ const registrySettings = {
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
-    npmAlwaysAuth: boolean;
+    npmAlwaysAuth: boolean|null;
     npmAuthIdent: string|null;
     npmAuthToken: string|null;
 
@@ -55,7 +55,7 @@ declare module '@yarnpkg/core' {
     npmRegistryServer: string;
 
     npmScopes:  Map<string, MapConfigurationValue<{
-      npmAlwaysAuth: boolean;
+      npmAlwaysAuth: boolean|null;
       npmAuthIdent: string|null;
       npmAuthToken: string|null;
 
@@ -63,7 +63,7 @@ declare module '@yarnpkg/core' {
       npmRegistryServer: string;
     }>>;
     npmRegistries: Map<string, MapConfigurationValue<{
-      npmAlwaysAuth: boolean;
+      npmAlwaysAuth: boolean|null;
       npmAuthIdent: string|null;
       npmAuthToken: string|null;
     }>>;

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -54,7 +54,7 @@ declare module '@yarnpkg/core' {
     npmPublishRegistry: string | null;
     npmRegistryServer: string;
 
-    npmScopes:  Map<string, MapConfigurationValue<{
+    npmScopes: Map<string, MapConfigurationValue<{
       npmAlwaysAuth: boolean|null;
       npmAuthIdent: string|null;
       npmAuthToken: string|null;

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -22,7 +22,10 @@ type RegistryOptions = {
   registry?: string,
 } | {
   ident?: Ident,
-  registry: string | RegistryConfiguration;
+  registry: string;
+} | {
+  ident?: never;
+  registry: RegistryConfiguration;
 };
 
 export type Options = httpUtils.Options & AuthOptions & RegistryOptions;

--- a/packages/yarnpkg-core/tests/Configuration.test.ts
+++ b/packages/yarnpkg-core/tests/Configuration.test.ts
@@ -141,7 +141,7 @@ describe(`Configuration`, () => {
 
         const scopeConfiguration = configuration.get(`npmScopes`);
         expect(scopeConfiguration.get(`foo`)?.get(`npmAuthToken`)).toBe(`token for foo`);
-        expect(scopeConfiguration.get(`foo`)?.get(`npmAlwaysAuth`)).toBe(false);
+        expect(scopeConfiguration.get(`foo`)?.get(`npmAlwaysAuth`)).toBe(null);
 
         expect(scopeConfiguration.get(`bar`)?.get(`npmAlwaysAuth`)).toBe(true);
       });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR refactors how the npm plugin evaluates `npmAuth*` properties defined at various levels in rc files. It most notably fixes the following case, where installing packages from a default registry with credentials created from `yarn npm login` will not authenticate requests:

```yaml
npmRegistries:
  "<my-registry>":
    npmAuthToken: ******

npmRegistryServer: "<my-registry>"
npmAlwaysAuth: true
```

This is because when Yarn searches for credentials on both scoped and unscoped packages, it only checks the value of `npmAlwaysAuth` at the level it discovers a value for `npmAuthToken` or `npmAuthIdent`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I rewrote most of the implementation of npmConfigUtils without disrupting the API surface. The primary way these util function was used goes

1. determine registry server from npmScopes
2. use auth config for scope
3. if no scope server or auth config, get auth config from npmRegistries config
4. if no npmRegistries auth ident or token, get auth config from top level

The problem here is that there's barely any room for the **top level** values to participate in evaluation of the auth configuration. The value of `npmAlwaysAuth` will end up being false by default because Yarn stops evaluating after it finds a non-null value for `npmAuthToken` or `npmAuthIdent`.

Instead, the new way I have Yarn evaluating configs goes more like

1. determine registry **configuration** from scope
  a. find registry server + auth configuration from npmScopes
  b. for each key in scope auth configuration, replace null values with values from npmRegistries configuration
2. if no scope registry configuration, use default (top-level) **configuration**
  a. find npmRegistries configuration for the default server
  b. for each key in npmRegistries configuration, replace null values with values from default (top-level configuration)

I designed it this way because within Yarn, the caller of these util functions seems to actually be more interested in receiving the registry server + associated auth configuration rather than just the registry server itself. When only the server is returned, the context of where in the config it was defined is lost, and then there's no "intuitive" way for Yarn to figure out if it's appropriate to fall back to the top-level auth config.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
