### PR TITLE
feat(core): add support for httpProxy and httpsProxy in networkSettings

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -38337,6 +38337,41 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["ws", [
+        ["npm:5.2.2", {
+          "packageLocation": "./.yarn/cache/ws-npm-5.2.2-173bcd57b2-c8217b5482.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "npm:5.2.2"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["npm:6.1.4", {
+          "packageLocation": "./.yarn/cache/ws-npm-6.1.4-7bee7fd05f-74c2245736.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "npm:6.1.4"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["npm:6.2.1", {
+          "packageLocation": "./.yarn/cache/ws-npm-6.2.1-bbe0ef9859-35d32b09e2.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "npm:6.2.1"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["npm:7.3.0", {
+          "packageLocation": "./.yarn/cache/ws-npm-7.3.0-2881a35eae-c1f386013b.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "npm:7.3.0"]
+          ],
+          "linkType": "SOFT",
+        }],
+        ["npm:7.3.1", {
+          "packageLocation": "./.yarn/cache/ws-npm-7.3.1-0fa30fe373-9302f1f665.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "npm:7.3.1"]
+          ],
+          "linkType": "SOFT",
+        }],
         ["virtual:3b5e69efaa2372701eeacd25836edffb24542c8451116315f985d26186b219fb4485f91e0a94a6978db5d292a078b1c57ceaae51a63ec1c16cb40561723db94c#npm:6.1.4", {
           "packageLocation": "./.yarn/$$virtual/ws-virtual-f68ec3df6c/0/cache/ws-npm-6.1.4-7bee7fd05f-74c2245736.zip/node_modules/ws/",
           "packageDependencies": [
@@ -38372,20 +38407,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             "utf-8-validate"
           ],
           "linkType": "HARD",
-        }],
-        ["npm:7.3.0", {
-          "packageLocation": "./.yarn/cache/ws-npm-7.3.0-2881a35eae-c1f386013b.zip/node_modules/ws/",
-          "packageDependencies": [
-            ["ws", "npm:7.3.0"]
-          ],
-          "linkType": "SOFT",
-        }],
-        ["npm:7.3.1", {
-          "packageLocation": "./.yarn/cache/ws-npm-7.3.1-0fa30fe373-9302f1f665.zip/node_modules/ws/",
-          "packageDependencies": [
-            ["ws", "npm:7.3.1"]
-          ],
-          "linkType": "SOFT",
         }],
         ["virtual:4ac7945935c7b9baa1c648c30910b97cc4b5310bd9c6e7f82899f24717f03acba3019fca67c456aeaef29db72c35d787ebde17b426ca35ee56f8bb84bc683d77#npm:7.3.1", {
           "packageLocation": "./.yarn/$$virtual/ws-virtual-f730b7fbe3/0/cache/ws-npm-7.3.1-0fa30fe373-9302f1f665.zip/node_modules/ws/",

--- a/.yarn/versions/c7c7f820.yml
+++ b/.yarn/versions/c7c7f820.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-github": patch
+  "@yarnpkg/plugin-http": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -347,6 +347,12 @@
             },
             "enableNetwork": {
               "$ref": "#/properties/enableNetwork"
+            },
+            "httpProxy": {
+              "$ref": "#/properties/httpProxy"
+            },
+            "httpsProxy": {
+              "$ref": "#/properties/httpsProxy"
             }
           },
           "_exampleKeys": ["caFilePath"]

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -345,6 +345,16 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
           type: SettingsType.BOOLEAN,
           default: null,
         },
+        httpProxy: {
+          description: `URL of the http proxy that must be used for outgoing http requests`,
+          type: SettingsType.STRING,
+          default: null,
+        },
+        httpsProxy: {
+          description: `URL of the http proxy that must be used for outgoing https requests`,
+          type: SettingsType.STRING,
+          default: null,
+        },
       },
     },
   },
@@ -504,13 +514,18 @@ export interface ConfigurationValueMap {
 
   enableMirror: boolean;
   enableNetwork: boolean;
-  httpProxy: string;
-  httpsProxy: string;
+  httpProxy: string | null;
+  httpsProxy: string | null;
   unsafeHttpWhitelist: Array<string>;
   httpTimeout: number;
   httpRetry: number;
   networkConcurrency: number;
-  networkSettings: Map<string, miscUtils.ToMapValue<{caFilePath: PortablePath | null, enableNetwork: boolean | null}>>;
+  networkSettings: Map<string, miscUtils.ToMapValue<{
+    caFilePath: PortablePath | null;
+    enableNetwork: boolean | null;
+    httpProxy: string | null;
+    httpsProxy: string | null;
+  }>>;
   caFilePath: PortablePath | null;
   enableStrictSsl: boolean;
 

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -65,8 +65,9 @@ export interface ToMapValue<T extends object> {
 export type MapValueToObjectValue<T> =
   T extends Map<infer K, infer V> ? (K extends string | number | symbol ? MapValueToObjectValue<Record<K, V>> : never)
     : T extends ToMapValue<infer V> ? MapValueToObjectValue<V>
-      : T extends object ? {[K in keyof T]: MapValueToObjectValue<T[K]>}
-        : T;
+      : T extends PortablePath ? PortablePath
+        : T extends object ? {[K in keyof T]: MapValueToObjectValue<T[K]>}
+          : T;
 
 /**
  * Converts Maps to indexable objects recursively.


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's only possible to set a proxy for all traffic or no traffic.

Fixes https://github.com/yarnpkg/berry/issues/1531
Fixes https://github.com/yarnpkg/berry/issues/1530
Closes https://github.com/yarnpkg/berry/pull/2104

**How did you fix it?**

Added support for setting `httpProxy` and `httpsProxy` in network settings

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.