### PR TITLE
fix(pnpify): turn portable path into native and setup fs patch

### DIFF
--- a/.yarn/versions/80f81cb1.yml
+++ b/.yarn/versions/80f81cb1.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -1,5 +1,6 @@
 import {StreamReport, Configuration}                                                                       from '@yarnpkg/core';
 import {NativePath, npath, ppath, xfs, Filename}                                                           from '@yarnpkg/fslib';
+import type {PnpApi}                                                                                       from '@yarnpkg/pnp';
 import {Command, UsageError}                                                                               from 'clipanion';
 
 import {dynamicRequire}                                                                                    from '../dynamicRequire';
@@ -73,7 +74,10 @@ export default class SdkCommand extends Command {
 
     const configuration = Configuration.create(currProjectRoot);
     const pnpPath = ppath.join(currProjectRoot, `.pnp.${isCJS}js` as Filename);
-    const pnpApi = dynamicRequire(npath.fromPortablePath(pnpPath));
+    const pnpApi = dynamicRequire(npath.fromPortablePath(pnpPath)) as PnpApi;
+
+    // Need to setup the fs patch so we can read from the archives
+    (pnpApi as unknown as {setup: Function})?.setup();
 
     const onlyBase = this.integrations.length === 1 && this.integrations[0] === `base`;
 

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -73,7 +73,7 @@ export default class SdkCommand extends Command {
 
     const configuration = Configuration.create(currProjectRoot);
     const pnpPath = ppath.join(currProjectRoot, `.pnp.${isCJS}js` as Filename);
-    const pnpApi = dynamicRequire(pnpPath);
+    const pnpApi = dynamicRequire(npath.fromPortablePath(pnpPath));
 
     const onlyBase = this.integrations.length === 1 && this.integrations[0] === `base`;
 

--- a/packages/yarnpkg-pnpify/sources/dynamicRequire.ts
+++ b/packages/yarnpkg-pnpify/sources/dynamicRequire.ts
@@ -1,6 +1,6 @@
 declare var __non_webpack_require__: any;
 
-const dynamicRequire = typeof __non_webpack_require__ !== `undefined`
+const dynamicRequire: NodeRequire = typeof __non_webpack_require__ !== `undefined`
   ? __non_webpack_require__
   : require;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

- Forgot to turn this one path into native again, from portable. Didn't get caught since the function accepts arbitrary strings (due to accepting bare identifiers).
- If run without a pnpapi already setup pnpify would fail to read files

**How did you fix it?**

- Turn the path into a NativePath.
- Call the `pnpapi`s `setup` function

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
