### PR TITLE
fix(pnpify): force enable allowLocalPluginLoads in the typescript sdk

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -66,6 +66,20 @@ const moduleWrapper = tsserver => {
       : str.replace(/^\^?zip:/, ``);
   }
 
+  // Force enable 'allowLocalPluginLoads'
+  // TypeScript tries to resolve plugins using a path relative to itself
+  // which doesn't work when using the global cache
+  // https://github.com/microsoft/TypeScript/blob/1b57a0395e0bff191581c9606aab92832001de62/src/server/project.ts#L2238
+  // VSCode doesn't want to enable 'allowLocalPluginLoads' due to security concerns but
+  // TypeScript already does local loads and if this code is running the user trusts the workspace
+  // https://github.com/microsoft/vscode/issues/45856
+  const ConfiguredProject = tsserver.server.ConfiguredProject;
+  const {enablePluginsWithOptions: originalEnablePluginsWithOptions} = ConfiguredProject.prototype;
+  ConfiguredProject.prototype.enablePluginsWithOptions = function() {
+    this.projectService.allowLocalPluginLoads = true;
+    return originalEnablePluginsWithOptions.apply(this, arguments);
+  };
+
   // And here is the point where we hijack the VSCode <-> TS communications
   // by adding ourselves in the middle. We locate everything that looks
   // like an absolute path of ours and normalize it.

--- a/.yarn/versions/e9cc398c.yml
+++ b/.yarn/versions/e9cc398c.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"


### PR DESCRIPTION
**What's the problem this PR addresses?**

TypeScript plugins doesn't work in VSCode when the global cache is enabled due to [TypeScript trying to resolve them using a path relative to itself](https://github.com/microsoft/TypeScript/blob/1b57a0395e0bff191581c9606aab92832001de62/src/server/project.ts#L2238) and [VSCode not wanting to turn on `allowLocalPluginLoads`](https://github.com/microsoft/vscode/issues/45856).

TypeScript resolves these paths depending on the Yarn config
```
node_modules:        /berry/node_modules
PnP /w global cache: /globalFolder/cache/typescript-patch-bd6352e847-7.zip/node_modules
PnP /w local cache:  /berry/.yarn/cache/typescript-patch-bd6352e847-35322004ca.zip/node_modules
```

The path for the global cache isn't controlled by anything so it goes to the native resolution which can't find anything, while the path for the local cache belongs to the project root so it is able to find the plugins

**How did you fix it?**

Force enable `allowLocalPluginLoads` in the SDK

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.