### PR TITLE
[website] Recommend using .gitattributes to treat release and plugin bundles as "binary"

### DIFF
--- a/packages/gatsby/content/getting-started/questions-and-answers.md
+++ b/packages/gatsby/content/getting-started/questions-and-answers.md
@@ -63,13 +63,6 @@ If you're not using Zero-Installs:
 .pnp.*
 ```
 
-Add a ".gitattributes" file to mark the release/plugin bundles binary content, so Git doesn't bother showing massive diffs when they're added/removed:
-
-```gitattributes
-/.yarn/releases/** binary
-/.yarn/plugins/** binary
-```
-
 If you're interested to know more about each of these files:
 
 - `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).
@@ -89,6 +82,13 @@ If you're interested to know more about each of these files:
 - `yarn.lock` should always be stored within your repository ([even if you develop a library](#should-lockfiles-be-committed-to-the-repository)).
 
 - `.yarnrc.yml` (and its older counterpart, `.yarnrc`) are configuration files. They should always be stored in your project.
+
+> **Tip:** You can also add a `.gitattributes` file to identify the release and plugin bundles as binary content. This way Git won't bother showing massive diffs when each time you subsequently add or update them:
+>
+> ```gitattributes
+> /.yarn/releases/** binary
+> /.yarn/plugins/** binary
+> ```
 
 ## Should lockfiles be committed to the repository?
 

--- a/packages/gatsby/content/getting-started/questions-and-answers.md
+++ b/packages/gatsby/content/getting-started/questions-and-answers.md
@@ -63,6 +63,13 @@ If you're not using Zero-Installs:
 .pnp.*
 ```
 
+Add a ".gitattributes" file to mark the release/plugin bundles binary content, so Git doesn't bother showing massive diffs when they're added/removed:
+
+```gitattributes
+/.yarn/releases/** binary
+/.yarn/plugins/** binary
+```
+
 If you're interested to know more about each of these files:
 
 - `.yarn/cache` and `.pnp.*` may be safely ignored, but you'll need to run `yarn install` to regenerate them between each branch switch - which would be optional otherwise, cf [Zero-Installs](/features/zero-installs).


### PR DESCRIPTION
**What's the problem this PR addresses?**

When the Yarn release and plugin bundles change, Git uses its standard line-by-line diff to show the changes.  This is probably not what you want, since those bundles are not really meant to be read by a human.

In my repo, I used ".gitattributes" to tell Git to treat them like binary files, which reduces the amount of garbage in the "git diff" output.  I thought this tip might be worth sharing on the official website.

<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
