### PR TITLE
perf(node-modules): cache install state

### DIFF
--- a/.yarn/versions/0b00790b.yml
+++ b/.yarn/versions/0b00790b.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -24,6 +24,8 @@ type BinSymlinkMap = Map<PortablePath, Map<Filename, PortablePath>>;
 type LoadManifest = (locator: LocatorKey, installLocation: PortablePath) => Promise<Pick<Manifest, 'bin'>>;
 
 export class NodeModulesLinker implements Linker {
+  private installStateCache: Map<string, Promise<InstallState | null>> = new Map();
+
   supportsPackage(pkg: Package, opts: MinimalLinkOptions) {
     return opts.project.configuration.get(`nodeLinker`) === `node-modules`;
   }
@@ -33,7 +35,9 @@ export class NodeModulesLinker implements Linker {
     if (workspace)
       return workspace.cwd;
 
-    const installState = await findInstallState(opts.project, {unrollAliases: true});
+    const installState = await miscUtils.getFactoryWithDefault(this.installStateCache, opts.project.cwd, async () => {
+      return await findInstallState(opts.project, {unrollAliases: true});
+    });
     if (installState === null)
       throw new UsageError(`Couldn't find the node_modules state file - running an install might help (findPackageLocation)`);
 
@@ -48,7 +52,9 @@ export class NodeModulesLinker implements Linker {
   }
 
   async findPackageLocator(location: PortablePath, opts: LinkOptions) {
-    const installState = await findInstallState(opts.project, {unrollAliases: true});
+    const installState = await miscUtils.getFactoryWithDefault(this.installStateCache, opts.project.cwd, async () => {
+      return await findInstallState(opts.project, {unrollAliases: true});
+    });
     if (installState === null)
       return null;
 

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -38,6 +38,7 @@ export class NodeModulesLinker implements Linker {
     const installState = await miscUtils.getFactoryWithDefault(this.installStateCache, opts.project.cwd, async () => {
       return await findInstallState(opts.project, {unrollAliases: true});
     });
+
     if (installState === null)
       throw new UsageError(`Couldn't find the node_modules state file - running an install might help (findPackageLocation)`);
 
@@ -55,6 +56,7 @@ export class NodeModulesLinker implements Linker {
     const installState = await miscUtils.getFactoryWithDefault(this.installStateCache, opts.project.cwd, async () => {
       return await findInstallState(opts.project, {unrollAliases: true});
     });
+
     if (installState === null)
       return null;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/yarnpkg/berry/pull/2564 but for the node-modules linker

ref https://github.com/yarnpkg/berry/issues/2575

**How did you fix it?**

Cache the install state

**Results**

Running `hyperfine -w 5 'yarn jest --version'` on https://github.com/jest-community/eslint-plugin-jest (cc @SimenB)
```diff
 Benchmark #1: yarn jest --version
-  Time (mean ± σ):      2.645 s ±  0.026 s    [User: 1.227 s, System: 0.288 s]
+  Time (mean ± σ):      2.347 s ±  0.020 s    [User: 930.2 ms, System: 235.9 ms]
-  Range (min … max):    2.624 s …  2.702 s    10 runs
+  Range (min … max):    2.320 s …  2.386 s    10 runs
```
(Ran on WSL2 over the network mounted C drive)

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.