### PR TITLE
docs: Hugo 0.79+ extended does not work with PnP

### DIFF
--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -161,6 +161,7 @@ The following tools unfortunately cannot be used with pure Plug'n'Play install (
 | React Native | Follow [react-native-community/cli#27](https://github.com/react-native-community/cli/issues/27) |
 | Pulumi | Follow [pulumi/pulumi#3586](https://github.com/pulumi/pulumi/issues/3586) |
 | VSCode Extension Manager (vsce) | Use the [vsce-yarn-patch](https://www.npmjs.com/package/vsce-yarn-patch) fork with the `node-modules` plugin enabled. The fork is required until [microsoft/vscode-vsce#493](https://github.com/microsoft/vscode-vsce/pull/493) is merged, as `vsce` currently uses the removed `yarn list` command |
+| Hugo | Hugo pipes expect a `node-modules` dir. Enable the `node-modules` plugin |
 
 This list is kept up-to-date based on the latest release we've published starting from the v2. In case you notice something off in your own project please try to upgrade Yarn and the problematic package first, then feel free to file an issue. And maybe a PR? 😊
 


### PR DESCRIPTION
See https://gohugo.io/hugo-pipes/babel/ - without resorting to the `node-modules` plugin, sadly, Hugo pipes cannot find dependencies such as babel. It looks like this has nothing to do with `$NODE_PATH`, it is simply incompatible with Yarn Berry. I've also filed an improvement proposal under gohugo: https://github.com/gohugoio/hugo/issues/8301


In case other people use Hugo in conjunction with Yarn Berry, without enabling the `node-modules` plugin, things go bad - provided you use a hugo pipe such as the babel preset. It expects mode packages to be in the classic dependency directory. 

I simply added hugo to the current incompatible list so other folks also know what's going on.
