### PR TITLE
fix(esbuild): fallback to default resolver when path isn't under pnp

### DIFF
--- a/.yarn/versions/41e6909c.yml
+++ b/.yarn/versions/41e6909c.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -48,11 +48,10 @@ export function pnpPlugin({
           ? args.importer
           : `${baseDir}/`;
 
-        // In theory we should delegate to the real resolution, but ESBuild
-        // doesn't currently offer any way to do that.
         const pnpApi = findPnpApi(effectiveImporter) as PnpApi | null;
         if (!pnpApi)
-          throw new Error(`Path is external to the project`);
+          // Path isn't controlled by PnP so delegate to the next resolver in the chain
+          return undefined;
 
         const path = pnpApi.resolveRequest(args.path, effectiveImporter, {
           considerBuiltins: true,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The esbuild pnp plugin throws if the path isn't under PnP instead of letting the next resolver run.

**How did you fix it?**

Return `undefined` on paths external to the pnpapi as documented here https://esbuild.github.io/plugins/#resolve-callbacks
> The callback can return without providing a path to pass on responsibility for path resolution to the next callback

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.