### PR TITLE
feat(plugin-init): no default files

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -248,6 +248,12 @@
       "default": [],
       "_exampleItems": ["**/.pnp.js"]
     },
+    "createDefaultFiles": {
+      "_package": "@yarnpkg/plugin-init",
+      "description": "If false, Yarn will not initialize your project directory with a git repo, a README, a gitignore, and other helpful additions.",
+      "type": "boolean",
+      "default": true
+    },
     "initScope": {
       "_package": "@yarnpkg/plugin-init",
       "description": "Scope used when creating packages via the `init` command.",

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -156,14 +156,21 @@ export default class InitCommand extends BaseCommand {
     const manifestPath = ppath.join(this.context.cwd, Manifest.fileName);
     await xfs.changeFilePromise(manifestPath, `${JSON.stringify(serialized, null, 2)}\n`);
 
-    const readmePath = ppath.join(this.context.cwd, `README.md` as Filename);
-    if (!xfs.existsSync(readmePath))
-      await xfs.writeFilePromise(readmePath, `# ${structUtils.stringifyIdent(manifest.name)}\n`);
+    const createDefaultFiles = configuration.get(`createDefaultFiles`);
+
+    if (createDefaultFiles) {
+      const readmePath = ppath.join(this.context.cwd, `README.md` as Filename);
+      if (!xfs.existsSync(readmePath)) {
+        await xfs.writeFilePromise(readmePath, `# ${structUtils.stringifyIdent(manifest.name)}\n`);
+      }
+    }
 
     if (!existingProject) {
       const lockfilePath = ppath.join(this.context.cwd, Filename.lockfile);
       await xfs.writeFilePromise(lockfilePath, ``);
+    }
 
+    if (!existingProject && createDefaultFiles) {
       const gitattributesLines = [
         `/.yarn/** linguist-vendored`,
       ];

--- a/packages/plugin-init/sources/index.ts
+++ b/packages/plugin-init/sources/index.ts
@@ -12,6 +12,11 @@ declare module '@yarnpkg/core' {
 
 const plugin: Plugin = {
   configuration: {
+    createDefaultFiles: {
+      description: `If true, create some basic files in the project directory`,
+      type: SettingsType.BOOLEAN,
+      default: true,
+    },
     initScope: {
       description: `Scope used when creating packages via the init command`,
       type: SettingsType.STRING,


### PR DESCRIPTION
**What's the problem this PR addresses?**

While trying out the new berry, I noticed that `yarn init` created tons of files in the dir where I was just trying to do the bare minimum initialization. I noticed that some of these files were not created the way I would like to create them, and that in any case I didn't expect or want these default files created in the first place. I tried to disable the creation of them, but saw from the code that they could be neither disabled nor customized (except for, to some extent, editorconfig).

In theory, I can imagine some sort of new-package-template system which would be `xfs.copyPromise`'d to the new package I'm `yarn init`-ing. However, this would be pretty complicated, so it seems easier to just provide the option to not generate anything (apart from the manifest & lockfile) and let the user figure out what s/he wants.

...

**How did you fix it?**

I added a new bool option `createDefaultFiles` (I might try to think of a better name, but let's have the is-this-an-acceptable-contribution conversation first) which controls whether the non-essential files are created. It defaults to true to preserve existing behavior.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

(Not yet; I want to see if this gets rejected first.)

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

(I mean, I don't even know what these are, but I guess so)