### PR TITLE
perf(core): concat strings before computing hash

### DIFF
--- a/.yarn/versions/cb4fb96b.yml
+++ b/.yarn/versions/cb4fb96b.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/hashUtils.ts
+++ b/packages/yarnpkg-core/sources/hashUtils.ts
@@ -5,8 +5,22 @@ import globby                     from 'globby';
 export function makeHash<T extends string = string>(...args: Array<BinaryLike | null>): T {
   const hash = createHash(`sha512`);
 
-  for (const arg of args)
-    hash.update(arg ? arg : ``);
+  let acc = ``;
+  for (const arg of args) {
+    if (typeof arg === `string`) {
+      acc += arg;
+    } else if (arg) {
+      if (acc) {
+        hash.update(acc);
+        acc = ``;
+      }
+
+      hash.update(arg);
+    }
+  }
+
+  if (acc)
+    hash.update(acc);
 
   return hash.digest(`hex`) as T;
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`hashUtils.makeHash` calls `Hash.update` for every argument

**How did you fix it?**

Concat all string arguments in a row before calling update

**Results**

Testing on the repro provided in https://github.com/yarnpkg/berry/issues/973#issuecomment-589201567
```diff
- 712ms (29%)     resolvePeerDependenciesImpl
+ 525ms (23.07%)  resolvePeerDependenciesImpl
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.