### PR TITLE
perf(fslib): run removePromise in parallel

### DIFF
--- a/.yarn/versions/6e4ec8bf.yml
+++ b/.yarn/versions/6e4ec8bf.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/fslib": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/FakeFS.ts
+++ b/packages/yarnpkg-fslib/sources/FakeFS.ts
@@ -274,8 +274,7 @@ export abstract class FakeFS<P extends Path> {
 
     if (stat.isDirectory()) {
       if (recursive)
-        for (const entry of await this.readdirPromise(p))
-          await this.removePromise(this.pathUtils.resolve(p, entry));
+        await Promise.all((await this.readdirPromise(p)).map(entry => this.removePromise(this.pathUtils.resolve(p, entry))));
 
       // 5 gives 1s worth of retries at worst
       let t = 0;

--- a/packages/yarnpkg-fslib/sources/FakeFS.ts
+++ b/packages/yarnpkg-fslib/sources/FakeFS.ts
@@ -273,8 +273,13 @@ export abstract class FakeFS<P extends Path> {
     }
 
     if (stat.isDirectory()) {
-      if (recursive)
-        await Promise.all((await this.readdirPromise(p)).map(entry => this.removePromise(this.pathUtils.resolve(p, entry))));
+      if (recursive) {
+        const entries = await this.readdirPromise(p);
+
+        await Promise.all(entries.map(entry => {
+          return this.removePromise(this.pathUtils.resolve(p, entry));
+        }));
+      }
 
       // 5 gives 1s worth of retries at worst
       let t = 0;


### PR DESCRIPTION
**What's the problem this PR addresses?**

When `removePromise` encounters a folder it deletes its content one item at a time instead of all at once.

Ref https://github.com/yarnpkg/berry/issues/2575

**How did you fix it?**

Change the for loop to a `map` and `Promise.all`

**Result**

Running `hyperfine -w 5 'yarn lint-staged'` on https://github.com/jest-community/eslint-plugin-jest (cc @SimenB)

```diff
Benchmark #1: yarn lint-staged
-  Time (mean ± σ):      1.454 s ±  0.024 s    [User: 749.1 ms, System: 170.3 ms]
+  Time (mean ± σ):      1.458 s ±  0.041 s    [User: 732.1 ms, System: 199.7 ms]
-  Range (min … max):    1.420 s …  1.493 s    10 runs
+  Range (min … max):    1.396 s …  1.513 s    10 runs
```

Close to no difference in perfs but removing in parallel makes sense

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.