### PR TITLE
doc(vscode-zipfs): add homepage for vscode-zipfs

### DIFF
--- a/.yarn/versions/1c2724e7.yml
+++ b/.yarn/versions/1c2724e7.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: patch

--- a/packages/vscode-zipfs/package.json
+++ b/packages/vscode-zipfs/package.json
@@ -5,6 +5,7 @@
   "publisher": "arcanis",
   "displayName": "ZipFS - a zip file system",
   "description": "Allows to easily inspect and modify files stored within zip archives.",
+  "homepage": "https://github.com/yarnpkg/berry/blob/master/packages/vscode-zipfs",
   "icon": "icon.png",
   "version": "2.2.3",
   "engines": {


### PR DESCRIPTION
Specifically, metadata for the vscode extensions manager

**What's the problem this PR addresses?**
on the vscode extension marketplace, the extension doesn't list repo or homepage -- the repo field has a ssh remote, and that isn't parsed by the extension marketplace, and the extension page inside vscode doesn't navigate to this repo when opening up "repository" from its ui.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
added "homepage" in vscode-zipfs's package.json

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
