### PR TITLE
fix(pnpify) Turn off in memory node_modules for prettier SDK

### DIFF
--- a/.yarn/versions/256bdd8e.yml
+++ b/.yarn/versions/256bdd8e.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 - The patched fs now supports file URLs.
 - The node-modules linker now ensures that hoisting result is terminal, by doing several hoisting rounds when needed
-
+- Prettier SDK does not use in memory node_modules anymore, instead it relies on prettier plugins to be specified in `plugins` prettier config property.
 ### Settings
 
 - Various `initFields` edge cases have been fixed.

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -19,7 +19,7 @@ export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: P
 
   await wrapper.writeManifest();
 
-  await wrapper.writeBinary(`index.js` as PortablePath, {usePnpify: true});
+  await wrapper.writeBinary(`index.js` as PortablePath);
 
   return wrapper;
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Prettier SDK used to rely on in memory node_modules for prettier plugin autoload purposes. It was turned out, because I believed that this is the only way for prettier to load its plugins in a PnP environment. But there is an explicit way for this, which works with PnP out of the box.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I turned off in memory node_modules usage, instead explicit plugins configuration should be used in prettier's `plugins` config property:
https://github.com/prettier/prettier/issues/7073#issuecomment-711954542

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
