### PR TITLE
chore(cli): throw on broken node v14.10.0

### DIFF
--- a/.yarn/versions/e3ed0187.yml
+++ b/.yarn/versions/e3ed0187.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -61,9 +61,10 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     // - 10.16+ for Brotli support on `plugin-compat`
     // - 10.17+ to silence `got` warning on `dns.promises`
     // - 14.0 and 14.1 empty http responses - https://github.com/sindresorhus/got/issues/1496
+    // - 14.10.0 broken streams - https://github.com/nodejs/node/pull/34035 (fix: https://github.com/nodejs/node/commit/0f94c6b4e4)
 
     const version = process.versions.node;
-    const range = `>=10.17 <14 || >14.1`;
+    const range = `>=10.17 <14 || 14.2 - 14.9 || >14.10.0`;
 
     if (process.env.YARN_IGNORE_NODE !== `1` && !semverUtils.satisfiesWithPrereleases(version, range))
       throw new UsageError(`This tool requires a Node version compatible with ${range} (got ${version}). Upgrade Node, or set \`YARN_IGNORE_NODE=1\` in your environment.`);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
`node v14.10.0` introduce a regression into `streams` which was fixed in https://github.com/nodejs/node/commit/0f94c6b4e4. This causes an issue for `yarn install` which uses `streams` for fetching packages.

**How did you fix it?**
<!-- A detailed description of your implementation. -->
A modification to the `semver` string used by `yarnpkg-cli` was sufficient to address this (thanks @merceyz).


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
-  [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
