### PR TITLE
fix: include *.d.ts in published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "build:plugin-commands": "node ./scripts/gen-plugin-commands.js > packages/yarnpkg-cli/sources/pluginCommands.ts",
-    "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && rsync -a --exclude '*.ts' --exclude '*.tsx' --include '*.d.ts' \"$0\"/sources/ \"$0\"/lib/ && node scripts/compile \"$@\"",
+    "build:compile": "rm -rf \"$0\"/lib && mkdir -p \"$0\"/lib && rsync -a --include '*.d.ts' --exclude '*.ts' --exclude '*.tsx' \"$0\"/sources/ \"$0\"/lib/ && node scripts/compile \"$@\"",
     "build:compile-inline": "find \"$0\"/sources -name '*.js' && babel \"$0\"/sources --out-dir \"$0\"/sources --extensions .ts,.tsx",
     "test:lint": "eslint --max-warnings 0 \"packages/**/@(sources|tests)/**/!(libzip).@(tsx|ts|js)\"",
     "test:unit": "jest",


### PR DESCRIPTION

**What's the problem this PR addresses?**
I've noticed that the @yarnpkg/parsers package doesn't contain type
definitions in `lib/grammars`[1], though they are present in the source
code.

This is because of the `rsync` command doesn't copy them to the `lib`
directory in `build:compile` script.

[1] https://cdn.jsdelivr.net/npm/@yarnpkg/parsers@2.3.0/lib/grammars/

**How did you fix it?**
<!-- A detailed description of your implementation. -->
`rsync` filter rules state[2]:

> As the list of files/directories to transfer is built, rsync checks
> each name to be transferred against the list of include/exclude
> patterns in turn, and the first matching pattern is acted on: if it is
> an exclude pattern, then that file is skipped; if it is an include
> pattern then that filename is not skipped; if no matching pattern is
> found, then the filename is not skipped.

Meaning, if a file is matched via `--exclude` processing stops there and
the file is excluded regardless of any `--include` rule.

This specifies the `--include` filter rule before any `--exclude` rule
so that the `*.d.ts` files are copied to the `lib` directory.

[2] https://man7.org/linux/man-pages/man1/rsync.1.html#FILTER_RULES

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
