### PR TITLE
fix(acceptance-tests): disable gpg signing of commits

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/stage.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/stage.test.js
@@ -79,6 +79,7 @@ describe(`Commands`, () => {
         // Otherwise we can't always commit
         await execFile(`git`, [`config`, `user.name`, `John Doe`], {cwd: path});
         await execFile(`git`, [`config`, `user.email`, `john.doe@example.org`], {cwd: path});
+        await execFile(`git`, [`config`, `commit.gpgSign`, `false`], {cwd: path});
 
         await mkdirp(`${path}/new-package`);
         await run(`${path}/new-package`, `init`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/check.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/check.test.js
@@ -182,6 +182,7 @@ function makeVersionCheckEnv(cb) {
     // Otherwise we can't always commit
     await git(`config`, `user.name`, `John Doe`);
     await git(`config`, `user.email`, `john.doe@example.org`);
+    await git(`config`, `commit.gpgSign`, `false`);
 
     await git(`add`, `.`);
     await git(`commit`, `-m`, `First commit`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/mergeConflictResolution.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/mergeConflictResolution.test.js
@@ -33,6 +33,7 @@ describe(`Features`, () => {
           await execFile(`git`, [`init`], {cwd: path});
           await execFile(`git`, [`config`, `user.email`, `you@example.com`], {cwd: path});
           await execFile(`git`, [`config`, `user.name`, `Your Name`], {cwd: path});
+          await execFile(`git`, [`config`, `commit.gpgSign`, `false`], {cwd: path});
 
           await run(`install`);
           await writeJson(`${path}/package.json`, {dependencies:{[`no-deps`]: `*`}});


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running all integration tests in the yarn repo asks for a gpg signature ± 10 times if git is configured to sign commits.

Fixes part of #2275

**How did you fix it?**

Configure tests that run git commands to not use gpg signatures on commits.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
