### PR TITLE
feat(plugin-init): stop creating unnecessary `.gitattributes`

### DIFF
--- a/.yarn/versions/2fd07169.yml
+++ b/.yarn/versions/2fd07169.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-init": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -169,18 +169,6 @@ export default class InitCommand extends BaseCommand {
       const lockfilePath = ppath.join(this.context.cwd, Filename.lockfile);
       await xfs.writeFilePromise(lockfilePath, ``);
 
-      const gitattributesLines = [
-        `/.yarn/** linguist-vendored`,
-      ];
-
-      const gitattributesBody = gitattributesLines.map(line => {
-        return `${line}\n`;
-      }).join(``);
-
-      const gitattributesPath = ppath.join(this.context.cwd, `.gitattributes` as Filename);
-      if (!xfs.existsSync(gitattributesPath))
-        await xfs.writeFilePromise(gitattributesPath, gitattributesBody);
-
       const gitignoreLines = [
         `/.yarn/*`,
         `!/.yarn/patches`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn init` creates a `.gitattributes` by default to exclude `.yarn` from GitHub language statistics (`linguist`), but this is no longer necessary as [they are already ignored by linguist](https://github.com/github/linguist/blob/736df2bb2a78ccc23115cdeb33aef31156f3efac/lib/linguist/vendor.yml#L44-L49).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Remove related code.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
