### PR TITLE
fix(vscode-zipfs): add `TerminalLinkProvider` disposable to `context.subscriptions`

### DIFF
--- a/.yarn/versions/7a4b3cc0.yml
+++ b/.yarn/versions/7a4b3cc0.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: patch

--- a/packages/vscode-zipfs/sources/TerminalLinkProvider.ts
+++ b/packages/vscode-zipfs/sources/TerminalLinkProvider.ts
@@ -77,5 +77,5 @@ export function registerTerminalLinkProvider() {
     },
   };
 
-  vscode.window.registerTerminalLinkProvider(terminalProvider);
+  return vscode.window.registerTerminalLinkProvider(terminalProvider);
 }

--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -16,7 +16,7 @@ function mount(uri: vscode.Uri) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  registerTerminalLinkProvider();
+  context.subscriptions.push(registerTerminalLinkProvider());
 
   context.subscriptions.push(vscode.workspace.registerFileSystemProvider(`zip`, new ZipFSProvider(), {
     isCaseSensitive: true,


### PR DESCRIPTION
**What's the problem this PR addresses?**

In https://github.com/yarnpkg/berry/pull/1835 I forgot to add the disposable returned by `vscode.window.registerTerminalLinkProvider` to `context.subscriptions`

**How did you fix it?**

Added it

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.