### PR TITLE
docs(website): fix json syntax on the manifest configuration page

### DIFF
--- a/packages/gatsby/src/components/json.tsx
+++ b/packages/gatsby/src/components/json.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   Container,
   Main,
@@ -12,10 +10,13 @@ import {
   Scalar,
 
   Theme,
-  ComponentPropsWithoutTheme,
+
+  themed,
 } from './syntax';
 
 const theme: Theme = {
+  name: `Json`,
+
   colors: {
     background: `#242424`,
     documentation: `#ddddcc`,
@@ -52,30 +53,16 @@ const theme: Theme = {
   },
 };
 
-export const JsonContainer = (props: ComponentPropsWithoutTheme<typeof Container>) => {
-  return <Container {...props} theme={theme} />;
-};
+export const JsonContainer = themed(Container, theme);
 
-export const JsonMain = (props: ComponentPropsWithoutTheme<typeof Main>) => {
-  return <Main {...props} theme={theme} />;
-};
+export const JsonMain = themed(Main, theme);
 
-export const JsonArrayProperty = (props: ComponentPropsWithoutTheme<typeof ArrayProperty>) => {
-  return <ArrayProperty {...props} theme={theme} />;
-};
+export const JsonArrayProperty = themed(ArrayProperty, theme);
 
-export const JsonObjectProperty = (props: ComponentPropsWithoutTheme<typeof DictionaryProperty>) => {
-  return <DictionaryProperty {...props} theme={theme} />;
-};
+export const JsonObjectProperty = themed(DictionaryProperty, theme);
 
-export const JsonScalarProperty = (props: ComponentPropsWithoutTheme<typeof ScalarProperty>) => {
-  return <ScalarProperty {...props} theme={theme} />;
-};
+export const JsonScalarProperty = themed(ScalarProperty, theme);
 
-export const JsonDictionary = (props: ComponentPropsWithoutTheme<typeof Dictionary>) => {
-  return <Dictionary {...props} theme={theme}/>;
-};
+export const JsonDictionary = themed(Dictionary, theme);
 
-export const JsonScalar = (props: ComponentPropsWithoutTheme<typeof Scalar>) => {
-  return <Scalar {...props} theme={theme} />;
-};
+export const JsonScalar = themed(Scalar, theme);

--- a/packages/gatsby/src/components/syml.tsx
+++ b/packages/gatsby/src/components/syml.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   Container,
   Main,
@@ -11,11 +9,14 @@ import {
   Scalar,
 
   Theme,
-  ComponentPropsWithoutTheme,
   Dictionary,
+
+  themed,
 } from './syntax';
 
 const theme: Theme = {
+  name: `Syml`,
+
   colors: {
     background: `#3f3f3f`,
     documentation: `#ddddcc`,
@@ -52,30 +53,16 @@ const theme: Theme = {
   },
 };
 
-export const SymlContainer = (props: ComponentPropsWithoutTheme<typeof Container>) => {
-  return <Container {...props} theme={theme} />;
-};
+export const SymlContainer = themed(Container, theme);
 
-export const SymlMain = (props: ComponentPropsWithoutTheme<typeof Main>) => {
-  return <Main {...props} theme={theme} />;
-};
+export const SymlMain = themed(Main, theme);
 
-export const SymlArrayProperty = (props: ComponentPropsWithoutTheme<typeof ArrayProperty>) => {
-  return <ArrayProperty {...props} theme={theme} />;
-};
+export const SymlArrayProperty = themed(ArrayProperty, theme);
 
-export const SymlObjectProperty = (props: ComponentPropsWithoutTheme<typeof DictionaryProperty>) => {
-  return <DictionaryProperty {...props} theme={theme} />;
-};
+export const SymlObjectProperty = themed(DictionaryProperty, theme);
 
-export const SymlScalarProperty = (props: ComponentPropsWithoutTheme<typeof ScalarProperty>) => {
-  return <ScalarProperty {...props} theme={theme} />;
-};
+export const SymlScalarProperty = themed(ScalarProperty, theme);
 
-export const SymlDictionary = (props: ComponentPropsWithoutTheme<typeof Dictionary>) => {
-  return <Dictionary {...props} theme={theme}/>;
-};
+export const SymlDictionary = themed(Dictionary, theme);
 
-export const SymlScalar = (props: ComponentPropsWithoutTheme<typeof Scalar>) => {
-  return <Scalar {...props} theme={theme} />;
-};
+export const SymlScalar = themed(Scalar, theme);

--- a/packages/gatsby/src/components/syntax.tsx
+++ b/packages/gatsby/src/components/syntax.tsx
@@ -289,7 +289,7 @@ export const ScalarProperty = ({theme, name, anchor = name, placeholder, descrip
   </Describe>
 </>;
 
-export function themed<T extends ThemeProps>(BaseComponent: React.ComponentType<T> | StyledComponent<any, ThemeProps, any>, theme: Theme) {
+export function themed<T extends ThemeProps>(BaseComponent: React.ComponentType<T> | StyledComponent<any, T, any>, theme: Theme) {
   const ThemedComponent = (props: T) => <BaseComponent {...props} theme={theme} />;
 
   ThemedComponent.BaseComponent = BaseComponent;

--- a/packages/gatsby/src/components/syntax.tsx
+++ b/packages/gatsby/src/components/syntax.tsx
@@ -1,11 +1,11 @@
 import {css}                                  from '@emotion/core';
-import styled                                 from '@emotion/styled';
+import styled, {StyledComponent}              from '@emotion/styled';
 import {FaLink}                               from 'react-icons/fa';
 import React, {PropsWithChildren, useContext} from 'react';
 
-import {SymlScalar}                           from './syml';
-
 export type Theme = {
+  name: string;
+
   colors: {
     background: string;
     documentation: string;
@@ -41,10 +41,6 @@ export type Theme = {
 export type ThemeProps = {
   theme: Theme;
 };
-
-export type ComponentPropsWithoutTheme<
-  T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = Omit<React.ComponentProps<T>, 'theme'>;
 
 const getColorForScalar = (theme: Theme, scalar: unknown) => {
   if (typeof scalar === `string`)
@@ -224,7 +220,7 @@ export type ArrayProps = KeyProps & {
 
 export const Array = ({theme, name, suffix, anchorTarget, children}: PropsWithChildren<ArrayProps>) => <div>
   <div>{name && <><Key theme={theme} name={name} anchorTarget={anchorTarget} /></>}{theme.arrays.leading}</div>
-  <div style={{position: `relative`, paddingLeft: `2em`, top: !(children as any).every((child: any) => child.type === SymlScalar) ? `2em` : ``}}>
+  <div style={{position: `relative`, paddingLeft: `2em`, top: !(children as any).every((child: any) => child.type.BaseComponent === Scalar) ? `2em` : ``}}>
     {React.Children.map(children, (child, index) =>
       <div key={index} style={{display: `flex`}}>
         <div>{theme.arrays.prefix}</div>
@@ -292,3 +288,12 @@ export const ScalarProperty = ({theme, name, anchor = name, placeholder, descrip
     </div>
   </Describe>
 </>;
+
+export function themed<T extends ThemeProps>(BaseComponent: React.ComponentType<T> | StyledComponent<any, ThemeProps, any>, theme: Theme) {
+  const ThemedComponent = (props: T) => <BaseComponent {...props} theme={theme} />;
+
+  ThemedComponent.BaseComponent = BaseComponent;
+  ThemedComponent.displayName = `${theme.name}${BaseComponent.displayName ?? BaseComponent.name}`;
+
+  return ThemedComponent;
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The elements of array properties inside the Manifest configuration page on the website got a bit scared of the `logFilters` introduced in https://github.com/yarnpkg/berry/pull/1907 and started breaking free:

![image](https://user-images.githubusercontent.com/32596136/100548849-d6bade80-3277-11eb-808b-79ed597c9ef1.png)


**How did you fix it?**
<!-- A detailed description of your implementation. -->

By trapping them back inside the arrays.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
