### PR TITLE
fix(constraints): print the current value on extraneous fields

### DIFF
--- a/.yarn/versions/7c6e77ff.yml
+++ b/.yarn/versions/7c6e77ff.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
@@ -161,8 +161,8 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (ex
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0039: workspace-a has an extraneous field dependencies set to null
-➤ YN0039: workspace-b has an extraneous field dependencies set to null
+  "stdout": "➤ YN0039: workspace-a has an extraneous field dependencies set to {\\"no-deps\\":\\"1.0.0\\",\\"no-deps-bin\\":\\"1.0.0\\"}
+➤ YN0039: workspace-b has an extraneous field dependencies set to {\\"no-deps\\":\\"1.0.0\\",\\"no-deps-bin\\":\\"1.0.0\\"}
 ➤ YN0000: Failed with errors
 ",
 }
@@ -255,7 +255,7 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0039: root-workspace-0b6124 has an extraneous field dependencies set to null
+  "stdout": "➤ YN0039: root-workspace-0b6124 has an extraneous field dependencies set to {\\"no-deps\\":\\"1.0.0\\"}
 ➤ YN0000: Failed with errors
 ",
 }
@@ -432,7 +432,7 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0039: root-workspace-0b6124 has an extraneous field dependencies set to null
+  "stdout": "➤ YN0039: root-workspace-0b6124 has an extraneous field dependencies set to {\\"no-deps\\":\\"1.0.0\\",\\"no-deps-bin\\":\\"1.0.0\\"}
 ➤ YN0000: Failed with errors
 ",
 }
@@ -522,7 +522,7 @@ exports[`Commands constraints test (two regular dependencies, two development de
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0039: root-workspace-0b6124 has an extraneous field dependencies set to null
+  "stdout": "➤ YN0039: root-workspace-0b6124 has an extraneous field dependencies set to {\\"no-deps\\":\\"1.0.0\\",\\"no-deps-bin\\":\\"1.0.0\\"}
 ➤ YN0000: Failed with errors
 ",
 }

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -220,7 +220,7 @@ async function processFieldConstraints(toSave: Set<Workspace>, errors: Array<[Me
               await setWorkspaceField(workspace, fieldPath, null);
               toSave.add(workspace);
             } else {
-              errors.push([MessageName.CONSTRAINTS_EXTRANEOUS_FIELD, `${structUtils.prettyWorkspace(configuration, workspace)} has an extraneous field ${formatUtils.pretty(configuration, fieldPath, `cyan`)} set to ${formatUtils.pretty(configuration, String(expectedValue), `magenta`)}`]);
+              errors.push([MessageName.CONSTRAINTS_EXTRANEOUS_FIELD, `${structUtils.prettyWorkspace(configuration, workspace)} has an extraneous field ${formatUtils.pretty(configuration, fieldPath, `cyan`)} set to ${formatUtils.pretty(configuration, JSON.stringify(actualValue), `magenta`)}`]);
             }
           }
         }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using constraints to enforce that a field shouldn't exist prints a message with the expected value (`null`) instead of the current value

**How did you fix it?**

Print the current value

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.