### PR TITLE
fix(shell): handle redirecting to /dev/null

### DIFF
--- a/.yarn/versions/6e262e49.yml
+++ b/.yarn/versions/6e262e49.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -836,6 +836,22 @@ describe(`Shell`, () => {
         });
       });
     });
+
+    describe(`>`, () => {
+      it(`should support redirecting to /dev/null`, async () => {
+        await expect(bufferResult(`(echo foo > /dev/null) && echo bar`)).resolves.toMatchObject({
+          stdout: `bar\n`,
+        });
+      });
+    });
+
+    describe(`>>`, () => {
+      it(`should support redirecting to /dev/null`, async () => {
+        await expect(bufferResult(`(echo foo >> /dev/null) && echo bar`)).resolves.toMatchObject({
+          stdout: `bar\n`,
+        });
+      });
+    });
   });
 
   describe(`Lists`, () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Redirecting output to `/dev/null` on Windows would cause the shell to crash which meant that installing Yarn v1 using Yarn v2 wasn't possible on Windows.

**How did you fix it?**

Send all redirects to `/dev/null` to a writable stream that does nothing with the data

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.