### PR TITLE
perf(core): setup binaries in parallel for executing scripts

### DIFF
--- a/.yarn/versions/7be5f20d.yml
+++ b/.yarn/versions/7be5f20d.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -345,8 +345,11 @@ async function initializePackageEnvironment(locator: Locator, {project, binFolde
 
     const env = await makeScriptEnv({project, binFolder, lifecycleScript});
 
-    for (const [binaryName, [, binaryPath]] of await getPackageAccessibleBinaries(locator, {project}))
-      await makePathWrapper(binFolder, toFilename(binaryName), process.execPath, [binaryPath]);
+    await Promise.all(
+      Array.from(await getPackageAccessibleBinaries(locator, {project}), ([binaryName, [, binaryPath]]) =>
+        makePathWrapper(binFolder, toFilename(binaryName), process.execPath, [binaryPath])
+      )
+    );
 
     const packageLocation = await linker.findPackageLocation(pkg, linkerOptions);
     const packageFs = new CwdFS(packageLocation, {baseFs: zipOpenFs});
@@ -526,8 +529,11 @@ export async function executePackageAccessibleBinary(locator: Locator, binaryNam
     const [, binaryPath] = binary;
     const env = await makeScriptEnv({project, binFolder});
 
-    for (const [binaryName, [, binaryPath]] of packageAccessibleBinaries)
-      await makePathWrapper(env.BERRY_BIN_FOLDER as PortablePath, toFilename(binaryName), process.execPath, [binaryPath]);
+    await Promise.all(
+      Array.from(packageAccessibleBinaries, ([binaryName, [, binaryPath]]) =>
+        makePathWrapper(env.BERRY_BIN_FOLDER as PortablePath, toFilename(binaryName), process.execPath, [binaryPath])
+      )
+    );
 
     let result;
     try {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The binaries created in `initializePackageEnvironment` and `executePackageAccessibleBinary` are created in serial which, with enough binaries, can cause noticeable slowdowns.

**How did you fix it?**

Create the binaries in parallel

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.