### PR TITLE
docs: fix links to playground

### DIFF
--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -121,7 +121,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-catch-links`,
       options: {
-        excludePattern: /^\/api$/,
+        excludePattern: /^\/(api|playground)$/,
       },
     },
     {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Links to the playground are treated as gatsby pages

Fixes https://github.com/yarnpkg/berry/issues/1714

**How did you fix it?**

Exclude the playground link as suggested in https://github.com/yarnpkg/berry/issues/1714#issuecomment-678811450

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.