### PR TITLE
Fix doctor not emitting nonzero exit code on failure

### DIFF
--- a/.yarn/versions/7e34fb4a.yml
+++ b/.yarn/versions/7e34fb4a.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": patch

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -358,7 +358,7 @@ class EntryCommand extends Command {
       return null;
     };
 
-    await StreamReport.start({
+    const report = await StreamReport.start({
       configuration,
       stdout: this.context.stdout,
     }, async report => {
@@ -410,6 +410,8 @@ class EntryCommand extends Command {
       report.reportSeparator();
       await reportedProgress;
     });
+
+    return report.exitCode();
   }
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Resolves #2521. 

**How did you fix it?**

Captured the report from `StreamReport.start()` and returned its exit code in the command's `execute` method.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
