### PR TITLE
fix(constraints): make constraints --fix persist changes to manifest

### DIFF
--- a/.yarn/versions/273ab9b6.yml
+++ b/.yarn/versions/273ab9b6.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch


### PR DESCRIPTION
**What's the problem this PR addresses?**

The change introduced in #1775 to fix fixing the field constraints
broke fixing dependency constraints, by overriding the changes made
to the manifest before persisting.

Fixes #2242

**How did you fix it?**

Dependency constraints work on the Manifest, field constraints work on the raw JSON object. Sync the two after every execution of the constraints to ensure every iteration uses the correct values.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
