### PR TITLE
Fixes using loose mode with nm linker enabled

### DIFF
--- a/.yarn/versions/3b907f33.yml
+++ b/.yarn/versions/3b907f33.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": minor
+  "@yarnpkg/plugin-pnp": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-node-modules/sources/PnpLooseLinker.ts
+++ b/packages/plugin-node-modules/sources/PnpLooseLinker.ts
@@ -16,10 +16,7 @@ export class PnpLooseLinker extends PnpLinker {
 class PnpLooseInstaller extends PnpInstaller {
   protected mode = `loose`;
 
-  async finalizeInstallWithPnp(pnpSettings: PnpSettings) {
-    if (this.opts.project.configuration.get(`pnpMode`) !== this.mode)
-      return undefined;
-
+  async transformPnpSettings(pnpSettings: PnpSettings) {
     const defaultFsLayer = new VirtualFS({
       baseFs: new ZipOpenFS({
         libzip: await getLibzipPromise(),
@@ -79,7 +76,5 @@ class PnpLooseInstaller extends PnpInstaller {
         }
       }
     }
-
-    return super.finalizeInstallWithPnp(pnpSettings);
   }
 }

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -255,6 +255,10 @@ export class PnpInstaller implements Installer {
     };
   }
 
+  async transformPnpSettings(pnpSettings: PnpSettings) {
+    // Nothing to transform
+  }
+
   async finalizeInstallWithPnp(pnpSettings: PnpSettings) {
     if (this.opts.project.configuration.get(`pnpMode`) !== this.mode)
       return;
@@ -282,6 +286,8 @@ export class PnpInstaller implements Installer {
         await xfs.removePromise(nodeModulesPath);
       }
     }
+
+    await this.transformPnpSettings(pnpSettings);
 
     if (this.opts.project.configuration.get(`pnpEnableInlining`)) {
       const loaderFile = generateInlinedScript(pnpSettings);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using the loose mode with the node-modules linker used to crash because the loose mode was being executed outside of the regular PnP execution context.

**How did you fix it?**

Refactored the logic so that the loose mode is only executed when `nodeLinker` is set to `pnp`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
