### PR TITLE
fix(core): skip building virtual workspaces

### DIFF
--- a/.yarn/versions/509c08b4.yml
+++ b/.yarn/versions/509c08b4.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -50,6 +50,7 @@ const mte = generatePkgDriver({
         [`YARN_ENABLE_PROGRESS_BARS`]: `false`,
         // Otherwise the output wouldn't be the same on CI vs non-CI
         [`YARN_ENABLE_INLINE_BUILDS`]: `false`,
+        [`YARN_PREFER_AGGREGATE_CACHE_INFO`]: `false`,
         // Otherwise we would more often test the fallback rather than the real logic
         [`YARN_PNP_FALLBACK_MODE`]: `none`,
         // Otherwise tests fail on systems where this is globally set to true

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -74,7 +74,7 @@ Object {
   "stdout": "➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Fetch step
-➤ YN0013: │ No packages were cached - one package had to be fetched
+➤ YN0013: │ no-deps@npm:2.0.0 can't be found in the cache and will be fetched from the remote registry
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Link step
 ➤ YN0007: │ foo@workspace:workspace must be built because it never did before or the last one failed

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/install.test.js.snap
@@ -66,3 +66,20 @@ Object {
 ",
 }
 `;
+
+exports[`Commands install should not build virtual workspaces 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0013: │ No packages were cached - one package had to be fetched
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0007: │ foo@workspace:workspace must be built because it never did before or the last one failed
+➤ YN0000: └ Completed
+➤ YN0000: Done
+",
+}
+`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -235,5 +235,32 @@ describe(`Commands`, () => {
         }
       )
     );
+
+    test(
+      `should not build virtual workspaces`,
+      makeTemporaryEnv(
+        {
+          workspaces: [`workspace`],
+          dependencies: {
+            foo: `workspace:*`,
+            'no-deps': `*`,
+          },
+        },
+        async ({path, run, source}) => {
+          await xfs.mkdirPromise(`${path}/workspace`);
+          await xfs.writeJsonPromise(`${path}/workspace/package.json`, {
+            name: `foo`,
+            scripts: {
+              postinstall: `echo "foo"`,
+            },
+            peerDependencies: {
+              'no-deps': `*`,
+            },
+          });
+
+          await expect(run(`install`)).resolves.toMatchSnapshot();
+        }
+      )
+    );
   });
 });

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -942,7 +942,8 @@ export class Project {
         const location = ppath.join(fetchResult.packageFs.getRealPath(), fetchResult.prefixPath);
         packageLocations.set(pkg.locatorHash, location);
 
-        if (buildScripts.length > 0) {
+        // Virtual workspaces shouldn't be built as they don't really exist
+        if (!structUtils.isVirtualLocator(pkg) && buildScripts.length > 0) {
           packageBuildDirectives.set(pkg.locatorHash, {
             directives: buildScripts,
             buildLocations: [location],


### PR DESCRIPTION
**What's the problem this PR addresses?**

When workspace-a depends on workspace-b, where workspace-b has a build script and a peer dependency, the core will build workspace-b twice. Once for the original and once for the virtual version.

**How did you fix it?**

Check if the workspace locator is virtual and skip the build if it is.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.