### PR TITLE
fix(core): don't run other build scripts for a `Package` when one failed

### DIFF
--- a/.yarn/versions/ff187132.yml
+++ b/.yarn/versions/ff187132.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -262,5 +262,23 @@ describe(`Commands`, () => {
         }
       )
     );
+
+    test(
+      `should not continue running build scripts if one of them fails`,
+      makeTemporaryEnv(
+        {
+          scripts: {
+            preinstall: `exit 1`,
+            postinstall: `echo 'foo'`,
+          },
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`, `--inline-builds`)).rejects.toMatchObject({
+            code: 1,
+            stdout: expect.not.stringContaining(`foo`),
+          });
+        }
+      )
+    );
   });
 });

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1228,7 +1228,7 @@ export class Project {
 
               const stdin = null;
 
-              await xfs.mktempPromise(async logDir => {
+              const wasBuildSuccessful = await xfs.mktempPromise(async logDir => {
                 const logFile = ppath.join(logDir, `build.log` as PortablePath);
 
                 const {stdout, stderr} = this.configuration.getSubprocessStreams(logFile, {
@@ -1273,6 +1273,10 @@ export class Project {
                 report.reportError(MessageName.BUILD_FAILED, buildMessage);
                 return false;
               });
+
+              if (!wasBuildSuccessful) {
+                return;
+              }
             }
           })());
         }


### PR DESCRIPTION
**What's the problem this PR addresses?**

If the build script `preinstall` fails `install` and `postinstall` is still run for a package and if those are successful the build is marked as successful even though it failed

**How did you fix it?**

Check if the script ran successfully and if it didn't, stop running scripts for that `Package`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.