### PR TITLE
Add license plugin to list of community plugins

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -63,4 +63,6 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**yarn.build**](https://yarn.build/) by [**Owen Kelly**](https://github.com/ojkelly/yarn.build) - run build commands across workspaces after detecting the ones which changed, and bundle them up into deployable AWS apps.
 
+- [**licenses**](https://github.com/tophat/yarn-plugin-licenses) by [**Noah Negin-Ulster**](https://noahnu.com/) - audit direct and indirect dependency licenses to ensure compliance
+
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!


### PR DESCRIPTION
**What's the problem this PR addresses?**
Adds a license plugin to the list of community plugins.

**How did you fix it?**
I found this plugin at [issue 1164](https://github.com/yarnpkg/berry/issues/1164#issuecomment-786720087). This plugin is especially useful for enforcing in CI that no direct or indirect dependencies with incompatible licenses are added to your project.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.