### PR TITLE
feat(core): aggregate cache info for cache cleanup

### DIFF
--- a/.yarn/versions/157b40e5.yml
+++ b/.yarn/versions/157b40e5.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1628,7 +1628,9 @@ export class Project {
       return;
 
     const preferAggregateCacheInfo = this.configuration.get(`preferAggregateCacheInfo`);
+
     let entriesRemoved = 0;
+    let lastEntryRemoved = null;
 
     for (const entry of await xfs.readdirPromise(cache.cwd)) {
       if (PRESERVED_FILES.has(entry))
@@ -1637,6 +1639,8 @@ export class Project {
       const entryPath = ppath.resolve(cache.cwd, entry);
       if (cache.markedFiles.has(entryPath))
         continue;
+
+      lastEntryRemoved = entry;
 
       if (cache.immutable) {
         report.reportError(MessageName.IMMUTABLE_CACHE, `${formatUtils.pretty(this.configuration, ppath.basename(entryPath), `magenta`)} appears to be unused and would be marked for deletion, but the cache is immutable`);
@@ -1655,7 +1659,7 @@ export class Project {
         MessageName.UNUSED_CACHE_ENTRY,
         entriesRemoved > 1
           ? `${entriesRemoved} packages appeared to be unused and were removed`
-          : `one package appeared to be unused and was removed`
+          : `${lastEntryRemoved} appeared to be unused and was removed`
       );
     }
 

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -1,4 +1,5 @@
 import sliceAnsi                                  from '@arcanis/slice-ansi';
+import {structUtils}                              from '@yarnpkg/core';
 import {Writable}                                 from 'stream';
 
 import {Configuration}                            from './Configuration';
@@ -160,6 +161,7 @@ export class StreamReport extends Report {
 
   private cacheHitCount: number = 0;
   private cacheMissCount: number = 0;
+  private lastCacheMiss: Locator | null = null;
 
   private warningCount: number = 0;
   private errorCount: number = 0;
@@ -231,6 +233,7 @@ export class StreamReport extends Report {
   }
 
   reportCacheMiss(locator: Locator, message?: string) {
+    this.lastCacheMiss = locator;
     this.cacheMissCount += 1;
 
     if (typeof message !== `undefined` && !this.configuration.get(`preferAggregateCacheInfo`)) {
@@ -538,13 +541,13 @@ export class StreamReport extends Report {
       if (this.cacheMissCount > 1) {
         fetchStatus += `, ${this.cacheMissCount} had to be fetched`;
       } else if (this.cacheMissCount === 1) {
-        fetchStatus += `, one had to be fetched`;
+        fetchStatus += `, one had to be fetched (${structUtils.prettyLocator(this.configuration, this.lastCacheMiss!)})`;
       }
     } else {
       if (this.cacheMissCount > 1) {
         fetchStatus += ` - ${this.cacheMissCount} packages had to be fetched`;
       } else if (this.cacheMissCount === 1) {
-        fetchStatus += ` - one package had to be fetched`;
+        fetchStatus += ` - one package had to be fetched (${structUtils.prettyLocator(this.configuration, this.lastCacheMiss!)})`;
       }
     }
 

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -1,11 +1,11 @@
 import sliceAnsi                                  from '@arcanis/slice-ansi';
-import {structUtils}                              from '@yarnpkg/core';
 import {Writable}                                 from 'stream';
 
 import {Configuration}                            from './Configuration';
 import {MessageName, stringifyMessageName}        from './MessageName';
 import {ProgressDefinition, Report, TimerOptions} from './Report';
 import * as formatUtils                           from './formatUtils';
+import * as structUtils                           from './structUtils';
 import {Locator}                                  from './types';
 
 export type StreamReportOptions = {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`preferAggregateCacheInfo` (defaults to true on CI) doesn't effect the cache cleanup causing a lot of info to be logged.

**How did you fix it?**

Respect `preferAggregateCacheInfo` in the cache cleanup and print a one line summary.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.