### PR TITLE
Fixes running yarn version check -i without changes

### DIFF
--- a/.yarn/versions/b749aab5.yml
+++ b/.yarn/versions/b749aab5.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -187,7 +187,7 @@ export default class VersionCheckCommand extends Command<CommandContext> {
     };
 
     const useReleases = (): [Releases, (workspace: Workspace, decision: versionUtils.Decision) => void] => {
-      const [releases, setReleases] = useState<Releases>(versionFile.releases);
+      const [releases, setReleases] = useState<Releases>(() => new Map(versionFile.releases));
 
       const setWorkspaceRelease = useCallback((workspace: Workspace, decision: versionUtils.Decision) => {
         const copy = new Map(releases);


### PR DESCRIPTION
**What's the problem this PR addresses?**
The `useReleases` hook wasn't making a clone of the source map, so when we returned without doing any change the returned array was still the source map - and since we were cleaning it before injecting the new changes, previous decisions were completely erased.

Fixes #2231 

**How did you fix it?**
We now keep a copy of the original releases, and we don't mutate the original one until the program exits.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
