### PR TITLE
fix(core): reset existing properties in Manifest#load

### DIFF
--- a/.yarn/versions/6e86083a.yml
+++ b/.yarn/versions/6e86083a.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -8,6 +8,9 @@ describe(`Commands`, () => {
   };
 
   const manifest = {
+    workspaces: [
+      `packages/*`,
+    ],
     dependencies: {
       'is-number': `1.0.0`,
     },
@@ -53,6 +56,19 @@ describe(`Commands`, () => {
 
       expect(fixedManifest.dependencies[`is-number`]).toBe(`2.0.0`);
       expect(fixedManifest.license).toBe(`BSD-2-Clause`);
+    }));
+
+    test(`test applying fix shouldn't duplicate workspaces`, makeTemporaryEnv(manifest, config, async ({path, run, source}) => {
+      await xfs.writeFilePromise(`${path}/constraints.pro`, `
+      gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
+      gen_enforced_field('.', 'license', 'BSD-2-Clause').
+      `);
+
+      await run(`constraints`, `--fix`);
+
+      const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
+
+      expect(fixedManifest.workspaces.length).toBe(1);
     }));
   });
 });

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -184,6 +184,7 @@ export class Manifest {
     this.raw = data;
     const errors: Array<Error> = [];
 
+    this.name = null;
     if (typeof data.name === `string`) {
       try {
         this.name = structUtils.parseIdent(data.name);
@@ -194,6 +195,8 @@ export class Manifest {
 
     if (typeof data.version === `string`)
       this.version = data.version;
+    else
+      this.version = null;
 
     if (Array.isArray(data.os)) {
       const os: Array<string> = [];
@@ -206,6 +209,8 @@ export class Manifest {
           os.push(item);
         }
       }
+    } else {
+      this.os = null;
     }
 
     if (Array.isArray(data.cpu)) {
@@ -219,25 +224,39 @@ export class Manifest {
           cpu.push(item);
         }
       }
+    } else {
+      this.cpu = null;
     }
 
     if (typeof data.type === `string`)
       this.type = data.type;
+    else
+      this.type = null;
 
     if (typeof data.private === `boolean`)
       this.private = data.private;
+    else
+      this.private = false;
 
     if (typeof data.license === `string`)
       this.license = data.license;
+    else
+      this.license = null;
 
     if (typeof data.languageName === `string`)
       this.languageName = data.languageName;
+    else
+      this.languageName = null;
 
     if (typeof data.main === `string`)
       this.main = normalizeSlashes(data.main);
+    else
+      this.main = null;
 
     if (typeof data.module === `string`)
       this.module = normalizeSlashes(data.module);
+    else
+      this.module = null;
 
     if (data.browser != null) {
       if (typeof data.browser === `string`) {
@@ -251,11 +270,14 @@ export class Manifest {
           );
         }
       }
+    } else {
+      this.browser = null;
     }
 
+    this.bin = new Map();
     if (typeof data.bin === `string`) {
       if (this.name !== null) {
-        this.bin = new Map([[this.name.name, normalizeSlashes(data.bin)]]);
+        this.bin.set(this.name.name, normalizeSlashes(data.bin));
       } else {
         errors.push(new Error(`String bin field, but no attached package name`));
       }
@@ -270,6 +292,7 @@ export class Manifest {
       }
     }
 
+    this.scripts = new Map();
     if (typeof data.scripts === `object` && data.scripts !== null) {
       for (const [key, value] of Object.entries(data.scripts)) {
         if (typeof value !== `string`) {
@@ -281,6 +304,7 @@ export class Manifest {
       }
     }
 
+    this.dependencies = new Map();
     if (typeof data.dependencies === `object` && data.dependencies !== null) {
       for (const [name, range] of Object.entries(data.dependencies)) {
         if (typeof range !== `string`) {
@@ -301,6 +325,7 @@ export class Manifest {
       }
     }
 
+    this.devDependencies = new Map();
     if (typeof data.devDependencies === `object` && data.devDependencies !== null) {
       for (const [name, range] of Object.entries(data.devDependencies)) {
         if (typeof range !== `string`) {
@@ -321,6 +346,7 @@ export class Manifest {
       }
     }
 
+    this.peerDependencies = new Map();
     if (typeof data.peerDependencies === `object` && data.peerDependencies !== null) {
       for (let [name, range] of Object.entries(data.peerDependencies)) {
         let ident;
@@ -350,6 +376,7 @@ export class Manifest {
         ? data.workspaces.packages
         : [];
 
+    this.workspaceDefinitions = [];
     for (const entry of workspaces) {
       if (typeof entry !== `string`) {
         errors.push(new Error(`Invalid workspace definition for '${entry}'`));
@@ -361,6 +388,7 @@ export class Manifest {
       });
     }
 
+    this.dependenciesMeta = new Map();
     if (typeof data.dependenciesMeta === `object` && data.dependenciesMeta !== null) {
       for (const [pattern, meta] of Object.entries(data.dependenciesMeta) as Array<[string, any]>) {
         if (typeof meta !== `object` || meta === null) {
@@ -393,6 +421,7 @@ export class Manifest {
       }
     }
 
+    this.peerDependenciesMeta = new Map();
     if (typeof data.peerDependenciesMeta === `object` && data.peerDependenciesMeta !== null) {
       for (const [pattern, meta] of Object.entries(data.peerDependenciesMeta) as Array<[string, any]>) {
         if (typeof meta !== `object` || meta === null) {
@@ -413,6 +442,7 @@ export class Manifest {
       }
     }
 
+    this.resolutions = [];
     if (typeof data.resolutions === `object` && data.resolutions !== null) {
       for (const [pattern, reference] of Object.entries(data.resolutions)) {
         if (typeof reference !== `string`) {
@@ -440,6 +470,8 @@ export class Manifest {
 
         this.files.add(filename as PortablePath);
       }
+    } else {
+      this.files = null;
     }
 
     if (typeof data.publishConfig === `object` && data.publishConfig !== null) {
@@ -502,6 +534,8 @@ export class Manifest {
           this.publishConfig.executableFiles.add(normalizeSlashes(value));
         }
       }
+    } else {
+      this.publishConfig = null;
     }
 
     if (typeof data.installConfig === `object` && data.installConfig !== null) {
@@ -518,6 +552,8 @@ export class Manifest {
           errors.push(new Error(`Unrecognized installConfig key: ${key}`));
         }
       }
+    } else {
+      this.installConfig = null;
     }
 
     // We treat optional dependencies after both the regular dependency field
@@ -555,6 +591,8 @@ export class Manifest {
 
     if (typeof data.preferUnplugged === `boolean`)
       this.preferUnplugged = data.preferUnplugged;
+    else
+      this.preferUnplugged = null;
 
     this.errors = errors;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

As mentioned by @merceyz  in https://github.com/yarnpkg/berry/pull/2245#issuecomment-748990256, #1775 introduced another bug because `Manifest#load` unconditionally adds to the `workspaceDefinitions` array which leads to duplicate entries in workspaces (and only in workspaces AFAICT) when constraints are fixed.

**How did you fix it?**

Reset existing manifest properties during `Manifest#load`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
