### PR TITLE
fix(constraints): preserve manifest when fixing dependencies

### DIFF
--- a/.yarn/versions/1b783d48.yml
+++ b/.yarn/versions/1b783d48.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -18,7 +18,7 @@ describe(`Commands`, () => {
     scripts: {
       echo: `echo`,
     },
-    unparsedKey: 'foo',
+    unparsedKey: `foo`,
   };
 
   describe(`constraints --fix`, () => {
@@ -85,7 +85,7 @@ describe(`Commands`, () => {
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
 
       expect(fixedManifest.scripts).toMatchObject({echo: `echo`});
-      expect(fixedManifest.unparsedKey).toBe('foo');
+      expect(fixedManifest.unparsedKey).toBe(`foo`);
     }));
   });
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -15,6 +15,10 @@ describe(`Commands`, () => {
       'is-number': `1.0.0`,
     },
     license: `MIT`,
+    scripts: {
+      echo: `echo`,
+    },
+    unparsedKey: 'foo',
   };
 
   describe(`constraints --fix`, () => {
@@ -69,6 +73,19 @@ describe(`Commands`, () => {
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
 
       expect(fixedManifest.workspaces.length).toBe(1);
+    }));
+
+    it(`should preserve the raw manifest data when applying a fix`, makeTemporaryEnv(manifest, config, async ({path, run, source}) => {
+      await xfs.writeFilePromise(`${path}/constraints.pro`, `
+      gen_enforced_dependency('.', 'is-number', null, dependencies).
+      `);
+
+      await run(`constraints`, `--fix`);
+
+      const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
+
+      expect(fixedManifest.scripts).toMatchObject({echo: `echo`});
+      expect(fixedManifest.unparsedKey).toBe('foo');
     }));
   });
 });

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -62,8 +62,11 @@ export default class ConstraintsCheckCommand extends BaseCommand {
         });
 
         // Dependency constraints work on the manifess, field constraints work on the raw JSON objects
-        for (const {manifest} of modifiedDependencies)
-          manifest.exportTo(manifest.raw = {});
+        for (const {manifest} of modifiedDependencies) {
+          const newManifest = {};
+          manifest.exportTo(newManifest);
+          manifest.raw = newManifest;
+        }
 
         const modifiedFields = new Set<Workspace>();
         await processFieldConstraints(modifiedFields, errors, result.enforcedFields, {


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/yarnpkg/berry/pull/2245 introduced a bug that causes fields in the manifest to be removed and have their order changed when fixing dependencies

**How did you fix it?**

Export the manifest to an empty object then assign it back to `manifest.raw`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.