### PR TITLE
fix(plugin-pnp): delete stale build state when unplugged folder is missing

### DIFF
--- a/.yarn/versions/b3f26d64.yml
+++ b/.yarn/versions/b3f26d64.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (existing contrib plugins are updated automatically, while new contrib plugins can be added by running `yarn plugin import from sources <name>`).
 
+### Bugfixes
+
+- The PnP linker now schedules packages to be rebuilt if their unplugged folder is removed
+
 ## 3.0.0-rc.2
 
 ```
@@ -60,7 +64,7 @@ yarn set version 3.0.0-rc.1
 
 - Yarn now has a proper [governance model](https://github.com/yarnpkg/berry/blob/master/GOVERNANCE.md).
 - The `node-modules` linker will now ensure that the generated install layouts are terminal, by doing several rounds when needed.
-- The `node-modules` linker will no longer prints warnings about postinstall scripts when a workspace depends on another workspace listing install scripts.
+- The `node-modules` linker will no longer print warnings about postinstall scripts when a workspace depends on another workspace listing install scripts.
 - Peer dependencies depending on their own parent are now properly hoisted by the node-modules linker.
 - Boolean values will be properly interpreted when specified inside the configuration file via the `${ENV_VAR}` syntax.
 - Should any of `preinstall`, `install`, `postinstall` fail, the remaining scripts will be skipped.

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1899,4 +1899,33 @@ describe(`Plug'n'Play`, () => {
       }
     )
   );
+
+  test(
+    `it should run the install scripts anew if the unplugged folder is removed`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          'no-deps-scripted': `*`,
+        },
+      },
+      async ({path, run, source}) => {
+        await expect(run(`install`)).resolves.toMatchObject({
+          code: 0,
+          stdout: expect.stringContaining(`YN0007`),
+        });
+
+        await expect(run(`install`)).resolves.toMatchObject({
+          code: 0,
+          stdout: expect.not.stringContaining(`YN0007`),
+        });
+
+        await xfs.removePromise(ppath.join(path, `.yarn/unplugged`));
+
+        await expect(run(`install`)).resolves.toMatchObject({
+          code: 0,
+          stdout: expect.stringContaining(`YN0007`),
+        });
+      }
+    )
+  );
 });

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -383,6 +383,10 @@ export class PnpInstaller implements Installer {
     if (await xfs.existsPromise(readyFile))
       return new CwdFS(unplugPath);
 
+    // Delete any build state for the locator so it can run anew, this allows users
+    // to remove `.yarn/unplugged` and have the builds run again
+    this.opts.project.storedBuildState.delete(locator.locatorHash);
+
     await xfs.mkdirPromise(unplugPath, {recursive: true});
     await xfs.copyPromise(unplugPath, PortablePath.dot, {baseFs: fetchResult.packageFs, overwrite: false});
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When deleting the `.yarn/unplugged` folder (or any folder in it) Yarn will reinstall the package(s) but not run any build scripts for them.

Fixes https://github.com/yarnpkg/berry/issues/2452 (One of the reasons I implemented https://github.com/yarnpkg/berry/pull/2574)

**How did you fix it?**

If the `.ready` file is missing delete the locator from `Project.storedBuildState`.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.