### PR TITLE
Downloads the compatible plugin for the current Yarn version if possible

### DIFF
--- a/.yarn/versions/41b9f38e.yml
+++ b/.yarn/versions/41b9f38e.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": major
+  "@yarnpkg/plugin-version": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -1,8 +1,9 @@
 import {BaseCommand}                                                                       from '@yarnpkg/cli';
 import {Configuration, MessageName, Project, ReportError, StreamReport, miscUtils, Report} from '@yarnpkg/core';
-import {formatUtils, httpUtils, structUtils}                                               from '@yarnpkg/core';
+import {YarnVersion, formatUtils, httpUtils, structUtils}                                  from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs}                                                   from '@yarnpkg/fslib';
 import {Command, Option, Usage}                                                            from 'clipanion';
+import semver                                                                              from 'semver';
 import {URL}                                                                               from 'url';
 import {runInNewContext}                                                                   from 'vm';
 
@@ -75,8 +76,11 @@ export default class PluginDlCommand extends BaseCommand {
           pluginSpec = this.name;
           pluginUrl = this.name;
         } else {
-          const ident = structUtils.parseIdent(this.name.replace(/^((@yarnpkg\/)?plugin-)?/, `@yarnpkg/plugin-`));
-          const identStr = structUtils.stringifyIdent(ident);
+          const locator = structUtils.parseLocator(this.name.replace(/^((@yarnpkg\/)?plugin-)?/, `@yarnpkg/plugin-`));
+          if (locator.reference !== `unknown` && !semver.valid(locator.reference))
+            throw new ReportError(MessageName.UNNAMED, `Official plugins only accept strict version references. Use an explicit URL if you wish to download them from another location.`);
+
+          const identStr = structUtils.stringifyIdent(locator);
           const data = await getAvailablePlugins(configuration);
 
           if (!Object.prototype.hasOwnProperty.call(data, identStr))
@@ -84,6 +88,12 @@ export default class PluginDlCommand extends BaseCommand {
 
           pluginSpec = identStr;
           pluginUrl = data[identStr].url;
+
+          if (locator.reference !== `unknown`) {
+            pluginUrl = pluginUrl.replace(/\/master\//, `/${identStr}/${locator.reference}/`);
+          } else if (YarnVersion !== null) {
+            pluginUrl = pluginUrl.replace(/\/master\//, `/@yarnpkg/cli/${YarnVersion}/`);
+          }
         }
 
         report.reportInfo(MessageName.UNNAMED, `Downloading ${formatUtils.pretty(configuration, pluginUrl, `green`)}`);

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -99,7 +99,7 @@ export default class VersionCheckCommand extends Command<CommandContext> {
     };
 
     const Undecided = ({workspace, active, decision, setDecision}: {workspace: Workspace, active?: boolean, decision: versionUtils.Decision, setDecision: (decision: versionUtils.Decision) => void}) => {
-      const currentVersion = workspace.manifest.version;
+      const currentVersion = workspace.manifest.raw.stableVersion ?? workspace.manifest.version;
       if (currentVersion === null)
         throw new Error(`Assertion failed: The version should have been set (${structUtils.prettyLocator(configuration, workspace.anchoredLocator)})`);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Plugins are currently downloaded straight from master. It has various drawbacks:

- Users still on the latest stable automatically get the rc plugins when running `yarn plugin import`.
- If we don't store the plugins in the repo until stable, then users using rc releases can't use plugins.

**How did you fix it?**

This PR changes from where official plugins will be downloaded. Instead of being from `master`, they'll now be downloaded from the `@yarnpkg/cli/<version>` tag, where `<version>` will be the version for the CLI running the command. This ensures that someone running `yarn plugin import` will always get the plugin version at the time of the release for their CLI.

I've also made it possible to import any specific version of the plugin, just in case.

It also fixes a bug caused by the new `--prerelease` flag.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
