### PR TITLE
[node_modules] Prevents aliased packages to include themselves

### DIFF
--- a/.yarn/versions/d66325dd.yml
+++ b/.yarn/versions/d66325dd.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@
 
 - Progress bars are rendered less often, which should help performances on some terminals.
 
+- Aliased packages no longer include themselves in node_modules installs
+
 ### CLI
 
-- The `upgrade-interactive` command will now only show upgrade suggestions for packages that have available upgrades (rather than all of them). 
+- The `upgrade-interactive` command will now only show upgrade suggestions for packages that have available upgrades (rather than all of them).
 
 - The `upgrade-interactive` command has received UI improvements that should make it easier to look at.
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -342,7 +342,7 @@ describe(`Node_Modules`, () => {
           version: `1.0.0`,
         });
         // We must not create self-reference directory 'node_modules/no-deps2/node_modules/no-deps'
-        expect(await xfs.existsPromise(`${path}/node_modules/no-deps2/node_modules/no-deps` as PortablePath)).toEqual(false);
+        await expect(xfs.existsPromise(`${path}/node_modules/no-deps2/node_modules/no-deps` as PortablePath)).resolves.toEqual(false);
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -341,6 +341,8 @@ describe(`Node_Modules`, () => {
           name: `no-deps-bins`,
           version: `1.0.0`,
         });
+        // We must not create self-reference directory 'node_modules/no-deps2/node_modules/no-deps'
+        expect(await xfs.existsPromise(`${path}/node_modules/no-deps2/node_modules/no-deps` as PortablePath)).toEqual(false);
       },
     ),
   );

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -384,7 +384,7 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
 
     for (const dep of pkg.dependencies) {
       // We do not want self-references in node_modules, since they confuse existing tools
-      if (dep === pkg || (pkg.identName.endsWith(WORKSPACE_NAME_SUFFIX) && dep.identName === pkg.identName.replace(WORKSPACE_NAME_SUFFIX, ``)))
+      if (dep === pkg || dep.identName === pkg.identName.replace(WORKSPACE_NAME_SUFFIX, ``))
         continue;
       const references = Array.from(dep.references).sort();
       const locator = {name: dep.identName, reference: references[0]};


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Aliased packages now include themselves during node_modules installs, thanks to @non25 for finding the bug.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have fixed the condition to detect self-references, actually simplified it and added the check into existing unit test.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
