### PR TITLE
Turns Type into a const enum

### DIFF
--- a/.yarn/versions/d883a19b.yml
+++ b/.yarn/versions/d883a19b.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -9,35 +9,41 @@ import * as miscUtils                                                       from
 import * as structUtils                                                     from './structUtils';
 import {Descriptor, Locator, Ident, PackageExtension, PackageExtensionType} from './types';
 
-// We have to make this enum a "const enum" to workaround a TS bug:
+// We have to workaround a TS bug:
 // https://github.com/microsoft/TypeScript/issues/35329
-export const enum Type {
-  NO_HINT = `NO_HINT`,
+//
+// We also can't use const enum because Babel doesn't support them:
+// https://github.com/babel/babel/issues/8741
+//
+export const Type = {
+  NO_HINT: `NO_HINT`,
 
-  NULL = `NULL`,
+  NULL: `NULL`,
 
-  SCOPE = `SCOPE`,
-  NAME = `NAME`,
-  RANGE = `RANGE`,
-  REFERENCE = `REFERENCE`,
+  SCOPE: `SCOPE`,
+  NAME: `NAME`,
+  RANGE: `RANGE`,
+  REFERENCE: `REFERENCE`,
 
-  NUMBER = `NUMBER`,
-  PATH = `PATH`,
-  URL = `URL`,
-  ADDED = `ADDED`,
-  REMOVED = `REMOVED`,
-  CODE = `CODE`,
+  NUMBER: `NUMBER`,
+  PATH: `PATH`,
+  URL: `URL`,
+  ADDED: `ADDED`,
+  REMOVED: `REMOVED`,
+  CODE: `CODE`,
 
-  DURATION = `DURATION`,
-  SIZE = `SIZE`,
+  DURATION: `DURATION`,
+  SIZE: `SIZE`,
 
-  IDENT = `IDENT`,
-  DESCRIPTOR = `DESCRIPTOR`,
-  LOCATOR = `LOCATOR`,
-  RESOLUTION = `RESOLUTION`,
-  DEPENDENT = `DEPENDENT`,
-  PACKAGE_EXTENSION = `PACKAGE_EXTENSION`,
-}
+  IDENT: `IDENT`,
+  DESCRIPTOR: `DESCRIPTOR`,
+  LOCATOR: `LOCATOR`,
+  RESOLUTION: `RESOLUTION`,
+  DEPENDENT: `DEPENDENT`,
+  PACKAGE_EXTENSION: `PACKAGE_EXTENSION`,
+} as const;
+
+export type Type = keyof typeof Type;
 
 export enum Style {
   BOLD = 1 << 1,
@@ -54,7 +60,7 @@ export const supportsHyperlinks = supportsColor && !process.env.GITHUB_ACTIONS;
 
 const chalkInstance = new chalk.Instance(chalkOptions);
 
-const colors = new Map([
+const colors = new Map<Type, [string, number] | null>([
   [Type.NO_HINT, null],
 
   [Type.NULL, [`#a853b5`, 129]],

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -9,7 +9,9 @@ import * as miscUtils                                                       from
 import * as structUtils                                                     from './structUtils';
 import {Descriptor, Locator, Ident, PackageExtension, PackageExtensionType} from './types';
 
-export enum Type {
+// We have to make this enum a "const enum" to workaround a TS bug:
+// https://github.com/microsoft/TypeScript/issues/35329
+export const enum Type {
   NO_HINT = `NO_HINT`,
 
   NULL = `NULL`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Context, this TS bug: https://github.com/microsoft/TypeScript/issues/35329

As a result, plugin authors can't use `formatUtils.pretty`, because everything gets inferred as `never`.

**How did you fix it?**

We can't use `const enum` because Babel doesn't support them. This diff thus fallback to a kind of "manual" implementation of enums, which should have the same public behaviour as the current one.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
