### PR TITLE
fix(cli): clipanion compatibility layer when used with default values

### DIFF
--- a/.yarn/versions/138dfd75.yml
+++ b/.yarn/versions/138dfd75.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/tools/backportClipanionCompatibility.ts
+++ b/packages/yarnpkg-cli/sources/tools/backportClipanionCompatibility.ts
@@ -6,11 +6,12 @@ export function backportClipanionCompatibility(clipanion: any) {
 
   for (const fn of [`Array`, `Boolean`, `String`]) {
     clipanion.Command[fn] = (...args: Array<any>) => (instance: any, propertyName: any) => {
-      Object.defineProperty(instance, propertyName, {
+      const value = clipanion.Option[fn](...args);
+      Object.defineProperty(instance, `__${propertyName}`, {
         configurable: false,
         enumerable: true,
-        value: clipanion.Option[fn](...args),
-        writable: true,
+        get() { return value; },
+        set(value) { this[propertyName] = value; },
       });
     };
   }

--- a/packages/yarnpkg-cli/sources/tools/backportClipanionCompatibility.ts
+++ b/packages/yarnpkg-cli/sources/tools/backportClipanionCompatibility.ts
@@ -4,7 +4,7 @@ export function backportClipanionCompatibility(clipanion: any) {
     instance.paths.push(p);
   };
 
-  for (const fn of [`Array`, `Boolean`, `String`]) {
+  for (const fn of [`Array`, `Boolean`, `String`, `Proxy`, `Rest`, `Counter`]) {
     clipanion.Command[fn] = (...args: Array<any>) => (instance: any, propertyName: any) => {
       const value = clipanion.Option[fn](...args);
       Object.defineProperty(instance, `__${propertyName}`, {

--- a/packages/yarnpkg-cli/sources/tools/backportClipanionCompatibility.ts
+++ b/packages/yarnpkg-cli/sources/tools/backportClipanionCompatibility.ts
@@ -10,8 +10,12 @@ export function backportClipanionCompatibility(clipanion: any) {
       Object.defineProperty(instance, `__${propertyName}`, {
         configurable: false,
         enumerable: true,
-        get() { return value; },
-        set(value) { this[propertyName] = value; },
+        get() {
+          return value;
+        },
+        set(value) {
+          this[propertyName] = value;
+        },
       });
     };
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The clipanion backward compatibility layer had a problem when used with commands that had default values.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Instead of trying to replace the property and keep the same name, we add a new one prefixed by `__` and proxy values to the underlying property. Solution was proposed by @arcanis on Discord.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
