### PR TITLE
chore(compat): update extensions list

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -15871,7 +15871,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["indexof", "npm:0.0.1"],
             ["parseqs", "npm:0.0.5"],
             ["parseuri", "npm:0.0.5"],
-            ["ws", "npm:6.1.4"],
+            ["ws", "virtual:3b5e69efaa2372701eeacd25836edffb24542c8451116315f985d26186b219fb4485f91e0a94a6978db5d292a078b1c57ceaae51a63ec1c16cb40561723db94c#npm:6.1.4"],
             ["xmlhttprequest-ssl", "npm:1.5.5"],
             ["yeast", "npm:0.1.2"]
           ],
@@ -29102,6 +29102,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["react-instantsearch-core", "virtual:eb5765c1be3f2b7a1a9c858067ab3666195e36c47c9b2fe716c62e4e446ec47422535a87f981ea7ae853716c3b5381687dfc4c840db6479d23905b3fdbd079bf#npm:6.6.0"],
             ["@babel/runtime", "npm:7.9.2"],
+            ["@types/algoliasearch", null],
             ["@types/react", "npm:16.9.2"],
             ["algoliasearch", null],
             ["algoliasearch-helper", "virtual:eb5765c1be3f2b7a1a9c858067ab3666195e36c47c9b2fe716c62e4e446ec47422535a87f981ea7ae853716c3b5381687dfc4c840db6479d23905b3fdbd079bf#npm:3.1.1"],
@@ -29110,6 +29111,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-fast-compare", "npm:3.2.0"]
           ],
           "packagePeers": [
+            "@types/algoliasearch",
             "@types/react",
             "algoliasearch",
             "react"
@@ -32510,7 +32512,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["graphql", "npm:14.6.0"],
             ["iterall", "npm:1.3.0"],
             ["symbol-observable", "npm:1.2.0"],
-            ["ws", "npm:5.2.2"]
+            ["ws", "virtual:e464fcb33c75f7effd14d8ce91448bbbb5e16109d03794b02822b5c9b86352828ff3537ed9e4c4d0328f172629cd9d08d1bb12520c96e3f8c2ae4056cccfdb98#npm:5.2.2"]
           ],
           "packagePeers": [
             "@types/graphql",
@@ -32528,7 +32530,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["graphql", null],
             ["iterall", "npm:1.3.0"],
             ["symbol-observable", "npm:1.2.0"],
-            ["ws", "npm:5.2.2"]
+            ["ws", "virtual:e464fcb33c75f7effd14d8ce91448bbbb5e16109d03794b02822b5c9b86352828ff3537ed9e4c4d0328f172629cd9d08d1bb12520c96e3f8c2ae4056cccfdb98#npm:5.2.2"]
           ],
           "packagePeers": [
             "@types/graphql",
@@ -35405,7 +35407,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["webpack-cli", null],
             ["webpack-dev-middleware", "virtual:ed266f3f91846e29655aeac7183fc26f8d6448132d8946974d5a85cdc46821c27477c717701330a230e4751fd77548492ce17b4308c660bdf9b589cc31fc5b76#npm:3.7.2"],
             ["webpack-log", "npm:2.0.0"],
-            ["ws", "npm:6.2.1"],
+            ["ws", "virtual:464c40fef8cd9c4629dc57bdcbc0da6c064017043c87638761c4241ddfc4b2dd80534769ea6cc0e28caf4148d848798661a9641cbf76a47278b9010b2fe0ee9c#npm:6.2.1"],
             ["yargs", "npm:13.3.2"]
           ],
           "packagePeers": [
@@ -35969,27 +35971,39 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["ws", [
-        ["npm:5.2.2", {
-          "packageLocation": "./.yarn/cache/ws-npm-5.2.2-173bcd57b2-c8217b5482.zip/node_modules/ws/",
+        ["virtual:3b5e69efaa2372701eeacd25836edffb24542c8451116315f985d26186b219fb4485f91e0a94a6978db5d292a078b1c57ceaae51a63ec1c16cb40561723db94c#npm:6.1.4", {
+          "packageLocation": "./.yarn/$$virtual/ws-virtual-f68ec3df6c/0/cache/ws-npm-6.1.4-7bee7fd05f-74c2245736.zip/node_modules/ws/",
           "packageDependencies": [
-            ["ws", "npm:5.2.2"],
-            ["async-limiter", "npm:1.0.0"]
+            ["ws", "virtual:3b5e69efaa2372701eeacd25836edffb24542c8451116315f985d26186b219fb4485f91e0a94a6978db5d292a078b1c57ceaae51a63ec1c16cb40561723db94c#npm:6.1.4"],
+            ["@types/bufferutil", null],
+            ["@types/utf-8-validate", null],
+            ["async-limiter", "npm:1.0.0"],
+            ["bufferutil", null],
+            ["utf-8-validate", null]
+          ],
+          "packagePeers": [
+            "@types/bufferutil",
+            "@types/utf-8-validate",
+            "bufferutil",
+            "utf-8-validate"
           ],
           "linkType": "HARD",
         }],
-        ["npm:6.1.4", {
-          "packageLocation": "./.yarn/cache/ws-npm-6.1.4-7bee7fd05f-74c2245736.zip/node_modules/ws/",
+        ["virtual:464c40fef8cd9c4629dc57bdcbc0da6c064017043c87638761c4241ddfc4b2dd80534769ea6cc0e28caf4148d848798661a9641cbf76a47278b9010b2fe0ee9c#npm:6.2.1", {
+          "packageLocation": "./.yarn/$$virtual/ws-virtual-ffb2c9c635/0/cache/ws-npm-6.2.1-bbe0ef9859-35d32b09e2.zip/node_modules/ws/",
           "packageDependencies": [
-            ["ws", "npm:6.1.4"],
-            ["async-limiter", "npm:1.0.0"]
+            ["ws", "virtual:464c40fef8cd9c4629dc57bdcbc0da6c064017043c87638761c4241ddfc4b2dd80534769ea6cc0e28caf4148d848798661a9641cbf76a47278b9010b2fe0ee9c#npm:6.2.1"],
+            ["@types/bufferutil", null],
+            ["@types/utf-8-validate", null],
+            ["async-limiter", "npm:1.0.0"],
+            ["bufferutil", null],
+            ["utf-8-validate", null]
           ],
-          "linkType": "HARD",
-        }],
-        ["npm:6.2.1", {
-          "packageLocation": "./.yarn/cache/ws-npm-6.2.1-bbe0ef9859-35d32b09e2.zip/node_modules/ws/",
-          "packageDependencies": [
-            ["ws", "npm:6.2.1"],
-            ["async-limiter", "npm:1.0.0"]
+          "packagePeers": [
+            "@types/bufferutil",
+            "@types/utf-8-validate",
+            "bufferutil",
+            "utf-8-validate"
           ],
           "linkType": "HARD",
         }],
@@ -35999,6 +36013,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ws", "virtual:4ac7945935c7b9baa1c648c30910b97cc4b5310bd9c6e7f82899f24717f03acba3019fca67c456aeaef29db72c35d787ebde17b426ca35ee56f8bb84bc683d77#npm:7.3.1"],
             ["@types/bufferutil", null],
             ["@types/utf-8-validate", null],
+            ["bufferutil", null],
+            ["utf-8-validate", null]
+          ],
+          "packagePeers": [
+            "@types/bufferutil",
+            "@types/utf-8-validate",
+            "bufferutil",
+            "utf-8-validate"
+          ],
+          "linkType": "HARD",
+        }],
+        ["virtual:e464fcb33c75f7effd14d8ce91448bbbb5e16109d03794b02822b5c9b86352828ff3537ed9e4c4d0328f172629cd9d08d1bb12520c96e3f8c2ae4056cccfdb98#npm:5.2.2", {
+          "packageLocation": "./.yarn/$$virtual/ws-virtual-2a492a59ea/0/cache/ws-npm-5.2.2-173bcd57b2-c8217b5482.zip/node_modules/ws/",
+          "packageDependencies": [
+            ["ws", "virtual:e464fcb33c75f7effd14d8ce91448bbbb5e16109d03794b02822b5c9b86352828ff3537ed9e4c4d0328f172629cd9d08d1bb12520c96e3f8c2ae4056cccfdb98#npm:5.2.2"],
+            ["@types/bufferutil", null],
+            ["@types/utf-8-validate", null],
+            ["async-limiter", "npm:1.0.0"],
             ["bufferutil", null],
             ["utf-8-validate", null]
           ],

--- a/.yarn/versions/24923973.yml
+++ b/.yarn/versions/24923973.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -45,10 +45,6 @@ packageExtensions:
   monaco-editor-webpack-plugin@*:
     dependencies:
       webpack: ^4.5.0
-  react-instantsearch-core@*:
-    peerDependenciesMeta:
-      algoliasearch:
-        optional: true
   react-instantsearch-dom@*:
     dependencies:
       react-fast-compare: "*"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -45,9 +45,6 @@ packageExtensions:
   monaco-editor-webpack-plugin@*:
     dependencies:
       webpack: ^4.5.0
-  react-instantsearch-dom@*:
-    dependencies:
-      react-fast-compare: "*"
   typedoc@*:
     peerDependenciesMeta:
       "@strictsoftware/typedoc-plugin-monorepo":

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -10,7 +10,7 @@ const optionalPeerDep = {
 
 export const packageExtensions: Array<[string, PackageExtensionData]> = [
   // https://github.com/SamVerschueren/stream-to-observable/pull/5
-  [`@samverschueren/stream-to-observable@*`, {
+  [`@samverschueren/stream-to-observable@<0.3.1`, {
     peerDependenciesMeta: {
       [`rxjs`]: optionalPeerDep,
       [`zenObservable`]: optionalPeerDep,
@@ -30,7 +30,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/visionmedia/debug/pull/727
-  [`debug@*`, {
+  [`debug@<4.2.0`, {
     peerDependenciesMeta: {
       [`supports-color`]: optionalPeerDep,
     },
@@ -78,7 +78,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/vadimdemedes/ink-select-input/pull/26
-  [`ink-select-input@*`, {
+  [`ink-select-input@<4.1.0`, {
     peerDependencies: {
       react: `^16.8.2`,
     },

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -193,4 +193,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'utf-8-validate': optionalPeerDep,
     },
   }],
+  // https://github.com/tajo/react-portal/pull/233
+  [`react-portal@*`, {
+    peerDependencies: {
+      'react-dom': `^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -182,4 +182,15 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'react-fast-compare': `^3.0.0`,
     },
   }],
+  // https://github.com/websockets/ws/pull/1626
+  [`ws@<7.2.1`, {
+    peerDependencies: {
+      bufferutil: `^4.0.1`,
+      'utf-8-validate': `^5.0.2`,
+    },
+    peerDependenciesMeta: {
+      bufferutil: optionalPeerDep,
+      'utf-8-validate': optionalPeerDep,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -176,4 +176,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       algoliasearch: `>= 3.1 < 5`,
     },
   }],
+  // https://github.com/algolia/react-instantsearch/pull/2975
+  [`react-instantsearch-dom@<=6.7.0`, {
+    dependencies: {
+      'react-fast-compare': `^3.0.0`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -170,4 +170,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       graphql: `14 - 15`,
     },
   }],
+  // https://github.com/algolia/react-instantsearch/pull/2975
+  [`react-instantsearch-core@<=6.7.0`, {
+    peerDependencies: {
+      algoliasearch: `>= 3.1 < 5`,
+    },
+  }],
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -22158,17 +22158,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-fast-compare@npm:*, react-fast-compare@npm:^3.0.0, react-fast-compare@npm:^3.1.1":
-  version: 3.2.0
-  resolution: "react-fast-compare@npm:3.2.0"
-  checksum: 6fe65c889eb4f326e97769135f97b3d63ac68737866f9c37f9625c9de4f5eaa9abed6f748eb3fd6a66808392118842916309cab7cfa99c67991f0c837433d6d2
-  languageName: node
-  linkType: hard
-
 "react-fast-compare@npm:^2.0.1":
   version: 2.0.4
   resolution: "react-fast-compare@npm:2.0.4"
   checksum: 4e4bfc3597414a36ee35977259012fff30c4f13a0e5dcabf958e91991bef8e9a3faee9dd666cfbdb0c2a0f0ddaf242ac2912054caa956a793c4cdff274dc5aec
+  languageName: node
+  linkType: hard
+
+"react-fast-compare@npm:^3.0.0, react-fast-compare@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "react-fast-compare@npm:3.2.0"
+  checksum: 6fe65c889eb4f326e97769135f97b3d63ac68737866f9c37f9625c9de4f5eaa9abed6f748eb3fd6a66808392118842916309cab7cfa99c67991f0c837433d6d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

I have some extensions to add to the compat plugin most of which have been released already but there are still things that depend on old versions so they're added anyways to ease PnP migration.

**How did you fix it?**

Added them

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.