### PR TITLE
fix(core): add missing setlocal in the cmd file for Windows

### DIFF
--- a/.yarn/versions/6f9b2372.yml
+++ b/.yarn/versions/6f9b2372.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -524,4 +524,25 @@ describe(`Scripts tests`, () => {
       });
     })
   );
+
+  test(
+    `it should be able to spawn binaries with a utf-8 path`,
+    makeTemporaryEnv(
+      {
+        name: `testbin`,
+        bin: `å.js`,
+        scripts: {
+          [`test`]: `testbin`,
+        },
+      },
+      async ({path, run, source}) => {
+        await xfs.writeFilePromise(`${path}/å.js`, `console.log('ok')`);
+        await run(`install`);
+
+        await expect(run(`test`)).resolves.toMatchObject({
+          stdout: `ok\n`,
+        });
+      }
+    )
+  );
 });

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -35,7 +35,7 @@ interface PackageManagerSelection {
 async function makePathWrapper(location: PortablePath, name: Filename, argv0: NativePath, args: Array<string> = []) {
   if (process.platform === `win32`) {
     // https://github.com/microsoft/terminal/issues/217#issuecomment-737594785
-    const cmdScript = `@goto #_undefined_# 2>NUL || @title %COMSPEC% & @"${argv0}" ${args.map(arg => `"${arg.replace(`"`, `""`)}"`).join(` `)} %*`;
+    const cmdScript = `@goto #_undefined_# 2>NUL || @title %COMSPEC% & @setlocal & @"${argv0}" ${args.map(arg => `"${arg.replace(`"`, `""`)}"`).join(` `)} %*`;
     await xfs.writeFilePromise(ppath.format({dir: location, name, ext: `.cmd`}), cmdScript);
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The cmd file written by `makePathWrapper` doesn't work with utf-8 characters on Windows

Fixes https://github.com/yarnpkg/berry/issues/2397

**How did you fix it?**

Add `@setlocal` to the script

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.