### PR TITLE
Add explanatory logging when installing git-based dependency

### DIFF
--- a/.yarn/versions/6df90ada.yml
+++ b/.yarn/versions/6df90ada.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-git/sources/GitFetcher.ts
+++ b/packages/plugin-git/sources/GitFetcher.ts
@@ -58,6 +58,7 @@ export class GitFetcher implements Fetcher {
       configuration: opts.project.configuration,
       report: opts.report,
       workspace: repoUrlParts.extra.workspace,
+      locator,
     });
 
     const sourceBuffer = await xfs.readFilePromise(packagePath);

--- a/packages/plugin-github/sources/GithubFetcher.ts
+++ b/packages/plugin-github/sources/GithubFetcher.ts
@@ -55,6 +55,7 @@ export class GithubFetcher implements Fetcher {
         configuration: opts.project.configuration,
         report: opts.report,
         workspace: repoUrlParts.extra.workspace,
+        locator,
       });
 
       const packedBuffer = await xfs.readFilePromise(packagePath);

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -154,10 +154,10 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
       const stdin = null;
       const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {prefix: cwd, report});
 
+      const projectName: string = await JSON.parse(xfs.readFilePromise(ppath.join(cwd, `package.json`), `utf8`))
+        .then((packageInfo: { name: string }) => packageInfo.name);
       stdout.write(`Installing the external project "${projectName}" from sources\n\n`);
 
-      let projectName: string = await JSON.parse(xfs.readFilePromise(ppath.join(cwd, 'package.json'), `utf8`))
-        .then((packageInfo: { name: string }) => packageInfo.name);
 
       const packageManager = await detectPackageManager(cwd, stdout, projectName);
       let effectivePackageManager: PackageManager;

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -151,7 +151,7 @@ export async function makeScriptEnv({project, locator, binFolder, lifecycleScrip
 const MAX_PREPARE_CONCURRENCY = 2;
 const prepareLimit = pLimit(MAX_PREPARE_CONCURRENCY);
 
-export async function prepareExternalProject(cwd: PortablePath, outputPath: PortablePath, {configuration, report, workspace = null}: {configuration: Configuration, report: Report, workspace?: string | null}) {
+export async function prepareExternalProject(cwd: PortablePath, outputPath: PortablePath, {configuration, report, workspace = null, locator}: {configuration: Configuration, report: Report, workspace?: string | null, locator: Locator}) {
   await prepareLimit(async () => {
     await xfs.mktempPromise(async logDir => {
       const logFile = ppath.join(logDir, `pack.log` as Filename);
@@ -159,18 +159,16 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
       const stdin = null;
       const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {prefix: cwd, report});
 
-      const projectName: string = await xfs.readFilePromise(ppath.join(cwd, `package.json` as PortablePath), `utf8`)
-        .then((packageInfo: string) => JSON.parse(packageInfo).name);
-      stdout.write(`Installing the external project "${projectName}" from sources\n\n`);
+      stdout.write(`Installing the external project "${locator.name}" from sources\n\n`);
 
       const packageManagerSelection = await detectPackageManager(cwd);
       let effectivePackageManager: PackageManager;
 
       if (packageManagerSelection !== null) {
-        stdout.write(`Installing the external project "${projectName}" using ${packageManagerSelection.packageManager}. Reason: ${packageManagerSelection.reason}\n\n`);
+        stdout.write(`Installing the external project "${locator.name}" using ${packageManagerSelection.packageManager}. Reason: ${packageManagerSelection.reason}\n\n`);
         effectivePackageManager = packageManagerSelection.packageManager;
       } else {
-        stdout.write(`No package manager detected for external project "${projectName}"; defaulting to Yarn\n\n`);
+        stdout.write(`No package manager detected for external project "${locator.name}"; defaulting to Yarn\n\n`);
         effectivePackageManager = PackageManager.Yarn2;
       }
 

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -159,16 +159,17 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
       const stdin = null;
       const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {prefix: cwd, report});
 
-      stdout.write(`Installing the external project "${locator.name}" from sources\n\n`);
+      const projectName = locator ? ` "${structUtils.stringifyLocator(locator)}"` : ``;
+      stdout.write(`Installing the external project${projectName} from sources\n\n`);
 
       const packageManagerSelection = await detectPackageManager(cwd);
       let effectivePackageManager: PackageManager;
 
       if (packageManagerSelection !== null) {
-        stdout.write(`Installing the external project "${locator.name}" using ${packageManagerSelection.packageManager}. Reason: ${packageManagerSelection.reason}\n\n`);
+        stdout.write(`Installing the external project${projectName} using ${packageManagerSelection.packageManager}. Reason: ${packageManagerSelection.reason}\n\n`);
         effectivePackageManager = packageManagerSelection.packageManager;
       } else {
-        stdout.write(`No package manager detected for external project "${locator.name}"; defaulting to Yarn\n\n`);
+        stdout.write(`No package manager detected for external project${projectName}; defaulting to Yarn\n\n`);
         effectivePackageManager = PackageManager.Yarn2;
       }
 

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -151,7 +151,7 @@ export async function makeScriptEnv({project, locator, binFolder, lifecycleScrip
 const MAX_PREPARE_CONCURRENCY = 2;
 const prepareLimit = pLimit(MAX_PREPARE_CONCURRENCY);
 
-export async function prepareExternalProject(cwd: PortablePath, outputPath: PortablePath, {configuration, report, workspace = null, locator}: {configuration: Configuration, report: Report, workspace?: string | null, locator: Locator}) {
+export async function prepareExternalProject(cwd: PortablePath, outputPath: PortablePath, {configuration, report, workspace = null, locator = null}: {configuration: Configuration, report: Report, workspace?: string | null, locator?: Locator|null}) {
   await prepareLimit(async () => {
     await xfs.mktempPromise(async logDir => {
       const logFile = ppath.join(logDir, `pack.log` as Filename);

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -154,8 +154,8 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
       const stdin = null;
       const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {prefix: cwd, report});
 
-      const projectName: string = await JSON.parse(xfs.readFilePromise(ppath.join(cwd, `package.json`), `utf8`))
-        .then((packageInfo: { name: string }) => packageInfo.name);
+      const projectName: string = await xfs.readFilePromise(ppath.join(cwd, `package.json` as PortablePath), `utf8`)
+        .then((packageInfo: string) => JSON.parse(packageInfo).name);
       stdout.write(`Installing the external project "${projectName}" from sources\n\n`);
 
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Yarn log output for external projects is confusing

Currently, when external projects (git/github projects) are listed in a project's package.json and those external projects use something other than Yarn v2, Yarn logs a message describing that the project will be built using the detected package manager without logging any references to which project it is referring to. Because there is no supplementary logs describing which projects it is affecting, it is very easy for users to misunderstand the warning and think that their whole repository is being built with the logged package manager. In addition, because there is no logs around which project it is referring to, if the user wanted to remedy this error they would have no way of knowing which projects to fix.

I spent 3 hours figuring this out myself the hard way, only by combing through the source of Yarn, which users shouldn't be expected to do.

...

**How did you fix it?**
I added more logging when external projects are detected that explicitly describes what project is affected and why the non-v2 package manager was detected.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
