### PR TITLE
fix(core): allow replacing boolean config values by env vars (#2339)

### DIFF
--- a/.yarn/versions/7aec09ed.yml
+++ b/.yarn/versions/7aec09ed.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -609,15 +609,15 @@ function parseSingleValue(configuration: Configuration, path: string, value: unk
     return value;
 
   const interpretValue = () => {
-    if (definition.type === SettingsType.BOOLEAN)
-      return miscUtils.parseBoolean(value);
-
-    if (typeof value !== `string`)
-      throw new Error(`Expected value (${value}) to be a string`);
-
     const valueWithReplacedVariables = miscUtils.replaceEnvVariables(value, {
       env: process.env,
     });
+
+    if (definition.type === SettingsType.BOOLEAN)
+      return miscUtils.parseBoolean(valueWithReplacedVariables);
+
+    if (typeof valueWithReplacedVariables !== `string`)
+      throw new Error(`Expected value (${valueWithReplacedVariables}) to be a string`);
 
     switch (definition.type) {
       case SettingsType.ABSOLUTE_PATH:

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -319,7 +319,8 @@ export function buildIgnorePattern(ignorePatterns: Array<string>) {
   }).join(`|`);
 }
 
-export function replaceEnvVariables(value: string, {env}: {env: {[key: string]: string | undefined}}) {
+export function replaceEnvVariables(value: unknown, {env}: {env: {[key: string]: string | undefined}}) {
+  if (typeof value !== `string`) return value;
   const regex = /\${(?<variableName>[\d\w_]+)(?<colon>:)?(?:-(?<fallback>[^}]*))?}/g;
 
   return value.replace(regex, (...args) => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
The [documentation ](https://yarnpkg.com/configuration/yarnrc) states that yarnrc settings can be replaced by environment variables, but currently, this doesn't work for Boolean settings.  This PR aims to fix this.
Closes #2339 

**How did you fix it?**
The previous implementation first checked if the setting was boolean, and if it was, it tried to parse it to a boolean right away, and never even tried to replace the value by an ENV var.

I changed the interpretValue function to make it first replace the value by the env var if applicable, then do other checks.
This means that miscUtils.replaceEnvVariables must now accept and handle unknown type values, so I changed it accordingly.
I feel like its cleaner to do it this way than to add more logic in interpretValue, but that could be debated.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [ ] I have set the packages that need to be released for my changes to be effective.
I have marked yarnpkg-core as needing a patch but I've left it's dependent plugins undecided ... I'm not familiar enough with the project structure to do better.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
