### PR TITLE
fix(pnpify): avoid importing from sources

### DIFF
--- a/.yarn/versions/51068c25.yml
+++ b/.yarn/versions/51068c25.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -1,4 +1,3 @@
-import {areLocatorsEqual}                                                     from '@yarnpkg/core/sources/structUtils';
 import {structUtils, Project, MessageName}                                    from '@yarnpkg/core';
 import {toFilename, npath, ppath}                                             from '@yarnpkg/fslib';
 import {NativePath, PortablePath, Filename}                                   from '@yarnpkg/fslib';
@@ -244,7 +243,7 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
         const parentReferencish = parentDependencies.get(name);
         if (parentReferencish) {
           const parentDependencyLocator = structUtils.parseLocator(Array.isArray(parentReferencish) ? `${parentReferencish[0]}@${parentReferencish[1]}` : `${name}@${parentReferencish}`);
-          if (!areLocatorsEqual(parentDependencyLocator, dependencyLocator)) {
+          if (!structUtils.areLocatorsEqual(parentDependencyLocator, dependencyLocator)) {
             errors.push({messageName: MessageName.NM_CANT_INSTALL_PORTAL, text: `Cannot link ${structUtils.prettyIdent(options.project.configuration, structUtils.parseIdent(locator.name))} into ${structUtils.prettyLocator(options.project.configuration, structUtils.parseLocator(`${parent.identName}@${parent.reference}`))} dependency ${structUtils.prettyLocator(options.project.configuration, dependencyLocator)} conflicts with parent dependency ${structUtils.prettyLocator(options.project.configuration, parentDependencyLocator)}`});
           }
         }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/pnpify` is importing from `@yarnpkg/core/sources/structUtils` which doesn't exist when published

Fixes https://github.com/yarnpkg/berry/runs/2322171355#step:5:124

**How did you fix it?**

Use `structUtils` from `@yarnpkg/core` instead

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.