### PR TITLE
fix(plugin-npm) use semver from semver utils

### DIFF
--- a/.yarn/versions/b339a0bb.yml
+++ b/.yarn/versions/b339a0bb.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -54,7 +54,7 @@ export class NpmSemverResolver implements Resolver {
     });
 
     const candidates = Object.keys(registryData.versions)
-      .map(version => new semver.SemVer(version))
+      .map(version => new semverUtils.SemVer(version))
       .filter(version => range.test(version));
 
     const noDeprecatedCandidates = candidates.filter(version => {
@@ -90,7 +90,7 @@ export class NpmSemverResolver implements Resolver {
     return references
       .map(reference => {
         try {
-          return new semver.SemVer(reference.slice(PROTOCOL.length));
+          return new semverUtils.SemVer(reference.slice(PROTOCOL.length));
         } catch {
           return null;
         }

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -1,5 +1,7 @@
 import semver from 'semver';
 
+export {SemVer} from 'semver';
+
 /**
  * Returns whether the given semver version satisfies the given range. Notably
  * this supports prerelease versions so that "2.0.0-rc.0" satisfies the range


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Closes https://github.com/yarnpkg/berry/issues/2224
This PR solves an issue with getting a different instance of semver in plugin-npm and in the core.
Complete details can be found in the mentioned issue.
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
Instead of using SemVer class from the semver package directly in plugin-npm, I explored the class from the semverUtils and use it from there.
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
