### PR TITLE
feat: make enableImmutableInstalls default to true on ci

### DIFF
--- a/.yarn/versions/5c15602e.yml
+++ b/.yarn/versions/5c15602e.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -135,7 +135,7 @@
     },
     "enableImmutableInstalls": {
       "_package": "@yarnpkg/plugin-essentials",
-      "description": "If true, Yarn will refuse to change the installation artifacts (apart the cache) when running an install. This flag is quite intrusive, you typically should only set it on your CI by manually passing the `--immutable` flag to `yarn install`.",
+      "description": "If true (the default on CI), Yarn will refuse to change the installation artifacts (apart from the cache) when running an install. This flag is quite intrusive, you typically should only set it on your CI by manually passing the `--immutable` flag to `yarn install`.",
       "type": "boolean",
       "default": false
     },

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -26,7 +26,7 @@ export default class YarnCommand extends BaseCommand {
 
       Note that running this command is not part of the recommended workflow. Yarn supports zero-installs, which means that as long as you store your cache and your .pnp.cjs file inside your repository, everything will work without requiring any install right after cloning your repository or switching branches.
 
-      If the \`--immutable\` option is set, Yarn will abort with an error exit code if the lockfile was to be modified (other paths can be added using the \`immutablePatterns\` configuration setting). For backward compatibility we offer an alias under the name of \`--frozen-lockfile\`, but it will be removed in a later release.
+      If the \`--immutable\` option is set (defaults to true on CI), Yarn will abort with an error exit code if the lockfile was to be modified (other paths can be added using the \`immutablePatterns\` configuration setting). For backward compatibility we offer an alias under the name of \`--frozen-lockfile\`, but it will be removed in a later release.
 
       If the \`--immutable-cache\` option is set, Yarn will abort with an error exit code if the cache folder was to be modified (either because files would be added, or because they'd be removed).
 
@@ -213,9 +213,7 @@ export default class YarnCommand extends BaseCommand {
       }
     }
 
-    const immutable = typeof this.immutable === `undefined` && typeof this.frozenLockfile === `undefined`
-      ? configuration.get(`enableImmutableInstalls`) ?? false
-      : this.immutable ?? this.frozenLockfile ?? false;
+    const immutable = this.immutable ?? configuration.get(`enableImmutableInstalls`);
 
     if (configuration.projectCwd !== null) {
       const fixReport = await StreamReport.start({

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -1,5 +1,6 @@
 import {Descriptor, Plugin, SettingsType, Package, formatUtils} from '@yarnpkg/core';
 import {Workspace}                                              from '@yarnpkg/core';
+import {isCI}                                                   from 'ci-info';
 
 import add                                                      from './commands/add';
 import bin                                                      from './commands/bin';
@@ -86,7 +87,7 @@ const plugin: Plugin = {
     enableImmutableInstalls: {
       description: `If true, prevents the install command from modifying the lockfile`,
       type: SettingsType.BOOLEAN,
-      default: false,
+      default: isCI,
     },
 
     defaultSemverRangePrefix: {

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -85,7 +85,7 @@ declare module '@yarnpkg/core' {
 const plugin: Plugin = {
   configuration: {
     enableImmutableInstalls: {
-      description: `If true, prevents the install command from modifying the lockfile`,
+      description: `If true (the default on CI), prevents the install command from modifying the lockfile`,
       type: SettingsType.BOOLEAN,
       default: isCI,
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR makes Yarn immutable by default on CI. One of the v3 roadmap items and something that was discussed previously in the v1 repo: https://github.com/yarnpkg/yarn/issues/5869.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
