### PR TITLE
fix(patch): make patchfile path relative to prefixPath

### DIFF
--- a/.yarn/versions/d2fb9e75.yml
+++ b/.yarn/versions/d2fb9e75.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/patch.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/patch.test.js
@@ -144,7 +144,7 @@ describe(`Protocols`, () => {
     );
 
     test(
-      `it should apply a patch when package is virtual`,
+      `it should apply patches relative to the package`,
       makeTemporaryEnv(
         {},
         async ({path, run, source}) => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/patch.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/patch.test.js
@@ -142,5 +142,33 @@ describe(`Protocols`, () => {
       ),
       10000,
     );
+
+    test(
+      `it should apply a patch when package is virtual`,
+      makeTemporaryEnv(
+        {},
+        async ({path, run, source}) => {
+          await xfs.mktempPromise(async fileTarget => {
+            await xfs.writeFilePromise(ppath.join(fileTarget, `my-patch.patch`), NO_DEPS_PATCH);
+            await xfs.writeFilePromise(ppath.join(fileTarget, `index.js`), `module.exports = require('no-deps');`);
+            await xfs.writeJsonPromise(ppath.join(fileTarget, `package.json`), {
+              dependencies: {[`no-deps`]: `patch:no-deps@1.0.0#my-patch.patch`},
+            });
+
+            await xfs.writeJsonPromise(ppath.join(path, `package.json`), {
+              dependencies: {[`file`]: `file:${fileTarget}`},
+            });
+
+            await run(`install`);
+
+            await expect(source(`require('file')`)).resolves.toMatchObject({
+              name: `no-deps`,
+              version: `1.0.0`,
+              hello: `world`,
+            });
+          });
+        },
+      ),
+    );
   });
 });

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -125,10 +125,10 @@ export async function loadPatchFiles(parentLocator: Locator | null, patchPaths: 
       },
 
       onRelative: async () => {
-        if (parentFetch === null)
+        if (effectiveParentFetch === null)
           throw new Error(`Assertion failed: The parent locator should have been fetched`);
 
-        return await parentFetch.packageFs.readFilePromise(patchPath, `utf8`);
+        return await effectiveParentFetch.packageFs.readFilePromise(ppath.join(effectiveParentFetch.prefixPath, patchPath), `utf8`);
       },
 
       onBuiltin: async name => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

In my project (which is using PnP and strict mode), I have `package-a` listed as a dependency, and `package-a` lists as a dependency `patch:package-b@1.0.0#./package-b.patch`.

When I attempt to do `yarn install` the top level, I get the error `ENOENT: no such file or directory, open './package-b.patch`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I'm not super familiar with the yarn code, but it appears that the `patchFiles` function is ignoring the `prefixPath` property.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
