### PR TITLE
fix(plugin-pnp): fix build script disabled logging

### DIFF
--- a/.yarn/versions/85263fbb.yml
+++ b/.yarn/versions/85263fbb.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -1,7 +1,7 @@
 import {Filename, xfs, ppath} from '@yarnpkg/fslib';
 
 const {
-  fs: {writeJson},
+  fs: {writeJson, writeFile},
 } = require(`pkg-tests-core`);
 
 describe(`Commands`, () => {
@@ -303,6 +303,38 @@ describe(`Commands`, () => {
           });
         }
       )
+    );
+
+    test(
+      `it should print a warning when using \`enableScripts: false\``,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-scripted`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc.yml`, `enableScripts: false`);
+        const {stdout} = await run(`install`, `--inline-builds`);
+        expect(stdout).toMatch(/YN0004/g);
+      }),
+    );
+
+    test(
+      `it should print an info when \`dependenciesMeta[].built: false\`, even when using using \`enableScripts: false\``,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-scripted`]: `1.0.0`,
+        },
+        dependenciesMeta: {
+          'no-deps-scripted': {
+            built: false,
+          },
+        },
+      }, async ({path, run, source}) => {
+        await writeFile(`${path}/.yarnrc.yml`, `enableScripts: false`);
+        const {stdout} = await run(`install`, `--inline-builds`);
+        expect(stdout).toMatch(/YN0005/g);
+        expect(stdout).not.toMatch(/YN0004/g);
+      }),
     );
   });
 });

--- a/packages/plugin-pnp/sources/jsInstallUtils.ts
+++ b/packages/plugin-pnp/sources/jsInstallUtils.ts
@@ -40,11 +40,6 @@ export function extractBuildScripts(pkg: Package, requirements: ExtractBuildScri
   if (buildScripts.length === 0)
     return [];
 
-  if (!configuration.get(`enableScripts`) && !dependencyMeta.built) {
-    report?.reportWarningOnce(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(configuration, pkg)} lists build scripts, but all build scripts have been disabled.`);
-    return [];
-  }
-
   if (pkg.linkType !== LinkType.HARD) {
     report?.reportWarningOnce(MessageName.SOFT_LINK_BUILD, `${structUtils.prettyLocator(configuration, pkg)} lists build scripts, but is referenced through a soft link. Soft links don't support build scripts, so they'll be ignored.`);
     return [];
@@ -52,6 +47,11 @@ export function extractBuildScripts(pkg: Package, requirements: ExtractBuildScri
 
   if (dependencyMeta && dependencyMeta.built === false) {
     report?.reportInfoOnce(MessageName.BUILD_DISABLED, `${structUtils.prettyLocator(configuration, pkg)} lists build scripts, but its build has been explicitly disabled through configuration.`);
+    return [];
+  }
+
+  if (!configuration.get(`enableScripts`) && !dependencyMeta.built) {
+    report?.reportWarningOnce(MessageName.DISABLED_BUILD_SCRIPTS, `${structUtils.prettyLocator(configuration, pkg)} lists build scripts, but all build scripts have been disabled.`);
     return [];
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Documentation states that you should get an info for any dependency
with `dependenciesMeta[].built: false` and `enableScripts: false`, but you currently get a warning.

Fixes #2705

**How did you fix it?**
Reorder "scripts disabled" reports

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
