### PR TITLE
fix(plugin-pack): avoid packing non file entries

### DIFF
--- a/.yarn/versions/f8c9a277.yml
+++ b/.yarn/versions/f8c9a277.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -1,11 +1,11 @@
-import {Report, Workspace, scriptUtils}                     from '@yarnpkg/core';
-import {FakeFS, JailFS, xfs, PortablePath, ppath, Filename} from '@yarnpkg/fslib';
-import {Hooks as StageHooks}                                from '@yarnpkg/plugin-stage';
-import mm                                                   from 'micromatch';
-import tar                                                  from 'tar-stream';
-import {createGzip}                                         from 'zlib';
+import {Report, Workspace, scriptUtils}                            from '@yarnpkg/core';
+import {FakeFS, JailFS, xfs, PortablePath, ppath, Filename, npath} from '@yarnpkg/fslib';
+import {Hooks as StageHooks}                                       from '@yarnpkg/plugin-stage';
+import mm                                                          from 'micromatch';
+import tar                                                         from 'tar-stream';
+import {createGzip}                                                from 'zlib';
 
-import {Hooks}                                              from './';
+import {Hooks}                                                     from './';
 
 const NEVER_IGNORE = [
   `/package.json`,
@@ -118,7 +118,7 @@ export async function genPackStream(workspace: Workspace, files?: Array<Portable
       } else if (stat.isSymbolicLink()) {
         pack.entry({...opts, mode, type: `symlink`, linkname: await xfs.readlinkPromise(source)}, cb);
       } else {
-        cb(null);
+        cb(new Error(`Unsupported file type ${stat.mode} for ${npath.fromPortablePath(file)}`));
       }
 
       await awaitTarget;
@@ -281,7 +281,7 @@ async function walk(initialCwd: PortablePath, {hasExplicitFileList, globalList, 
       for (const entry of entries) {
         cwdList.push([ppath.resolve(cwd, entry), nextIgnoreLists]);
       }
-    } else {
+    } else if (stat.isFile() || stat.isSymbolicLink()) {
       list.push(ppath.relative(PortablePath.root, cwd));
     }
   }

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -117,6 +117,8 @@ export async function genPackStream(workspace: Workspace, files?: Array<Portable
         pack.entry({...opts, mode, type: `file`}, content, cb);
       } else if (stat.isSymbolicLink()) {
         pack.entry({...opts, mode, type: `symlink`, linkname: await xfs.readlinkPromise(source)}, cb);
+      } else {
+        cb(null);
       }
 
       await awaitTarget;


### PR DESCRIPTION
**What's the problem this PR addresses?**

If the list of files passed to `packUtils.genPackStream` is anything but a file or symlink it would await a promise that would never resolve and since there was nothing left in the event loop node would terminate.

**How did you fix it?**

Reject the promise if the entry isn't a file nor a symlink and make `packUtils.genPackList` not add them to the list in the first place

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.