### PR TITLE
Allow an empty files array in package.json

### DIFF
--- a/.yarn/versions/636369e8.yml
+++ b/.yarn/versions/636369e8.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/fa98e249.yml
+++ b/.yarn/versions/fa98e249.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-pack": patch

--- a/.yarn/versions/fa98e249.yml
+++ b/.yarn/versions/fa98e249.yml
@@ -1,5 +1,0 @@
-releases:
-  "@yarnpkg/cli": patch
-  "@yarnpkg/core": patch
-  "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-pack": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -593,5 +593,22 @@ describe(`Commands`, () => {
         expect(xfs.existsSync(`${tmpDir}/test.tgz`)).toEqual(true);
       }),
     );
+
+    test(
+      `it should not include any extra files when the "files" field is empty`,
+      makeTemporaryEnv({
+        main: `lib/a.js`,
+        files: [],
+      }, async ({path, run, source}) => {
+        await fsUtils.writeFile(`${path}/lib/a.js`, `module.exports = 42;\n`);
+        await fsUtils.writeFile(`${path}/src/a.ts`, `module.exports = 42;\n`);
+
+        await run(`install`);
+
+        const {stdout} = await run(`pack`, `--dry-run`);
+        expect(stdout).toMatch(/lib\/a\.js/);
+        expect(stdout).not.toMatch(/src\/a\.ts/);
+      }),
+    );
   });
 });

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -429,7 +429,7 @@ export class Manifest {
       }
     }
 
-    if (Array.isArray(data.files) && data.files.length !== 0) {
+    if (Array.isArray(data.files)) {
       this.files = new Set();
 
       for (const filename of data.files) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes #2166 

**How did you fix it?**

Set `manifest.files` to an empty Set even if the files array is empty.  This allows packUtils to recognize that a value was set, even though it was empty.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
