### PR TITLE
fix(node-modules) Allow hoisting child when it peer depends on its parent

### DIFF
--- a/.yarn/versions/8cf7ae4d.yml
+++ b/.yarn/versions/8cf7ae4d.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - The patched fs now supports file URLs.
 - The node-modules linker now ensures that hoisting result is terminal, by doing several hoisting rounds when needed
 - The node-modules linker no longer prints warnings about postinstall scripts when a workspace depends on another workspace with install scripts
+- The dependencies peer depending on their own parent are now properly hoisted by node-modules linker
 - Prettier SDK does not use in memory node_modules anymore, instead it relies on prettier plugins to be specified in `plugins` prettier config property.
 ### Settings
 

--- a/packages/yarnpkg-pnpify/sources/hoist.ts
+++ b/packages/yarnpkg-pnpify/sources/hoist.ts
@@ -429,7 +429,7 @@ const hoistTo = (tree: HoisterWorkTree, rootNodePath: Array<HoisterWorkTree>, ro
   return {anotherRoundNeeded, isGraphChanged};
 };
 
-const getNodeHoistInfo = (rootNodePathLocators: Set<Locator>, nodePath: Array<HoisterWorkTree>, node: HoisterWorkTree, usedDependencies: Map<PackageName, HoisterWorkTree>, hoistIdents: Map<PackageName, Ident>, hoistIdentMap: Map<Ident, Array<Ident>>, shadowedNodes: ShadowedNodes, {outputReason}: {outputReason: boolean}): HoistInfo => {
+const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<Locator>, nodePath: Array<HoisterWorkTree>, node: HoisterWorkTree, usedDependencies: Map<PackageName, HoisterWorkTree>, hoistIdents: Map<PackageName, Ident>, hoistIdentMap: Map<Ident, Array<Ident>>, shadowedNodes: ShadowedNodes, {outputReason}: {outputReason: boolean}): HoistInfo => {
   let reasonRoot;
   let reason: string | null = null;
   let dependsOn: Set<HoisterWorkTree> | null = new Set();
@@ -489,7 +489,7 @@ const getNodeHoistInfo = (rootNodePathLocators: Set<Locator>, nodePath: Array<Ho
           continue;
 
         const parentDepNode = parent.dependencies.get(name);
-        if (parentDepNode) {
+        if (parentDepNode && rootNode.dependencies.get(name) !== parentDepNode) {
           if (idx === nodePath.length - 1) {
             dependsOn!.add(parentDepNode);
           } else {
@@ -539,7 +539,7 @@ const hoistGraph = (tree: HoisterWorkTree, rootNodePath: Array<HoisterWorkTree>,
     const dependantTree = new Map<PackageName, Set<PackageName>>();
     const hoistInfos = new Map<HoisterWorkTree, HoistInfo>();
     for (const subDependency of getSortedRegularDependencies(parentNode)) {
-      const hoistInfo = getNodeHoistInfo(rootNodePathLocators, [rootNode, ...nodePath, parentNode], subDependency, usedDependencies, hoistIdents, hoistIdentMap, shadowedNodes, {outputReason: options.debugLevel >= DebugLevel.REASONS});
+      const hoistInfo = getNodeHoistInfo(rootNode, rootNodePathLocators, [rootNode, ...nodePath, parentNode], subDependency, usedDependencies, hoistIdents, hoistIdentMap, shadowedNodes, {outputReason: options.debugLevel >= DebugLevel.REASONS});
 
       hoistInfos.set(subDependency, hoistInfo);
       if (hoistInfo.isHoistable === Hoistable.DEPENDS) {

--- a/packages/yarnpkg-pnpify/tests/hoist.test.ts
+++ b/packages/yarnpkg-pnpify/tests/hoist.test.ts
@@ -517,4 +517,17 @@ describe(`hoist`, () => {
     const AC = Array.from(Array.from(hoistedTree.dependencies).filter(x => x.name === `A`)[0].dependencies).filter(x => x.name === `C`);
     expect(AC).toEqual([]);
   });
+
+  it(`should hoist dependencies that peer dependent on their parent`, () => {
+    // . -> A -> B --> A
+    // should be hoisted to:
+    // . -> A
+    //   -> B
+    const tree = {
+      '.': {dependencies: [`A`]},
+      A: {dependencies: [`A`, `B`]},
+      B: {dependencies: [`A`], peerNames: [`A`]},
+    };
+    expect(getTreeHeight(hoist(toTree(tree), {check: true}))).toEqual(2);
+  });
 });

--- a/packages/yarnpkg-pnpify/tests/hoist.test.ts
+++ b/packages/yarnpkg-pnpify/tests/hoist.test.ts
@@ -519,15 +519,17 @@ describe(`hoist`, () => {
   });
 
   it(`should hoist dependencies that peer dependent on their parent`, () => {
-    // . -> A -> B --> A
+    // . -> C -> A -> B --> A
     // should be hoisted to:
     // . -> A
     //   -> B
+    //   -> C
     const tree = {
-      '.': {dependencies: [`A`]},
+      '.': {dependencies: [`C`]},
+      C: {dependencies: [`A`]},
       A: {dependencies: [`A`, `B`]},
       B: {dependencies: [`A`], peerNames: [`A`]},
     };
-    expect(getTreeHeight(hoist(toTree(tree), {check: true}))).toEqual(2);
+    expect(getTreeHeight(hoist(toTree(tree), {check: true, debugLevel: 2}))).toEqual(2);
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Currently when a dependency peer depends on its parent it is not get hoisted by nm linker
Fixes: #2500

**How did you fix it?**

I'm going to update check for this special case to allow hoisting.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
