### PR TITLE
Improves yarn run performances

### DIFF
--- a/.yarn/versions/a1a1cf29.yml
+++ b/.yarn/versions/a1a1cf29.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -2,7 +2,7 @@ import {miscUtils, structUtils, formatUtils, Descriptor, LocatorHash}           
 import {FetchResult, Locator, Package}                                                                       from '@yarnpkg/core';
 import {Linker, LinkOptions, MinimalLinkOptions, Manifest, MessageName, DependencyMeta, LinkType, Installer} from '@yarnpkg/core';
 import {CwdFS, PortablePath, VirtualFS, npath, ppath, xfs, Filename}                                         from '@yarnpkg/fslib';
-import {generateInlinedScript, generateSplitScript, PackageRegistry, PnpSettings}                            from '@yarnpkg/pnp';
+import {generateInlinedScript, generateSplitScript, PackageRegistry, PnpApi, PnpSettings}                    from '@yarnpkg/pnp';
 import {UsageError}                                                                                          from 'clipanion';
 
 import {getPnpPath}                                                                                          from './index';
@@ -22,6 +22,8 @@ const FORCED_UNPLUG_PACKAGES = new Set([
 export class PnpLinker implements Linker {
   protected mode = `strict`;
 
+  private pnpCache: Map<string, PnpApi> = new Map();
+
   supportsPackage(pkg: Package, opts: MinimalLinkOptions) {
     if (opts.project.configuration.get(`nodeLinker`) !== `pnp`)
       return false;
@@ -37,7 +39,9 @@ export class PnpLinker implements Linker {
     if (!xfs.existsSync(pnpPath))
       throw new UsageError(`The project in ${formatUtils.pretty(opts.project.configuration, `${opts.project.cwd}/package.json`, formatUtils.Type.PATH)} doesn't seem to have been installed - running an install there might help`);
 
-    const pnpFile = miscUtils.dynamicRequireNoCache(pnpPath);
+    const pnpFile = miscUtils.getFactoryWithDefault(this.pnpCache, pnpPath, () => {
+      return miscUtils.dynamicRequireNoCache(pnpPath);
+    });
 
     const packageLocator = {name: structUtils.stringifyIdent(locator), reference: locator.reference};
     const packageInformation = pnpFile.getPackageInformation(packageLocator);
@@ -53,7 +57,10 @@ export class PnpLinker implements Linker {
     if (!xfs.existsSync(pnpPath))
       return null;
 
-    const pnpFile = miscUtils.dynamicRequireNoCache(pnpPath);
+    const pnpFile = miscUtils.getFactoryWithDefault(this.pnpCache, pnpPath, () => {
+      return miscUtils.dynamicRequireNoCache(pnpPath);
+    });
+
     const locator = pnpFile.findPackageLocator(npath.fromPortablePath(location));
     if (!locator)
       return null;


### PR DESCRIPTION
**What's the problem this PR addresses?**

We were always re-requiring the PnP API anew, even inside tight loops.

Closes https://github.com/yarnpkg/berry/issues/2560

**How did you fix it?**

The PnP API is now cached. This should be fine, considering that users will just have to create a new linker (from the configuration class) to clear all such caches.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
