### PR TITLE
docs: fix h1 css leaking into search results

### DIFF
--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -10,12 +10,18 @@ const Container = styled.article`
   line-height: 1.7;
 `;
 
+const TitleContainer = styled.div`
+  border-bottom: 1px solid;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+
+  flex-wrap: wrap-reverse;
+`;
 const Title = styled.h1`
   box-sizing: border-box;
 
   margin: 0;
-
-  border-bottom: 1px solid;
 
   font-weight: 600;
   font-size: 2rem;
@@ -24,12 +30,6 @@ const Title = styled.h1`
   + div > blockquote {
     font-style: normal;
   }
-
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-
-  flex-wrap: wrap-reverse;
 `;
 
 const EditLink = styled.a`
@@ -175,10 +175,12 @@ const Content = styled.div`
 
 export const PrerenderedMarkdown = ({title, children, editUrl}) => <>
   <Container>
-    <Title title={title}>
-      {title.match(/^`.*`$/) ? <code>{title.slice(1, -1)}</code> : title}
+    <TitleContainer>
+      <Title>
+        {title.match(/^`.*`$/) ? <code>{title.slice(1, -1)}</code> : title}
+      </Title>
       {editUrl && <EditLink target="_blank" href={editUrl}>Edit this page on GitHub</EditLink>}
-    </Title>
+    </TitleContainer>
     <Content dangerouslySetInnerHTML={{__html: children}} />
   </Container>
 </>;

--- a/packages/gatsby/src/components/toc/index.js
+++ b/packages/gatsby/src/components/toc/index.js
@@ -189,7 +189,7 @@ export const Toc = ({ headingSelector, getTitle, getDepth, ...rest }) => {
       headingSelector || Array.from({ length: 6 }, (_, i) => `article h` + (i + 1))
     const nodes = Array.from(document.querySelectorAll(selector))
     const titles = nodes.map(node => ({
-      title: getTitle ? getTitle(node) : (node.title || node.innerText || node.textContent),
+      title: getTitle ? getTitle(node) : (node.innerText || node.textContent),
       depth: getDepth ? getDepth(node) : Number(node.nodeName[1]),
     }))
     // Compute the minimum heading depth. Will be subtracted from each heading's


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

fixes: 
![image](https://user-images.githubusercontent.com/697707/112462954-59f1ca00-8d6a-11eb-9808-afef9d684841.png)


**How did you fix it?**
<!-- A detailed description of your implementation. -->

Seems algolia parses the h1 as it is. This reorganizes the html so that the `h1` tag only contains the title, and moves the "Edit on GitHub" link outside of it

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
