### PR TITLE
Bugfix/allow underscore in dist tags

### DIFF
--- a/.yarn/versions/26ce5b4f.yml
+++ b/.yarn/versions/26ce5b4f.yml
@@ -1,5 +1,30 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
 
 declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/.yarn/versions/26ce5b4f.yml
+++ b/.yarn/versions/26ce5b4f.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-dlx"

--- a/.yarn/versions/26ce5b4f.yml
+++ b/.yarn/versions/26ce5b4f.yml
@@ -1,9 +1,6 @@
 releases:
   "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
-  "@yarnpkg/plugin-node-modules": patch
-  "@yarnpkg/plugin-npm": patch
-  "@yarnpkg/plugin-npm-cli": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
@@ -18,6 +15,9 @@ declined:
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
   - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
   - "@yarnpkg/plugin-pnp"

--- a/packages/yarnpkg-core/sources/ProtocolResolver.ts
+++ b/packages/yarnpkg-core/sources/ProtocolResolver.ts
@@ -5,7 +5,7 @@ import * as semverUtils                                  from './semverUtils';
 import * as structUtils                                  from './structUtils';
 import {Descriptor, Locator, DescriptorHash, Package}    from './types';
 
-export const TAG_REGEXP = /^(?!v)[a-z0-9-._]+$/i;
+export const TAG_REGEXP = /^(?!v)[a-z0-9._-]+$/i;
 
 export class ProtocolResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {

--- a/packages/yarnpkg-core/sources/ProtocolResolver.ts
+++ b/packages/yarnpkg-core/sources/ProtocolResolver.ts
@@ -5,7 +5,7 @@ import * as semverUtils                                  from './semverUtils';
 import * as structUtils                                  from './structUtils';
 import {Descriptor, Locator, DescriptorHash, Package}    from './types';
 
-export const TAG_REGEXP = /^(?!v)[a-z0-9-.]+$/i;
+export const TAG_REGEXP = /^(?!v)[a-z0-9-._]+$/i;
 
 export class ProtocolResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {

--- a/packages/yarnpkg-core/tests/ProtocolResolver.test.ts
+++ b/packages/yarnpkg-core/tests/ProtocolResolver.test.ts
@@ -1,0 +1,17 @@
+import {TAG_REGEXP} from "../sources/ProtocolResolver";
+
+describe(`ProtocolResolver`, () => {
+  describe(`TAG_REGEXP`, () => {
+    const validTags = [
+      `canary`,
+      `latest`,
+      `next`,
+      `legacy_v1`,
+    ];
+
+    it(`should allow all valid tags`, () => {
+      const badTags = validTags.filter(tag => !TAG_REGEXP.test(tag));
+      expect(badTags.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**
When trying to resolve a package by a dist tag, yarn fails to add if the dist tag has underscore character. Underscore character should be allowed.

Relevant discussion happened here:
https://github.com/yarnpkg/berry/pull/1271#discussion_r417869505

Underscore was discussed and later fell out along the way. Looks like it was just a miss.

<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Resolves #2439
...

**How did you fix it?**
Updated the validation regex to include the underscore character. Also, I wrote a unit test.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
