### PR TITLE
fix(core): always load home config in loose mode

### DIFF
--- a/.yarn/versions/62828ed0.yml
+++ b/.yarn/versions/62828ed0.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/rcFiles.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/rcFiles.test.js
@@ -1,3 +1,4 @@
+const {xfs, npath} = require(`@yarnpkg/fslib`);
 const {
   fs: {writeFile},
   misc: {parseJsonStream},
@@ -41,6 +42,29 @@ describe(`Features`, () => {
           });
         },
       ),
+    );
+
+    test(
+      `it should always load home config in loose mode`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await xfs.writeFilePromise(
+          `${path}/.yarnrc.yml`,
+          `unknownConfigKey: 42\n`
+        );
+        await xfs.mkdirPromise(`${path}/project`);
+        await xfs.writeJsonPromise(`${path}/project/package.json`, {});
+        await xfs.writeFilePromise(`${path}/project/yarn.lock`, ``);
+
+        await expect(
+          run(`install`, {
+            cwd: `${path}/project`,
+            env: {
+              HOME: npath.fromPortablePath(path),
+              USERPROFILE: npath.fromPortablePath(path),
+            },
+          })
+        ).resolves.toMatchObject({code: 0});
+      })
     );
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

When the users home directory is an ancestor of the current project directory the global config is parsed in strict mode which means having configs for newer versions of Yarn in the global config causes older versions to throw.

**How did you fix it?**

Mark the config in the home directory as non-strict so the location of it doesn't matter

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.