### PR TITLE
fix(pnpify): added additional option to cocvim sdk

### DIFF
--- a/.yarn/versions/78bcf3fc.yml
+++ b/.yarn/versions/78bcf3fc.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/sdks/cocvim.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/cocvim.ts
@@ -28,6 +28,7 @@ export const generateEslintWrapper: GenerateIntegrationWrapper = async (pnpApi: 
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addCocVimWorkspaceConfiguration(pnpApi, CocVimConfiguration.settings, {
+    [`workspace.workspaceFolderCheckCwd`]: false,
     [`tsserver.tsdk`]: npath.fromPortablePath(
       ppath.dirname(
         wrapper.getProjectPathTo(


### PR DESCRIPTION
**What's the problem this PR addresses?**

The generated `.vim/coc-settings.json` sets relative filepaths to `.yarn/...`. The path is relative to the `coc.nvim` workspace root.

The appearance of files such as `package.json` at multiple levels in a monorepo setup causes `coc.nvim` to sometimes resolve to the incorrect workspace root and so `.yarn/...` is a broken path.

**How did you fix it?**

I added an option in neoclide/coc.nvim#2807 to always try and resolve the root from ~~right-to-left~~ left-to-right through the path, rather than checking the current working directory first.

I then set this option in the `cocvim` sdk, specifically in the `tsserver` section, as this was the integration that was failing.

**Checklist**

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
