### PR TITLE
fix(dlx): use binary name if package name doesn't match

### DIFF
--- a/.github/workflows/e2e-vue-cli-workflow.yml
+++ b/.github/workflows/e2e-vue-cli-workflow.yml
@@ -33,5 +33,5 @@ jobs:
 
         echo '{"useTaobaoRegistry": false}' | tee ~/.vuerc
 
-        yarn dlx -p @vue/cli vue create -d my-vue && cd my-vue
+        yarn dlx @vue/cli create -d my-vue && cd my-vue
         yarn build

--- a/.yarn/versions/0ae1c66a.yml
+++ b/.yarn/versions/0ae1c66a.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-dlx": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -96,7 +96,7 @@ export default class DlxCommand extends BaseCommand {
 
       const pkgs = this.packages ?? [this.command];
 
-      const command = structUtils.parseDescriptor(this.command).name;
+      let command = structUtils.parseDescriptor(this.command).name;
 
       const addExitCode = await this.cli.run([`add`, `--`, ...pkgs], {cwd: tmpDir, quiet: this.quiet});
       if (addExitCode !== 0)
@@ -113,7 +113,13 @@ export default class DlxCommand extends BaseCommand {
 
       await project.restoreInstallState();
 
+      const binaries = await scriptUtils.getWorkspaceAccessibleBinaries(workspace);
+
+      if (binaries.has(command) === false && binaries.size === 1 && typeof this.packages === `undefined`)
+        command = Array.from(binaries)[0][0];
+
       return await scriptUtils.executeWorkspaceAccessibleBinary(workspace, command, this.args, {
+        packageAccessibleBinaries: binaries,
         cwd: this.context.cwd,
         stdin: this.context.stdin,
         stdout: this.context.stdout,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn dlx` on a package where the binary name doesn't match the package name requires explicitly listing it using `yarn dlx -p <package> <binary name>`, but this is only necessary if the package has multiple binaries.

Closes #2013

**How did you fix it?**

If there is only one binary available and the binary name wasn't explicitly provided use it instead of the package name

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.