### PR TITLE
ci: avoid running old benchmark

### DIFF
--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -12,6 +12,7 @@ cd "$BENCH_DIR"
 
 bench() {
   SUBTEST_NAME=$1; shift
+  echo "Testing $SUBTEST_NAME"
   hyperfine ${HYPERFINE_OPTIONS:-} --export-json=bench-$SUBTEST_NAME.json --min-runs=10 --warmup=1 "$@"
 }
 
@@ -84,8 +85,6 @@ case $PACKAGE_MANAGER in
       'yarn install'
     bench install-cache-and-lock \
       --prepare 'rm -rf .yarn node_modules' \
-      'yarn install'
-    bench install-ready \
       'yarn install'
     bench install-ready \
       --prepare 'yarn remove dummy-pkg || true' \


### PR DESCRIPTION
**What's the problem this PR addresses?**

The benchmark suite is running one of the old benchmarks which has its output overwritten by the next benchmark in the list meaning its data isn't used.

**How did you fix it?**

Removed the old benchmark

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.