### PR TITLE
fix(patch): throw on patch files without changes

### DIFF
--- a/.yarn/versions/eeae7dcf.yml
+++ b/.yarn/versions/eeae7dcf.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/patch.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/patch.test.js
@@ -170,5 +170,22 @@ describe(`Protocols`, () => {
         },
       ),
     );
+
+    test(
+      `it should throw on invalid patch files`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `patch:no-deps@1.0.0#my-patch.patch`},
+        },
+        async ({path, run, source}) => {
+          await xfs.writeFilePromise(ppath.join(path, `my-patch.patch`), NO_DEPS_PATCH, {encoding: `utf16le`});
+
+          await expect(run(`install`)).rejects.toMatchObject({
+            code: 1,
+            stdout: expect.stringContaining(`Unable to parse patch file: No changes found`),
+          });
+        },
+      ),
+    );
   });
 });

--- a/packages/plugin-patch/sources/tools/parse.ts
+++ b/packages/plugin-patch/sources/tools/parse.ts
@@ -409,6 +409,9 @@ export function interpretParsedPatchFile(files: Array<FileDeets>): ParsedPatchFi
     }
   }
 
+  if (result.length === 0)
+    throw new Error(`Unable to parse patch file: No changes found. Make sure the patch is a valid UTF8 encoded string`);
+
   return result;
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When adding a patch file with invalid content Yarn "applies" it successfully even though it didn't apply anything

Fixes https://github.com/yarnpkg/berry/issues/2553

**How did you fix it?**

Throw if no changes were found in the patch file

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.