### PR TITLE
ci: set useTaobaoRegistry to false in vue e2e test

### DIFF
--- a/.github/workflows/e2e-vue-cli-workflow.yml
+++ b/.github/workflows/e2e-vue-cli-workflow.yml
@@ -30,5 +30,8 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
+
+        yarn dlx -p @vue/cli vue config --set useTaobaoRegistry false
+
         yarn dlx -p @vue/cli vue create -d my-vue && cd my-vue
         yarn build

--- a/.github/workflows/e2e-vue-cli-workflow.yml
+++ b/.github/workflows/e2e-vue-cli-workflow.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
 
-        yarn dlx -p @vue/cli vue config --set useTaobaoRegistry false
+        echo '{"useTaobaoRegistry": false}' | tee ~/.vuerc
 
         yarn dlx -p @vue/cli vue create -d my-vue && cd my-vue
         yarn build


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The Vue CLI E2E test [loves](https://github.com/yarnpkg/berry/runs/1867663657?check_suite_focus=true#step:5:51) [to](https://github.com/yarnpkg/berry/runs/1866168981?check_suite_focus=true#step:5:51) [randomly](https://github.com/yarnpkg/berry/runs/1811994939?check_suite_focus=true#step:5:51) [fail](https://github.com/yarnpkg/berry/runs/1799884287?check_suite_focus=true#step:5:51) because when the network connection isn't that good it prompts the user whether they want to use the taobao registry, even on CI.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Set useTaobaoRegistry to false.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
