### PR TITLE
[node-modules] Fixes soft and hard link merging after hoisting

### DIFF
--- a/.yarn/versions/596b22dd.yml
+++ b/.yarn/versions/596b22dd.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -403,20 +403,20 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
         if (prevNode) {
           if (prevNode.dirList) {
             throw new Error(`Assertion failed: ${nodeModulesLocation} cannot merge dir node with leaf node`);
-          } else {
+          } else if (prevNode.linkType === LinkType.HARD && leafNode.linkType === LinkType.HARD) {
+            // We merge together HARD nodes, SOFT nodes are just overwritten
             const locator1 = structUtils.parseLocator(prevNode.locator);
             const locator2 = structUtils.parseLocator(leafNode.locator);
 
-            if (prevNode.linkType !== leafNode.linkType)
-              throw new Error(`Assertion failed: ${nodeModulesLocation} cannot merge nodes with different link types`);
-            else if (locator1.identHash !== locator2.identHash)
+            if (locator1.identHash !== locator2.identHash)
               throw new Error(`Assertion failed: ${nodeModulesLocation} cannot merge nodes with different idents ${structUtils.stringifyLocator(locator1)} and ${structUtils.stringifyLocator(locator2)}`);
 
             leafNode.aliases = [...leafNode.aliases, ...prevNode.aliases, structUtils.parseLocator(prevNode.locator).reference];
           }
         }
 
-        tree.set(nodeModulesLocation, leafNode);
+        if (!prevNode || leafNode.linkType === LinkType.HARD)
+          tree.set(nodeModulesLocation, leafNode);
 
         const segments = nodeModulesLocation.split(`/`);
         const nodeModulesIdx = segments.indexOf(NODE_MODULES);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

In Berry we have two link kinds for dependencies:
1. A soft link - a kind of dependency when the files are not controlled by Berry. The examples of the soft links are workspaces, `portal:` and `link:` dependencies. 
2. A hard link - a kind of dependency, when the files are controlled by Berry. The examples of the hard links are normal dependencies installed from the registry or from GitHub.

After hoisting two dependencies might end up having the same name but different link types. For example, the root workspace can have inner workspace with the name 'foo' and depend on the package with the name `foo` from the registry, both of them are dependencies of the root workspace, but they have different link types. NM linker had not always handled this situation correctly and often tried to merge soft and hard links, when hard link just need to take precedence and just overwrite the soft link.

The problem were initially spotted by Babel team here:
https://github.com/babel/babel/pull/12583#discussion_r553391274
CC: @nicolo-ribaudo @merceyz 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Now NM linker do not try to merge soft and hard links together, the hard link just overwrites the soft link in the resulting nm tree, this does not affect the traversal, the nm will still traverse children of both dependency link kinds.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
