### PR TITLE
fix(core): use atomic writes for the global cache

### DIFF
--- a/.yarn/versions/11055917.yml
+++ b/.yarn/versions/11055917.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -210,24 +210,31 @@ export class Cache {
       if (this.immutable)
         throw new ReportError(MessageName.IMMUTABLE_CACHE, `Cache entry required but missing for ${structUtils.prettyLocator(this.configuration, locator)}`);
 
-      const {path: originalPath, source: packageSource} = await loadPackageThroughMirror();
+      const {path: cachePathTemp, source: packageSource} = await loadPackageThroughMirror();
 
-      await xfs.chmodPromise(originalPath, 0o644);
+      await xfs.chmodPromise(cachePathTemp, 0o644);
 
       // Do this before moving the file so that we don't pollute the cache with corrupted archives
-      const checksum = await validateFile(originalPath);
+      const checksum = await validateFile(cachePathTemp);
 
       const cachePath = this.getLocatorPath(locator, checksum);
       if (!cachePath)
         throw new Error(`Assertion failed: Expected the cache path to be available`);
 
+      let mirrorPathTemp: null | PortablePath = null;
+      if (packageSource !== `mirror` && mirrorPath !== null) {
+        const tempDir = await xfs.mktempPromise();
+        mirrorPathTemp = ppath.join(tempDir, this.getVersionFilename(locator));
+        await xfs.copyFilePromise(cachePathTemp, mirrorPathTemp, fs.constants.COPYFILE_FICLONE);
+      }
+
       return await this.writeFileWithLock(cachePath, async () => {
         return await this.writeFileWithLock(packageSource === `mirror` ? null : mirrorPath, async () => {
           // Doing a move is important to ensure atomic writes (todo: cross-drive?)
-          await xfs.movePromise(originalPath, cachePath);
-
-          if (packageSource !== `mirror` && mirrorPath !== null)
-            await xfs.copyFilePromise(cachePath, mirrorPath, fs.constants.COPYFILE_FICLONE);
+          await Promise.all([
+            xfs.movePromise(cachePathTemp, cachePath),
+            mirrorPathTemp && mirrorPath && xfs.movePromise(mirrorPathTemp, mirrorPath),
+          ]);
 
           return [cachePath, checksum] as const;
         });

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -231,10 +231,10 @@ export class Cache {
       return await this.writeFileWithLock(cachePath, async () => {
         return await this.writeFileWithLock(packageSource === `mirror` ? null : mirrorPath, async () => {
           // Doing a move is important to ensure atomic writes (todo: cross-drive?)
-          await Promise.all([
-            xfs.movePromise(cachePathTemp, cachePath),
-            mirrorPathTemp && mirrorPath && xfs.movePromise(mirrorPathTemp, mirrorPath),
-          ]);
+          await xfs.movePromise(cachePathTemp, cachePath);
+
+          if (mirrorPathTemp && mirrorPath)
+            await xfs.movePromise(mirrorPathTemp, mirrorPath);
 
           return [cachePath, checksum] as const;
         });


### PR DESCRIPTION
**What's the problem this PR addresses?**

When a install is cancelled at just the right time the global cache gets corrupted while copying from the local cache to the global cache.

Fixes https://github.com/yarnpkg/berry/issues/2349

**How did you fix it?**

Create a second copy of the zip file entry and use a `move` to get the zip file into the global cache

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.