### PR TITLE
docs: remove yarnUpgradePath

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -568,7 +568,7 @@
         "type": "string"
       },
       "default": [],
-      "_exampleItems": ["./subdir/.*"]
+      "_exampleItems": ["./subdir/*"]
     },
     "pnpMode": {
       "_package": "@yarnpkg/plugin-pnp",
@@ -657,13 +657,6 @@
     "yarnPath": {
       "_package": "@yarnpkg/core",
       "description": "The path of a Yarn binary, which will be executed instead of any other (including the global one) for any command run within the directory covered by the rc file. If the file extension ends with `.js` it will be required, and will be spawned in any other case.\n\nThe `yarnPath` setting is currently the preferred way to install Yarn within a project, as it ensures that your whole team will use the exact same Yarn version, without having to individually keep it up-to-date.",
-      "type": "string",
-      "format": "uri-reference",
-      "examples": ["./scripts/yarn-2.0.0-rc001.js"]
-    },
-    "yarnUpgradePath": {
-      "_package": "@yarnpkg/core",
-      "description": "If set, the `yarn set version` command will store the downloaded file at this location instead of the one referenced by `yarnPath`. This settings is useful if you want the file referenced in `yarnPath` to be a wrapper, and the real Yarn binary to be stored elsewhere.",
       "type": "string",
       "format": "uri-reference",
       "examples": ["./scripts/yarn-2.0.0-rc001.js"]


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarnUpgradePath` isn't a implemented setting but is documented as if it was

Fixes https://github.com/yarnpkg/berry/issues/1014

**How did you fix it?**

Remove the documentation for it

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.