### PR TITLE
refactor(plugin-workspace-tools): remove legacy -a flag

### DIFF
--- a/.yarn/versions/53e3eb6b.yml
+++ b/.yarn/versions/53e3eb6b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": major

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### **Breaking Changes**
 
 - The `initVersion` and `initLicense` configuration options have been removed. `initFields` should be used instead.
+- The `-a` alias flag of `yarn workspaces foreach` got removed; use `-A,--all` instead, which is strictly the same.
 
 ### API
 

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -62,10 +62,6 @@ export default class WorkspacesForeachCommand extends BaseCommand {
   @Command.Proxy()
   args: Array<string> = [];
 
-  // TODO: remove in next major
-  @Command.Boolean(`-a`, {hidden: true})
-  allLegacy: boolean = false;
-
   @Command.Boolean(`-R,--recursive`, {description: `Find packages via dependencies/devDependencies instead of using the workspaces field`})
   recursive: boolean = false;
 
@@ -147,8 +143,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project, workspace: cwdWorkspace} = await Project.find(configuration, this.context.cwd);
 
-    const all = this.all ?? this.allLegacy;
-    if (!all && !cwdWorkspace)
+    if (!this.all && !cwdWorkspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     const command = this.cli.process([this.commandName, ...this.args]) as {path: Array<string>, scriptName?: string};
@@ -159,7 +154,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     if (command.path.length === 0)
       throw new UsageError(`Invalid subcommand name for iteration - use the 'run' keyword if you wish to execute a script`);
 
-    const rootWorkspace = all
+    const rootWorkspace = this.all
       ? project.topLevelWorkspace
       : cwdWorkspace!;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The `-a` flag of `yarn workspaces foreach` was deprecated because it is identical to its alternatives, `-A,--all`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed it for the 3.x release.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
