### PR TITLE
feat(plugin-workspace-tools): foreach log process start/exit events in verbose mode

### DIFF
--- a/.yarn/versions/7b489a47.yml
+++ b/.yarn/versions/7b489a47.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": minor

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -35,13 +35,21 @@ exports[`Commands workspace foreach should never run the scripts on workspaces t
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: [workspace-c]: Test Workspace C
+  "stdout": "➤ YN0000: [workspace-c]: Process started
+➤ YN0000: [workspace-c]: Test Workspace C
+➤ YN0000: [workspace-c]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-d]: Process started
 ➤ YN0000: [workspace-d]: Test Workspace D
+➤ YN0000: [workspace-d]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-e]: Process started
 ➤ YN0000: [workspace-e]: Test Workspace E
+➤ YN0000: [workspace-e]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-f]: Process started
 ➤ YN0000: [workspace-f]: Test Workspace F
+➤ YN0000: [workspace-f]: Process exited (exit code 0)
 ➤ YN0000: Done
 ",
 }
@@ -66,9 +74,13 @@ exports[`Commands workspace foreach should only run the scripts on workspaces th
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: [workspace-a]: Test Workspace A
+  "stdout": "➤ YN0000: [workspace-a]: Process started
+➤ YN0000: [workspace-a]: Test Workspace A
+➤ YN0000: [workspace-a]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-b]: Process started
 ➤ YN0000: [workspace-b]: Test Workspace B
+➤ YN0000: [workspace-b]: Process exited (exit code 0)
 ➤ YN0000: Done
 ",
 }
@@ -78,17 +90,29 @@ exports[`Commands workspace foreach should prefix the output with run with --ver
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: [workspace-a]: Test Workspace A
+  "stdout": "➤ YN0000: [workspace-a]: Process started
+➤ YN0000: [workspace-a]: Test Workspace A
+➤ YN0000: [workspace-a]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-b]: Process started
 ➤ YN0000: [workspace-b]: Test Workspace B
+➤ YN0000: [workspace-b]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-c]: Process started
 ➤ YN0000: [workspace-c]: Test Workspace C
+➤ YN0000: [workspace-c]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-d]: Process started
 ➤ YN0000: [workspace-d]: Test Workspace D
+➤ YN0000: [workspace-d]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-e]: Process started
 ➤ YN0000: [workspace-e]: Test Workspace E
+➤ YN0000: [workspace-e]: Process exited (exit code 0)
 
+➤ YN0000: [workspace-f]: Process started
 ➤ YN0000: [workspace-f]: Test Workspace F
+➤ YN0000: [workspace-f]: Process exited (exit code 0)
 ➤ YN0000: Done
 ",
 }

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -222,6 +222,9 @@ export default class WorkspacesForeachCommand extends BaseCommand {
         const [stderr, stderrEnd] = createStream(report, {prefix, interlaced});
 
         try {
+          if (this.verbose)
+            report.reportInfo(null, `${prefix} Process started`);
+
           const exitCode = (await this.cli.run([this.commandName, ...this.args], {
             cwd: workspace.cwd,
             stdout,
@@ -231,11 +234,11 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           stdout.end();
           stderr.end();
 
-          const emptyStdout = await stdoutEnd;
-          const emptyStderr = await stderrEnd;
+          await stdoutEnd;
+          await stderrEnd;
 
-          if (this.verbose && emptyStdout && emptyStderr)
-            report.reportInfo(null, `${prefix} Process exited without output (exit code ${exitCode})`);
+          if (this.verbose)
+            report.reportInfo(null, `${prefix} Process exited (exit code ${exitCode})`);
 
           if (exitCode === 130) {
             // Process exited with the SIGINT signal, aka ctrl+c. Since the process didn't handle

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -225,6 +225,8 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           if (this.verbose)
             report.reportInfo(null, `${prefix} Process started`);
 
+          const start = Date.now();
+
           const exitCode = (await this.cli.run([this.commandName, ...this.args], {
             cwd: workspace.cwd,
             stdout,
@@ -237,8 +239,11 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           await stdoutEnd;
           await stderrEnd;
 
-          if (this.verbose)
-            report.reportInfo(null, `${prefix} Process exited (exit code ${exitCode})`);
+          const end = Date.now();
+          if (this.verbose) {
+            const timerMessage = configuration.get(`enableTimers`) ? `, completed in ${formatUtils.pretty(configuration, end - start, formatUtils.Type.DURATION)}` : ``;
+            report.reportInfo(null, `${prefix} Process exited (exit code ${exitCode})${timerMessage}`);
+          }
 
           if (exitCode === 130) {
             // Process exited with the SIGINT signal, aka ctrl+c. Since the process didn't handle


### PR DESCRIPTION
**What's the problem this PR addresses?**
When using `yarn workspaces foreach`  it may be difficult to track when process start and exit, especially when a process exit with an error code. Currently the verbose flag don't log start of process, and log process exit only when process doesn't output something, but it can happen a process log something and fail with an exit code.


**How did you fix it?**
Change the behavior of the verbose flag to be more clear:
* always log when a process is started
* always log when a process exit, whatever it's exit code and whatever if the output is empty or not

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
