### PR TITLE
feat: make `yarn set version from sources` update contrib plugins

### DIFF
--- a/.yarn/versions/cf75bb5b.yml
+++ b/.yarn/versions/cf75bb5b.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-**Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (plus any relevant plugin by running `yarn plugin import from sources <name>`).
+**Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (existing contrib plugins are updated automatically, while new contrib plugins can be added by running `yarn plugin import from sources <name>`).
 
 **Important:** Development of the next major version (3.x) is happening on the master branch. A list of breaking changes can be found below.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Each time the user runs `yarn set version from sources` they have to update the contrib plugins to that same commit, because otherwise things might break (e.g. plugin uses a function that doesn't exist anymore in the updated bundle).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

`yarn set version from sources` will now update all existing contrib plugins automatically (can be toggled off by using the `--skip-plugins` flag). Currently, they are build sequentially because, this way, we can stream the output. When I get the time, I will open a followup PR that builds them in parallel while still somehow making the output look pretty.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
