### PR TITLE
fix(builder): ensure version segment does not start with zero

### DIFF
--- a/.yarn/versions/ee6dfd28.yml
+++ b/.yarn/versions/ee6dfd28.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -23,7 +23,7 @@ const pkgJsonVersion = (basedir: string): string => {
 const suggestHash = async (basedir: string) => {
   try {
     const unique = await execFile(`git`, [`show`, `-s`, `--pretty=format:%ad.%t`, `--date=short`], {cwd: basedir});
-    return `git.${unique.stdout.trim().replace(/-/g, ``)}`;
+    return `git.${unique.stdout.trim().replace(/-/g, ``).replace(`.`, `.hash-`)}`;
   } catch {
     return null;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

When building from sources the hash `@yarnpkg/builder` adds to the version can start with zero (`0`) which is not valid semver

Fixes the failing tests in https://github.com/yarnpkg/berry/pull/2261

**How did you fix it?**

Prefix the hash segment with `hash-`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.