### PR TITLE
[node-modules] Support reducing trees requiring multiple hoisting passes to a terminal result 

### DIFF
--- a/.yarn/versions/21795af1.yml
+++ b/.yarn/versions/21795af1.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Bugfixes
 
 - The patched fs now supports file URLs.
+- The node-modules linker now ensures that hoisting result is terminal, by doing several hoisting rounds when needed
 
 ### Settings
 

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -183,7 +183,7 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
   if (node.decoupled)
     return node;
 
-  const {name, references, ident, locator, dependencies, originalDependencies, hoistedDependencies, peerNames, reasons, isHoistBorder, hoistedFrom} = node;
+  const {name, references, ident, locator, dependencies, originalDependencies, hoistedDependencies, peerNames, reasons, isHoistBorder} = node;
   // To perform node hoisting from parent node we must clone parent nodes up to the root node,
   // because some other package in the tree might depend on the parent package where hoisting
   // cannot be performed
@@ -199,7 +199,7 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
     reasons: new Map(reasons),
     decoupled: true,
     isHoistBorder,
-    hoistedFrom,
+    hoistedFrom: [],
   };
   const selfDep = clone.dependencies.get(name);
   if (selfDep && selfDep.ident == clone.ident)

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -149,11 +149,11 @@ const getUsedDependencies = (rootNodePath: Array<HoisterWorkTree>): Map<PackageN
   const rootNode = rootNodePath[rootNodePath.length - 1];
   const usedDependencies = new Map(rootNode.dependencies);
   const seenNodes = new Set<HoisterWorkTree>();
-  const useableDependencies = new Map<PackageName, HoisterWorkTree>();
+  const reachableDependencies = new Map<PackageName, HoisterWorkTree>();
 
   for (const node of rootNodePath)
     for (const dep of node.dependencies.values())
-      useableDependencies.set(dep.name, dep);
+      reachableDependencies.set(dep.name, dep);
 
   const hiddenDependencies = new Set<PackageName>();
   const addUsedDependencies = (node: HoisterWorkTree, hiddenDependencies: Set<PackageName>) => {
@@ -163,8 +163,8 @@ const getUsedDependencies = (rootNodePath: Array<HoisterWorkTree>): Map<PackageN
 
     for (const dep of node.hoistedDependencies.values()) {
       if (!hiddenDependencies.has(dep.name)) {
-        const useableDep = useableDependencies.get(dep.name)!;
-        usedDependencies.set(useableDep.name, useableDep);
+        const reachableDependency = reachableDependencies.get(dep.name)!;
+        usedDependencies.set(reachableDependency.name, reachableDependency);
       }
     }
 
@@ -180,11 +180,7 @@ const getUsedDependencies = (rootNodePath: Array<HoisterWorkTree>): Map<PackageN
     }
   };
 
-  for (const dep of rootNode.dependencies.values()) {
-    if (!rootNode.peerNames.has(dep.name)) {
-      addUsedDependencies(rootNode, hiddenDependencies);
-    }
-  }
+  addUsedDependencies(rootNode, hiddenDependencies);
 
   return usedDependencies;
 };

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -496,20 +496,23 @@ const hoistGraph = (tree: HoisterWorkTree, rootNodePath: Array<HoisterWorkTree>,
         parentNode.hoistedDependencies.set(node.name, node);
         parentNode.reasons.delete(node.name);
         const hoistedNode = rootNode.dependencies.get(node.name);
+        let hoistedFrom: string | null = null;
+        if (options.debugLevel >= DebugLevel.REASONS)
+          hoistedFrom = [``].concat(Array.from(locatorPath).slice(rootNodePathLocators.size).concat([parentNode.locator]).map(x => prettyPrintLocator(x))).join(`→`);
         // Add hoisted node to root node, in case it is not already there
         if (!hoistedNode) {
           // Avoid adding other version of root node to itself
           if (rootNode.ident !== node.ident) {
             rootNode.dependencies.set(node.name, node);
             if (options.debugLevel >= DebugLevel.REASONS)
-              node.hoistedFrom.push(Array.from(locatorPath).concat([parentNode.locator]).map(x => prettyPrintLocator(x)).join(`→`));
+              node.hoistedFrom.push(hoistedFrom!);
             newNodes.add(node);
           }
         } else {
           for (const reference of node.references) {
             hoistedNode.references.add(reference);
             if (options.debugLevel >= DebugLevel.REASONS) {
-              hoistedNode.hoistedFrom.push(Array.from(locatorPath).concat([parentNode.locator]).map(x => prettyPrintLocator(x)).join(`→`));
+              hoistedNode.hoistedFrom.push(hoistedFrom!);
             }
           }
         }

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -183,7 +183,7 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
   if (node.decoupled)
     return node;
 
-  const {name, references, ident, locator, dependencies, originalDependencies, hoistedDependencies, peerNames, reasons, isHoistBorder} = node;
+  const {name, references, ident, locator, dependencies, originalDependencies, hoistedDependencies, peerNames, reasons, isHoistBorder, hoistedFrom} = node;
   // To perform node hoisting from parent node we must clone parent nodes up to the root node,
   // because some other package in the tree might depend on the parent package where hoisting
   // cannot be performed
@@ -199,7 +199,7 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
     reasons: new Map(reasons),
     decoupled: true,
     isHoistBorder,
-    hoistedFrom: [],
+    hoistedFrom,
   };
   const selfDep = clone.dependencies.get(name);
   if (selfDep && selfDep.ident == clone.ident)
@@ -505,7 +505,7 @@ const hoistGraph = (tree: HoisterWorkTree, rootNodePath: Array<HoisterWorkTree>,
               node.hoistedFrom.push(Array.from(locatorPath).concat([parentNode.locator]).map(x => prettyPrintLocator(x)).join(`→`));
             newNodes.add(node);
           }
-        } else if (nodePath.length > 0) {
+        } else {
           for (const reference of node.references) {
             hoistedNode.references.add(reference);
             if (options.debugLevel >= DebugLevel.REASONS) {

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -115,19 +115,22 @@ export const hoist = (tree: HoisterTree, opts: HoistOptions = {}): HoisterResult
   const check = opts.check || debugLevel >= DebugLevel.INTENSIVE_CHECK;
   const hoistingLimits = opts.hoistingLimits || new Map();
   const options: InternalHoistOptions = {check, debugLevel, hoistingLimits};
+  let startTime: number;
 
   if (options.debugLevel >= DebugLevel.PERF)
-    console.time(`hoist`);
+    startTime = Date.now();
 
   const treeCopy = cloneTree(tree, options);
 
   let isGraphChanged = false;
+  let round = 0;
   do {
     isGraphChanged = hoistTo(treeCopy, [treeCopy], new Set([treeCopy.locator]), options);
+    round++;
   } while (isGraphChanged);
 
   if (options.debugLevel >= DebugLevel.PERF)
-    console.timeEnd(`hoist`);
+    console.log(`hoist time: ${Date.now() - startTime!}ms, rounds: ${round}`);
 
   if (options.debugLevel >= DebugLevel.CHECK) {
     const checkLog = selfCheck(treeCopy);

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -117,7 +117,7 @@ export const hoist = (tree: HoisterTree, opts: HoistOptions = {}): HoisterResult
   const debugLevel = opts.debugLevel || Number(process.env.NM_DEBUG_LEVEL || DebugLevel.NONE);
   const check = opts.check || debugLevel >= DebugLevel.INTENSIVE_CHECK;
   const hoistingLimits = opts.hoistingLimits || new Map();
-  const options: InternalHoistOptions = {check, debugLevel, hoistingLimits, fastLookupPossible: false};
+  const options: InternalHoistOptions = {check, debugLevel, hoistingLimits, fastLookupPossible: true};
   let startTime: number;
 
   if (options.debugLevel >= DebugLevel.PERF)


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Fixes issue:
https://github.com/babel/babel/pull/12583#discussion_r553391274
The issue happens because the dependency graph was not fully hoisted, which resulted in an unlucky situation when the place was temporary occupied in a single workspace by conflicting versions of the same dependency.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The simplified example of a dependency graph requiring multiple hoisting passes is below:
```
. -> A -> D@X -> F@X -> E@X -> B@Y -> C@Z
                            -> C@X
                     -> C@Z
              -> C@X      
  -> B@X
  -> C@Z
  -> D@Y
  -> E@Y
  -> F@Y
```
We try to hoist everything we can to the `.` node first, we cannot hoist anything
Then we try to hoist everything we can to `A` (`C@Z` has a priority, because its more popular), we have
```
. -> A -> D@X -> C@X
       -> F@X
       -> E@X -> C@X
       -> B@Y 
       -> C@Z
  -> B@X
  -> C@Z
  -> D@Y
  -> E@Y
  -> F@Y
```

And now we can hoist `C@Z` from `A`, but we need another pass to do it, because we need to try to hoist to the root again, and the final result will be:
```
. -> A -> D@X -> C@X
       -> F@X
       -> E@X -> C@X
       -> B@Y 
  -> B@X
  -> C@Z
  -> D@Y
  -> E@Y
  -> F@Y
```

I have fixed the issue by adding support of detecting the case when multiple rounds of hoisting are needed. The algorithm stops when detection yields no results, thus the minimum number of required rounds are performed. I have also added to a self-check the validation whether result is actually terminal, by doing another hoisting round and checking whether any hoisting was performed during this additional round.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
