### PR TITLE
feat(plugin-git): make git: protocol default to HEAD

### DIFF
--- a/.yarn/versions/a278601e.yml
+++ b/.yarn/versions/a278601e.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-git": minor
+  "@yarnpkg/plugin-github": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
+++ b/packages/plugin-git/sources/__snapshots__/gitUtils.test.js.snap
@@ -94,7 +94,7 @@ Object {
   "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "head",
-    "request": "master",
+    "request": "HEAD",
   },
 }
 `;
@@ -164,7 +164,7 @@ Object {
   "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "head",
-    "request": "master",
+    "request": "HEAD",
   },
 }
 `;
@@ -175,7 +175,7 @@ Object {
   "repo": "https://github.com/GitHubOrg/foo2bar.js.git",
   "treeish": Object {
     "protocol": "head",
-    "request": "master",
+    "request": "HEAD",
   },
 }
 `;
@@ -241,7 +241,7 @@ Object {
   "repo": "https://github.com/GitHubOrg/foo-bar.js.git",
   "treeish": Object {
     "protocol": "head",
-    "request": "master",
+    "request": "HEAD",
   },
 }
 `;

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -60,7 +60,7 @@ export function splitRepoUrl(url: string): RepoUrlParts {
       repo: url,
       treeish: {
         protocol: TreeishProtocols.Head,
-        request: `master`,
+        request: `HEAD`,
       },
       extra: {},
     };
@@ -89,7 +89,7 @@ export function splitRepoUrl(url: string): RepoUrlParts {
       request = extra[requestedProtocol]! as string;
     } else {
       protocol = TreeishProtocols.Head;
-      request = `master`;
+      request = `HEAD`;
     }
 
     for (const key of Object.values(TreeishProtocols))
@@ -176,7 +176,7 @@ export async function lsRemote(repo: string, configuration: Configuration) {
 
   let res: {stdout: string};
   try {
-    res = await execUtils.execvp(`git`, [`ls-remote`, `--refs`, normalizedRepoUrl], {
+    res = await execUtils.execvp(`git`, [`ls-remote`, normalizedRepoUrl], {
       cwd: configuration.startingCwd,
       env: makeGitEnvironment(),
       strict: true,
@@ -188,7 +188,7 @@ export async function lsRemote(repo: string, configuration: Configuration) {
 
   const refs = new Map();
 
-  const matcher = /^([a-f0-9]{40})\t(refs\/[^\n]+)/gm;
+  const matcher = /^([a-f0-9]{40})\t([^\n]+)/gm;
   let match;
 
   while ((match = matcher.exec(res.stdout)) !== null)
@@ -214,7 +214,7 @@ export async function resolveUrl(url: string, configuration: Configuration) {
       }
 
       case TreeishProtocols.Head: {
-        const head = refs.get(`refs/heads/${request}`);
+        const head = refs.get(request === `HEAD` ? request : `refs/heads/${request}`);
         if (typeof head === `undefined`)
           throw new Error(`Unknown head ("${request}")`);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The `git:` protocol hardcoded `master` instead of using the actual `HEAD`. This meant that it was impossible to install repos like https://github.com/arcanis/typanion without specifying the default branch name.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've made the `git:` protocol use the actual `HEAD` pseudo-ref when no specific head is requested.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
