### PR TITLE
fix(pnpify): preserve comments in arrays

### DIFF
--- a/.yarn/versions/dacba3b2.yml
+++ b/.yarn/versions/dacba3b2.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/sdkUtils.ts
+++ b/packages/yarnpkg-pnpify/sources/sdkUtils.ts
@@ -3,10 +3,18 @@ import {PnpApi}                          from '@yarnpkg/pnp';
 import CJSON                             from 'comment-json';
 import mergeWith                         from 'lodash/mergeWith';
 
-export const merge = (object: unknown, source: unknown) =>
-  mergeWith(object, source, (objValue, srcValue) => {
-    if (Array.isArray(objValue))
-      return [...new Set(objValue.concat(srcValue))];
+export const merge = (cjsonData: unknown, patch: unknown) =>
+  mergeWith(cjsonData, patch, (cjsonValue: unknown, patchValue: unknown) => {
+    // We need to preserve comments in CommentArrays, so we can't use spread or Sets
+    if (Array.isArray(cjsonValue) && Array.isArray(patchValue)) {
+      for (const patchItem of patchValue) {
+        if (!cjsonValue.includes(patchItem)) {
+          cjsonValue.push(patchItem);
+        }
+      }
+
+      return cjsonValue;
+    }
 
     return undefined;
   });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When PnPify was generating the SDKs, comments in arrays it updated weren't preserved because we were using spread + sets, which erased the comment information from the `CommentArray` instance generated by `cjson`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By using manual iteration. I can confirm that comments are properly preserved now.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
