### PR TITLE
fix(essentials): skip loading external plugins when using `yarn link`

### DIFF
--- a/.yarn/versions/45babb85.yml
+++ b/.yarn/versions/45babb85.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -53,7 +53,7 @@ export default class LinkCommand extends BaseCommand {
 
     const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
 
-    const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins);
+    const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
     const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
 
     if (!workspace2)


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn link` loads plugins from the target causing errors if the CLI versions mismatch

**How did you fix it?**

Skip loading plugins in the link target

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.