### PR TITLE
ci: fix e2e tests

### DIFF
--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -17,6 +17,9 @@ echo Yarn Version: $(yarn -v)
 # We want to see what fails (if anything fails)
 export YARN_ENABLE_INLINE_BUILDS=1
 
+# We want to allow installs to modify the lockfile
+export YARN_ENABLE_IMMUTABLE_INSTALLS=0
+
 # Otherwise git commit doesn't work, and some tools require it
 git config --global user.email "you@example.com"
 git config --global user.name "John Doe"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I accidentally broke the e2e tests because I didn't realize that they'd be affected by https://github.com/yarnpkg/berry/pull/2530.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Set  `enableImmutableInstalls` to false before the tests run.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
