### PR TITLE
fix(plugin-npm): npm semver loose mode

### DIFF
--- a/.yarn/versions/69ddbe20.yml
+++ b/.yarn/versions/69ddbe20.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-compat": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/69ddbe20.yml
+++ b/.yarn/versions/69ddbe20.yml
@@ -1,23 +1,16 @@
 releases:
   "@yarnpkg/cli": patch
-  "@yarnpkg/core": patch
-  "@yarnpkg/plugin-compat": patch
   "@yarnpkg/plugin-npm": patch
-  "@yarnpkg/plugin-npm-cli": patch
 
 declined:
+  - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"
-  - "@yarnpkg/plugin-exec"
-  - "@yarnpkg/plugin-file"
-  - "@yarnpkg/plugin-git"
-  - "@yarnpkg/plugin-github"
-  - "@yarnpkg/plugin-http"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
-  - "@yarnpkg/plugin-link"
   - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
   - "@yarnpkg/plugin-pnp"
@@ -26,5 +19,5 @@ declined:
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
+  - "@yarnpkg/core"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/pnpify"

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -54,7 +54,8 @@ export class NpmSemverResolver implements Resolver {
     });
 
     const candidates = Object.keys(registryData.versions)
-      .map(version => new semverUtils.SemVer(version, { loose: true }))
+      .filter(version => !!semverUtils.valid(version))
+      .map(version => new semverUtils.SemVer(version))
       .filter(version => range.test(version));
 
     const noDeprecatedCandidates = candidates.filter(version => {

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -1,12 +1,12 @@
-import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions, Manifest, DescriptorHash, Package} from '@yarnpkg/core';
-import {Descriptor, Locator, semverUtils}                                                                             from '@yarnpkg/core';
-import {LinkType}                                                                                                     from '@yarnpkg/core';
-import {structUtils}                                                                                                  from '@yarnpkg/core';
-import semver                                                                                                         from 'semver';
+import {ReportError, MessageName, Resolver, ResolveOptions, MinimalResolveOptions, Manifest, DescriptorHash, Package, miscUtils} from '@yarnpkg/core';
+import {Descriptor, Locator, semverUtils}                                                                                        from '@yarnpkg/core';
+import {LinkType}                                                                                                                from '@yarnpkg/core';
+import {structUtils}                                                                                                             from '@yarnpkg/core';
+import semver                                                                                                                    from 'semver';
 
-import {NpmSemverFetcher}                                                                                             from './NpmSemverFetcher';
-import {PROTOCOL}                                                                                                     from './constants';
-import * as npmHttpUtils                                                                                              from './npmHttpUtils';
+import {NpmSemverFetcher}                                                                                                        from './NpmSemverFetcher';
+import {PROTOCOL}                                                                                                                from './constants';
+import * as npmHttpUtils                                                                                                         from './npmHttpUtils';
 
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);
 const NODE_GYP_MATCH = /\b(node-gyp|prebuild-install)\b/;
@@ -53,10 +53,17 @@ export class NpmSemverResolver implements Resolver {
       jsonResponse: true,
     });
 
-    const candidates = Object.keys(registryData.versions)
-      .filter(version => !!semverUtils.valid(version))
-      .map(version => new semverUtils.SemVer(version))
-      .filter(version => range.test(version));
+    const candidates = miscUtils.mapAndFilter(Object.keys(registryData.versions), version => {
+      try {
+        const candidate = new semverUtils.SemVer(version);
+        if (range.test(candidate))
+          return candidate;
+
+        return miscUtils.mapAndFilter.skip;
+      } catch (_e) {
+        return miscUtils.mapAndFilter.skip;
+      }
+    });
 
     const noDeprecatedCandidates = candidates.filter(version => {
       return !registryData.versions[version.raw].deprecated;

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -54,7 +54,7 @@ export class NpmSemverResolver implements Resolver {
     });
 
     const candidates = Object.keys(registryData.versions)
-      .map(version => new semverUtils.SemVer(version))
+      .map(version => new semverUtils.SemVer(version, { loose: true }))
       .filter(version => range.test(version));
 
     const noDeprecatedCandidates = candidates.filter(version => {

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -56,13 +56,12 @@ export class NpmSemverResolver implements Resolver {
     const candidates = miscUtils.mapAndFilter(Object.keys(registryData.versions), version => {
       try {
         const candidate = new semverUtils.SemVer(version);
-        if (range.test(candidate))
+        if (range.test(candidate)) {
           return candidate;
+        }
+      } catch { }
 
-        return miscUtils.mapAndFilter.skip;
-      } catch (_e) {
-        return miscUtils.mapAndFilter.skip;
-      }
+      return miscUtils.mapAndFilter.skip;
     });
 
     const noDeprecatedCandidates = candidates.filter(version => {

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export {SemVer} from 'semver';
+export {SemVer, valid} from 'semver';
 
 /**
  * Returns whether the given semver version satisfies the given range. Notably

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-export {SemVer, valid} from 'semver';
+export {SemVer} from 'semver';
 
 /**
  * Returns whether the given semver version satisfies the given range. Notably


### PR DESCRIPTION
**What's the problem this PR addresses?**

yarn install throws error:

`Invalid version: xxxx@xxxxx`

Context:
migrating an existing project to yarn 2 with private registry. some packages were released with arbitrary versions. leading to the yarn2 complains `invalid version`. but i think it's pretty common issue even in npm public registry packages. so, worth fixing in `plugin-npm`

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

As per https://github.com/npm/node-semver/blob/093b40f8a7cb67946527b739fe8f8974c888e2a0/internal/re.js#L94 npm package version can be arbitrary, so version like `1.2.3-alpha.00`, `1.0.0alpha1` etc... breaks the current logic. Maybe better to create SemVer in loose mode.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
