### PR TITLE
Adds an extension for NextAuth.js

### DIFF
--- a/.yarn/versions/34ceb174.yml
+++ b/.yarn/versions/34ceb174.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -225,4 +225,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       protobufjs: `^6.8.6`,
     },
   }],
+  // https://github.com/nextauthjs/next-auth/pull/1034
+  [`next-auth@*`, {
+    dependencies: {
+      process: `^0.11.10`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
NextAuth.js is not usable with Yarn 2 PnP due to wrong dependency. I tried to patch NextAuth.js first but they rejected it. So I'm fixing Next.js and Yarn instead. I already have fixed the Next.js side and this is the remaining piece.

**How did you fix it?**
Added an extension

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

###### References
- https://github.com/nextauthjs/next-auth/pull/1034
- https://github.com/vercel/next.js/pull/20971