### PR TITLE
fix(node-modules): prefer binaries from calling workspace

### DIFF
--- a/.yarn/versions/9179116a.yml
+++ b/.yarn/versions/9179116a.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-1.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-1.0.0/bin.js
@@ -1,0 +1,1 @@
+console.log(__dirname);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-1.0.0/package.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "node-modules-path",
+    "version": "1.0.0",
+    "bin": {
+        "get-node-modules-path": "./bin.js"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-2.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-2.0.0/bin.js
@@ -1,0 +1,1 @@
+console.log(__dirname);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-2.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/node-modules-path-2.0.0/package.json
@@ -1,0 +1,8 @@
+
+{
+    "name": "node-modules-path",
+    "version": "2.0.0",
+    "bin": {
+        "get-node-modules-path": "./bin.js"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1002,6 +1002,11 @@ describe(`Node_Modules`, () => {
         dependencies: {
           [`node-modules-path`]: `1.0.0`,
         },
+        scripts: {
+          wa: `yarn ./workspace-a get-node-modules-path`,
+          wb: `yarn ./workspace-b get-node-modules-path`,
+          wc: `yarn ./workspace-c get-node-modules-path`,
+        },
       },
       {
         nodeLinker: `node-modules`,
@@ -1034,9 +1039,9 @@ describe(`Node_Modules`, () => {
         await expect(xfs.existsPromise(`${path}/workspace-b/node_modules/node-modules-path` as PortablePath)).resolves.toEqual(true);
         await expect(xfs.existsPromise(`${path}/workspace-c/node_modules/node-modules-path` as PortablePath)).resolves.toEqual(true);
 
-        expect((await run(`run`, `--cwd`, `${path}/workspace-b`, `get-node-modules-path`)).stdout.trim()).toEqual(`${path}/workspace-b/node_modules/node-modules-path`);
-        expect((await run(`run`, `--cwd`, `${path}/workspace-a`, `get-node-modules-path`)).stdout.trim()).toEqual(`${path}/workspace-a/node_modules/node-modules-path`);
-        expect((await run(`run`, `--cwd`, `${path}/workspace-c`, `get-node-modules-path`)).stdout.trim()).toEqual(`${path}/workspace-c/node_modules/node-modules-path`);
+        expect((await run(`run`, `wb`)).stdout.trim()).toContain(`workspace-b`);
+        expect((await run(`run`, `wa`)).stdout.trim()).toContain(`workspace-a`);
+        expect((await run(`run`, `wc`)).stdout.trim()).toContain(`workspace-c`);
       }
     )
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -994,4 +994,50 @@ describe(`Node_Modules`, () => {
       }
     )
   );
+  test(
+    `should prefer bin executables from the calling workspace`,
+    makeTemporaryEnv(
+      {
+        workspaces: [`workspace-a`, `workspace-b`, `workspace-c`],
+        dependencies: {
+          [`node-modules-path`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run}) => {
+        await writeJson(`${path}/workspace-a/package.json`, {
+          name: `workspace-a`,
+          dependencies: {
+            [`node-modules-path`]: `2.0.0`,
+          },
+        });
+
+        await writeJson(`${path}/workspace-b/package.json`, {
+          name: `workspace-b`,
+          dependencies: {
+            [`node-modules-path`]: `2.0.0`,
+          },
+        });
+        await writeJson(`${path}/workspace-c/package.json`, {
+          name: `workspace-c`,
+          dependencies: {
+            [`node-modules-path`]: `2.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        await expect(xfs.existsPromise(`${path}/node_modules/node-modules-path` as PortablePath)).resolves.toEqual(true);
+        await expect(xfs.existsPromise(`${path}/workspace-a/node_modules/node-modules-path` as PortablePath)).resolves.toEqual(true);
+        await expect(xfs.existsPromise(`${path}/workspace-b/node_modules/node-modules-path` as PortablePath)).resolves.toEqual(true);
+        await expect(xfs.existsPromise(`${path}/workspace-c/node_modules/node-modules-path` as PortablePath)).resolves.toEqual(true);
+
+        expect((await run(`run`, `--cwd`, `${path}/workspace-b`, `get-node-modules-path`)).stdout.trim()).toEqual(`${path}/workspace-b/node_modules/node-modules-path`);
+        expect((await run(`run`, `--cwd`, `${path}/workspace-a`, `get-node-modules-path`)).stdout.trim()).toEqual(`${path}/workspace-a/node_modules/node-modules-path`);
+        expect((await run(`run`, `--cwd`, `${path}/workspace-c`, `get-node-modules-path`)).stdout.trim()).toEqual(`${path}/workspace-c/node_modules/node-modules-path`);
+      }
+    )
+  );
 });

--- a/packages/plugin-node-modules/sources/NodeModulesLinker.ts
+++ b/packages/plugin-node-modules/sources/NodeModulesLinker.ts
@@ -49,7 +49,8 @@ export class NodeModulesLinker implements Linker {
       throw err;
     }
 
-    return locatorInfo.locations[0];
+    const startingCwd = opts.project.configuration.startingCwd;
+    return locatorInfo.locations.find(location => ppath.contains(startingCwd, location)) || locatorInfo.locations[0];
   }
 
   async findPackageLocator(location: PortablePath, opts: LinkOptions) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
`plugin-node-modules` picks the first bin it finds in any workspace instead of preferring the one in the current workspace
Closes #2666

**How did you fix it?**
Instead of picking the first match, we now look for the bin that is in the current workspace and fallback to the previous behavior.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
