### PR TITLE
feat(dlx): allow specifying an array of packages

### DIFF
--- a/.yarn/versions/d4afcb16.yml
+++ b/.yarn/versions/d4afcb16.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-dlx": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -25,8 +25,8 @@ export default class DlxCommand extends BaseCommand {
     ]],
   });
 
-  pkg = Option.String(`-p,--package`, {
-    description: `The package to run the provided command from`,
+  packages = Option.Array(`-p,--package`, {
+    description: `The package(s) to install before running the command`,
   });
 
   quiet = Option.Boolean(`-q,--quiet`, false, {
@@ -94,8 +94,8 @@ export default class DlxCommand extends BaseCommand {
         await xfs.writeFilePromise(targetYarnrc, `enableGlobalCache: ${enableGlobalCache}\nenableTelemetry: false\n`);
       }
 
-      const pkgs = typeof this.pkg !== `undefined`
-        ? [this.pkg]
+      const pkgs = typeof this.packages !== `undefined`
+        ? [...this.packages]
         : [this.command];
 
       const command = structUtils.parseDescriptor(this.command).name;

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -94,9 +94,7 @@ export default class DlxCommand extends BaseCommand {
         await xfs.writeFilePromise(targetYarnrc, `enableGlobalCache: ${enableGlobalCache}\nenableTelemetry: false\n`);
       }
 
-      const pkgs = typeof this.packages !== `undefined`
-        ? [...this.packages]
-        : [this.command];
+      const pkgs = this.packages ?? [this.command];
 
       const command = structUtils.parseDescriptor(this.command).name;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

To run packages like `yeoman` you need to install the `yo` package and some kind of generator at the same time, doing this with `yarn dlx` is not possible as it only accepts one package

Fixes #2572 
Fixes #944

**How did you fix it?**

Allow specifying an array of packages, example:

```
yarn dlx -p generator-joplin -p yo yo joplin
```

`yo` isn't actually able to find the generators but they are installed so that's an upstream issue

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.