### PR TITLE
chore(cli): throw on broken node 14 releases

### DIFF
--- a/.yarn/versions/1c88d26a.yml
+++ b/.yarn/versions/1c88d26a.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -60,11 +60,12 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     // Non-exhaustive known requirements:
     // - 10.16+ for Brotli support on `plugin-compat`
     // - 10.17+ to silence `got` warning on `dns.promises`
+    // - 14.0 and 14.1 empty http responses - https://github.com/sindresorhus/got/issues/1496
 
     const version = process.versions.node;
-    const range = `>=10.17`;
+    const range = `>=10.17 <14 || >14.1`;
 
-    if (!semverUtils.satisfiesWithPrereleases(version, range) && process.env.YARN_IGNORE_NODE !== `1`)
+    if (process.env.YARN_IGNORE_NODE !== `1` && !semverUtils.satisfiesWithPrereleases(version, range))
       throw new UsageError(`This tool requires a Node version compatible with ${range} (got ${version}). Upgrade Node, or set \`YARN_IGNORE_NODE=1\` in your environment.`);
 
     // Since we only care about a few very specific settings (yarn-path and ignore-path) we tolerate extra configuration key.


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node 14.0 and 14.1 have a bug in their stream implementation causing empty requests, we should warn about it to prevent issues getting opened here.

Closes https://github.com/yarnpkg/berry/issues/2151

**How did you fix it?**

Throw when the node version is detected as 14.0 or 14.1

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.