### PR TITLE
fix(workspace-tools): don't follow dev dependencies for `focus --production`

### DIFF
--- a/.yarn/versions/12a089c0.yml
+++ b/.yarn/versions/12a089c0.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": minor

--- a/.yarn/versions/12a089c0.yml
+++ b/.yarn/versions/12a089c0.yml
@@ -1,2 +1,2 @@
 releases:
-  "@yarnpkg/plugin-workspace-tools": minor
+  "@yarnpkg/plugin-workspace-tools": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -85,6 +85,61 @@ describe(`Commands`, () => {
     );
 
     test(
+      `should follow local workspace devDependencies`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, {
+            cwd: ppath.join(path, `packages/quux`),
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-npm-1.0.0-`),
+            expect.stringContaining(`no-deps-npm-2.0.0-`),
+          ]);
+        }
+      )
+    );
+
+    test(
+      `should not follow local workspace devDependencies for production installs`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupProject(path);
+
+          await run(`install`);
+
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
+          await xfs.removePromise(cacheFolder);
+
+          await run(`workspaces`, `focus`, `quux`, `--production`, {
+            cwd: path,
+          });
+
+          await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
+            `.gitignore`,
+            expect.stringContaining(`no-deps-npm-1.0.0-`),
+          ]);
+        }
+      )
+    );
+
+    test(
       `should install development dependencies by default`,
       makeTemporaryEnv(
         {
@@ -173,4 +228,5 @@ async function setupProject(path) {
   await pkg(`bar`, {[`no-deps`]: `2.0.0`});
   await pkg(`baz`, {[`bar`]: `workspace:*`});
   await pkg(`qux`, {[`no-deps`]: `1.0.0`}, {[`no-deps-bins`]: `1.0.0`}, {postinstall: `echo 'postinstall' > postinstall.log`});
+  await pkg(`quux`, {[`no-deps`]: `1.0.0`}, {[`bar`]: `workspace:*`})
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -98,6 +98,7 @@ describe(`Commands`, () => {
             cwd: ppath.join(path, `packages/quux`),
           });
 
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
           await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
             `.gitignore`,
             expect.stringContaining(`no-deps-npm-1.0.0-`),
@@ -121,6 +122,7 @@ describe(`Commands`, () => {
             cwd: path,
           });
 
+          const cacheFolder = ppath.join(path, `.yarn/cache`);
           await expect(xfs.readdirPromise(cacheFolder)).resolves.toEqual([
             `.gitignore`,
             expect.stringContaining(`no-deps-npm-1.0.0-`),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -228,5 +228,5 @@ async function setupProject(path) {
   await pkg(`bar`, {[`no-deps`]: `2.0.0`});
   await pkg(`baz`, {[`bar`]: `workspace:*`});
   await pkg(`qux`, {[`no-deps`]: `1.0.0`}, {[`no-deps-bins`]: `1.0.0`}, {postinstall: `echo 'postinstall' > postinstall.log`});
-  await pkg(`quux`, {[`no-deps`]: `1.0.0`}, {[`bar`]: `workspace:*`})
+  await pkg(`quux`, {[`no-deps`]: `1.0.0`}, {[`bar`]: `workspace:*`});
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -94,11 +94,6 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupProject(path);
 
-          await run(`install`);
-
-          const cacheFolder = ppath.join(path, `.yarn/cache`);
-          await xfs.removePromise(cacheFolder);
-
           await run(`workspaces`, `focus`, {
             cwd: ppath.join(path, `packages/quux`),
           });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/focus.test.js
@@ -117,11 +117,6 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupProject(path);
 
-          await run(`install`);
-
-          const cacheFolder = ppath.join(path, `.yarn/cache`);
-          await xfs.removePromise(cacheFolder);
-
           await run(`workspaces`, `focus`, `quux`, `--production`, {
             cwd: path,
           });

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,7 +1,9 @@
 import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
-import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
+import {Cache, Configuration, Manifest, HardDependencies, Project, StreamReport, Workspace} from '@yarnpkg/core';
 import {structUtils}                                                      from '@yarnpkg/core';
 import {Command, Option, Usage}                                           from 'clipanion';
+import { convertMapsToIndexableObjects } from 'packages/yarnpkg-core/sources/miscUtils';
+import { makeProcess } from 'packages/yarnpkg-shell/sources/pipe';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
@@ -64,8 +66,9 @@ export default class WorkspacesFocus extends BaseCommand {
     // Note: remember that new elements can be added in a set even while
     // iterating over it (because they're added at the end)
 
+    const dependencyTypes: HardDependencies[] = this.production ? ['dependencies'] : Manifest.hardDependencies;
     for (const workspace of requiredWorkspaces) {
-      for (const dependencyType of Manifest.hardDependencies) {
+      for (const dependencyType of dependencyTypes) {
         for (const descriptor of workspace.manifest.getForScope(dependencyType).values()) {
           const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
 

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,7 +1,7 @@
-import {BaseCommand, WorkspaceRequiredError}                                                from '@yarnpkg/cli';
-import {Cache, Configuration, Manifest, HardDependencies, Project, StreamReport, Workspace} from '@yarnpkg/core';
-import {structUtils}                                                                        from '@yarnpkg/core';
-import {Command, Option, Usage}                                                             from 'clipanion';
+import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
+import {Cache, Configuration, Manifest, Project, StreamReport, Workspace} from '@yarnpkg/core';
+import {structUtils}                                                      from '@yarnpkg/core';
+import {Command, Option, Usage}                                           from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
@@ -64,9 +64,8 @@ export default class WorkspacesFocus extends BaseCommand {
     // Note: remember that new elements can be added in a set even while
     // iterating over it (because they're added at the end)
 
-    const dependencyTypes: Array<HardDependencies> = this.production ? [`dependencies`] : Manifest.hardDependencies;
     for (const workspace of requiredWorkspaces) {
-      for (const dependencyType of dependencyTypes) {
+      for (const dependencyType of this.production ? [`dependencies`] : Manifest.hardDependencies) {
         for (const descriptor of workspace.manifest.getForScope(dependencyType).values()) {
           const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
 

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -1,9 +1,9 @@
-import {BaseCommand, WorkspaceRequiredError}                              from '@yarnpkg/cli';
+import {BaseCommand, WorkspaceRequiredError}                                                from '@yarnpkg/cli';
 import {Cache, Configuration, Manifest, HardDependencies, Project, StreamReport, Workspace} from '@yarnpkg/core';
-import {structUtils}                                                      from '@yarnpkg/core';
-import {Command, Option, Usage}                                           from 'clipanion';
-import { convertMapsToIndexableObjects } from 'packages/yarnpkg-core/sources/miscUtils';
-import { makeProcess } from 'packages/yarnpkg-shell/sources/pipe';
+import {structUtils}                                                                        from '@yarnpkg/core';
+import {Command, Option, Usage}                                                             from 'clipanion';
+import {convertMapsToIndexableObjects}                                                      from 'packages/yarnpkg-core/sources/miscUtils';
+import {makeProcess}                                                                        from 'packages/yarnpkg-shell/sources/pipe';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {
@@ -66,7 +66,7 @@ export default class WorkspacesFocus extends BaseCommand {
     // Note: remember that new elements can be added in a set even while
     // iterating over it (because they're added at the end)
 
-    const dependencyTypes: HardDependencies[] = this.production ? ['dependencies'] : Manifest.hardDependencies;
+    const dependencyTypes: Array<HardDependencies> = this.production ? [`dependencies`] : Manifest.hardDependencies;
     for (const workspace of requiredWorkspaces) {
       for (const dependencyType of dependencyTypes) {
         for (const descriptor of workspace.manifest.getForScope(dependencyType).values()) {

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -2,8 +2,6 @@ import {BaseCommand, WorkspaceRequiredError}                                    
 import {Cache, Configuration, Manifest, HardDependencies, Project, StreamReport, Workspace} from '@yarnpkg/core';
 import {structUtils}                                                                        from '@yarnpkg/core';
 import {Command, Option, Usage}                                                             from 'clipanion';
-import {convertMapsToIndexableObjects}                                                      from 'packages/yarnpkg-core/sources/miscUtils';
-import {makeProcess}                                                                        from 'packages/yarnpkg-shell/sources/pipe';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesFocus extends BaseCommand {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn workspaces focus <somePackage>` was following workspace devDependencies and installing their dependencies, even when `--production` was turned on. This appears to be a bug.
...

**How did you fix it?**

When `--production` is passed, I only examine `dependencies`, not any dev deps.


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
