### PR TITLE
Improves telemetry for better version support

### DIFF
--- a/.yarn/versions/e2ae2e88.yml
+++ b/.yarn/versions/e2ae2e88.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/TelemetryManager.ts
+++ b/packages/yarnpkg-core/sources/TelemetryManager.ts
@@ -160,7 +160,7 @@ export class TelemetryManager {
       // Also the max amount of queries (at worst once a week, remember)
       const maxValues = 20;
 
-      for (const [metricName, values] of Object.entries(upload.values))
+      for (const [metricName, values] of Object.entries<any>(upload.values))
         if (values.length > 0)
           toSend.set(metricName, values.slice(0, maxValues));
 

--- a/packages/yarnpkg-core/sources/TelemetryManager.ts
+++ b/packages/yarnpkg-core/sources/TelemetryManager.ts
@@ -156,11 +156,11 @@ export class TelemetryManager {
       // payload, so we instead send one query for each of them.
       for (const type of [`values`, `enumerators`] as const) {
         for (const [metricName, values] of Object.entries(upload[type])) {
-          // Something likely went weird, discard the metric altogether
-          if (values.length > 10)
-            continue;
+          const asArray = Array.isArray(values)
+            ? values
+            : [values];
 
-          for (const value of values) {
+          for (const value of asArray) {
             sendPayload({
               userId,
               reportType: `secondary`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
Datadog doesn't support sending multiple times the same tag with different values. As a result, the following payload:

```json
{
  "versions": ["2.5.0", "2.4.0", "2.6.0"]
}
```

Is turned into `versions:2.5.0-2.4.0-2.6.0`. It makes it difficult to write queries like "how many people use the 2.4 line", since we now have to glob into the value. For instance here, we would have to write something like `versions:*-2.4.*`, but using wildcards as both prefix and suffix isn't supported by Datadog at the moment.

**How did you fix it?**

The telemetry manager will now submit one query for each metric (while still optimizing them to send multiple different metrics in the same batch). It means that the following:

```json
{
  "versions": ["2.5.0", "2.4.0", "2.6.0"],
  "dependencies": [67, 95]
}
```

Will send the following three requests:

```
versions:2.5.0 dependencies:67
versions:2.4.0 dependencies:95
versions:2.6.0
```

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
