### PR TITLE
chore(compat): add testcafe extensions

### DIFF
--- a/.yarn/versions/ad9f0dd6.yml
+++ b/.yarn/versions/ad9f0dd6.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -205,4 +205,18 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       [`react`]: `*`,
     },
   }],
+  // https://github.com/DevExpress/testcafe/pull/5872
+  [`testcafe@*`, {
+    dependencies: {
+      '@babel/plugin-transform-for-of': `^7.12.1`,
+      '@babel/runtime': `^7.12.5`,
+    },
+  }],
+  // https://github.com/DevExpress/testcafe-legacy-api/pull/51
+  [`testcafe-legacy-api@*`, {
+    dependencies: {
+      'testcafe-hammerhead': `^17.0.1`,
+      'read-file-relative': `^1.2.0`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -206,14 +206,14 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/DevExpress/testcafe/pull/5872
-  [`testcafe@*`, {
+  [`testcafe@<=1.10.1`, {
     dependencies: {
       '@babel/plugin-transform-for-of': `^7.12.1`,
       '@babel/runtime': `^7.12.5`,
     },
   }],
   // https://github.com/DevExpress/testcafe-legacy-api/pull/51
-  [`testcafe-legacy-api@*`, {
+  [`testcafe-legacy-api@<=4.2.0`, {
     dependencies: {
       'testcafe-hammerhead': `^17.0.1`,
       'read-file-relative': `^1.2.0`,


### PR DESCRIPTION

**What's the problem this PR addresses?**
TestCafe won’t run with Yarn 2, because of missing dependencies that aren’t explicitly listed.

https://github.com/DevExpress/testcafe-legacy-api/pull/51
https://github.com/DevExpress/testcafe/pull/5872

**How did you fix it?**
I added the packages required by `testcafe` and `testcafe-legacy-api` to the `plugin-compat` database.
PRs have also been submitted to the TestCafe project.


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
