### PR TITLE
Hides virtuals from VSCode

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -27509,6 +27509,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["pkg-tests-specs", "workspace:packages/acceptance-tests/pkg-tests-specs"],
             ["@types/lodash", "npm:4.14.136"],
             ["@types/tar", "npm:4.0.0"],
+            ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/monorepo", "workspace:."],

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -17,20 +17,21 @@ const moduleWrapper = tsserver => {
   // doesn't understand. This layer makes sure to remove the protocol
   // before forwarding it to TS, and to add it back on all returned paths.
 
-  // We also take the opportunity to turn virtual paths into physical ones;
-  // this makes is much easier to work with workspaces that list peer
-  // dependencies, since otherwise Ctrl+Click would bring us to the virtual
-  // file instances instead of the real ones.
-
   function toVSCodePath(str) {
     // We add the `zip:` prefix to both `.zip/` paths and virtual paths
     if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || str.match(/\$\$virtual\//))) {
+      // We also take the opportunity to turn virtual paths into physical ones;
+      // this makes is much easier to work with workspaces that list peer
+      // dependencies, since otherwise Ctrl+Click would bring us to the virtual
+      // file instances instead of the real ones.
+      const physicalFilePath = resolveVirtual(str) || str;
+
       // Absolute VSCode `Uri.fsPath`s need to start with a slash.
       // VSCode only adds it automatically for supported schemes,
       // so we have to do it manually for the `zip` scheme.
       // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
       // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
-      return `${isVSCode ? '^' : ''}zip:${resolveVirtual(str).replace(/^\/?/, `/`)}`;
+      return `${isVSCode ? '^' : ''}zip:${physicalFilePath.replace(/^\/?/, `/`)}`;
     } else {
       return str;
     }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -17,7 +17,7 @@ const moduleWrapper = tsserver => {
   // doesn't understand. This layer makes sure to remove the protocol
   // before forwarding it to TS, and to add it back on all returned paths.
 
-  function toVSCodePath(str) {
+  function toEditorPath(str) {
     // We add the `zip:` prefix to both `.zip/` paths and virtual paths
     if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || str.match(/\$\$virtual\//))) {
       // We also take the opportunity to turn virtual paths into physical ones;
@@ -37,7 +37,7 @@ const moduleWrapper = tsserver => {
     }
   }
 
-  function fromVSCodePath(str) {
+  function fromEditorPath(str) {
     return process.platform === `win32`
       ? str.replace(/^\^?zip:\//, ``)
       : str.replace(/^\^?zip:/, ``);
@@ -65,13 +65,13 @@ const moduleWrapper = tsserver => {
       }
 
       return originalOnMessage.call(this, JSON.stringify(parsedMessage, (key, value) => {
-        return typeof value === `string` ? fromVSCodePath(value) : value;
+        return typeof value === `string` ? fromEditorPath(value) : value;
       }));
     },
 
     send(/** @type {any} */ msg) {
       return originalSend.call(this, JSON.parse(JSON.stringify(msg, (key, value) => {
-        return typeof value === `string` ? toVSCodePath(value) : value;
+        return typeof value === `string` ? toEditorPath(value) : value;
       })));
     }
   });

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -25,7 +25,7 @@ const moduleWrapper = tsserver => {
       // dependencies, since otherwise Ctrl+Click would bring us to the virtual
       // file instances instead of the real ones.
       const physicalFilePath = (resolveVirtual(str) || str)
-        .replace(/\//g, `/`)
+        .replace(/\\/g, `/`)
         .replace(/^\/?/, `/`);
 
       // Absolute VSCode `Uri.fsPath`s need to start with a slash.

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -24,14 +24,16 @@ const moduleWrapper = tsserver => {
       // this makes is much easier to work with workspaces that list peer
       // dependencies, since otherwise Ctrl+Click would bring us to the virtual
       // file instances instead of the real ones.
-      const physicalFilePath = resolveVirtual(str) || str;
+      const physicalFilePath = (resolveVirtual(str) || str)
+        .replace(/\/g, `/`)
+        .replace(/^\/?/, `/`);
 
       // Absolute VSCode `Uri.fsPath`s need to start with a slash.
       // VSCode only adds it automatically for supported schemes,
       // so we have to do it manually for the `zip` scheme.
       // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
       // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
-      return `${isVSCode ? '^' : ''}zip:${physicalFilePath.replace(/^\/?/, `/`)}`;
+      return `${isVSCode ? '^' : ''}zip:${physicalFilePath}`;
     } else {
       return str;
     }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -10,11 +10,41 @@ const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 const moduleWrapper = tsserver => {
+  const {isAbsolute} = require(`path`);
+  const {resolveVirtual} = require(`pnpapi`);
+
   // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
   // doesn't understand. This layer makes sure to remove the protocol
   // before forwarding it to TS, and to add it back on all returned paths.
 
-  const {isAbsolute} = require(`path`);
+  // We also take the opportunity to turn virtual paths into physical ones;
+  // this makes is much easier to work with workspaces that list peer
+  // dependencies, since otherwise Ctrl+Click would bring us to the virtual
+  // file instances instead of the real ones.
+
+  function toVSCodePath(str) {
+    // We add the `zip:` prefix to both `.zip/` paths and virtual paths
+    if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || str.match(/\$\$virtual\//))) {
+      // Absolute VSCode `Uri.fsPath`s need to start with a slash.
+      // VSCode only adds it automatically for supported schemes,
+      // so we have to do it manually for the `zip` scheme.
+      // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
+      // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
+      return `${isVSCode ? '^' : ''}zip:${resolveVirtual(str).replace(/^\/?/, `/`)}`;
+    } else {
+      return str;
+    }
+  }
+
+  function fromVSCodePath(str) {
+    return process.platform === `win32`
+      ? str.replace(/^\^?zip:\//, ``)
+      : str.replace(/^\^?zip:/, ``);
+  }
+
+  // And here is the point where we hijack the VSCode <-> TS communications
+  // by adding ourselves in the middle. We locate everything that looks
+  // like an absolute path of ours and normalize it.
 
   const Session = tsserver.server.Session;
   const {onMessage: originalOnMessage, send: originalSend} = Session.prototype;
@@ -26,44 +56,24 @@ const moduleWrapper = tsserver => {
 
       if (
         parsedMessage != null &&
-        typeof parsedMessage === 'object' &&
+        typeof parsedMessage === `object` &&
         parsedMessage.arguments &&
-        parsedMessage.arguments.hostInfo === 'vscode'
+        parsedMessage.arguments.hostInfo === `vscode`
       ) {
         isVSCode = true;
       }
 
       return originalOnMessage.call(this, JSON.stringify(parsedMessage, (key, value) => {
-        return typeof value === 'string' ? removeZipPrefix(value) : value;
+        return typeof value === `string` ? fromVSCodePath(value) : value;
       }));
     },
 
     send(/** @type {any} */ msg) {
       return originalSend.call(this, JSON.parse(JSON.stringify(msg, (key, value) => {
-        return typeof value === 'string' ? addZipPrefix(value) : value;
+        return typeof value === `string` ? toVSCodePath(value) : value;
       })));
     }
   });
-
-  function addZipPrefix(str) {
-    // We add the `zip:` prefix to both `.zip/` paths and virtual paths
-    if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || str.match(/\$\$virtual\//))) {
-      // Absolute VSCode `Uri.fsPath`s need to start with a slash.
-      // VSCode only adds it automatically for supported schemes,
-      // so we have to do it manually for the `zip` scheme.
-      // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
-      // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
-      return `${isVSCode ? '^' : ''}zip:${str.replace(/^\/?/, `/`)}`;
-    } else {
-      return str;
-    }
-  }
-
-  function removeZipPrefix(str) {
-    return process.platform === 'win32'
-      ? str.replace(/^\^?zip:\//, ``)
-      : str.replace(/^\^?zip:/, ``);
-  }
 };
 
 if (existsSync(absPnpApiPath)) {

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -25,7 +25,7 @@ const moduleWrapper = tsserver => {
       // dependencies, since otherwise Ctrl+Click would bring us to the virtual
       // file instances instead of the real ones.
       const physicalFilePath = (resolveVirtual(str) || str)
-        .replace(/\/g, `/`)
+        .replace(/\//g, `/`)
         .replace(/^\/?/, `/`);
 
       // Absolute VSCode `Uri.fsPath`s need to start with a slash.

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "3.9.5-pnpify",
+  "version": "4.1.0-beta-pnpify",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/.yarn/versions/f81f5c56.yml
+++ b/.yarn/versions/f81f5c56.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/acceptance-tests/pkg-tests-specs/package.json
+++ b/packages/acceptance-tests/pkg-tests-specs/package.json
@@ -1,28 +1,29 @@
 {
-    "name": "pkg-tests-specs",
-    "private": true,
-    "license": "BSD-2-Clause",
-    "main": "./sources/index.js",
-    "dependencies": {
-        "@yarnpkg/core": "workspace:^2.3.1",
-        "@yarnpkg/fslib": "workspace:^2.3.0",
-        "@yarnpkg/monorepo": "workspace:0.0.0",
-        "@yarnpkg/parsers": "workspace:^2.3.0",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.15",
-        "pkg-tests-core": "workspace:0.0.0",
-        "semver": "^7.1.2",
-        "tar": "^4.4.6"
-    },
-    "repository": {
-        "type": "git",
-        "url": "ssh://git@github.com/yarnpkg/berry.git"
-    },
-    "devDependencies": {
-        "@types/lodash": "^4.14.136",
-        "@types/tar": "^4.0.0"
-    },
-    "engines": {
-        "node": ">=10.19.0"
-    }
+  "name": "pkg-tests-specs",
+  "private": true,
+  "license": "BSD-2-Clause",
+  "main": "./sources/index.js",
+  "dependencies": {
+    "@yarnpkg/cli": "workspace:^2.3.3",
+    "@yarnpkg/core": "workspace:^2.3.1",
+    "@yarnpkg/fslib": "workspace:^2.3.0",
+    "@yarnpkg/monorepo": "workspace:0.0.0",
+    "@yarnpkg/parsers": "workspace:^2.3.0",
+    "fs-extra": "^7.0.1",
+    "lodash": "^4.17.15",
+    "pkg-tests-core": "workspace:0.0.0",
+    "semver": "^7.1.2",
+    "tar": "^4.4.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/yarnpkg/berry.git"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.136",
+    "@types/tar": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=10.19.0"
+  }
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/editorSdks.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/editorSdks.test.js
@@ -147,6 +147,11 @@ describe(`Features`, () => {
             .replace(/\\/g, `/`)
             .replace(/^\/?/, `/`);
 
+          // Same thing, but this file has virtual instances.
+          const yarnpkgCli = npath.normalize(npath.join(__dirname, `../../../../yarnpkg-cli/sources/index.ts`))
+            .replace(/\\/g, `/`)
+            .replace(/^\/?/, `/`);
+
           // Some sanity check to make sure everything is A-OK
           expect(lodashTypeDef).toContain(`.zip`);
 
@@ -159,6 +164,13 @@ describe(`Features`, () => {
 
           await runAndWait(`zip:${lodashTypeDir}`, {
             seq: 1,
+            type: `request`,
+            command: `typeDefinition`,
+            arguments: {file: ourUtilityFile, line: 7, offset: 9},
+          });
+
+          await runAndWait(yarnpkgCli, {
+            seq: 2,
             type: `request`,
             command: `typeDefinition`,
             arguments: {file: ourUtilityFile, line: 6, offset: 9},

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/editorSdks.utility.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/editorSdks.utility.ts
@@ -3,4 +3,5 @@
 // This file MUST NOT CHANGE. We're using it for the VSCode / TS integration
 // tests, which require to reference symbols by their offset.
 
+import '@yarnpkg/cli';
 import 'lodash';

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -44,7 +44,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       // doesn't understand. This layer makes sure to remove the protocol
       // before forwarding it to TS, and to add it back on all returned paths.
 
-      function toVSCodePath(str) {
+      function toEditorPath(str) {
         // We add the \`zip:\` prefix to both \`.zip/\` paths and virtual paths
         if (isAbsolute(str) && !str.match(/^\\^zip:/) && (str.match(/\\.zip\\//) || str.match(/\\$\\$virtual\\//))) {
           // We also take the opportunity to turn virtual paths into physical ones;
@@ -64,7 +64,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
         }
       }
 
-      function fromVSCodePath(str) {
+      function fromEditorPath(str) {
         return process.platform === \`win32\`
           ? str.replace(/^\\^?zip:\\//, \`\`)
           : str.replace(/^\\^?zip:/, \`\`);
@@ -92,13 +92,13 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           }
 
           return originalOnMessage.call(this, JSON.stringify(parsedMessage, (key, value) => {
-            return typeof value === \`string\` ? fromVSCodePath(value) : value;
+            return typeof value === \`string\` ? fromEditorPath(value) : value;
           }));
         },
 
         send(/** @type {any} */ msg) {
           return originalSend.call(this, JSON.parse(JSON.stringify(msg, (key, value) => {
-            return typeof value === \`string\` ? toVSCodePath(value) : value;
+            return typeof value === \`string\` ? toEditorPath(value) : value;
           })));
         }
       });

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -51,14 +51,16 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           // this makes is much easier to work with workspaces that list peer
           // dependencies, since otherwise Ctrl+Click would bring us to the virtual
           // file instances instead of the real ones.
-          const physicalFilePath = resolveVirtual(str) || str;
+          const physicalFilePath = (resolveVirtual(str) || str)
+            .replace(/\\/g, \`/\`)
+            .replace(/^\\/?/, \`/\`);
 
           // Absolute VSCode \`Uri.fsPath\`s need to start with a slash.
           // VSCode only adds it automatically for supported schemes,
           // so we have to do it manually for the \`zip\` scheme.
           // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
           // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
-          return \`\${isVSCode ? '^' : ''}zip:\${physicalFilePath.replace(/^\\/?/, \`/\`)}\`;
+          return \`\${isVSCode ? '^' : ''}zip:\${physicalFilePath}\`;
         } else {
           return str;
         }

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -52,7 +52,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           // dependencies, since otherwise Ctrl+Click would bring us to the virtual
           // file instances instead of the real ones.
           const physicalFilePath = (resolveVirtual(str) || str)
-            .replace(/\\//g, \`/\`)
+            .replace(/\\\\/g, \`/\`)
             .replace(/^\\/?/, \`/\`);
 
           // Absolute VSCode \`Uri.fsPath\`s need to start with a slash.

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -52,7 +52,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           // dependencies, since otherwise Ctrl+Click would bring us to the virtual
           // file instances instead of the real ones.
           const physicalFilePath = (resolveVirtual(str) || str)
-            .replace(/\\/g, \`/\`)
+            .replace(/\\//g, \`/\`)
             .replace(/^\\/?/, \`/\`);
 
           // Absolute VSCode \`Uri.fsPath\`s need to start with a slash.

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -44,20 +44,21 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       // doesn't understand. This layer makes sure to remove the protocol
       // before forwarding it to TS, and to add it back on all returned paths.
 
-      // We also take the opportunity to turn virtual paths into physical ones;
-      // this makes is much easier to work with workspaces that list peer
-      // dependencies, since otherwise Ctrl+Click would bring us to the virtual
-      // file instances instead of the real ones.
-
       function toVSCodePath(str) {
         // We add the \`zip:\` prefix to both \`.zip/\` paths and virtual paths
         if (isAbsolute(str) && !str.match(/^\\^zip:/) && (str.match(/\\.zip\\//) || str.match(/\\$\\$virtual\\//))) {
+          // We also take the opportunity to turn virtual paths into physical ones;
+          // this makes is much easier to work with workspaces that list peer
+          // dependencies, since otherwise Ctrl+Click would bring us to the virtual
+          // file instances instead of the real ones.
+          const physicalFilePath = resolveVirtual(str) || str;
+
           // Absolute VSCode \`Uri.fsPath\`s need to start with a slash.
           // VSCode only adds it automatically for supported schemes,
           // so we have to do it manually for the \`zip\` scheme.
           // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
           // https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
-          return \`\${isVSCode ? '^' : ''}zip:\${resolveVirtual(str).replace(/^\\/?/, \`/\`)}\`;
+          return \`\${isVSCode ? '^' : ''}zip:\${physicalFilePath.replace(/^\\/?/, \`/\`)}\`;
         } else {
           return str;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20912,6 +20912,7 @@ fsevents@^1.2.7:
   dependencies:
     "@types/lodash": ^4.14.136
     "@types/tar": ^4.0.0
+    "@yarnpkg/cli": "workspace:^2.3.3"
     "@yarnpkg/core": "workspace:^2.3.1"
     "@yarnpkg/fslib": "workspace:^2.3.0"
     "@yarnpkg/monorepo": "workspace:0.0.0"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Opening a virtual file in VSCode is 100% a disappointment. First you have more risks that something will go wrong (since it's difficult for them to work perfectly with file watcher mechanisms), but even in the best case it still takes an extra tab and looses the state of the real file. In most cases you end up closing the file and looking for the real one.

**How did you fix it?**

The SDK won't return virtual paths anymore to VSCode. It's slightly incorrect in that ctrl+click will lead to a file that *may* have different resolutions than what the virtual file would have had, but that seems an acceptable tradeoff compared to the overall IDE usability (especially when using workspaces w/ peer dependencies).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
