### PR TITLE
docs(shell): fix example in readme

### DIFF
--- a/packages/yarnpkg-shell/README.md
+++ b/packages/yarnpkg-shell/README.md
@@ -7,7 +7,7 @@ A JavaScript implementation of a bash-like shell (we use it in Yarn 2 to provide
 ```ts
 import {execute} from '@yarnpkg/shell';
 
-process.exitCode = await execute(`ls "$1" | wc -l`, [process.cwd()]);
+process.exitCode = await execute(`ls "$0" | wc -l`, [process.cwd()]);
 ```
 
 ## Features


### PR DESCRIPTION
**What's the problem this PR addresses?**
Running the example for `@yarn-pkg/shell` as-is yields an `Unbound argument #1` error. The wrong example makes using arguments confusing until you try to pass more than one argument, especially considering the indices are different than the normal argument variables in a typical script.

No issue filed.

...

**How did you fix it?**
Updated the docs example to use `$0` instead of `$1`. This matches the usage in the [relevant test](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-shell/tests/shell.test.ts#L397).
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
