### PR TITLE
fix(node-modules): avoid soft-link warning on workspace dependencies

### DIFF
--- a/.yarn/versions/920e00bf.yml
+++ b/.yarn/versions/920e00bf.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - The patched fs now supports file URLs.
 - The node-modules linker now ensures that hoisting result is terminal, by doing several hoisting rounds when needed
+- The node-modules linker no longer prints warnings about postinstall scripts when a workspace depends on another workspace with install scripts
 - Prettier SDK does not use in memory node_modules anymore, instead it relies on prettier plugins to be specified in `plugins` prettier config property.
 ### Settings
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -839,4 +839,31 @@ describe(`Node_Modules`, () => {
       },
     ),
   );
+
+  test(
+    `should not warn when depending on workspaces with postinstall`,
+    makeTemporaryEnv(
+      {
+        workspaces: ['dep'],
+        dependencies: {
+          dep: `workspace:*`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({ path, run }) => {
+        await writeJson(`${path}/dep/package.json`, {
+          name: `dep`,
+          scripts: {
+            postinstall: `echo 'dep'`,
+          },
+        });
+  
+        const {stdout} = await run(`install`);
+  
+        expect(stdout).not.toContain(`YN0006`);
+      }
+    )
+  );  
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -844,7 +844,7 @@ describe(`Node_Modules`, () => {
     `should not warn when depending on workspaces with postinstall`,
     makeTemporaryEnv(
       {
-        workspaces: ['dep'],
+        workspaces: [`dep`],
         dependencies: {
           dep: `workspace:*`,
         },
@@ -852,18 +852,18 @@ describe(`Node_Modules`, () => {
       {
         nodeLinker: `node-modules`,
       },
-      async ({ path, run }) => {
+      async ({path, run}) => {
         await writeJson(`${path}/dep/package.json`, {
           name: `dep`,
           scripts: {
             postinstall: `echo 'dep'`,
           },
         });
-  
+
         const {stdout} = await run(`install`);
-  
+
         expect(stdout).not.toContain(`YN0006`);
       }
     )
-  );  
+  );
 });

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -296,6 +296,10 @@ class NodeModulesInstaller implements Installer {
       if (typeof slot === `undefined`)
         throw new Error(`Assertion failed: Expected the slot to exist`);
 
+      // Workspaces are built by the core
+      if (this.opts.project.tryWorkspaceByLocator(slot.pkg))
+        continue;
+
       const buildScripts = jsInstallUtils.extractBuildScripts(slot.pkg, slot.customPackageData, slot.dependencyMeta, {configuration: this.opts.project.configuration, report: this.opts.report});
       if (buildScripts.length === 0)
         continue;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `node-modules` linker prints a `YN0006` warning when a workspace depends on a workspace with postinstall scripts

```diff
➤ YN0000: ┌ Link step
- ➤ YN0006: │ dep@workspace:dep lists build scripts, but is referenced through a soft link. Soft links don't support build scripts, so they'll be ignored.
➤ YN0007: │ dep@workspace:dep must be built because it never did before or the last one failed
➤ YN0000: └ Completed
```


**How did you fix it?**

Skip workspace dependencies when fetching build scripts

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.