### PR TITLE
fix(core): make unresolved workspace error more descriptive

### DIFF
--- a/.yarn/versions/fbda37a0.yml
+++ b/.yarn/versions/fbda37a0.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -379,7 +379,7 @@ export class Project {
 
     const dup = this.workspacesByIdent.get(workspace.locator.identHash);
     if (typeof dup !== `undefined`)
-      throw new Error(`Duplicate workspace name ${structUtils.prettyIdent(this.configuration, workspace.locator)}: ${workspaceCwd} conflicts with ${dup.cwd}`);
+      throw new Error(`Duplicate workspace name ${structUtils.prettyIdent(this.configuration, workspace.locator)}: ${npath.fromPortablePath(workspaceCwd)} conflicts with ${npath.fromPortablePath(dup.cwd)}`);
 
     this.workspaces.push(workspace);
 

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -507,7 +507,7 @@ export class Project {
     for (const workspace of this.workspaces) {
       const pkg = this.storedPackages.get(workspace.anchoredLocator.locatorHash);
       if (!pkg)
-        throw new Error(`Assertion failed: Expected workspace to have been resolved`);
+        throw new Error(`Assertion failed: Expected workspace ${structUtils.prettyWorkspace(this.configuration, workspace)} (${formatUtils.pretty(this.configuration, ppath.join(workspace.cwd, `package.json` as Filename), formatUtils.Type.PATH)}) to have been resolved. Run "yarn install" to update the lockfile`);
 
       workspace.dependencies = new Map(pkg.dependencies);
     }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -507,7 +507,7 @@ export class Project {
     for (const workspace of this.workspaces) {
       const pkg = this.storedPackages.get(workspace.anchoredLocator.locatorHash);
       if (!pkg)
-        throw new Error(`Assertion failed: Expected workspace ${structUtils.prettyWorkspace(this.configuration, workspace)} (${formatUtils.pretty(this.configuration, ppath.join(workspace.cwd, `package.json` as Filename), formatUtils.Type.PATH)}) to have been resolved. Run "yarn install" to update the lockfile`);
+        throw new Error(`Assertion failed: Expected workspace ${structUtils.prettyWorkspace(this.configuration, workspace)} (${formatUtils.pretty(this.configuration, ppath.join(workspace.cwd, Filename.manifest), formatUtils.Type.PATH)}) to have been resolved. Run "yarn install" to update the lockfile`);
 
       workspace.dependencies = new Map(pkg.dependencies);
     }

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -157,7 +157,7 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
       const logFile = ppath.join(logDir, `pack.log` as Filename);
 
       const stdin = null;
-      const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {prefix: cwd, report});
+      const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {prefix: npath.fromPortablePath(cwd), report});
 
       const devirtualizedLocator = locator && structUtils.isVirtualLocator(locator)
         ? structUtils.devirtualizeLocator(locator)


### PR DESCRIPTION
**What's the problem this PR addresses?**

When the core runs into a workspace that hasn't been resolved it isn't descriptive about which workspace it is nor how to fix it.

**How did you fix it?**

Make the error more descriptive

```diff
- Internal Error: Assertion failed: Expected workspace to have been resolved
+ Internal Error: Assertion failed: Expected workspace foo (/berry/packages/acceptance-tests/package.json) to have been resolved. Run "yarn install" to update the lockfile
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.