### PR TITLE
fix: Display of latest and range matches

### DIFF
--- a/.yarn/versions/5bb5e685.yml
+++ b/.yarn/versions/5bb5e685.yml
@@ -1,0 +1,4 @@
+releases:
+  "@yarnpkg/libui": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -127,6 +127,10 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       }
 
       if (latest && latest !== resolution && latest !== descriptor.range) {
+        // If we don't also have a range match, then we need to put a spacer value in.
+        if (suggestions.length == 1)
+          suggestions.push({value: null, label: ``});
+
         suggestions.push({
           value: latest,
           label: colorizeVersionDiff(descriptor.range, latest),

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -124,17 +124,18 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
           value: resolution,
           label: colorizeVersionDiff(descriptor.range, resolution),
         });
+      } else {
+        suggestions.push({value: null, label: ``});
       }
 
       if (latest && latest !== resolution && latest !== descriptor.range) {
         // If we don't also have a range match, then we need to put a spacer value in.
-        if (suggestions.length == 1)
-          suggestions.push({value: null, label: ``});
-
         suggestions.push({
           value: latest,
           label: colorizeVersionDiff(descriptor.range, latest),
         });
+      } else {
+        suggestions.push({value: null, label: ``});
       }
 
       return suggestions;

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -129,7 +129,6 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       }
 
       if (latest && latest !== resolution && latest !== descriptor.range) {
-        // If we don't also have a range match, then we need to put a spacer value in.
         suggestions.push({
           value: latest,
           label: colorizeVersionDiff(descriptor.range, latest),

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -55,10 +55,10 @@ export const ItemOptions = function <T>({
 
       return (
         <Box key={label} width={boxWidth} marginLeft={1}>
-          <Text wrap="truncate">
+          <Text wrap={`truncate`}>
             <Gem active={isGemActive} />{` `}{label}
           </Text>
-          { skewer ? <Pad active={active} length={padWidth}/> : null }
+          {skewer ? <Pad active={active} length={padWidth}/> : null}
         </Box>
       );
     })}

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -41,6 +41,13 @@ export const ItemOptions = function <T>({
         .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, ``);
 
       const padWidth = Math.max(0, boxWidth - (simpleLabel).length - 2);
+
+      if (!label) {
+        return (
+          <Box key={index} width={boxWidth} marginLeft={1} />
+        );
+      }
+
       return (
         <Box key={label} width={boxWidth} marginLeft={1}>
           <Text wrap="truncate">

--- a/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
+++ b/packages/yarnpkg-libui/sources/components/ItemOptions.tsx
@@ -21,8 +21,12 @@ export const ItemOptions = function <T>({
   onChange: (value: T) => void,
   sizes?: Array<number>
 }) {
-  const values = options.map(({value}) => value);
-  const selectedIndex = values.indexOf(value);
+  // Our possible values are those that have been provided with a label so that
+  // the user can see what they're selecting.
+  const values = options.filter(({label}) => !!label).map(({value}) => value);
+  const selectedIndex = options.findIndex(o => {
+    return o.value === value && o.label != ``;
+  });
 
   useListInput(value, values, {
     active,
@@ -35,6 +39,7 @@ export const ItemOptions = function <T>({
     {options.map(({label}, index) => {
       const isGemActive = index === selectedIndex;
       const boxWidth = sizes[index] -1 || 0;
+
       const simpleLabel = label
         // https://stackoverflow.com/a/29497680
         // eslint-disable-next-line no-control-regex
@@ -44,7 +49,7 @@ export const ItemOptions = function <T>({
 
       if (!label) {
         return (
-          <Box key={index} width={boxWidth} marginLeft={1} />
+          <Box key={`spacer-${index}`} width={boxWidth} marginLeft={1}/>
         );
       }
 

--- a/packages/yarnpkg-libui/sources/components/Pad.tsx
+++ b/packages/yarnpkg-libui/sources/components/Pad.tsx
@@ -12,7 +12,7 @@ export const Pad = ({length, active}: PadProps) => {
     return null;
 
   const text = length > 1
-    ? ` ${chalk.underline(` `.repeat(length - 1))}`
+    ? ` ${`-`.repeat(length - 1)}`
     : ` `;
 
   return <Text dimColor={!active}>{text}</Text>;

--- a/packages/yarnpkg-libui/sources/components/Pad.tsx
+++ b/packages/yarnpkg-libui/sources/components/Pad.tsx
@@ -1,4 +1,3 @@
-import chalk  from 'chalk';
 import {Text} from 'ink';
 import React  from 'react';
 


### PR DESCRIPTION
When we don't have a range match, but we do have a latest match, show it in the correct column.

fixes #2200

...

**How did you fix it?**
In order to ensure we always display three columns of upgrade choices, we always provide three options. However, those that shouldn't be displayed as selectable options have an empty string for the label value. When choosing which ItemOptions should be keyboard selectable, we filter out those that don't have labels. This ties up with the fact that no label means a user can't see it to select it.

![fix2200](https://user-images.githubusercontent.com/1522832/101609106-77d73100-39fe-11eb-84a6-148945813b12.gif)


<strike>
**What is still broken?** 

Selecting the latest version in an intuitive manner. Consider the options presented for an upgrade with latest, but no range match:

```
[ { value: null, label: '3.9.0' }, {value: null, label: '' }, { value: '4.0.0', label: '4.0.0' }]
```

When we press right from the first column, `ItemOption` is still passed `null` as a value, and the first index it finds with that value is zero so it doesn't move the selection. Pressing left works fine. 

I'm not sure where best to manage the exception here; the keypress handler seems like a bad place to put an exception as it's currently very generic about the options it takes and it would need to take into account looping. I considered adding some wrapping around the `onChange` in `ItemOptions` to make it skip instead, but the solution there would be to repeat the last keypress to get the correct direction, and I don't think we know what that is.

If there are other column lists with skippable entries being created anywhere that I can use as inspiration, please let me know!
</strike>
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
