### PR TITLE
docs: fix typo for the YN0004 error code

### DIFF
--- a/packages/gatsby/content/advanced/error-codes.md
+++ b/packages/gatsby/content/advanced/error-codes.md
@@ -72,9 +72,9 @@ There's already good documentation online explaining how to get rid of cyclic de
 
 A package has build scripts, but they've been disabled across the project.
 
-Build scripts can be disabled on a global basis through the use of the `enable-scripts` settings. When it happens, a warning is still emitted to let you know that the installation might not be complete.
+Build scripts can be disabled on a global basis through the use of the `enableScripts` settings. When it happens, a warning is still emitted to let you know that the installation might not be complete.
 
-The safest way to downgrade the warning into a notification is to explicitly disable build scripts for the affected packages through the use of the `dependenciesMeta[].build` key.
+The safest way to downgrade the warning into a notification is to explicitly disable build scripts for the affected packages through the use of the `dependenciesMeta[].built` key.
 
 ## YN0005 - `BUILD_DISABLED`
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fix a typo in the error docs.  It's `dependenciesMeta[].built` not `.build`.

#2705

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
