### PR TITLE
fix(plugin-npm): parse reference in NpmSemverResolver.getSatisfying

### DIFF
--- a/.yarn/versions/b3cffd46.yml
+++ b/.yarn/versions/b3cffd46.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -97,7 +97,8 @@ export class NpmSemverResolver implements Resolver {
     return references
       .map(reference => {
         try {
-          return new semverUtils.SemVer(reference.slice(PROTOCOL.length));
+          const {selector} = structUtils.parseRange(reference, {requireProtocol: PROTOCOL});
+          return new semverUtils.SemVer(selector);
         } catch {
           return null;
         }

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -99,13 +99,12 @@ export class NpmSemverResolver implements Resolver {
         const {selector} = structUtils.parseRange(reference, {requireProtocol: PROTOCOL});
         const version = new semverUtils.SemVer(selector);
 
-        if (!range.test(version))
-          return miscUtils.mapAndFilter.skip;
+        if (range.test(version)) {
+          return {reference, version};
+        }
+      } catch { }
 
-        return {reference, version};
-      } catch {
-        return miscUtils.mapAndFilter.skip;
-      }
+      return miscUtils.mapAndFilter.skip;
     })
       .sort((a, b) => -a.version.compare(b.version))
       .map(({reference}) => structUtils.makeLocator(descriptor, reference));

--- a/packages/plugin-npm/tests/NpmSemverResolver.test.ts
+++ b/packages/plugin-npm/tests/NpmSemverResolver.test.ts
@@ -1,0 +1,22 @@
+import {structUtils}       from '@yarnpkg/core';
+
+import {NpmSemverResolver} from '../sources/NpmSemverResolver';
+
+describe(`NpmSemverResolver`, () => {
+  describe(`getSatisfying`, () => {
+    it(`should match when the reference contains a __archiveUrl`, async () => {
+      const resolver = new NpmSemverResolver();
+
+      const reference = `npm:1.0.0::__archiveUrl=foo.tgz`;
+
+      const results = await resolver.getSatisfying(
+        structUtils.makeDescriptor(structUtils.makeIdent(null, `foo`), `*`),
+        [reference],
+        null as any,
+      );
+
+      expect(results.length).toEqual(1);
+      expect(results[0].reference).toEqual(reference);
+    });
+  });
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `NpmSemverResolver` doesn't parse the references passed to it in `getSatisfying`

Fixes https://github.com/yarnpkg/berry/issues/2377
Fixes https://github.com/yarnpkg/berry/issues/2467 (probably, no repro so i'm not sure)

**How did you fix it?**

Parse the references instead of just stripping off the protocol before checking if they are valid semver

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.