### PR TITLE
perf(ZipOpenFS): replace FILE_PARTS_REGEX with indexOf implementation

### DIFF
--- a/.yarn/versions/f01fa2ef.yml
+++ b/.yarn/versions/f01fa2ef.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/fslib": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/pnp": patch
+  vscode-zipfs: patch
+
+declined:
+  - "@yarnpkg/esbuild-plugin-pnp"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
@@ -9,11 +9,34 @@ import {NodeFS}                                                                 
 import {ZipFS}                                                                                                                                       from './ZipFS';
 import {watchFile, unwatchFile, unwatchAllFiles}                                                                                                     from './algorithms/watchFile';
 import * as errors                                                                                                                                   from './errors';
-import {Filename, FSPath, PortablePath}                                                                                                              from './path';
+import {Filename, FSPath, PortablePath, ppath}                                                                                                       from './path';
 
 const ZIP_FD = 0x80000000;
 
-const FILE_PARTS_REGEX = /.*?(?<!\/)\.zip(?=\/|$)/;
+const DOT_ZIP = `.zip`;
+
+/**
+ * Extracts the archive part (ending in the first `.zip`) from a path.
+ *
+ * The indexOf-based implementation is ~3.7x faster than a RegExp-based implementation.
+ */
+export const getArchivePart = (path: string) => {
+  const idx = path.indexOf(DOT_ZIP);
+  if (idx === -1)
+    return null;
+
+  // Disallow files named ".zip"
+  if (idx > 0 && path[idx - 1] === ppath.sep)
+    return null;
+
+  const nextCharIdx = idx + DOT_ZIP.length;
+
+  // The path either has to end in ".zip" or contain an archive subpath (".zip/...")
+  if (path.length > nextCharIdx && path[nextCharIdx] !== ppath.sep)
+    return null;
+
+  return path.slice(0, nextCharIdx) as PortablePath;
+};
 
 export type ZipOpenFSOptions = {
   baseFs?: FakeFS<PortablePath>,
@@ -851,11 +874,11 @@ export class ZipOpenFS extends BasePortableFakeFS {
     let filePath = `` as PortablePath;
 
     while (true) {
-      const parts = FILE_PARTS_REGEX.exec(p.substr(filePath.length));
-      if (!parts)
+      const archivePart = getArchivePart(p.substr(filePath.length));
+      if (!archivePart)
         return null;
 
-      filePath = this.pathUtils.join(filePath, parts[0] as PortablePath);
+      filePath = this.pathUtils.join(filePath, archivePart);
 
       if (this.isZip.has(filePath) === false) {
         if (this.notZip.has(filePath))

--- a/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
@@ -26,7 +26,7 @@ export const getArchivePart = (path: string) => {
     return null;
 
   // Disallow files named ".zip"
-  if (idx > 0 && path[idx - 1] === ppath.sep)
+  if (path[idx - 1] === ppath.sep)
     return null;
 
   const nextCharIdx = idx + DOT_ZIP.length;

--- a/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
@@ -22,7 +22,7 @@ const DOT_ZIP = `.zip`;
  */
 export const getArchivePart = (path: string) => {
   const idx = path.indexOf(DOT_ZIP);
-  if (idx === -1)
+  if (idx <= 0)
     return null;
 
   // Disallow files named ".zip"

--- a/packages/yarnpkg-fslib/tests/ZipOpenFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/ZipOpenFS.test.ts
@@ -20,6 +20,7 @@ const ZIP_FILE2 = ppath.join(ZIP_DIR2, `foo.txt` as Filename);
 
 describe(`getArchivePart`, () => {
   const tests = [
+    [`.zip`, null],
     [`foo`, null],
     [`foo.zip`, `foo.zip`],
     [`foo.zip/bar`, `foo.zip`],

--- a/packages/yarnpkg-fslib/tests/ZipOpenFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/ZipOpenFS.test.ts
@@ -1,5 +1,6 @@
 import {getLibzipSync}          from '@yarnpkg/libzip';
 
+import {getArchivePart}         from '../sources/ZipOpenFS';
 import {ppath, npath, Filename} from '../sources/path';
 import {ZipOpenFS}              from '../sources';
 
@@ -16,6 +17,26 @@ const ZIP_DIR2 = ppath.join(
 
 export const ZIP_FILE1 = ppath.join(ZIP_DIR1, `foo.txt` as Filename);
 const ZIP_FILE2 = ppath.join(ZIP_DIR2, `foo.txt` as Filename);
+
+describe(`getArchivePart`, () => {
+  const tests = [
+    [`foo`, null],
+    [`foo.zip`, `foo.zip`],
+    [`foo.zip/bar`, `foo.zip`],
+    [`foo.zip/bar/baz`, `foo.zip`],
+    [`/a/b/c/foo.zip`, `/a/b/c/foo.zip`],
+    [`./a/b/c/foo.zip`, `./a/b/c/foo.zip`],
+    [`./a/b/c/.zip`, null],
+    [`./a/b/c/foo.zipp`, null],
+    [`./a/b/c/foo.zip/bar/baz/qux.zip`, `./a/b/c/foo.zip`],
+  ] as const;
+
+  for (const [path, result] of tests) {
+    test(`getArchivePart(${JSON.stringify(path)}) === ${JSON.stringify(result)}`, () => {
+      expect(getArchivePart(path)).toStrictEqual(result);
+    });
+  }
+});
 
 describe(`ZipOpenFS`, () => {
   it(`can read from a zip file`, () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`findZip` inside `ZipOpenFS` isn't as fast as it can be because we use a regexp to extract the archive part from paths.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By using an `indexOf`-based implementation that is 3.7x faster.

Profiled on the Storybook repo (lockfile only install):
- Before: `337.0 ms` (spent executing the regexp)
- After: `89.2 ms` (spent inside `getArchivePart`)

I haven't tested how much it improves PnP runtime's perf, but it would be interesting to see. :thinking:

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
