### PR TITLE
docs: add edit on github link to doc pages

### DIFF
--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -161,11 +161,12 @@ const Content = styled.div`
   }
 `;
 
-export const PrerenderedMarkdown = ({title, children}) => <>
+export const PrerenderedMarkdown = ({title, children, editUrl}) => <>
   <Container>
     <Title>
       {title.match(/^`.*`$/) ? <code>{title.slice(1, -1)}</code> : title}
     </Title>
+    {editUrl && <a target="_blank" href={editUrl}>Edit this page on GitHub</a>}
     <Content dangerouslySetInnerHTML={{__html: children}} />
   </Container>
 </>;

--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -175,7 +175,7 @@ const Content = styled.div`
 
 export const PrerenderedMarkdown = ({title, children, editUrl}) => <>
   <Container>
-    <Title>
+    <Title title={title}>
       {title.match(/^`.*`$/) ? <code>{title.slice(1, -1)}</code> : title}
       {editUrl && <EditLink target="_blank" href={editUrl}>Edit this page on GitHub</EditLink>}
     </Title>

--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -24,6 +24,18 @@ const Title = styled.h1`
   + div > blockquote {
     font-style: normal;
   }
+
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+
+  flex-wrap: wrap-reverse;
+`;
+
+const EditLink = styled.a`
+  font-size: initial;
+  font-weight: initial;
+  line-height: initial;
 `;
 
 const Content = styled.div`
@@ -165,8 +177,8 @@ export const PrerenderedMarkdown = ({title, children, editUrl}) => <>
   <Container>
     <Title>
       {title.match(/^`.*`$/) ? <code>{title.slice(1, -1)}</code> : title}
+      {editUrl && <EditLink target="_blank" href={editUrl}>Edit this page on GitHub</EditLink>}
     </Title>
-    {editUrl && <a target="_blank" href={editUrl}>Edit this page on GitHub</a>}
     <Content dangerouslySetInnerHTML={{__html: children}} />
   </Container>
 </>;

--- a/packages/gatsby/src/components/toc/index.js
+++ b/packages/gatsby/src/components/toc/index.js
@@ -189,7 +189,7 @@ export const Toc = ({ headingSelector, getTitle, getDepth, ...rest }) => {
       headingSelector || Array.from({ length: 6 }, (_, i) => `article h` + (i + 1))
     const nodes = Array.from(document.querySelectorAll(selector))
     const titles = nodes.map(node => ({
-      title: getTitle ? getTitle(node) : (node.innerText || node.textContent),
+      title: getTitle ? getTitle(node) : (node.title || node.innerText || node.textContent),
       depth: getDepth ? getDepth(node) : Number(node.nodeName[1]),
     }))
     // Compute the minimum heading depth. Will be subtracted from each heading's

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -11,11 +11,20 @@ const GlobalStyleOverrides = css`
   --header-border-bottom: 1px solid #cfdee9;
 }
 `;
+const GIT_URL_EDIT_PREFIX = "https://github.com/yarnpkg/berry/tree/master/packages/gatsby/content"
+const CONTENT_DIR = "/content/"
+
+function getGitPageUrl(postAbsolutePath) {
+  const pathIndex =
+    postAbsolutePath.indexOf(CONTENT_DIR) + CONTENT_DIR.length;
+  const relativePath = postAbsolutePath.slice(pathIndex);
+  return `${GIT_URL_EDIT_PREFIX}/${relativePath}`;
+}
 
 // eslint-disable-next-line arca/no-default-export
 export default function Template({data, pageContext: {category}}) {
   const {allMarkdownRemark, markdownRemark} = data;
-  const {frontmatter, html} = markdownRemark;
+  const {frontmatter, html, fileAbsolutePath} = markdownRemark;
 
   return <>
     <Global styles={GlobalStyleOverrides} />
@@ -28,7 +37,7 @@ export default function Template({data, pageContext: {category}}) {
         description={frontmatter.description}
         keywords={[`package manager`, `yarn`, `yarnpkg`, frontmatter.path.split(`/`).reverse()[0]]}
       />
-      <PrerenderedMarkdown title={frontmatter.title}>
+      <PrerenderedMarkdown title={frontmatter.title} editUrl={getGitPageUrl(fileAbsolutePath)}>
         {html}
       </PrerenderedMarkdown>
     </LayoutContentNav>
@@ -52,6 +61,7 @@ export const pageQuery = graphql`
     }
     markdownRemark(frontmatter: {category: {eq: $category}, path: {eq: $path}}) {
       html
+      fileAbsolutePath
       frontmatter {
         path
         title

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -11,8 +11,8 @@ const GlobalStyleOverrides = css`
   --header-border-bottom: 1px solid #cfdee9;
 }
 `;
-const GIT_URL_EDIT_PREFIX = "https://github.com/yarnpkg/berry/tree/master/packages/gatsby/content"
-const CONTENT_DIR = "/content/"
+const GIT_URL_EDIT_PREFIX = `https://github.com/yarnpkg/berry/tree/master/packages/gatsby/content`;
+const CONTENT_DIR = `/content/`;
 
 function getGitPageUrl(postAbsolutePath) {
   const pathIndex =

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -15,6 +15,7 @@ const GIT_URL_EDIT_PREFIX = `https://github.com/yarnpkg/berry/tree/master/packag
 const CONTENT_DIR = `/content/`;
 
 function getGitPageUrl(postAbsolutePath) {
+  if (!postAbsolutePath) return undefined;
   const pathIndex =
     postAbsolutePath.indexOf(CONTENT_DIR) + CONTENT_DIR.length;
   const relativePath = postAbsolutePath.slice(pathIndex);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This adds an `Edit this page on Github` link to markdown based documentation pages.

It should make it easy for people to contribute improvements, grammar fixes, etc, to the docs.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added logic to parse out the absolute file path of an article and transform it to a github url that links to the specific page.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
