### PR TITLE
perf(core): only call mkdir for the cache and mirror once

### DIFF
--- a/.yarn/versions/511adc40.yml
+++ b/.yarn/versions/511adc40.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/localMirror.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/localMirror.test.js
@@ -27,8 +27,8 @@ describe(`Features`, () => {
       await xfs.removePromise(`${path}/.yarn/global/cache`);
       await run(`install`);
 
-      const exists = await xfs.existsSync(`${path}/.yarn/global/cache`);
-      expect(exists).toEqual(false);
+      const fileCount = (await xfs.readdirPromise(`${path}/.yarn/global/cache`)).length;
+      expect(fileCount).toEqual(0);
     }));
   });
 });

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -128,10 +128,7 @@ export class Cache {
       await xfs.changeFilePromise(gitignorePath, `/.gitignore\n*.flock\n`);
     }
 
-    const mirrorCwd = this.mirrorCwd;
-    if (mirrorCwd) {
-      await xfs.mkdirPromise(mirrorCwd, {recursive: true});
-    }
+    await xfs.mkdirPromise(this.mirrorCwd || this.cwd, {recursive: true});
   }
 
   async fetchPackageFromCache(locator: Locator, expectedChecksum: string | null, {onHit, onMiss, loader, skipIntegrityCheck}: {onHit?: () => void, onMiss?: () => void, loader?: () => Promise<ZipFS>, skipIntegrityCheck?: boolean}): Promise<[FakeFS<PortablePath>, () => void, string]> {

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -127,6 +127,11 @@ export class Cache {
 
       await xfs.changeFilePromise(gitignorePath, `/.gitignore\n*.flock\n`);
     }
+
+    const mirrorCwd = this.mirrorCwd;
+    if (mirrorCwd) {
+      await xfs.mkdirPromise(mirrorCwd, {recursive: true});
+    }
   }
 
   async fetchPackageFromCache(locator: Locator, expectedChecksum: string | null, {onHit, onMiss, loader, skipIntegrityCheck}: {onHit?: () => void, onMiss?: () => void, loader?: () => Promise<ZipFS>, skipIntegrityCheck?: boolean}): Promise<[FakeFS<PortablePath>, () => void, string]> {
@@ -306,8 +311,6 @@ export class Cache {
   private async writeFileWithLock<T>(file: PortablePath | null, generator: () => Promise<T>) {
     if (file === null)
       return await generator();
-
-    await xfs.mkdirPromise(ppath.dirname(file), {recursive: true});
 
     return await xfs.lockPromise(file, async () => {
       return await generator();


### PR DESCRIPTION
**What's the problem this PR addresses?**

When populating the cache and/or mirror we call `mkdir` to create the folder(s) before writing every entry which is unnecessary as the cache folder is created during the setup though the folder for the mirror isn't.

**How did you fix it?**

Create the folder for the mirror in `setup` and remove the `mkdir` call from `writeFileWithLock`.

**Result**

Copying from the mirror to the local cache

```
Before
➤ YN0000: ┌ Fetch step
➤ YN0013: │ No packages were cached - 6157 packages had to be fetched
➤ YN0000: └ Completed in 12s 716ms

After
➤ YN0000: ┌ Fetch step
➤ YN0013: │ No packages were cached - 6157 packages had to be fetched
➤ YN0000: └ Completed in 11s 563ms
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.