### PR TITLE
refactor(core)!: remove deprecated structUtils.requirableIdent

### DIFF
--- a/.yarn/versions/98504c20.yml
+++ b/.yarn/versions/98504c20.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - The `initVersion` and `initLicense` configuration options have been removed. `initFields` should be used instead.
 
+### API
+
+- `structUtils.requirableIdent` got removed; use `structUtils.stringifyIdent` instead, which is strictly the same.
+
 ### Settings
 
 - Various `initFields` edge cases have been fixed.

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -167,10 +167,10 @@ class NodeModulesInstaller implements Installer {
 
     for (const [descriptor, locator] of dependencies) {
       const target = !structUtils.areIdentsEqual(descriptor, locator)
-        ? [structUtils.requirableIdent(locator), locator.reference] as [string, string]
+        ? [structUtils.stringifyIdent(locator), locator.reference] as [string, string]
         : locator.reference;
 
-      slot.pnpNode.packageDependencies.set(structUtils.requirableIdent(descriptor), target);
+      slot.pnpNode.packageDependencies.set(structUtils.stringifyIdent(descriptor), target);
     }
   }
 

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -39,7 +39,7 @@ export class PnpLinker implements Linker {
 
     const pnpFile = miscUtils.dynamicRequireNoCache(pnpPath);
 
-    const packageLocator = {name: structUtils.requirableIdent(locator), reference: locator.reference};
+    const packageLocator = {name: structUtils.stringifyIdent(locator), reference: locator.reference};
     const packageInformation = pnpFile.getPackageInformation(packageLocator);
 
     if (!packageInformation)
@@ -101,7 +101,7 @@ export class PnpInstaller implements Installer {
   }
 
   async installPackage(pkg: Package, fetchResult: FetchResult) {
-    const key1 = structUtils.requirableIdent(pkg);
+    const key1 = structUtils.stringifyIdent(pkg);
     const key2 = pkg.reference;
 
     const isWorkspace =
@@ -158,7 +158,7 @@ export class PnpInstaller implements Installer {
     // just ignore their declared peer dependencies.
     if (structUtils.isVirtualLocator(pkg)) {
       for (const descriptor of pkg.peerDependencies.values()) {
-        packageDependencies.set(structUtils.requirableIdent(descriptor), null);
+        packageDependencies.set(structUtils.stringifyIdent(descriptor), null);
         packagePeers.add(structUtils.stringifyIdent(descriptor));
       }
 
@@ -190,10 +190,10 @@ export class PnpInstaller implements Installer {
 
     for (const [descriptor, locator] of dependencies) {
       const target = !structUtils.areIdentsEqual(descriptor, locator)
-        ? [structUtils.requirableIdent(locator), locator.reference] as [string, string]
+        ? [structUtils.stringifyIdent(locator), locator.reference] as [string, string]
         : locator.reference;
 
-      packageInformation.packageDependencies.set(structUtils.requirableIdent(descriptor), target);
+      packageInformation.packageDependencies.set(structUtils.stringifyIdent(descriptor), target);
     }
   }
 
@@ -201,7 +201,7 @@ export class PnpInstaller implements Installer {
     for (const dependentPath of dependentPaths) {
       const packageInformation = this.getDiskInformation(dependentPath);
 
-      packageInformation.packageDependencies.set(structUtils.requirableIdent(locator), locator.reference);
+      packageInformation.packageDependencies.set(structUtils.stringifyIdent(locator), locator.reference);
     }
   }
 
@@ -226,7 +226,7 @@ export class PnpInstaller implements Installer {
     const pnpFallbackMode = this.opts.project.configuration.get(`pnpFallbackMode`);
 
     const blacklistedLocations = blacklistedPaths;
-    const dependencyTreeRoots = this.opts.project.workspaces.map(({anchoredLocator}) => ({name: structUtils.requirableIdent(anchoredLocator), reference: anchoredLocator.reference}));
+    const dependencyTreeRoots = this.opts.project.workspaces.map(({anchoredLocator}) => ({name: structUtils.stringifyIdent(anchoredLocator), reference: anchoredLocator.reference}));
     const enableTopLevelFallback = pnpFallbackMode !== `none`;
     const fallbackExclusionList = [];
     const fallbackPool = new Map();
@@ -237,7 +237,7 @@ export class PnpInstaller implements Installer {
     if (pnpFallbackMode === `dependencies-only`)
       for (const pkg of this.opts.project.storedPackages.values())
         if (this.opts.project.tryWorkspaceByLocator(pkg))
-          fallbackExclusionList.push({name: structUtils.requirableIdent(pkg), reference: pkg.reference});
+          fallbackExclusionList.push({name: structUtils.stringifyIdent(pkg), reference: pkg.reference});
 
     await this.finalizeInstallWithPnp({
       blacklistedLocations,
@@ -382,7 +382,7 @@ export class PnpInstaller implements Installer {
   }
 
   private getPackageInformation(locator: Locator) {
-    const key1 = structUtils.requirableIdent(locator);
+    const key1 = structUtils.stringifyIdent(locator);
     const key2 = locator.reference;
 
     const packageInformationStore = this.packageRegistry.get(key1);

--- a/packages/yarnpkg-core/sources/CorePlugin.ts
+++ b/packages/yarnpkg-core/sources/CorePlugin.ts
@@ -10,12 +10,12 @@ export const CorePlugin: Plugin = {
   hooks: {
     reduceDependency: (dependency: Descriptor, project: Project, locator: Locator, initialDependency: Descriptor, {resolver, resolveOptions}: {resolver: Resolver, resolveOptions: ResolveOptions}) => {
       for (const {pattern, reference} of project.topLevelWorkspace.manifest.resolutions) {
-        if (pattern.from && pattern.from.fullName !== structUtils.requirableIdent(locator))
+        if (pattern.from && pattern.from.fullName !== structUtils.stringifyIdent(locator))
           continue;
         if (pattern.from && pattern.from.description && pattern.from.description !== locator.reference)
           continue;
 
-        if (pattern.descriptor.fullName !== structUtils.requirableIdent(dependency))
+        if (pattern.descriptor.fullName !== structUtils.stringifyIdent(dependency))
           continue;
         if (pattern.descriptor.description && pattern.descriptor.description !== dependency.range)
           continue;

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -569,17 +569,6 @@ export function convertToManifestRange(range: string) {
 }
 
 /**
- * @deprecated Prefer using `stringifyIdent`
- */
-export function requirableIdent(ident: Ident) {
-  if (ident.scope) {
-    return `@${ident.scope}/${ident.name}`;
-  } else {
-    return `${ident.name}`;
-  }
-}
-
-/**
  * Returns a string from an ident (eg. `@types/lodash`).
  */
 export function stringifyIdent(ident: Ident) {
@@ -810,5 +799,5 @@ export function prettyDependent(configuration: Configuration, locator: Locator, 
  * them to a different location if that's a critical requirement.
  */
 export function getIdentVendorPath(ident: Ident) {
-  return `node_modules/${requirableIdent(ident)}` as PortablePath;
+  return `node_modules/${stringifyIdent(ident)}` as PortablePath;
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`structUtils.requirableIdent` has been deprecated for a while and work on V3 has started

**How did you fix it?**

Removed it

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.