### PR TITLE
Hash telemetry enumerators

### DIFF
--- a/.yarn/versions/5d046bd4.yml
+++ b/.yarn/versions/5d046bd4.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/TelemetryManager.ts
+++ b/packages/yarnpkg-core/sources/TelemetryManager.ts
@@ -1,6 +1,7 @@
 import {Filename, xfs, PortablePath, ppath} from '@yarnpkg/fslib';
 
 import {Configuration}                      from './Configuration';
+import * as hashUtils                       from './hashUtils';
 import * as httpUtils                       from './httpUtils';
 import * as miscUtils                       from './miscUtils';
 
@@ -85,7 +86,7 @@ export class TelemetryManager {
   }
 
   private reportEnumerator(metric: MetricName, value: string) {
-    miscUtils.getSetWithDefault(this.enumerators, metric).add(value);
+    miscUtils.getSetWithDefault(this.enumerators, metric).add(hashUtils.makeHash(value));
   }
 
   private reportHit(metric: MetricName, extra: string = `*`) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
The enumerators (ie properties submitted as the different number of elements rather than the elements themselves) were still stored in the telemetry file as their actual value. This wasn't a problem per-se (we never transmitted them), but it could be worrying for users to see them (it happened at least twice that someone thought we were accidentally sending them).

**How did you fix it?**
The file will now only contain their hash representation. It doesn't change anything functionally speaking, but now it's clearer that those values simply can't be leaked.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
