### PR TITLE
Adds an extension for CRA

### DIFF
--- a/.yarn/versions/651a3475.yml
+++ b/.yarn/versions/651a3475.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -199,4 +199,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'react-dom': `^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0`,
     },
   }],
+  // https://github.com/facebook/create-react-app/pull/9872
+  [`create-react-app@*`, {
+    peerDependencies: {
+      [`react`]: `*`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
CRA hasn't merged https://github.com/facebook/create-react-app/pull/9872 yet, causing our tests to fail for two months.

**How did you fix it?**
I've added a forced peer dependency on React to CRA; I couldn't update `react-refresh` since package extensions can no longer override dependencies, but that should be enough for our tests.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
