### PR TITLE
perf(core): avoid copying back to mirror when fetching from it

### DIFF
--- a/.yarn/versions/e4a42765.yml
+++ b/.yarn/versions/e4a42765.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"


### PR DESCRIPTION
**What's the problem this PR addresses?**

When the core fetches from the offline mirror it copies the result back into it again which is redundant and increases the risk of corrupting it.

Helps with https://github.com/yarnpkg/berry/issues/2349 but doesn't fix it

**How did you fix it?**

Skip copying back to the mirror when we just fetched from it

**Results**

Testing with https://github.com/yarnpkg/berry/blob/ef6f09d5b333df040776c761349b0ad8c1e0c995/scripts/bench-run.sh#L70-L72

```diff
   Testing install-cache-and-lock
   Benchmark #1: yarn install
-    Time (mean ± σ):     11.326 s ±  0.142 s    [User: 14.781 s, System: 5.490 s]
-    Range (min … max):   11.197 s … 11.598 s    10 runs
+    Time (mean ± σ):     10.956 s ±  0.082 s    [User: 14.544 s, System: 4.898 s]
+    Range (min … max):   10.827 s … 11.113 s    10 runs
```

File operations done while fetching from the mirror:
```diff
 open local flock
 write local flock
-  open mirror flock
-  write mirror flock
     move temp -> local
-    copy local -> mirror
-  close mirror flock
-  unlink mirror flock
 close local flock
 unlink local flock
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.