### PR TITLE
fix(plugin-patch): diffFolders returned silently when 'git' failed

### DIFF
--- a/.yarn/versions/52395a7b.yml
+++ b/.yarn/versions/52395a7b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-patch": patch

--- a/.yarn/versions/52395a7b.yml
+++ b/.yarn/versions/52395a7b.yml
@@ -1,2 +1,3 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-patch": patch

--- a/.yarn/versions/52395a7b.yml
+++ b/.yarn/versions/52395a7b.yml
@@ -1,9 +1,9 @@
 releases:
   "@yarnpkg/cli": patch
-  "@yarnpkg/plugin-compat": patch
   "@yarnpkg/plugin-patch": patch
 
 declined:
+  - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"

--- a/.yarn/versions/52395a7b.yml
+++ b/.yarn/versions/52395a7b.yml
@@ -1,3 +1,22 @@
 releases:
   "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
   "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/commands/patchCommit.ts
+++ b/packages/plugin-patch/sources/commands/patchCommit.ts
@@ -12,7 +12,8 @@ export default class PatchCommitCommand extends BaseCommand {
 
   static usage: Usage = Command.Usage({
     description: `
-      This will turn the folder passed in parameter into a patchfile suitable for consumption with the \`patch:\` protocol.
+      This will print a patchfile based on the diff between the folder passed in and the original version of the package.
+      Such file is suitable for consumption with the \`patch:\` protocol.
 
       Only folders generated through \`yarn patch\` are accepted as valid input for \`yarn patch-commit\`.
     `,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn patch-commit /path/to/generated/dir` returned without output nor generates any file when an incompatible `git` was present in the system.

The `diffFolders` function runs `git` and disregarded the return status `code` and `stderr`, which means it resolved with an empty value of `stdout`.

The default `git` that's included with OS X does not support one of the arguments passed to it. Example:

```sh
❯ git diff --src-prefix=a/ --dst-prefix=b/ --ignore-cr-at-eol --full-index --no-index /private/.../xfs-adf9c270 /private/.../xfs-e4548122
fatal: invalid diff option/value: --ignore-cr-at-eol
```

Berry thinks an empty string is the result of the diff, prints it to stdout and incorrectly returns status 0.

Closes #2331

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

**How did you fix it?**

Added a helpful & actionable error message.

I've also checked for other usages of `execUtils.execvp` without `strict: true`. There is one other that also ignores the status code, but I believe it's intentional - it's in the init command (runs `git init` at the very end).

Also made the description of what the command does a bit clearer (it doesn't actually generate any files, it only outputs it to stdout).

<!-- A detailed description of your implementation. -->

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
