### PR TITLE
feat(plugin-version): allow to apply recursively without clear version file

### DIFF
--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -83,9 +83,11 @@ export default class VersionApplyCommand extends BaseCommand {
       if (this.all) {
         filteredReleases = allReleases;
       } else {
-        const relevantWorkspaces = this.recursive
-          ? workspace.getRecursiveWorkspaceDependencies()
-          : [workspace];
+        const relevantWorkspaces = !this.recursive
+          ? [workspace]
+          : workspace.manifest.private && workspace.manifest.workspaceDefinitions.length
+            ? [workspace, ...workspace.getRecursiveWorkspaceChildren()]
+            : workspace.getRecursiveWorkspaceDependencies();
 
         for (const child of relevantWorkspaces) {
           const release = allReleases.get(child);


### PR DESCRIPTION
I would like to apply my versions recursively in children workspaces without clearing my version file. The `--all` option removes the version file, and the recursive option is used to set transitive dependencies.

Related to https://github.com/yarnpkg/berry/issues/2762

I don't know if this is the correct method, maybe it would be better to add a --update option which when used with --all updates the version file rather than removing it?