### PR TITLE
Removes Node 10 from the matrix

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-eslint-workflow.yml
+++ b/.github/workflows/e2e-eslint-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-fsevents-workflow.yml
+++ b/.github/workflows/e2e-fsevents-workflow.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-gatsby-workflow.yml
+++ b/.github/workflows/e2e-gatsby-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-husky-workflow.yml
+++ b/.github/workflows/e2e-husky-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-jest-workflow.yml
+++ b/.github/workflows/e2e-jest-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-mocha-workflow.yml
+++ b/.github/workflows/e2e-mocha-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-nm-angular-workflow.yml
+++ b/.github/workflows/e2e-nm-angular-workflow.yml
@@ -36,7 +36,7 @@ jobs:
 
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
         version: 10.x

--- a/.github/workflows/e2e-nm-angular-workflow.yml
+++ b/.github/workflows/e2e-nm-angular-workflow.yml
@@ -39,7 +39,7 @@ jobs:
     - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -36,10 +36,10 @@ jobs:
 
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-nyc-workflow.yml
+++ b/.github/workflows/e2e-nyc-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-pnpify-workflow.yml
+++ b/.github/workflows/e2e-pnpify-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
         version: 10.x

--- a/.github/workflows/e2e-pnpify-workflow.yml
+++ b/.github/workflows/e2e-pnpify-workflow.yml
@@ -21,7 +21,7 @@ jobs:
     - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-prettier-workflow.yml
+++ b/.github/workflows/e2e-prettier-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-rollup-workflow.yml
+++ b/.github/workflows/e2e-rollup-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-snowpack-workflow.yml
+++ b/.github/workflows/e2e-snowpack-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-typescript-workflow.yml
+++ b/.github/workflows/e2e-typescript-workflow.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-vue-cli-workflow.yml
+++ b/.github/workflows/e2e-vue-cli-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/e2e-webpack-workflow.yml
+++ b/.github/workflows/e2e-webpack-workflow.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |
@@ -38,11 +38,11 @@ jobs:
 
         mkdir src
         echo "import _ from 'lodash';function printHello() { console.log(_.join(['Hello', 'webpack'], ' '))}; printHello();" | tee src/index.js
-        
+
         yarn webpack info
         yarn webpack
         [[ "$(node dist/main.js)" = "Hello webpack" ]]
-        
+
     - name: 'raw-loader'
       run: |
         source scripts/e2e-setup-ci.sh

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -150,7 +150,6 @@ jobs:
       fail-fast: false
       matrix:
         node:
-        - 10
         - 12
         - 14
         - 15

--- a/.github/workflows/plugin-compat-workflow.yml
+++ b/.github/workflows/plugin-compat-workflow.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Build the standard bundle'
       run: |

--- a/.github/workflows/sherlock-workflow.yml
+++ b/.github/workflows/sherlock-workflow.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: 'Use Node.js 10.x'
+    - name: 'Install Node'
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: 'Always use the latest sherlock'
       run: |

--- a/.yarn/versions/20cff2cf.yml
+++ b/.yarn/versions/20cff2cf.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### **Breaking Changes**
 
+- Node 10 isn't supported anymore.
 - The `initVersion` and `initLicense` configuration options have been removed. `initFields` should be used instead.
 - Yarn will now generate `.pnp.cjs` files (instead of `.pnp.js`) when using PnP, regardless of what the `type` field inside the manifest is set to.
 - The `-a` alias flag of `yarn workspaces foreach` got removed; use `-A,--all` instead, which is strictly the same.

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -57,13 +57,11 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
 
   async function exec(cli: Cli<CommandContext>): Promise<void> {
     // Non-exhaustive known requirements:
-    // - 10.16+ for Brotli support on `plugin-compat`
-    // - 10.17+ to silence `got` warning on `dns.promises`
     // - 14.0 and 14.1 empty http responses - https://github.com/sindresorhus/got/issues/1496
     // - 14.10.0 broken streams - https://github.com/nodejs/node/pull/34035 (fix: https://github.com/nodejs/node/commit/0f94c6b4e4)
 
     const version = process.versions.node;
-    const range = `>=10.17 <14 || 14.2 - 14.9 || >14.10.0`;
+    const range = `>=12 <14 || 14.2 - 14.9 || >14.10.0`;
 
     if (process.env.YARN_IGNORE_NODE !== `1` && !semverUtils.satisfiesWithPrereleases(version, range))
       throw new UsageError(`This tool requires a Node version compatible with ${range} (got ${version}). Upgrade Node, or set \`YARN_IGNORE_NODE=1\` in your environment.`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node 10 will reach its end of life in april; it's probably fine to remove it now, otherwise we'll be blocked with it for at least another year, and we currently use `got` which has fairly strict "last Node" requirements (so it's likely we would be blocked from further upgrades).

**How did you fix it?**

Removed 10.x from the matrix.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
