### PR TITLE
refactor(pnpify): remove old sdk folder removal

### DIFF
--- a/.yarn/versions/78cfdc45.yml
+++ b/.yarn/versions/78cfdc45.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": major
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### **Breaking Changes**
 
 - The `initVersion` and `initLicense` configuration options have been removed. `initFields` should be used instead.
+- The old PnPify SDK folder (`.vscode/pnpify`) won't be cleaned up anymore.
 
 ### API
 

--- a/packages/yarnpkg-pnpify/sources/generateSdk.ts
+++ b/packages/yarnpkg-pnpify/sources/generateSdk.ts
@@ -12,7 +12,6 @@ import {BASE_SDKS}                                                  from './sdks
 import {COC_VIM_SDKS}                                               from './sdks/cocvim';
 import {VSCODE_SDKS}                                                from './sdks/vscode';
 
-export const OLD_SDK_FOLDER = `.vscode/pnpify` as PortablePath;
 export const SDK_FOLDER = `.yarn/sdks` as PortablePath;
 
 export const INTEGRATIONS_FILE = `integrations.yml` as Filename;
@@ -279,13 +278,6 @@ export const generateSdk = async (pnpApi: PnpApi, {requestedIntegrations, preexi
     ...requestedIntegrations,
     ...preexistingIntegrations,
   ]);
-
-  // TODO: remove in next major
-  const oldTargetFolder = ppath.join(projectRoot, OLD_SDK_FOLDER);
-  if (xfs.existsSync(oldTargetFolder) && !xfs.lstatSync(oldTargetFolder).isSymbolicLink()) {
-    report.reportWarning(MessageName.UNNAMED, `Cleaning up the existing SDK files in the old ${formatUtils.pretty(configuration, OLD_SDK_FOLDER, formatUtils.Type.PATH)} folder. You might need to manually update existing references outside the ${formatUtils.pretty(configuration, `.vscode`, formatUtils.Type.PATH)} folder (e.g. .gitignore)...`);
-    await xfs.removePromise(oldTargetFolder);
-  }
 
   if (xfs.existsSync(targetFolder)) {
     report.reportWarning(MessageName.UNNAMED, `Cleaning up the existing SDK files...`);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The `@yarnpkg/pnpify` behavior that removed the old SDK folder (`.vscode/pnpify`) was deprecated.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed it for the 3.x release.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
