### PR TITLE
fix(core): `--immutable` covers Project.persist

### DIFF
--- a/.yarn/versions/4a4e5597.yml
+++ b/.yarn/versions/4a4e5597.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/immutablePatterns.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/immutablePatterns.test.ts
@@ -123,6 +123,24 @@ describe(`Features`, () => {
       )
     );
 
+    it(`should prevent reformatting of manifests when so configured`,
+      makeTemporaryEnv(
+        {
+        },
+        {
+          nodeLinker: `node-modules`,
+          immutablePatterns: [`package.json`],
+        },
+        async ({path, run, source}) => {
+          // create lockfile
+          await run(`install`);
+          // empty dependencies block will be deleted by persist()
+          await xfs.writeJsonPromise(ppath.join(path, Filename.manifest), {dependencies: {}});
+          await expect(run(`install`, `--immutable`)).rejects.toThrow(/The checksum for package.json has been modified by this install/);
+        },
+      )
+    );
+
     it(`shouldn't fail when a folder didn't change`,
       makeTemporaryEnv(
         {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1414,18 +1414,18 @@ export class Project {
       }
     });
 
+    const immutablePatterns = opts.immutable
+      ? [...new Set(this.configuration.get(`immutablePatterns`))].sort()
+      : [];
+
+    const before = await Promise.all(immutablePatterns.map(async pattern => {
+      return hashUtils.checksumPattern(pattern, {cwd: this.cwd});
+    }));
+
     if (typeof opts.persistProject === `undefined` || opts.persistProject)
       await this.persist();
 
     await opts.report.startTimerPromise(`Link step`, async () => {
-      const immutablePatterns = opts.immutable
-        ? [...new Set(this.configuration.get(`immutablePatterns`))].sort()
-        : [];
-
-      const before = await Promise.all(immutablePatterns.map(async pattern => {
-        return hashUtils.checksumPattern(pattern, {cwd: this.cwd});
-      }));
-
       await this.linkEverything(opts);
 
       const after = await Promise.all(immutablePatterns.map(async pattern => {


### PR DESCRIPTION
Fixes #2699

**What's the problem this PR addresses?**
`immutablePatterns` cannot cover `package.json`.

**How did you fix it?**
Create `before` hashes before persisting the project.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
