### PR TITLE
fix(core): use non-webpack require for cache busting

### DIFF
--- a/.yarn/versions/f5ab92bd.yml
+++ b/.yarn/versions/f5ab92bd.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Cache busting didn't properly work, which leads to problems e.g. when trying to execute things after an installation.

I've got a plugin that updates manifests, runs an installation and then runs a command (`ng update <package that was updated> --migrateOnly --from <previous version>`).
If the package providing that command (`@angular/cli`) got updated, the command fails with

```
➤ YN0000: ┌ Running migrations
➤ YN0000: │ Migrating @angular/cli from 11.0.3 to 11.0.4
➤ YN0001: │ UsageError: Couldn't find @angular/cli@npm:11.0.4 in the currently installed PnP map - running an install might help
    at S.findPackageLocation (/redacted/.yarn/releases/yarn-2.4.0.cjs:2:265399)
    at P (/redacted/.yarn/releases/yarn-2.4.0.cjs:2:428606)
    at U (/redacted/.yarn/releases/yarn-2.4.0.cjs:2:428949)
    at Module.T (/redacted/.yarn/releases/yarn-2.4.0.cjs:2:429498)
    at /redacted/yarn-plugin-angular/bundles/@yarnpkg/plugin-angular.dev.js:39769:67
    at a.mktempPromise (/redacted/.yarn/releases/yarn-2.4.0.cjs:2:513904)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async /redacted/yarn-plugin-angular/bundles/@yarnpkg/plugin-angular.dev.js:39761:17
    at async f.startTimerPromise (/redacted/.yarn/releases/yarn-2.4.0.cjs:2:389740)
```

The cause lies in `miscUtils.dynamicRequireNoCache`, which clears the cache of webpack's require function rather than node's require function.

**How did you fix it?**

Have `dynamicRequireNoCache` clear the dynamic require's cache and node's module rather than webpack's require and webpack's module.


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
