### PR TITLE
feat(doctor): warn on bundleDependencies

### DIFF
--- a/.yarn/versions/0cbbb51e.yml
+++ b/.yarn/versions/0cbbb51e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": minor

--- a/packages/yarnpkg-doctor/README.md
+++ b/packages/yarnpkg-doctor/README.md
@@ -16,19 +16,20 @@ You'll get a pretty output with all the warnings.
 - no unmet peer dependencies
 - no node_module strings
 - no unqualified webpack loaders
+- no bundleDependencies
 
 ### no unlisted dependencies
 
 This rule warns when imported dependencies are not listed in a project/workspace's package.json.
 
-Node allows you to import any package without having a version specified in your package.json. This can lead to subtle and hard to solve bugs. 
+Node allows you to import any package without having a version specified in your package.json. This can lead to subtle and hard to solve bugs.
 
-For example: 
+For example:
 1. Node might find a globally installed package and the project works on your machine. While other your colleagues might be missing the globally installed package or (worse) have an incompatible version installed.
 
 2. Or Node might find a transitive dependency (dependency of a dependency) and use that. If you remove or upgrade that dependency and it affects the transitive dependency then it can trigger all sorts of bugs.
 
-By making sure all dependencies are listed in the package.json pnp can make your project less brittle. 
+By making sure all dependencies are listed in the package.json pnp can make your project less brittle.
 
 ### no unmet peer dependencies
 
@@ -36,9 +37,9 @@ This rule warns when a package has unmet peer dependencies.
 
 Peer dependencies are useful for allowing package authors to delegate control of a dependency's version to the package user. When used correctly they prevent version conflicts and reduce bundle sizes.
 
-Peer dependencies must be manually added to the package user's package.json. Because they responsibility of the package user they can be overlooked. 
+Peer dependencies must be manually added to the package user's package.json. Because they responsibility of the package user they can be overlooked.
 
-This rule ensures that all peer dependencies are included and therefore installed for your project. 
+This rule ensures that all peer dependencies are included and therefore installed for your project.
 
 ### no node module strings
 
@@ -68,7 +69,7 @@ This rule disallows referencing loaders or plugins in string literals in a `webp
 
 Ensures that third party tools (CRA, Next, Vue-cli, etc) resolve their own versions of loaders and presets.
 
-When loaders and plugins are included as strings e.g `loader: 'file-loader'` in a `webpack.config.js` then Webpack will try to resolve it from the point of view of the project root. 
+When loaders and plugins are included as strings e.g `loader: 'file-loader'` in a `webpack.config.js` then Webpack will try to resolve it from the point of view of the project root.
 
 If the webpack config is located in a dependency, as with tools such as Create-React-App, Next.js and Gatsby, then Webpack might accidentally use an different hoisted version of a plugin. This can cause various weird bugs and crashes.
 
@@ -91,6 +92,12 @@ const webpackConfig = {
 ```
 
 This rule is a temporary measure to address this [issue](https://github.com/webpack/webpack/issues/9648)
+
+### no bundleDependencies
+
+This rule warns when the `bundleDependencies` (or `bundledDependencies`) field is used.
+
+Visit [the dedicated section](https://yarnpkg.com/getting-started/migration#dont-use-bundledependencies) on the website to learn more.
 
 ## Further reading
 

--- a/packages/yarnpkg-doctor/fixtures/bundle-dependencies/package.json
+++ b/packages/yarnpkg-doctor/fixtures/bundle-dependencies/package.json
@@ -1,0 +1,5 @@
+{
+  "bundleDependencies": [
+    "lodash"
+  ]
+}

--- a/packages/yarnpkg-doctor/fixtures/bundled-dependencies/package.json
+++ b/packages/yarnpkg-doctor/fixtures/bundled-dependencies/package.json
@@ -1,0 +1,5 @@
+{
+  "bundledDependencies": [
+    "lodash"
+  ]
+}

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -296,6 +296,9 @@ async function processWorkspace(workspace: Workspace, {configuration, fileList, 
     if (scriptName.match(/^(pre|post)(?!(install|pack)$)/) && !scriptName.match(/^prettier/))
       report.reportWarning(MessageName.UNNAMED, `User scripts prefixed with "pre" or "post" (like "${scriptName}") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly`);
 
+  if (Array.isArray(workspace.manifest.raw.bundleDependencies) || Array.isArray(workspace.manifest.raw.bundledDependencies))
+    report.reportWarning(MessageName.UNNAMED, `The bundleDependencies (or bundledDependencies) field is not supported anymore; prefer using a bundler`);
+
   for (const p of fileList) {
     const parsed = await parseFile(p);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I've just come across one of my old stashes - it makes the doctor warn when the `bundleDependencies` or `bundledDependencies` fields are used.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
