### PR TITLE
Adds npm_package_name

### DIFF
--- a/.yarn/versions/0f833eb2.yml
+++ b/.yarn/versions/0f833eb2.yml
@@ -1,13 +1,13 @@
 releases:
   "@yarnpkg/cli": minor
   "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
   "@yarnpkg/plugin-exec": minor
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
-  - "@yarnpkg/plugin-essentials"
   - "@yarnpkg/plugin-file"
   - "@yarnpkg/plugin-git"
   - "@yarnpkg/plugin-github"

--- a/.yarn/versions/0f833eb2.yml
+++ b/.yarn/versions/0f833eb2.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-exec": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -469,6 +469,27 @@ describe(`Scripts tests`, () => {
   );
 
   test(
+    `it should make expose some basic information via the environment`,
+    makeTemporaryEnv({
+      name: `helloworld`,
+      version: `1.2.3`,
+      scripts: {
+        [`test`]: `node -p 'JSON.stringify(process.env)'`,
+      },
+    }, async ({path, run, source}) => {
+      await run(`install`);
+
+      const {stdout} = await run(`run`, `test`);
+      const env = JSON.parse(stdout);
+
+      expect(env).toMatchObject({
+        npm_package_name: `helloworld`,
+        npm_package_version: `1.2.3`,
+      });
+    })
+  );
+
+  test(
     `it should setup the correct path for locally installed binaries`,
     makeTemporaryEnv({
       scripts: {

--- a/packages/gatsby/content/advanced/lifecycle-scripts.md
+++ b/packages/gatsby/content/advanced/lifecycle-scripts.md
@@ -32,3 +32,23 @@ Depending on your use case, here's how you can avoid postinstall scripts:
 - Native packages can be built to [WebAssembly](https://webassembly.org), which is already supported in Node 12 and beyond. On top of being portable and fast, WebAssembly packages also have the benefit to make your libraries available not only to Node but also to your browser users. And since their compilation is made upfront, your users won't be impacted by slow compilation time problems.
 
 - Project sustainability is a big topic, but the gist is that we don't think postinstall scripts are a viable solution. We however are committed to providing a specific field in the package.json that would signal to the package managers that a project would like to communicate its existence with the user in an integrated and respectful way.
+
+## Environment variables
+
+When running scripts and binaries, some environment variables are usually made available:
+
+- `$INIT_CWD` represents the directory from which the script has been invoked. This isn't the same as the cwd, which for scripts is always equal to the closest package root.
+
+- `$PROJECT_CWD` is the root of the project on the filesystem.
+
+- `$npm_package_name` is the name of the package that lists the script being executed.
+
+- `$npm_package_version` is its version.
+
+- `$npm_execpath` is the path to the Yarn binary.
+
+- `$npm_node_execpath` is the path to the Node binary.
+
+- `$npm_config_user_agent` is a string defining the Yarn version currently in use.
+
+- `$npm_lifecycle_event` is the name of the script or lifecycle event, if relevant.

--- a/packages/plugin-essentials/sources/commands/exec.ts
+++ b/packages/plugin-essentials/sources/commands/exec.ts
@@ -28,7 +28,7 @@ export default class ExecCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project} = await Project.find(configuration, this.context.cwd);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     return await xfs.mktempPromise(async binFolder => {
       const {code} = await execUtils.pipevp(this.commandName, this.args, {
@@ -36,7 +36,7 @@ export default class ExecCommand extends BaseCommand {
         stdin: this.context.stdin,
         stdout: this.context.stdout,
         stderr: this.context.stderr,
-        env: await scriptUtils.makeScriptEnv({project, binFolder}),
+        env: await scriptUtils.makeScriptEnv({project, locator: workspace?.anchoredLocator, binFolder}),
       });
 
       return code;

--- a/packages/plugin-essentials/sources/commands/exec.ts
+++ b/packages/plugin-essentials/sources/commands/exec.ts
@@ -28,7 +28,7 @@ export default class ExecCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
+    const {project, locator} = await Project.find(configuration, this.context.cwd);
 
     return await xfs.mktempPromise(async binFolder => {
       const {code} = await execUtils.pipevp(this.commandName, this.args, {
@@ -36,7 +36,7 @@ export default class ExecCommand extends BaseCommand {
         stdin: this.context.stdin,
         stdout: this.context.stdout,
         stderr: this.context.stderr,
-        env: await scriptUtils.makeScriptEnv({project, locator: workspace?.anchoredLocator, binFolder}),
+        env: await scriptUtils.makeScriptEnv({project, locator, binFolder}),
       });
 
       return code;

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -88,7 +88,7 @@ export class ExecFetcher implements Fetcher {
 
   private async generatePackage(cwd: PortablePath, locator: Locator, generatorPath: PortablePath, opts: FetchOptions) {
     return await xfs.mktempPromise(async binFolder => {
-      const env = await scriptUtils.makeScriptEnv({project: opts.project, locator, binFolder});
+      const env = await scriptUtils.makeScriptEnv({project: opts.project, binFolder});
       const runtimeFile = ppath.join(cwd, `runtime.js` as Filename);
 
       return await xfs.mktempPromise(async logDir => {

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -88,7 +88,7 @@ export class ExecFetcher implements Fetcher {
 
   private async generatePackage(cwd: PortablePath, locator: Locator, generatorPath: PortablePath, opts: FetchOptions) {
     return await xfs.mktempPromise(async binFolder => {
-      const env = await scriptUtils.makeScriptEnv({project: opts.project, binFolder});
+      const env = await scriptUtils.makeScriptEnv({project: opts.project, locator, binFolder});
       const runtimeFile = ppath.join(cwd, `runtime.js` as Filename);
 
       return await xfs.mktempPromise(async logDir => {

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -100,16 +100,15 @@ export async function makeScriptEnv({project, locator, binFolder, lifecycleScrip
     if (!project)
       throw new Error(`Assertion failed: Missing project`);
 
-    const pkg = project.storedPackages.get(locator.locatorHash);
-    if (typeof pkg === `undefined`)
-      throw new Error(`Assertion failed: Expected locator to be registered`);
-
     // Workspaces have 0.0.0-use.local in their "pkg" registrations, so we
     // need to access the actual workspace to get its real version.
-    const workspace = project.tryWorkspaceByLocator(pkg);
+    const workspace = project.tryWorkspaceByLocator(locator);
+    const version = workspace
+      ? workspace.manifest.version ?? ``
+      : project.storedPackages.get(locator.locatorHash)!.version ?? ``;
 
-    scriptEnv.npm_package_name = structUtils.stringifyIdent(pkg);
-    scriptEnv.npm_package_version = workspace?.manifest.version ?? pkg.version ?? ``;
+    scriptEnv.npm_package_name = structUtils.stringifyIdent(locator);
+    scriptEnv.npm_package_version = version;
   }
 
   const version = YarnVersion !== null

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -61,7 +61,7 @@ async function detectPackageManager(location: PortablePath) {
   return null;
 }
 
-export async function makeScriptEnv({project, binFolder, lifecycleScript}: {project?: Project, binFolder: PortablePath, lifecycleScript?: string}) {
+export async function makeScriptEnv({project, locator, binFolder, lifecycleScript}: {project?: Project, locator?: Locator, binFolder: PortablePath, lifecycleScript?: string}) {
   const scriptEnv: {[key: string]: string} = {};
   for (const [key, value] of Object.entries(process.env))
     if (typeof value !== `undefined`)
@@ -95,6 +95,22 @@ export async function makeScriptEnv({project, binFolder, lifecycleScript}: {proj
 
   scriptEnv.npm_execpath = `${nBinFolder}${npath.sep}yarn`;
   scriptEnv.npm_node_execpath = `${nBinFolder}${npath.sep}node`;
+
+  if (locator) {
+    if (!project)
+      throw new Error(`Assertion failed: Missing project`);
+
+    const pkg = project.storedPackages.get(locator.locatorHash);
+    if (typeof pkg === `undefined`)
+      throw new Error(`Assertion failed: Expected locator to be registered`);
+
+    // Workspaces have 0.0.0-use.local in their "pkg" registrations, so we
+    // need to access the actual workspace to get its real version.
+    const workspace = project.tryWorkspaceByLocator(pkg);
+
+    scriptEnv.npm_package_name = structUtils.stringifyIdent(pkg);
+    scriptEnv.npm_package_version = workspace?.manifest.version ?? pkg.version ?? ``;
+  }
 
   const version = YarnVersion !== null
     ? `yarn/${YarnVersion}`
@@ -342,7 +358,7 @@ async function initializePackageEnvironment(locator: Locator, {project, binFolde
     if (!linker)
       throw new Error(`The package ${structUtils.prettyLocator(project.configuration, pkg)} isn't supported by any of the available linkers`);
 
-    const env = await makeScriptEnv({project, binFolder, lifecycleScript});
+    const env = await makeScriptEnv({project, locator, binFolder, lifecycleScript});
 
     await Promise.all(
       Array.from(await getPackageAccessibleBinaries(locator, {project}), ([binaryName, [, binaryPath]]) =>
@@ -526,7 +542,7 @@ export async function executePackageAccessibleBinary(locator: Locator, binaryNam
 
   return await xfs.mktempPromise(async binFolder => {
     const [, binaryPath] = binary;
-    const env = await makeScriptEnv({project, binFolder});
+    const env = await makeScriptEnv({project, locator, binFolder});
 
     await Promise.all(
       Array.from(packageAccessibleBinaries, ([binaryName, [, binaryPath]]) =>


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `$npm_package_name` and `$npm_package_version` variables weren't exposed in order to prevent the explosion of variables we would need to put in the environment, and avoid ambiguities when a package wouldn't list them and would accidentally "inherit" those from other scripts.

After more consideration, I think it's reasonable to add those two since every package will have them, so there's no ambiguity issue.

Fixes #1659

**How did you fix it?**

Added the relevant environment variables, plus documentation, plus test.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
