### PR TITLE
feat(plugin-essentials): config unset

### DIFF
--- a/.yarn/versions/630f0472.yml
+++ b/.yarn/versions/630f0472.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/630f0472.yml
+++ b/.yarn/versions/630f0472.yml
@@ -1,6 +1,6 @@
 releases:
-  "@yarnpkg/cli": patch
-  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
 
 declined:
   - "@yarnpkg/plugin-compat"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
@@ -1,0 +1,48 @@
+import {xfs} from '@yarnpkg/fslib';
+
+describe(`Commands`, () => {
+  describe(`config unset`, () => {
+    test(
+      `it should unset a simple config correctly`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`config`, `set`, `pnpShebang`, `#!/usr/bin/env iojs\n`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`pnpShebang`);
+        await expect(run(`config`, `unset`, `pnpShebang`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`Successfully unset`),
+        });
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.not.toContain(`pnpShebang`);
+      }),
+    );
+
+    test(
+      `it should unset a complex config correctly`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`config`, `set`, `npmScopes.yarnpkg`, `--json`, JSON.stringify({
+          npmAlwaysAuth: false,
+        }));
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`npmScopes`);
+        await expect(run(`config`, `unset`, `npmScopes`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`Successfully unset`),
+        });
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.not.toContain(`npmScopes`);
+      }),
+    );
+
+    test(
+      `it should unset a nested config correctly`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`config`, `set`, `npmScopes.yarnpkg`, `--json`, JSON.stringify({
+          npmRegistryServer: `https://registry.yarnpkg.com`,
+          npmAlwaysAuth: false,
+        }));
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`npmScopes`);
+        await expect(run(`config`, `unset`, `npmScopes.yarnpkg.npmAlwaysAuth`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`Successfully unset`),
+        });
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`npmScopes`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`npmRegistryServer`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.not.toContain(`npmAlwaysAuth`);
+      }),
+    );
+  });
+});

--- a/packages/plugin-essentials/sources/commands/config/get.ts
+++ b/packages/plugin-essentials/sources/commands/config/get.ts
@@ -5,7 +5,7 @@ import getPath                                  from 'lodash/get';
 import {inspect}                                from 'util';
 
 // eslint-disable-next-line arca/no-default-export
-export default class ConfigSetCommand extends BaseCommand {
+export default class ConfigGetCommand extends BaseCommand {
   @Command.String()
   name!: string;
 

--- a/packages/plugin-essentials/sources/commands/config/unset.ts
+++ b/packages/plugin-essentials/sources/commands/config/unset.ts
@@ -1,0 +1,71 @@
+import {BaseCommand}                              from '@yarnpkg/cli';
+import {Configuration, StreamReport, MessageName} from '@yarnpkg/core';
+import {Command, Usage, UsageError}               from 'clipanion';
+import cloneDeep                                  from 'lodash/cloneDeep';
+import unsetPath                                  from 'lodash/unset';
+
+// eslint-disable-next-line arca/no-default-export
+export default class ConfigUnsetCommand extends BaseCommand {
+  @Command.String()
+  name!: string;
+
+  @Command.Boolean(`-H,--home`, {description: `Update the home configuration instead of the project configuration`})
+  home: boolean = false;
+
+  static usage: Usage = Command.Usage({
+    description: `unset a configuration settings`,
+    details: `
+      This command will set a configuration setting.
+    `,
+    examples: [[
+      `Unset a simple configuration setting`,
+      `yarn config set initScope`,
+    ], [
+      `Unset a complex configuration setting`,
+      `yarn config set packageExtensions`,
+    ], [
+      `Unset a nested configuration setting`,
+      `yarn config set npmScopes.company.npmRegistryServer`,
+    ]],
+  });
+
+  @Command.Path(`config`, `unset`)
+  async execute() {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    if (!configuration.projectCwd)
+      throw new UsageError(`This command must be run from within a project folder`);
+
+    const name = this.name.replace(/[.[].*$/, ``);
+    const path = this.name.replace(/^[^.[]*\.?/, ``);
+
+    const setting = configuration.settings.get(name);
+    if (typeof setting === `undefined`)
+      throw new UsageError(`Couldn't find a configuration settings named "${name}"`);
+
+    const updateConfiguration: (patch: ((current: any) => any)) => Promise<void> =
+      this.home
+        ? patch => Configuration.updateHomeConfiguration(patch)
+        : patch => Configuration.updateConfiguration(configuration.projectCwd!, patch);
+
+    await updateConfiguration(current => {
+      if (path) {
+        const clone = cloneDeep(current);
+        unsetPath(clone, this.name);
+        return clone;
+      } else {
+        const next = unsetPath({...current}, name);
+        return next;
+      }
+    });
+
+    const report = await StreamReport.start({
+      configuration,
+      includeFooter: false,
+      stdout: this.context.stdout,
+    }, async report => {
+      report.reportInfo(MessageName.UNNAMED, `Successfully unset ${this.name}`);
+    });
+
+    return report.exitCode();
+  }
+}

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -6,6 +6,7 @@ import bin                                                      from './commands
 import cleanCache                                               from './commands/cache/clean';
 import getConfig                                                from './commands/config/get';
 import setConfig                                                from './commands/config/set';
+import unsetConfig                                              from './commands/config/unset';
 import config                                                   from './commands/config';
 import dedupe                                                   from './commands/dedupe';
 import clipanionEntry                                           from './commands/entries/clipanion';
@@ -99,6 +100,7 @@ const plugin: Plugin = {
     cleanCache,
     getConfig,
     setConfig,
+    unsetConfig,
     setResolutionPolicy,
     setVersionFromSources,
     setVersionPolicy,


### PR DESCRIPTION
**What's the problem this PR addresses?**

There is currently no way to unset a config from the CLI

**How did you fix it?**

Add a `config unset` command

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
