### PR TITLE
Allow yarn workspaces focus --production --immutable

### DIFF
--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -32,6 +32,10 @@ export default class WorkspacesFocus extends BaseCommand {
   all = Option.Boolean(`-A,--all`, false, {
     description: `Install the entire project`,
   });
+  
+  immutable = Option.Boolean(`--immutable`, false, {
+    description: `Perform an immutable install`,
+  });
 
   workspaces = Option.Rest();
 
@@ -103,7 +107,7 @@ export default class WorkspacesFocus extends BaseCommand {
       stdout: this.context.stdout,
       includeLogs: true,
     }, async (report: StreamReport) => {
-      await project.install({cache, report, persistProject: false});
+      await project.install({cache, report, persistProject: false, immutable: this.immutable });
     });
 
     return report.exitCode();


### PR DESCRIPTION
(I totally believe I'm missing something, so if this functionality already exists elsewhere, please feel free to point me in that direction!)

Right now, I can't seem to find a way to replicate yarn v1 functionality of `yarn install --only=production --frozen-lockfile`. It seems that either I can get the functionality of either:
  * `yarn install --only=production` with `yarn workspaces focus --production`; or
  * `yarn install --frozen-lockfile` with `yarn install --immutable`

But I haven't been able to find a way to do both. Doing both is important if you want to only install production deps and make sure that those deps are pinned in your lockfile (for example, when building a docker container or running CI). 

This change adds support for that by adding an --immutable flag to `yarn workspaces focus --production`.

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
