### PR TITLE
docs: fix plugin example for using hooks

### DIFF
--- a/packages/gatsby/content/advanced/plugin-tutorial.md
+++ b/packages/gatsby/content/advanced/plugin-tutorial.md
@@ -142,7 +142,7 @@ module.exports = {
   name: `plugin-hello-world`,
   factory: require => ({
     hooks: {
-      setupScriptEnvironment(scriptEnv) {
+      setupScriptEnvironment(project, scriptEnv) {
         scriptEnv.HELLO_WORLD = `my first plugin!`;
       },
     },


### PR DESCRIPTION
According to the source code, the signature is `setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>`.

https://github.com/yarnpkg/berry/blob/dfda0204eef1503cc650fb5c77c4fdcedc37d769/packages/plugin-pnp/sources/index.ts#L25

So the example in the doc seems to be wrong (as it says that the 1st argument is the envs and not the project.