### PR TITLE
feat(npm): add hook for getting the authentication header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ package.tgz
 !/packages/yarnpkg-pnp/lib/hook.js
 
 /vscode-case-study
+
+.idea

--- a/.yarn/versions/c743d681.yml
+++ b/.yarn/versions/c743d681.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/packages/plugin-npm/sources/Hooks.ts
+++ b/packages/plugin-npm/sources/Hooks.ts
@@ -1,0 +1,8 @@
+import {Configuration, Ident} from "@yarnpkg/core";
+
+export type Hooks = {
+  getNpmAuthenticationHeader?: (currentHeader: string | undefined, registry: string, {
+    configuration,
+    ident,
+  }: { configuration: Configuration, ident?: Ident }) => Promise<string | undefined>
+};

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -1,5 +1,6 @@
 import {Plugin, SettingsType, miscUtils} from '@yarnpkg/core';
 
+import {Hooks}                           from './Hooks';
 import {NpmHttpFetcher}                  from './NpmHttpFetcher';
 import {NpmRemapResolver}                from './NpmRemapResolver';
 import {NpmSemverFetcher}                from './NpmSemverFetcher';
@@ -12,6 +13,7 @@ import * as npmPublishUtils              from './npmPublishUtils';
 export {npmConfigUtils};
 export {npmHttpUtils};
 export {npmPublishUtils};
+export type {Hooks};
 
 const authSettings = {
   npmAlwaysAuth: {

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -5,6 +5,7 @@ export enum RegistryType {
   PUBLISH_REGISTRY = `npmPublishRegistry`,
 }
 
+
 export interface MapLike {
   get(key: string): any;
 }

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -3,6 +3,7 @@ import {MessageName, ReportError}        from '@yarnpkg/core';
 import {prompt}                          from 'enquirer';
 import {URL}                             from 'url';
 
+import {Hooks}                           from "./Hooks";
 import * as npmConfigUtils               from './npmConfigUtils';
 import {MapLike}                         from './npmConfigUtils';
 
@@ -56,7 +57,7 @@ export async function get(path: string, {configuration, headers, ident, authType
   if (typeof registry !== `string`)
     throw new Error(`Assertion failed: The registry should be a string`);
 
-  const auth = getAuthenticationHeader(registry, {authType, configuration, ident});
+  const auth = await getAuthenticationHeader(registry, {authType, configuration, ident});
   if (auth)
     headers = {...headers, authorization: auth};
 
@@ -83,7 +84,7 @@ export async function post(path: string, body: httpUtils.Body, {attemptedAs, con
   if (typeof registry !== `string`)
     throw new Error(`Assertion failed: The registry should be a string`);
 
-  const auth = getAuthenticationHeader(registry, {authType, configuration, ident});
+  const auth = await getAuthenticationHeader(registry, {authType, configuration, ident});
   if (auth)
     headers = {...headers, authorization: auth};
 
@@ -117,7 +118,7 @@ export async function put(path: string, body: httpUtils.Body, {attemptedAs, conf
   if (typeof registry !== `string`)
     throw new Error(`Assertion failed: The registry should be a string`);
 
-  const auth = getAuthenticationHeader(registry, {authType, configuration, ident});
+  const auth = await getAuthenticationHeader(registry, {authType, configuration, ident});
   if (auth)
     headers = {...headers, authorization: auth};
 
@@ -151,7 +152,7 @@ export async function del(path: string, {attemptedAs, configuration, headers, id
   if (typeof registry !== `string`)
     throw new Error(`Assertion failed: The registry should be a string`);
 
-  const auth = getAuthenticationHeader(registry, {authType, configuration, ident});
+  const auth = await getAuthenticationHeader(registry, {authType, configuration, ident});
   if (auth)
     headers = {...headers, authorization: auth};
 
@@ -178,12 +179,20 @@ export async function del(path: string, {attemptedAs, configuration, headers, id
   }
 }
 
-function getAuthenticationHeader(registry: string, {authType = AuthType.CONFIGURATION, configuration, ident}: {authType?: AuthType, configuration: Configuration, ident: RegistryOptions['ident']}) {
+async function getAuthenticationHeader(registry: string, {authType = AuthType.CONFIGURATION, configuration, ident}: {authType?: AuthType, configuration: Configuration, ident: RegistryOptions['ident']}) {
   const effectiveConfiguration = npmConfigUtils.getAuthConfiguration(registry, {configuration, ident});
   const mustAuthenticate = shouldAuthenticate(effectiveConfiguration, authType);
 
   if (!mustAuthenticate)
     return null;
+
+  const header = await configuration.reduceHook((hooks: Hooks) => {
+    return hooks.getNpmAuthenticationHeader;
+  }, undefined, registry, {configuration, ident});
+
+  if (header)
+    return header;
+
 
   if (effectiveConfiguration.get(`npmAuthToken`))
     return `Bearer ${effectiveConfiguration.get(`npmAuthToken`)}`;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Adds a hook for adding authentication headers, intended to be used for OAuth style authentication flows.
Closes #2067

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
I used reduceHook inside getAuthenticationHeader to collect the potential values from the hook, then return the provided value if there is one instead of checking npmAuthToken or npmAuthIdent

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
