### PR TITLE
fix(core): always call callback in DefaultStream._flush

### DIFF
--- a/.yarn/versions/19147bf1.yml
+++ b/.yarn/versions/19147bf1.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -225,6 +225,8 @@ export class DefaultStream extends Transform {
   _flush(cb: any) {
     if (this.active && this.ifEmpty.length > 0) {
       cb(null, this.ifEmpty);
+    } else {
+      cb(null);
     }
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`DefaultStream._flush` doesn't call the callback if the stream isn't empty which, because [node 15 waits for it](https://github.com/nodejs/node/pull/34314), causes the event loop to become empty and the process exits early during `workspaces foreach` calls

Note that the tests catch this when they run under node 15 but I can't enable it because of https://github.com/yarnpkg/berry/issues/2232

**How did you fix it?**

Always call the callback.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.