### PR TITLE
perf(core): avoid persisting install state if it didn't change

### DIFF
--- a/.yarn/versions/bdbb6a34.yml
+++ b/.yarn/versions/bdbb6a34.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1087,8 +1087,6 @@ export class Project {
 
     this.installersCustomData = installersCustomData;
 
-    await this.persistInstallStateFile();
-
     // Step 4: Build the packages in multiple steps
 
     if (skipBuild)
@@ -1168,6 +1166,8 @@ export class Project {
     // remove the state from packages that got removed
     const nextBState = new Map<LocatorHash, string>();
 
+    let isInstallStatePersisted = false;
+
     while (buildablePackages.size > 0) {
       const savedSize = buildablePackages.size;
       const buildPromises = [];
@@ -1206,6 +1206,11 @@ export class Project {
         if (this.storedBuildState.get(pkg.locatorHash) === buildHash) {
           nextBState.set(pkg.locatorHash, buildHash);
           continue;
+        }
+
+        if (!isInstallStatePersisted) {
+          await this.persistInstallStateFile();
+          isInstallStatePersisted = true;
         }
 
         if (this.storedBuildState.has(pkg.locatorHash))

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1103,7 +1103,7 @@ export class Project {
     const globalHashGenerator = createHash(`sha512`);
     globalHashGenerator.update(process.versions.node);
 
-    this.configuration.triggerHook(hooks => {
+    await this.configuration.triggerHook(hooks => {
       return hooks.globalHashGeneration;
     }, this, (data: Buffer | string) => {
       globalHashGenerator.update(`\0`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

During an install Yarn serializes and compresses the install state twice when it hasn't changed, once before checking build scripts and once after everything is done, which with a large Project is expensive.

**How did you fix it?**

- Don't call `Project.persistInstallStateFile` unless a build actually needs to run
- Check if the serialized state is different from the previous one before compressing it

**Result**

Running `yarn install` in the Storybook repo (using PnP) when nothing has changed

```diff
- Done with warnings in 4s 748ms
+ Done with warnings in 3s 569ms
```

Gatsby benchmark
```diff
 $ bash scripts/bench-run.sh yarn gatsby $(mktemp -d)
 Benchmark #1: yarn add dummy-pkg@link:./dummy-pkg
-  Time (mean ± σ):      2.901 s ±  0.061 s    [User: 2.639 s, System: 0.523 s]
-  Range (min … max):    2.827 s …  2.985 s    10 runs
+  Time (mean ± σ):      2.751 s ±  0.061 s    [User: 2.544 s, System: 0.474 s]
+  Range (min … max):    2.657 s …  2.796 s    10 runs
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.