### PR TITLE
fix(fslib): return real path in mktempSync

### DIFF
--- a/.yarn/versions/52b83537.yml
+++ b/.yarn/versions/52b83537.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/fslib": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/xfs.ts
+++ b/packages/yarnpkg-fslib/sources/xfs.ts
@@ -82,7 +82,7 @@ export const xfs: XFS = Object.assign(new NodeFS(), {
           }
         }
       } else {
-        return p;
+        return realP;
       }
     }
   },

--- a/packages/yarnpkg-fslib/tests/xfs.test.ts
+++ b/packages/yarnpkg-fslib/tests/xfs.test.ts
@@ -1,0 +1,35 @@
+import {xfs} from '../sources';
+
+describe(`xfs`, () => {
+  describe(`detachTemp`, () => {
+    it(`should detach temp created by mktempSync`, async () => {
+      const temp = xfs.mktempSync();
+      xfs.detachTemp(temp);
+
+      const otherTemp = xfs.mktempSync(t => {
+        xfs.detachTemp(t);
+        return t;
+      });
+
+      xfs.rmtempSync();
+
+      await expect(xfs.existsPromise(temp)).resolves.toBe(true);
+      await expect(xfs.existsPromise(otherTemp)).resolves.toBe(true);
+    });
+
+    it(`should detach temp created by mktempPromise`, async () => {
+      const temp = await xfs.mktempPromise();
+      xfs.detachTemp(temp);
+
+      const otherTemp = await xfs.mktempPromise(async t => {
+        xfs.detachTemp(t);
+        return t;
+      });
+
+      xfs.rmtempPromise();
+
+      await expect(xfs.existsPromise(temp)).resolves.toBe(true);
+      await expect(xfs.existsPromise(otherTemp)).resolves.toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes #2420

**How did you fix it?**

Return the real path, as is already the case in `mktempPromise`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
