### PR TITLE
feat(essentials): add unlink command

### DIFF
--- a/.yarn/versions/ca467354.yml
+++ b/.yarn/versions/ca467354.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/cd76e49c.yml
+++ b/.yarn/versions/cd76e49c.yml
@@ -1,14 +1,21 @@
 releases:
-  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
   "@yarnpkg/plugin-essentials": minor
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
   - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
@@ -18,5 +25,6 @@ declined:
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
-  - "@yarnpkg/core"
+  - "@yarnpkg/cli"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/unlink.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/unlink.test.js
@@ -25,7 +25,7 @@ describe(`Commands`, () => {
 
         await run(`unlink`, `${tmp}/my-package`);
 
-        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({});
+        await expect(readJson(`${path}/package.json`)).resolves.toEqual({});
       }),
     );
 
@@ -59,22 +59,22 @@ describe(`Commands`, () => {
             cwd: `${path}/packages/workspace`,
           });
 
-          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
             resolutions: {
               [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
               [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
             },
-          });
+          }));
 
           await run(`unlink`, `${tmp}/my-package-b`, {
             cwd: `${path}/packages/workspace`,
           });
 
-          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
             resolutions: {
               [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
             },
-          });
+          }));
         },
       ),
     );
@@ -109,23 +109,78 @@ describe(`Commands`, () => {
             cwd: `${path}/packages/workspace`,
           });
 
-          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
             resolutions: {
               [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
               [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
             },
-          });
+          }));
 
           await run(`unlink`, ``, {
             cwd: `${path}/packages/workspace`,
           });
 
-          await expect(readJson(`${path}/package.json`)).resolves.not.toMatchObject({
+          await expect(readJson(`${path}/package.json`)).resolves.not.toEqual(expect.objectContaining({
             resolutions: expect.objectContaining({
               [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
               [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
             }),
+          }));
+        },
+      ),
+    );
+
+    test(
+      `it should remove all resolutions matching the specified glob`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run, source}) => {
+          const tmp = await createTemporaryFolder();
+
+          await writeJson(`${tmp}/my-package-a/package.json`, {
+            name: `my-package-a`,
           });
+
+          await writeJson(`${tmp}/my-package-b/package.json`, {
+            name: `my-package-b`,
+          });
+
+          await writeJson(`${path}/packages/workspace/package.json`, {
+            name: `workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package-a`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package-b`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
+            resolutions: {
+              [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
+              [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
+            },
+          }));
+
+          await run(`unlink`, `my-*-b`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
+            resolutions: {
+              [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
+            },
+          }));
+          await expect(readJson(`${path}/package.json`)).resolves.not.toEqual(expect.objectContaining({
+            resolutions: {
+              [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
+            },
+          }));
         },
       ),
     );
@@ -155,21 +210,21 @@ describe(`Commands`, () => {
         await run(`link`, `${tmp}/my-workspace`, `--all`);
         await run(`link`, `${tmp}/my-package`);
 
-        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
           resolutions: {
             [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
             [`workspace-a`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
             [`workspace-b`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
           },
-        });
+        }));
 
         await run(`unlink`, `${tmp}/my-workspace`, `--all`);
 
-        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(readJson(`${path}/package.json`)).resolves.toEqual(expect.objectContaining({
           resolutions: {
             [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
           },
-        });
+        }));
       }),
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/unlink.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/unlink.test.js
@@ -1,0 +1,176 @@
+import {npath} from '@yarnpkg/fslib';
+
+const {
+  fs: {createTemporaryFolder, readJson, writeJson},
+} = require(`pkg-tests-core`);
+
+describe(`Commands`, () => {
+  describe(`unlink`, () => {
+    test(
+      `it should allow to unlink a project from another one`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmp = await createTemporaryFolder();
+
+        await writeJson(`${tmp}/my-package/package.json`, {
+          name: `my-package`,
+        });
+
+        await run(`link`, `${tmp}/my-package`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          resolutions: {
+            [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
+          },
+        });
+
+        await run(`unlink`, `${tmp}/my-package`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({});
+      }),
+    );
+
+    test(
+      `it should remove the resolution override from the top-level workspace`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run, source}) => {
+          const tmp = await createTemporaryFolder();
+
+          await writeJson(`${tmp}/my-package-a/package.json`, {
+            name: `my-package-a`,
+          });
+
+          await writeJson(`${tmp}/my-package-b/package.json`, {
+            name: `my-package-b`,
+          });
+
+          await writeJson(`${path}/packages/workspace/package.json`, {
+            name: `workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package-a`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package-b`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+            resolutions: {
+              [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
+              [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
+            },
+          });
+
+          await run(`unlink`, `${tmp}/my-package-b`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+            resolutions: {
+              [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
+            },
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should remove all resolutions with the portal protocol when no destination specified`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run, source}) => {
+          const tmp = await createTemporaryFolder();
+
+          await writeJson(`${tmp}/my-package-a/package.json`, {
+            name: `my-package-a`,
+          });
+
+          await writeJson(`${tmp}/my-package-b/package.json`, {
+            name: `my-package-b`,
+          });
+
+          await writeJson(`${path}/packages/workspace/package.json`, {
+            name: `workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package-a`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await run(`link`, `${tmp}/my-package-b`, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+            resolutions: {
+              [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
+              [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
+            },
+          });
+
+          await run(`unlink`, ``, {
+            cwd: `${path}/packages/workspace`,
+          });
+
+          await expect(readJson(`${path}/package.json`)).resolves.not.toMatchObject({
+            resolutions: expect.objectContaining({
+              [`my-package-a`]: `portal:${npath.toPortablePath(`${tmp}/my-package-a`)}`,
+              [`my-package-b`]: `portal:${npath.toPortablePath(`${tmp}/my-package-b`)}`,
+            }),
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should allow to unlink all workspaces specified from another project`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmp = await createTemporaryFolder();
+
+        await writeJson(`${tmp}/my-workspace/package.json`, {
+          private: true,
+          workspaces: [`packages/*`],
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-a/package.json`, {
+          name: `workspace-a`,
+        });
+
+        await writeJson(`${tmp}/my-workspace/packages/workspace-b/package.json`, {
+          name: `workspace-b`,
+        });
+
+        await writeJson(`${tmp}/my-package/package.json`, {
+          name: `my-package`,
+        });
+
+        await run(`link`, `${tmp}/my-workspace`, `--all`);
+        await run(`link`, `${tmp}/my-package`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          resolutions: {
+            [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
+            [`workspace-a`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-a`)}`,
+            [`workspace-b`]: `portal:${npath.toPortablePath(`${tmp}/my-workspace/packages/workspace-b`)}`,
+          },
+        });
+
+        await run(`unlink`, `${tmp}/my-workspace`, `--all`);
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          resolutions: {
+            [`my-package`]: `portal:${npath.toPortablePath(`${tmp}/my-package`)}`,
+          },
+        });
+      }),
+    );
+  });
+});

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/unlink.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/unlink.test.js
@@ -116,7 +116,7 @@ describe(`Commands`, () => {
             },
           }));
 
-          await run(`unlink`, ``, {
+          await run(`unlink`, `--all`, {
             cwd: `${path}/packages/workspace`,
           });
 

--- a/packages/gatsby/content/getting-started/migration.md
+++ b/packages/gatsby/content/getting-started/migration.md
@@ -311,7 +311,6 @@ Those features simply haven't been implemented yet. Help welcome!
 | `yarn list`     | `yarn why` may provide some information in the meantime |
 | `yarn owner`    | Will eventually be available as `yarn npm owner` |
 | `yarn team`     | Will eventually be available as `yarn npm team` |
-| `yarn unlink`   | Manually remove the `resolutions` entries from the `package.json` file for now |
 
 ## Troubleshooting
 

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -13,8 +13,6 @@ export default class LinkCommand extends BaseCommand {
     description: `connect the local project to another one`,
     details: `
       This command will set a new \`resolutions\` field in the project-level manifest and point it to the workspace at the specified location (even if part of another project).
-
-      There is no \`yarn unlink\` command. To unlink the workspaces from the current project one must revert the changes made to the \`resolutions\` field.
     `,
     examples: [[
       `Register a remote workspace for use in the current project`,

--- a/packages/plugin-essentials/sources/commands/unlink.ts
+++ b/packages/plugin-essentials/sources/commands/unlink.ts
@@ -34,7 +34,9 @@ export default class UnlinkCommand extends BaseCommand {
     description: `Unlink all workspaces belonging to the target project from the current one`,
   });
 
-  leadingArgument = Option.String({required: false});
+  leadingArgument = Option.String({
+    required: false,
+  });
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
@@ -86,7 +88,9 @@ export default class UnlinkCommand extends BaseCommand {
       }
     }
 
-    topLevelWorkspace.manifest.resolutions = topLevelWorkspace.manifest.resolutions.filter(({pattern}) => !workspacesToUnlink.has(pattern.descriptor.fullName));
+    topLevelWorkspace.manifest.resolutions = topLevelWorkspace.manifest.resolutions.filter(({pattern}) => {
+      return !workspacesToUnlink.has(pattern.descriptor.fullName);
+    });
 
     const report = await StreamReport.start({
       configuration,

--- a/packages/plugin-essentials/sources/commands/unlink.ts
+++ b/packages/plugin-essentials/sources/commands/unlink.ts
@@ -1,0 +1,82 @@
+import {BaseCommand, WorkspaceRequiredError}                      from '@yarnpkg/cli';
+import {Cache, Configuration, Project, StreamReport, structUtils} from '@yarnpkg/core';
+import {npath, ppath}                                             from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                       from 'clipanion';
+
+// eslint-disable-next-line arca/no-default-export
+export default class UnlinkCommand extends BaseCommand {
+  static paths = [
+    [`unlink`],
+  ];
+
+  static usage: Usage = Command.Usage({
+    description: `disconnect the local project from another one`,
+    details: `
+      This command will remove any resolutions in the project-level manifest that would have been added via a yarn link with similar arguments.
+    `,
+    examples: [[
+      `Unregister a remote workspace in the current project`,
+      `$0 unlink ~/ts-loader`,
+    ], [
+      `Unregister all workspaces from a remote project in the current project`,
+      `$0 unlink ~/jest --all`,
+    ]],
+  });
+
+  all = Option.Boolean(`-A,--all`, false, {
+    description: `Unlink all workspaces belonging to the target project from the current one`,
+  });
+
+  destination = Option.String({required: false});
+
+  async execute() {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
+    const cache = await Cache.find(configuration);
+
+    if (!workspace)
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
+
+    const topLevelWorkspace = project.topLevelWorkspace;
+    const unlinkedWorkspaces = new Set<string>();
+
+    if (this.destination) {
+      const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
+
+      const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
+      const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
+
+      if (!workspace2)
+        throw new WorkspaceRequiredError(project2.cwd, absoluteDestination);
+
+      if (this.all) {
+        for (const workspace of project2.workspaces)
+          if (workspace.manifest.name)
+            unlinkedWorkspaces.add(structUtils.stringifyIdent(workspace.locator));
+
+        if (unlinkedWorkspaces.size === 0) {
+          throw new UsageError(`No workspace found to be unlinked in the target project`);
+        }
+      } else {
+        if (!workspace2.manifest.name)
+          throw new UsageError(`The target workspace doesn't have a name and thus cannot be unlinked`);
+
+        unlinkedWorkspaces.add(structUtils.stringifyIdent(workspace2.locator));
+      }
+
+      topLevelWorkspace.manifest.resolutions = topLevelWorkspace.manifest.resolutions.filter(({pattern}) =>
+        !unlinkedWorkspaces.has(pattern.descriptor.fullName));
+    } else {
+      topLevelWorkspace.manifest.resolutions = topLevelWorkspace.manifest.resolutions.filter(({reference}) => !reference.startsWith(`portal:`));
+    }
+
+    const report = await StreamReport.start({
+      configuration,
+      stdout: this.context.stdout,
+    }, async (report: StreamReport) => {
+      await project.install({cache, report});
+    });
+
+    return report.exitCode();
+  }
+}

--- a/packages/plugin-essentials/sources/commands/unlink.ts
+++ b/packages/plugin-essentials/sources/commands/unlink.ts
@@ -1,8 +1,8 @@
-import {BaseCommand, WorkspaceRequiredError}                      from '@yarnpkg/cli';
-import {Cache, Configuration, Project, StreamReport, structUtils} from '@yarnpkg/core';
-import {npath, ppath, xfs}                                        from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}                       from 'clipanion';
-import micromatch                                                 from 'micromatch';
+import {BaseCommand, WorkspaceRequiredError}                                 from '@yarnpkg/cli';
+import {Cache, Configuration, miscUtils, Project, StreamReport, structUtils} from '@yarnpkg/core';
+import {npath, ppath}                                                        from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                                  from 'clipanion';
+import micromatch                                                            from 'micromatch';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UnlinkCommand extends BaseCommand {
@@ -23,7 +23,7 @@ export default class UnlinkCommand extends BaseCommand {
       `$0 unlink ~/jest --all`,
     ], [
       `Unregister all previously linked workspaces`,
-      `$0 unlink`,
+      `$0 unlink --all`,
     ], [
       `Unregister all workspaces matching a glob`,
       `$0 unlink '@babel/*'`,
@@ -47,7 +47,7 @@ export default class UnlinkCommand extends BaseCommand {
     const topLevelWorkspace = project.topLevelWorkspace;
     const workspacesToUnlink = new Set<string>();
 
-    if (!this.leadingArgument) {
+    if (!this.leadingArgument && this.all) {
       for (const {pattern, reference} of topLevelWorkspace.manifest.resolutions) {
         if (reference.startsWith(`portal:`)) {
           workspacesToUnlink.add(pattern.descriptor.fullName);
@@ -57,7 +57,7 @@ export default class UnlinkCommand extends BaseCommand {
 
     if (this.leadingArgument) {
       const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.leadingArgument));
-      if (!structUtils.tryParseIdent(this.leadingArgument) && await xfs.existsPromise(absoluteDestination)) {
+      if (miscUtils.isPathLike(this.leadingArgument)) {
         const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
         const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
 

--- a/packages/plugin-essentials/sources/commands/unlink.ts
+++ b/packages/plugin-essentials/sources/commands/unlink.ts
@@ -57,7 +57,7 @@ export default class UnlinkCommand extends BaseCommand {
 
     if (this.destination) {
       const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
-      if (await xfs.existsPromise(absoluteDestination)) {
+      if (!structUtils.tryParseIdent(this.destination) && await xfs.existsPromise(absoluteDestination)) {
         const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
         const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
 

--- a/packages/plugin-essentials/sources/commands/unlink.ts
+++ b/packages/plugin-essentials/sources/commands/unlink.ts
@@ -34,7 +34,7 @@ export default class UnlinkCommand extends BaseCommand {
     description: `Unlink all workspaces belonging to the target project from the current one`,
   });
 
-  destination = Option.String({required: false});
+  leadingArgument = Option.String({required: false});
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
@@ -47,7 +47,7 @@ export default class UnlinkCommand extends BaseCommand {
     const topLevelWorkspace = project.topLevelWorkspace;
     const workspacesToUnlink = new Set<string>();
 
-    if (!this.destination) {
+    if (!this.leadingArgument) {
       for (const {pattern, reference} of topLevelWorkspace.manifest.resolutions) {
         if (reference.startsWith(`portal:`)) {
           workspacesToUnlink.add(pattern.descriptor.fullName);
@@ -55,9 +55,9 @@ export default class UnlinkCommand extends BaseCommand {
       }
     }
 
-    if (this.destination) {
-      const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
-      if (!structUtils.tryParseIdent(this.destination) && await xfs.existsPromise(absoluteDestination)) {
+    if (this.leadingArgument) {
+      const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.leadingArgument));
+      if (!structUtils.tryParseIdent(this.leadingArgument) && await xfs.existsPromise(absoluteDestination)) {
         const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
         const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
 
@@ -80,7 +80,7 @@ export default class UnlinkCommand extends BaseCommand {
         }
       } else {
         const fullNames = [...topLevelWorkspace.manifest.resolutions.map(({pattern}) => pattern.descriptor.fullName)];
-        for (const fullName of micromatch(fullNames, this.destination)) {
+        for (const fullName of micromatch(fullNames, this.leadingArgument)) {
           workspacesToUnlink.add(fullName);
         }
       }

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -32,6 +32,7 @@ import run                                                      from './commands
 import setResolutionPolicy                                      from './commands/set/resolution';
 import setVersionFromSources                                    from './commands/set/version/sources';
 import setVersionPolicy                                         from './commands/set/version';
+import unlink                                                   from './commands/unlink';
 import up                                                       from './commands/up';
 import why                                                      from './commands/why';
 import listWorkspaces                                           from './commands/workspaces/list';
@@ -119,6 +120,7 @@ const plugin: Plugin = {
     info,
     install,
     link,
+    unlink,
     node,
     pluginImportSources,
     pluginImport,

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -379,3 +379,9 @@ export function tryParseOptionalBoolean(value: unknown): boolean | undefined | n
 export type FilterKeys<T extends {}, Filter> = {
   [K in keyof T]: T[K] extends Filter ? K : never;
 }[keyof T];
+
+export function isPathLike(value: string): boolean {
+  if (npath.isAbsolute(value) || value.match(/^(\.{1,2}|~)\//))
+    return true;
+  return false;
+}

--- a/packages/yarnpkg-core/tests/miscUtils.test.ts
+++ b/packages/yarnpkg-core/tests/miscUtils.test.ts
@@ -35,4 +35,25 @@ describe(`miscUtils`, () => {
       ).toBeUndefined();
     });
   });
+
+  describe(`isPathLike`, () => {
+    it.each([
+      `/some/abs/path`,
+      `~/home/directory`,
+      `../parent/directory`,
+      `./current/directory`,
+    ])(`should return true for %s`, pathLike => {
+      expect(miscUtils.isPathLike(pathLike)).toBe(true);
+    });
+
+    it.each([
+      `{some-glob,}`,
+      `pkg-a`,
+      `@scope/ident`,
+      `scope/ident`,
+      `~`,
+    ])(`should return false for %s`, pathLike => {
+      expect(miscUtils.isPathLike(pathLike)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

As a developer, I want to link local packages for local development, but revert the local links before committing other package.json and yarn.lock changes to the upstream VCS repository.

Currently the "reverting" process requires manual modification of the package.json. Manual modification means we rely on hacked together scripts to achieve automation (CI, commit hooks, dev experience tooling, etc).

This functionality to remove the effects of a `yarn link` should be present in yarn.

This closes #2459

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Add a complimentary command `yarn unlink` which takes the same workspace path as `yarn link` (so it's the opposite), and removes resolutions from the top level manifest.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
