### PR TITLE
Add fsevents to plugin-compat README

### DIFF
--- a/.yarn/versions/cccd82b4.yml
+++ b/.yarn/versions/cccd82b4.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-compat"

--- a/packages/plugin-compat/README.md
+++ b/packages/plugin-compat/README.md
@@ -9,5 +9,7 @@ This plugin is included by default in Yarn.
 ## Compatibility Features
 
 - Various [extensions](/configuration/yarnrc#packageExtensions) are enabled by default (full list [here](https://github.com/yarnpkg/berry/blob/master/packages/plugin-compat/sources/extensions.ts))
-- [`typescript`](/package/typescript): Auto-merge of [#35206](https://github.com/microsoft/TypeScript/pull/35206)
-- [`resolve`](/package/resolve): Implements [`normalize-options.js`](https://github.com/browserify/resolve/pull/174)
+- [`fsevents`](/packages/plugin-compat/extra/fsevents): Makes fsevents aware of the virtual filesystem: [#692](https://github.com/yarnpkg/berry/pull/692)
+- [`typescript`](/packages/plugin-compat/extra/typescript): Auto-merge of [#35206](https://github.com/microsoft/TypeScript/pull/35206)
+- [`resolve`](/packages/plugin-compat/extra/resolve): Implements [`normalize-options.js`](https://github.com/browserify/resolve/pull/174)
+


### PR DESCRIPTION
**What's the problem this PR addresses?**
I found that a handful of new cache packages were downloaded when moving from yarn v1 to v2 (although I had to compare the cache manually to find them, see https://github.com/yarnpkg/berry/issues/2465).  After some digging, I found that they were being added by plugin-compat, although it wasn't immediately obvious where the `fsevents-patch` files were coming from.  Eventually I realized that it was also from plugin-compat, although the readme didn't mention it.

**How did you fix it?**

I added `fsevents` to the readme, and updated some of the links that were broken.

I declined the version bump, not sure if that was the right thing for a readme update or not...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
