### PR TITLE
docs(plugin-init): add missing equals sign to -i example

### DIFF
--- a/.yarn/versions/9f429226.yml
+++ b/.yarn/versions/9f429226.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-init": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -47,7 +47,7 @@ export default class InitCommand extends BaseCommand {
       `yarn init -p`,
     ], [
       `Create a new package and store the Yarn release inside`,
-      `yarn init -i latest`,
+      `yarn init -i=latest`,
     ], [
       `Create a new private package and defines it as a workspace root`,
       `yarn init -w`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The example for `yarn init -i` was missing a equals sign

Closes https://github.com/yarnpkg/berry/issues/2248

**How did you fix it?**

Add the missing equals sign

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.