### PR TITLE
Add support for --exclude flag to dedupe command

### DIFF
--- a/.yarn/versions/4811d64f.yml
+++ b/.yarn/versions/4811d64f.yml
@@ -1,2 +1,7 @@
 releases:
   "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/.yarn/versions/4811d64f.yml
+++ b/.yarn/versions/4811d64f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-essentials": minor

--- a/packages/plugin-essentials/sources/commands/dedupe.ts
+++ b/packages/plugin-essentials/sources/commands/dedupe.ts
@@ -24,6 +24,9 @@ export default class DedupeCommand extends BaseCommand {
   @Command.Rest()
   patterns: Array<string> = [];
 
+  @Command.Array(`-e,--exclude`, {description: `Glob exclude patterns`})
+  exclude: Array<string> = [];
+
   @Command.String(`-s,--strategy`, {description: `The strategy to use when deduping dependencies`})
   strategy: dedupeUtils.Strategy = dedupeUtils.Strategy.HIGHEST;
 
@@ -82,6 +85,9 @@ export default class DedupeCommand extends BaseCommand {
       `Dedupe all packages with the \`@babel/*\` scope`,
       `$0 dedupe '@babel/*'`,
     ], [
+      `Dedupe all packages excluding those with the \`@babel/*\` scope`,
+      `$0 dedupe --exclude '@babel/*'`,
+    ],[
       `Check for duplicates (can be used as a CI step)`,
       `$0 dedupe --check`,
     ]],
@@ -100,7 +106,7 @@ export default class DedupeCommand extends BaseCommand {
       stdout: this.context.stdout,
       json: this.json,
     }, async report => {
-      dedupedPackageCount = await dedupeUtils.dedupe(project, {strategy: this.strategy, patterns: this.patterns, cache, report});
+      dedupedPackageCount = await dedupeUtils.dedupe(project, {strategy: this.strategy, patterns: this.patterns, exclude: this.exclude, cache, report});
     });
 
     if (dedupeReport.hasErrors())

--- a/packages/plugin-essentials/sources/commands/dedupe.ts
+++ b/packages/plugin-essentials/sources/commands/dedupe.ts
@@ -87,7 +87,7 @@ export default class DedupeCommand extends BaseCommand {
     ], [
       `Dedupe all packages excluding those with the \`@babel/*\` scope`,
       `$0 dedupe --exclude '@babel/*'`,
-    ],[
+    ], [
       `Check for duplicates (can be used as a CI step)`,
       `$0 dedupe --check`,
     ]],


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
This adds support for an --exclude flag for the dedupe plugin. This can be useful in situations where you want further control on which dependencies should be touched or left alone during the dedupe process.
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
The implementation is analogous to the current --patterns flag which provides globs for which dependencies to include in the dedupe. --exclude will provide patterns for which dependencies to exclude in the dedupe. 
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
