### PR TITLE
Implements `yarn version apply --prerelease`

### DIFF
--- a/.yarn/versions/b5ea4a20.yml
+++ b/.yarn/versions/b5ea4a20.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": major

--- a/.yarn/versions/b5ea4a20.yml
+++ b/.yarn/versions/b5ea4a20.yml
@@ -1,2 +1,30 @@
 releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
   "@yarnpkg/plugin-version": major
+  "@yarnpkg/plugin-workspace-tools": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -66,7 +66,7 @@ export default class VersionApplyCommand extends BaseCommand {
       stdout: this.context.stdout,
     }, async report => {
       const prerelease = this.prerelease
-        ? typeof this.prerelease !== `boolean` ? this.prerelease : `rc.%d`
+        ? typeof this.prerelease !== `boolean` ? this.prerelease : `rc.%n`
         : null;
 
       let releases = await versionUtils.resolveVersionFiles(project, {prerelease});
@@ -84,13 +84,15 @@ export default class VersionApplyCommand extends BaseCommand {
 
       versionUtils.applyReleases(project, releases, {report, prerelease});
 
-      if (prerelease) {
+      if (!prerelease) {
         if (this.all) {
           await versionUtils.clearVersionFiles(project);
         } else {
           await versionUtils.updateVersionFiles(project);
         }
       }
+
+      report.reportSeparator();
 
       await project.install({cache, report});
     });

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -39,6 +39,10 @@ export default class VersionApplyCommand extends BaseCommand {
     description: `Apply the deferred version changes on all workspaces`,
   });
 
+  dryRun = Option.Boolean(`--dry-run`, false, {
+    description: `Print the versions without actually generating the package archive`,
+  });
+
   prerelease = Option.String(`--prerelease`, {
     description: `Add a prerelease identifier to new versions`,
     tolerateBoolean: true,
@@ -100,19 +104,21 @@ export default class VersionApplyCommand extends BaseCommand {
         return;
       }
 
-      versionUtils.applyReleases(project, filteredReleases, {report, prerelease});
+      versionUtils.applyReleases(project, filteredReleases, {report});
 
-      if (!prerelease) {
-        if (this.all) {
-          await versionUtils.clearVersionFiles(project);
-        } else {
-          await versionUtils.updateVersionFiles(project);
+      if (!this.dryRun) {
+        if (!prerelease) {
+          if (this.all) {
+            await versionUtils.clearVersionFiles(project);
+          } else {
+            await versionUtils.updateVersionFiles(project);
+          }
         }
+
+        report.reportSeparator();
+
+        await project.install({cache, report});
       }
-
-      report.reportSeparator();
-
-      await project.install({cache, report});
     });
 
     return applyReport.exitCode();

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -103,9 +103,16 @@ export default class VersionCheckCommand extends Command<CommandContext> {
       if (currentVersion === null)
         throw new Error(`Assertion failed: The version should have been set (${structUtils.prettyLocator(configuration, workspace.anchoredLocator)})`);
 
-      const strategies: Array<versionUtils.Decision> = semver.prerelease(currentVersion) === null
-        ? [versionUtils.Decision.UNDECIDED, versionUtils.Decision.DECLINE, versionUtils.Decision.PATCH, versionUtils.Decision.MINOR, versionUtils.Decision.MAJOR, versionUtils.Decision.PRERELEASE]
-        : [versionUtils.Decision.UNDECIDED, versionUtils.Decision.DECLINE, versionUtils.Decision.PRERELEASE, versionUtils.Decision.MAJOR];
+      if (semver.prerelease(currentVersion) !== null)
+        throw new Error(`Assertion failed: Prerelease identifiers shouldn't be found (${currentVersion})`);
+
+      const strategies: Array<versionUtils.Decision> = [
+        versionUtils.Decision.UNDECIDED,
+        versionUtils.Decision.DECLINE,
+        versionUtils.Decision.PATCH,
+        versionUtils.Decision.MINOR,
+        versionUtils.Decision.MAJOR,
+      ];
 
       useListInput(decision, strategies, {
         active: active!,

--- a/packages/plugin-version/sources/versionUtils.test.ts
+++ b/packages/plugin-version/sources/versionUtils.test.ts
@@ -1,0 +1,17 @@
+import * as versionUtils from './versionUtils';
+
+describe(`versionUtils`, () => {
+  describe(`applyPrerelease`, () => {
+    it(`should add the given prerelease pattern when needed`, () => {
+      expect(versionUtils.applyPrerelease(`1.2.3`, {current: `1.2.3`, prerelease: `rc.%n`})).toEqual(`1.2.3-rc.1`);
+    });
+
+    it(`should bump the prerelease number if there's already one`, () => {
+      expect(versionUtils.applyPrerelease(`1.2.3`, {current: `1.2.3-rc.41`, prerelease: `rc.%n`})).toEqual(`1.2.3-rc.42`);
+    });
+
+    it(`should reset the prerelease number when the version would change`, () => {
+      expect(versionUtils.applyPrerelease(`1.3.0`, {current: `1.2.3-rc.41`, prerelease: `rc.%n`})).toEqual(`1.3.0-rc.1`);
+    });
+  });
+});

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -466,6 +466,11 @@ export function applyReleases(project: Project, newVersions: Map<Workspace, stri
     const oldVersion = workspace.manifest.version;
     workspace.manifest.version = newVersion;
 
+    if (semver.prerelease(newVersion) === null)
+      delete workspace.manifest.raw.stableVersion;
+    else if (!workspace.manifest.raw.stableVersion)
+      workspace.manifest.raw.stableVersion = oldVersion;
+
     const identString = workspace.manifest.name !== null
       ? structUtils.stringifyIdent(workspace.manifest.name)
       : null;

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -103,8 +103,8 @@ export type VersionFile = {
   baseTitle: null,
 });
 
-export async function resolveVersionFiles(project: Project) {
-  const candidateReleases = new Map<Workspace, string>();
+export async function resolveVersionFiles(project: Project, {prerelease = null}: {prerelease?: string | null} = {}) {
+  let candidateReleases = new Map<Workspace, string>();
 
   const deferredVersionFolder = project.configuration.get(`deferredVersionFolder`);
   if (!xfs.existsSync(deferredVersionFolder))
@@ -130,11 +130,16 @@ export async function resolveVersionFiles(project: Project) {
       if (workspace.manifest.version === null)
         throw new Error(`Assertion failed: Expected the workspace to have a version (${structUtils.prettyLocator(project.configuration, workspace.anchoredLocator)})`);
 
+      // If there's a `stableVersion` field, then we assume that `version`
+      // contains a prerelease version and that we need to base the version
+      // bump relative to the latest stable instead.
+      const baseVersion = workspace.manifest.raw.stableVersion ?? workspace.manifest.version;
+
       const candidateRelease = candidateReleases.get(workspace);
-      const suggestedRelease = applyStrategy(workspace.manifest.version, decision as any);
+      const suggestedRelease = applyStrategy(baseVersion, decision as any);
 
       if (suggestedRelease === null)
-        throw new Error(`Assertion failed: Expected ${workspace.manifest.version} to support being bumped via strategy ${decision}`);
+        throw new Error(`Assertion failed: Expected ${baseVersion} to support being bumped via strategy ${decision}`);
 
       const bestRelease = typeof candidateRelease !== `undefined`
         ? semver.gt(suggestedRelease, candidateRelease) ? suggestedRelease : candidateRelease
@@ -142,6 +147,12 @@ export async function resolveVersionFiles(project: Project) {
 
       candidateReleases.set(workspace, bestRelease);
     }
+  }
+
+  if (prerelease) {
+    candidateReleases = new Map([...candidateReleases].map(([workspace, release]) => {
+      return [workspace, applyPrerelease(release, {current: workspace.manifest.version!, prerelease})];
+    }));
   }
 
   return candidateReleases;
@@ -415,7 +426,7 @@ export function applyStrategy(version: string | null, strategy: string) {
   return nextVersion;
 }
 
-export function applyReleases(project: Project, newVersions: Map<Workspace, string>, {report}: {report: Report}) {
+export function applyReleases(project: Project, newVersions: Map<Workspace, string>, {report, prerelease}: {report: Report, prerelease: string | null}) {
   const allDependents: Map<Workspace, Array<[
     Workspace,
     AllDependencies,
@@ -499,4 +510,70 @@ export function applyReleases(project: Project, newVersions: Map<Workspace, stri
       dependent.manifest[set].set(identHash, newDescriptor);
     }
   }
+}
+
+const placeholders: Map<string, {
+  extract: (parts: Array<string | number>) => [string | number, Array<string | number>] | null,
+  generate: (previous?: number) => string,
+}> = new Map([
+  [`%n`, {
+    extract: parts => {
+      if (parts.length >= 1) {
+        return [parts[0], parts.slice(1)];
+      } else {
+        return null;
+      }
+    },
+    generate: (previous = 0) => {
+      return `${previous + 1}`;
+    },
+  }],
+]);
+
+export function applyPrerelease(version: string, {current, prerelease}: {current: string, prerelease: string}) {
+  const currentVersion = new semver.SemVer(current);
+
+  let currentPreParts = currentVersion.prerelease.slice();
+  const nextPreParts = [];
+
+  currentVersion.prerelease = [];
+
+  // If the version we have in mind has nothing in common with the one we want,
+  // we don't want to reuse its prerelease identifiers (1.0.0-rc.5 -> 1.1.0->rc.1)
+  if (currentVersion.format() !== version)
+    currentPreParts.length = 0;
+
+  let patternMatched = true;
+
+  const patternParts = prerelease.split(/\./g);
+  for (const part of patternParts) {
+    const placeholder = placeholders.get(part);
+
+    if (typeof placeholder === `undefined`) {
+      nextPreParts.push(part);
+
+      if (currentPreParts[0] === part) {
+        currentPreParts.shift();
+      } else {
+        patternMatched = false;
+      }
+    } else {
+      const res = patternMatched
+        ? placeholder.extract(currentPreParts)
+        : null;
+
+      if (res !== null && typeof res[0] === `number`) {
+        nextPreParts.push(placeholder.generate(res[0]));
+        currentPreParts = res[1];
+      } else {
+        nextPreParts.push(placeholder.generate());
+        patternMatched = false;
+      }
+    }
+  }
+
+  if (currentVersion.prerelease)
+    currentVersion.prerelease = [];
+
+  return `${version}-${nextPreParts.join(`.`)}`;
 }

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -426,7 +426,7 @@ export function applyStrategy(version: string | null, strategy: string) {
   return nextVersion;
 }
 
-export function applyReleases(project: Project, newVersions: Map<Workspace, string>, {report, prerelease}: {report: Report, prerelease: string | null}) {
+export function applyReleases(project: Project, newVersions: Map<Workspace, string>, {report}: {report: Report}) {
   const allDependents: Map<Workspace, Array<[
     Workspace,
     AllDependencies,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current version workflow doesn't handle prereleases particularly well. It requires to know ahead of time whether a package will be released as prerelease or not, which doesn't match the reality (we often merge PRs, and only much later decide to cut a prerelease).

**How did you fix it?**

This PR removes the prerelease flag from the `yarn version check -i` command, and adds a new `--prerelease` flag to `yarn version apply`. Setting it has two effects:

- It prevents the version definitions from being discarded (since we need to recompute the new version from the latest stable at each new prerelease, we need to keep the list of changes since the latest stable).
- It adds a prerelease identifier at the end of the versions. The identifier is a dot-separated string of components which accepts one placeholder: `%n`. When found, `%n` will evaluate to "the existing number plus one".

So for example, `yarn version apply --prerelease=rc.%n` will set packages to `1.0.0-rc.1`, then `1.0.0-rc.2`, etc. The logic supports changing version priority, cf tests.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
