### PR TITLE
Adds the dist-scripts to the released packages

### DIFF
--- a/scripts/dist-scripts/yarn
+++ b/scripts/dist-scripts/yarn
@@ -3,7 +3,7 @@ argv0=$(echo "$0" | sed -e 's,\\,/,g')
 basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
 
 case "$(uname -s)" in
-  Darwin) basedir="$( cd "$( dirname "$argv0" )" && pwd )";;
+  Darwin) basedir="$(cd "$( dirname "$argv0")" && pwd)";;
   Linux) basedir=$(dirname "$(readlink -f "$0" || echo "$argv0")");;
   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
   *MSYS*) basedir=`cygpath -w "$basedir"`;;

--- a/scripts/dist-scripts/yarn.cmd
+++ b/scripts/dist-scripts/yarn.cmd
@@ -1,2 +1,1 @@
-@echo off
-node "%~dp0\yarn.js" %*
+@goto #_undefined_# 2>NUL || @title %COMSPEC% & @setlocal & node "%~dp0\yarn.js" %*

--- a/scripts/release/03-release-npm.sh
+++ b/scripts/release/03-release-npm.sh
@@ -20,7 +20,8 @@ jq > "$TEMP_DIR"/package.json \
   "$REPO_DIR"/packages/yarnpkg-cli/package.json
 
 cp "$REPO_DIR"/packages/yarnpkg-cli/bin/yarn.js "$TEMP_DIR"/bin/yarn.js
-chmod +x "$TEMP_DIR"/bin/yarn.js
+cp "$REPO_DIR"/scripts/dist-scripts/* "$TEMP_DIR"/bin
+chmod +x "$TEMP_DIR"/bin/*
 
 cd "$TEMP_DIR"
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Volta would benefit from the shims being in the archive (https://github.com/volta-cli/volta/issues/651#issuecomment-818990073).

Note that those scripts are generally untested (which is why they were initially removed) and currently provided on a best effort basis, so YMMV.

**How did you fix it?**

Added the shims we already had to the archive. It won't affect the 2.4.1, since it has already been published, but will benefit starting from 3.0.0-rc.3.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
