### PR TITLE
fix(pnpify): make go to definition work with coc.nvim

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,6 @@
+{
+  "eslint.packageManager": "yarn",
+  "eslint.nodePath": ".yarn/sdks",
+  "workspace.workspaceFolderCheckCwd": false,
+  "tsserver.tsdk": ".yarn/sdks/typescript/lib"
+}

--- a/.yarn/sdks/integrations.yml
+++ b/.yarn/sdks/integrations.yml
@@ -3,3 +3,4 @@
 
 integrations:
   - vscode
+  - vim

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -63,9 +63,9 @@ const moduleWrapper = tsserver => {
           // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
           case `coc-nvim`: {
             if (isVirtual(str)) {
-              str = normalize(resolved);
+              str = resolved;
             }
-            str = str.replace(/\.zip\//, `.zip::`);
+            str = normalize(str).replace(/\.zip\//, `.zip::`);
             str = resolve(`zipfile:${str}`);
           } break;
 

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -13,6 +13,8 @@ const moduleWrapper = tsserver => {
   const {isAbsolute} = require(`path`);
   const pnpApi = require(`pnpapi`);
 
+  const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
+
   const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
     return `${locator.name}@${locator.reference}`;
   }));
@@ -23,7 +25,7 @@ const moduleWrapper = tsserver => {
 
   function toEditorPath(str) {
     // We add the `zip:` prefix to both `.zip/` paths and virtual paths
-    if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || str.match(/\/(\$\$virtual|__virtual__)\//))) {
+    if (isAbsolute(str) && !str.match(/^\^zip:/) && (str.match(/\.zip\//) || isVirtual(str))) {
       // We also take the opportunity to turn virtual paths into physical ones;
       // this makes is much easier to work with workspaces that list peer
       // dependencies, since otherwise Ctrl+Click would bring us to the virtual
@@ -60,7 +62,7 @@ const moduleWrapper = tsserver => {
           // We have to resolve the actual file system path from virtual path
           // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
           case `coc-nvim`: {
-            if (str.match(/\/(\$\$virtual|__virtual__)\//)) {
+            if (isVirtual(str)) {
               str = normalize(resolved);
             }
             str = str.replace(/\.zip\//, `.zip::`);

--- a/.yarn/versions/18b674ec.yml
+++ b/.yarn/versions/18b674ec.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": minor
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -83,11 +83,11 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
                 str = \`^zip:\${str}\`;
               } break;
 
-              // To make "go to definition work",
-              // resolve the actual file system path from virtual path
-              // and convert to scheme supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
+              // To make "go to definition" work,
+              // We have to resolve the actual file system path from virtual path
+              // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
               case \`coc-nvim\`: {
-                str = normalize(resolved).replace(/\\.zip\\//, \`.zip::\`);
+                str = src.replace(/\\.zip\\//, \`.zip::\`);
                 str = resolve(\`zipfile:\${str}\`);
               } break;
 

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -90,9 +90,9 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
               case \`coc-nvim\`: {
                 if (isVirtual(str)) {
-                  str = normalize(resolved);
+                  str = resolved;
                 }
-                str = str.replace(/\\.zip\\//, \`.zip::\`);
+                str = normalize(str).replace(/\\.zip\\//, \`.zip::\`);
                 str = resolve(\`zipfile:\${str}\`);
               } break;
 

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -87,7 +87,10 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               // We have to resolve the actual file system path from virtual path
               // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
               case \`coc-nvim\`: {
-                str = src.replace(/\\.zip\\//, \`.zip::\`);
+                if (str.match(/\\/(\\$\\$virtual|__virtual__)\\//)) {
+                  str = normalize(resolved);
+                }
+                str = str.replace(/\\.zip\\//, \`.zip::\`);
                 str = resolve(\`zipfile:\${str}\`);
               } break;
 

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -62,15 +62,13 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           // errors on react).
           //
           const resolved = pnpApi.resolveVirtual(str);
+          const normalize = str => str.replace(/\\\\/g, \`/\`).replace(/^\\/?/, \`/\`);
           if (resolved) {
             const locator = pnpApi.findPackageLocator(resolved);
             if (locator && dependencyTreeRoots.has(\`\${locator.name}@\${locator.reference}\`)) {
-             str = resolved;
+             str = normalize(resolved);
             }
           }
-
-          str = str.replace(/\\\\/g, \`/\`)
-          str = str.replace(/^\\/?/, \`/\`);
 
           if (str.match(/\\.zip\\//)) {
             swtich (hostInfo) {
@@ -88,9 +86,9 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               // resolve the actual file system path from virtual path
               // and convert to scheme supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
               case \`coc-nvim\`:
-                str = str.replace(/\\$\\$virtual\\/([\\-\\w\\/]+)\\/cache/, \`cache\`);
-                str = str.replace(/\\.zip\\//, \`.zip::\`);
+                str = normalize(resolved).replace(/\\.zip\\//, \`.zip::\`);
                 str = resolve(\`zipfile:\${str}\`);
+                break;
 
               default:
                 str = \`zip:\${str}\`; break;

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -71,7 +71,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           }
 
           if (str.match(/\\.zip\\//)) {
-            swtich (hostInfo) {
+            switch (hostInfo) {
               // Absolute VSCode \`Uri.fsPath\`s need to start with a slash.
               // VSCode only adds it automatically for supported schemes,
               // so we have to do it manually for the \`zip\` scheme.
@@ -79,19 +79,21 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               //
               // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
               //
-              case \`vscode\`:
-                str = \`^zip:\${str}\`; break;
+              case \`vscode\`: {
+                str = \`^zip:\${str}\`;
+              } break;
 
               // To make "go to definition work",
               // resolve the actual file system path from virtual path
               // and convert to scheme supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
-              case \`coc-nvim\`:
+              case \`coc-nvim\`: {
                 str = normalize(resolved).replace(/\\.zip\\//, \`.zip::\`);
                 str = resolve(\`zipfile:\${str}\`);
-                break;
+              } break;
 
-              default:
-                str = \`zip:\${str}\`; break;
+              default: {
+                str = \`zip:\${str}\`;
+              } break;
             }
           }
         }

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -40,6 +40,8 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       const {isAbsolute} = require(\`path\`);
       const pnpApi = require(\`pnpapi\`);
 
+      const isVirtual = str => str.match(/\\/(\\$\\$virtual|__virtual__)\\//);
+
       const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
         return \`\${locator.name}@\${locator.reference}\`;
       }));
@@ -50,7 +52,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
       function toEditorPath(str) {
         // We add the \`zip:\` prefix to both \`.zip/\` paths and virtual paths
-        if (isAbsolute(str) && !str.match(/^\\^zip:/) && (str.match(/\\.zip\\//) || str.match(/\\/(\\$\\$virtual|__virtual__)\\//))) {
+        if (isAbsolute(str) && !str.match(/^\\^zip:/) && (str.match(/\\.zip\\//) || isVirtual(str))) {
           // We also take the opportunity to turn virtual paths into physical ones;
           // this makes is much easier to work with workspaces that list peer
           // dependencies, since otherwise Ctrl+Click would bring us to the virtual
@@ -87,7 +89,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               // We have to resolve the actual file system path from virtual path
               // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
               case \`coc-nvim\`: {
-                if (str.match(/\\/(\\$\\$virtual|__virtual__)\\//)) {
+                if (isVirtual(str)) {
                   str = normalize(resolved);
                 }
                 str = str.replace(/\\.zip\\//, \`.zip::\`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

fixes https://github.com/neoclide/coc-tsserver/issues/244

https://twitter.com/KrComet/status/1370033304464855044

`gd`(Go to Definition) is not working for [coc-tsserver](https://github.com/neoclide/coc-tsserver) host.

...

**How did you fix it?**

I was looking for a way to search inside zip with vim, and it seems to possible with [vim-rzip](https://github.com/lbrayner/vim-rzip) plugin.

This patch makes it possible to resolve paths compatible with vim-rzip in the coc-nvim host.

https://github.com/lbrayner/vim-rzip is required for the user's vim config.

...
