### PR TITLE
fix(node-modules): add missing await to symlinkPromise

### DIFF
--- a/.yarn/versions/a7b438c0.yml
+++ b/.yarn/versions/a7b438c0.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -604,15 +604,15 @@ const symlinkPromise = async (srcPath: PortablePath, dstPath: PortablePath) => {
 
   try {
     if (process.platform === `win32`) {
-      stats = xfs.lstatSync(srcPath);
+      stats = await xfs.lstatPromise(srcPath);
     }
   } catch (e) {
   }
 
   if (process.platform == `win32` && (!stats || stats.isDirectory())) {
-    xfs.symlinkPromise(srcPath, dstPath, `junction`);
+    await xfs.symlinkPromise(srcPath, dstPath, `junction`);
   } else {
-    xfs.symlinkPromise(ppath.relative(ppath.dirname(dstPath), srcPath), dstPath);
+    await xfs.symlinkPromise(ppath.relative(ppath.dirname(dstPath), srcPath), dstPath);
   }
 };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `node-modules` linker doesn't await its calls to `xfs.symlinkPromise` in `symlinkPromise`

**How did you fix it?**

`await` the two calls to `xfs.symlinkPromise`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.