### PR TITLE
fix(constraints): always treat an expected null range as extraneous

### DIFF
--- a/.yarn/versions/10571222.yml
+++ b/.yarn/versions/10571222.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
@@ -28,6 +28,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (empty project / gen_enforced_dependency (extraneous2)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (empty project / gen_enforced_dependency (incompatible)) 1`] = `
 Object {
   "code": 1,
@@ -109,6 +118,19 @@ Object {
 `;
 
 exports[`Commands constraints test (multiple workspaces / gen_enforced_dependency (extraneous)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0025: workspace-a has an extraneous dependency on no-deps (in dependencies)
+➤ YN0025: workspace-a has an extraneous dependency on no-deps (in devDependencies)
+➤ YN0025: workspace-b has an extraneous dependency on no-deps (in dependencies)
+➤ YN0025: workspace-b has an extraneous dependency on no-deps (in devDependencies)
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (multiple workspaces / gen_enforced_dependency (extraneous2)) 1`] = `
 Object {
   "code": 1,
   "stderr": "",
@@ -221,6 +243,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (one regular dependency / gen_enforced_dependency (extraneous2)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (one regular dependency / gen_enforced_dependency (incompatible)) 1`] = `
 Object {
   "code": 1,
@@ -306,6 +337,15 @@ Object {
   "stderr": "",
   "stdout": "➤ YN0025: root-workspace-0b6124 has an extraneous dependency on no-deps (in devDependencies)
 ➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (two development dependencies / gen_enforced_dependency (extraneous2)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
 ",
 }
 `;
@@ -398,6 +438,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (two regular dependencies / gen_enforced_dependency (extraneous2)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (two regular dependencies / gen_enforced_dependency (incompatible)) 1`] = `
 Object {
   "code": 1,
@@ -484,6 +533,15 @@ Object {
   "stdout": "➤ YN0025: root-workspace-0b6124 has an extraneous dependency on no-deps (in dependencies)
 ➤ YN0025: root-workspace-0b6124 has an extraneous dependency on no-deps (in devDependencies)
 ➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (two regular dependencies, two development dependencies / gen_enforced_dependency (extraneous2)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
 ",
 }
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
@@ -9,6 +9,13 @@ const constraints = {
   [`gen_enforced_dependency (missing)`]: `gen_enforced_dependency(WorkspaceCwd, 'one-fixed-dep', '1.0.0', peerDependencies).`,
   [`gen_enforced_dependency (incompatible)`]: `gen_enforced_dependency(WorkspaceCwd, 'no-deps', '2.0.0', dependencies).`,
   [`gen_enforced_dependency (extraneous)`]: `gen_enforced_dependency(WorkspaceCwd, 'no-deps', null, _).`,
+  [`gen_enforced_dependency (extraneous2)`]:
+    `
+    gen_enforced_dependency(WorkspaceCwd, 'no-deps', null, _) :-
+      WorkspaceCwd \\= '.'.
+    gen_enforced_dependency(WorkspaceCwd, 'no-deps', '1.0.0', DependencyType) :- 
+      workspace_has_dependency(WorkspaceCwd, 'no-deps', '1.0.0', DependencyType).
+    `,
   [`gen_enforced_dependency (ambiguous)`]: `gen_enforced_dependency(WorkspaceCwd, 'no-deps', '1.0.0', dependencies). gen_enforced_dependency(WorkspaceCwd, 'no-deps', '2.0.0', dependencies).`,
   [`gen_enforced_field (missing)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies["a-new-dep"]', '1.0.0').`,
   [`gen_enforced_field (incompatible)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies["no-deps"]', '2.0.0').`,

--- a/packages/gatsby/content/features/constraints.md
+++ b/packages/gatsby/content/features/constraints.md
@@ -143,7 +143,7 @@ gen_enforced_dependency(
 ).
 ```
 
-The `gen_enforced_dependency` rule offers a neat way to inform the package manager that a specific workspace MUST either depend on a specific range of a specific dependency (if `DependencyRange` is non-null) or not depend at all on the dependency (if `DependencyRange` is null) in the `DependencyType` dependencies block.
+The `gen_enforced_dependency` rule offers a neat way to inform the package manager that a specific workspace MUST either depend on a specific range of a specific dependency (if `DependencyRange` is non-null) or not depend at all on the dependency (if `DependencyRange` is null; takes precedence over any conflicting range) in the `DependencyType` dependencies block.
 
 Running `yarn constraints --fix` will instruct Yarn to fix the detected errors the best it can, but in some cases ambiguities will arise. Those will have to be solved manually, although Yarn will help you in the process.
 

--- a/packages/plugin-constraints/sources/Constraints.ts
+++ b/packages/plugin-constraints/sources/Constraints.ts
@@ -89,11 +89,6 @@ function extractError(val: any) {
   return err;
 }
 
-// Node 8 doesn't have Symbol.asyncIterator
-// https://github.com/Microsoft/TypeScript/issues/14151#issuecomment-280812617
-if (Symbol.asyncIterator == null)
-  (Symbol as any).asyncIterator = Symbol.for(`Symbol.asyncIterator`);
-
 class Session {
   private readonly session: pl.type.Session;
 

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -136,7 +136,8 @@ async function processDependencyConstraints(toSave: Set<Workspace>, errors: Arra
         throw new Error(`Assertion failed: The ident should have been registered`);
 
       for (const [dependencyType, byDependencyTypeStore] of byIdentStore) {
-        const expectedRanges = [...byDependencyTypeStore];
+        // If any of the expected ranges are `null` then the dependency should be removed
+        const expectedRanges = byDependencyTypeStore.has(null) ? [null] : [...byDependencyTypeStore];
         if (expectedRanges.length > 2) {
           errors.push([MessageName.CONSTRAINTS_AMBIGUITY, `${structUtils.prettyWorkspace(configuration, workspace)} must depend on ${structUtils.prettyIdent(configuration, dependencyIdent)} via conflicting ranges ${expectedRanges.slice(0, -1).map(expectedRange => structUtils.prettyRange(configuration, String(expectedRange))).join(`, `)}, and ${structUtils.prettyRange(configuration, String(expectedRanges[expectedRanges.length - 1]))} (in ${dependencyType})`]);
         } else if (expectedRanges.length > 1) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using constraints to enforce that all workspaces depend on the same version of a dependency and that some workspace can't depend on a dependency reports them as conflicting instead of extraneous

**How did you fix it?**

If any of the expected ranges are null always treat it as extraneous

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.