### PR TITLE
fix(shell): throw error when redirecting to file in non-existent folder

### DIFF
--- a/.yarn/versions/4d8c2fcd.yml
+++ b/.yarn/versions/4d8c2fcd.yml
@@ -1,0 +1,31 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -259,7 +259,10 @@ const BUILTINS = new Map<string, ShellBuiltin>([
     // Close all the outputs (since the shell never closes the output stream)
     await Promise.all(outputs.map(output => {
       // Wait until the output got flushed to the disk
-      return new Promise<void>(resolve => {
+      return new Promise<void>((resolve, reject) => {
+        output.on(`error`, error => {
+          reject(error);
+        });
         output.on(`close`, () => {
           resolve();
         });

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -689,6 +689,14 @@ describe(`Shell`, () => {
           await expect(xfs.readFilePromise(file2, `utf8`)).resolves.toEqual(`hello world\n`);
         });
       });
+
+      it(`should throw on output redirections to inexistent folder`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" > "inexistent-folder/file.txt"`,
+          )).rejects.toThrowError(`ENOENT: no such file or directory, open`);
+        });
+      });
     });
 
     describe(`>>`, () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell wasn't throwing errors when redirecting to files in non-existent folders on Node 14.x (it works on all other versions).

Fixes #2818.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Explicitly reject the promise on write stream errors.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
