### PR TITLE
Implements enableMessageNames

### DIFF
--- a/.yarn/versions/c958a387.yml
+++ b/.yarn/versions/c958a387.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -236,6 +236,11 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     default: isCI,
     defaultText: `<dynamic>`,
   },
+  enableMessageNames: {
+    description: `If true, the CLI will prefix most messages with codes suitable for search engines`,
+    type: SettingsType.BOOLEAN,
+    default: true,
+  },
   enableProgressBars: {
     description: `If true, the CLI is allowed to show a progress bar for long-running events`,
     type: SettingsType.BOOLEAN,

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -78,6 +78,9 @@ const defaultStyle = (supportsEmojis && Object.keys(PROGRESS_STYLES).find(name =
 })) || `default`;
 
 export function formatName(name: MessageName | null, {configuration, json}: {configuration: Configuration, json: boolean}) {
+  if (!configuration.get(`enableMessageNames`))
+    return ``;
+
   const num = name === null ? 0 : name;
   const label = stringifyMessageName(num);
 
@@ -90,6 +93,8 @@ export function formatName(name: MessageName | null, {configuration, json}: {con
 
 export function formatNameWithHyperlink(name: MessageName | null, {configuration, json}: {configuration: Configuration, json: boolean}) {
   const code = formatName(name, {configuration, json});
+  if (!code)
+    return code;
 
   // Only print hyperlinks if allowed per configuration
   if (!configuration.get(`enableHyperlinks`))
@@ -360,7 +365,10 @@ export class StreamReport extends Report {
 
     this.commit();
 
-    const message = `${formatUtils.pretty(this.configuration, `➤`, `blueBright`)} ${this.formatNameWithHyperlink(name)}: ${this.formatIndent()}${text}`;
+    const formattedName = this.formatNameWithHyperlink(name);
+    const prefix = formattedName ? `${formattedName}: ` : ``;
+
+    const message = `${formatUtils.pretty(this.configuration, `➤`, `blueBright`)} ${prefix}${this.formatIndent()}${text}`;
 
     if (!this.json) {
       if (this.forgettableNames.has(name)) {
@@ -389,8 +397,11 @@ export class StreamReport extends Report {
 
     this.commit();
 
+    const formattedName = this.formatNameWithHyperlink(name);
+    const prefix = formattedName ? `${formattedName}: ` : ``;
+
     if (!this.json) {
-      this.writeLineWithForgettableReset(`${formatUtils.pretty(this.configuration, `➤`, `yellowBright`)} ${this.formatNameWithHyperlink(name)}: ${this.formatIndent()}${text}`);
+      this.writeLineWithForgettableReset(`${formatUtils.pretty(this.configuration, `➤`, `yellowBright`)} ${prefix}${this.formatIndent()}${text}`);
     } else {
       this.reportJson({type: `warning`, name, displayName: this.formatName(name), indent: this.formatIndent(), data: text});
     }
@@ -401,8 +412,11 @@ export class StreamReport extends Report {
 
     this.commit();
 
+    const formattedName = this.formatNameWithHyperlink(name);
+    const prefix = formattedName ? `${formattedName}: ` : ``;
+
     if (!this.json) {
-      this.writeLineWithForgettableReset(`${formatUtils.pretty(this.configuration, `➤`, `redBright`)} ${this.formatNameWithHyperlink(name)}: ${this.formatIndent()}${text}`, {truncate: false});
+      this.writeLineWithForgettableReset(`${formatUtils.pretty(this.configuration, `➤`, `redBright`)} ${prefix}${this.formatIndent()}${text}`, {truncate: false});
     } else {
       this.reportJson({type: `error`, name, displayName: this.formatName(name), indent: this.formatIndent(), data: text});
     }
@@ -584,7 +598,10 @@ export class StreamReport extends Report {
       const ok = this.progressStyle.chars[0].repeat(progress.lastScaledSize);
       const ko = this.progressStyle.chars[1].repeat(this.progressMaxScaledSize - progress.lastScaledSize);
 
-      this.stdout.write(`${formatUtils.pretty(this.configuration, `➤`, `blueBright`)} ${this.formatName(null)}: ${spinner} ${ok}${ko}\n`);
+      const formattedName = this.formatName(null);
+      const prefix = formattedName ? `${formattedName}: ` : ``;
+
+      this.stdout.write(`${formatUtils.pretty(this.configuration, `➤`, `blueBright`)} ${prefix}${spinner} ${ok}${ko}\n`);
     }
 
     this.progressTimeout = setTimeout(() => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I can understand why some people would prefer to reclaim some of their terminal with by removing the message names from the output. I still think we should add them by default (otherwise they'd be completely pointless, since the people who would most need them would be unaware of their existence), but power users should have a way to skip them.

**How did you fix it?**

A new `enableMessageNames` setting now lets you remove the message names from the output. As any setting, it can be configured in the home `.yarnrc.yml` file, in a project-local one, or via the environment.

![image](https://user-images.githubusercontent.com/1037931/109000362-e80f5d80-76a3-11eb-876b-3b4a5f932cfd.png)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
