### PR TITLE
fix: restore build state to prevent rebuilds

### DIFF
--- a/.yarn/versions/9c2796ec.yml
+++ b/.yarn/versions/9c2796ec.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-version": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/dedupe.ts
+++ b/packages/plugin-essentials/sources/commands/dedupe.ts
@@ -88,6 +88,10 @@ export default class DedupeCommand extends BaseCommand {
     const {project} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     let dedupedPackageCount: number = 0;
     const dedupeReport = await StreamReport.start({
       configuration,

--- a/packages/plugin-essentials/sources/commands/explain/peerRequirements.ts
+++ b/packages/plugin-essentials/sources/commands/explain/peerRequirements.ts
@@ -41,6 +41,10 @@ export default class ExplainPeerRequirementsCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project} = await Project.find(configuration, this.context.cwd);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     // peerRequirements aren't stored inside the install state
     await project.applyLightResolution();
 

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -47,6 +47,10 @@ export default class LinkCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
 
     const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins);

--- a/packages/plugin-essentials/sources/commands/rebuild.ts
+++ b/packages/plugin-essentials/sources/commands/rebuild.ts
@@ -41,7 +41,9 @@ export default class RunCommand extends BaseCommand {
     for (const identStr of this.idents)
       filteredIdents.add(structUtils.parseIdent(identStr).identHash);
 
-    await project.restoreInstallState();
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
 
     await project.resolveEverything({
       cache,

--- a/packages/plugin-essentials/sources/commands/set/resolution.ts
+++ b/packages/plugin-essentials/sources/commands/set/resolution.ts
@@ -36,6 +36,10 @@ export default class SetResolutionCommand extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -96,6 +96,10 @@ export default class UpCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     const allDescriptors = [...project.storedDescriptors.values()];
 
     const stringifiedIdents = allDescriptors.map(descriptor => {
@@ -139,6 +143,10 @@ export default class UpCommand extends BaseCommand {
 
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
+
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
 
     const interactive = this.interactive ?? configuration.get(`preferInteractive`);
 

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -44,6 +44,10 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     const colorizeRawDiff = (from: string, to: string) => {
       const diff = diffWords(from, to);
       let str = ``;

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -44,6 +44,10 @@ export default class VersionApplyCommand extends BaseCommand {
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     const applyReport = await StreamReport.start({
       configuration,
       json: this.json,

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -40,6 +40,10 @@ export default class WorkspacesFocus extends BaseCommand {
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+
     let requiredWorkspaces: Set<Workspace>;
     if (this.all) {
       requiredWorkspaces = new Set(project.workspaces);

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1579,6 +1579,11 @@ export class Project {
       if (typeof installState.installersCustomData !== `undefined`)
         this.installersCustomData = installState.installersCustomData;
 
+    if (restoreBuildState)
+      Object.assign(this, pick(installState, INSTALL_STATE_FIELDS.restoreBuildState));
+
+    // Resolutions needs to be restored last otherwise applyLightResolution will persist a new state
+    // before the rest is restored
     if (restoreResolutions) {
       if (installState.lockFileChecksum === this.lockFileChecksum) {
         Object.assign(this, pick(installState, INSTALL_STATE_FIELDS.restoreResolutions));
@@ -1586,10 +1591,6 @@ export class Project {
       } else {
         await this.applyLightResolution();
       }
-    }
-
-    if (restoreBuildState) {
-      Object.assign(this, pick(installState, INSTALL_STATE_FIELDS.restoreBuildState));
     }
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When I moved the build state into the install state in https://github.com/yarnpkg/berry/pull/2574 commands that called `Project.install` but didn't call `Project.restoreInstallState` started causing all packages to rebuild

**How did you fix it?**

Call `Project.restoreInstallState`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.