### PR TITLE
fix(essentials): `set version` - get version of bundle in a temp directory

### DIFF
--- a/.yarn/versions/785fed9b.yml
+++ b/.yarn/versions/785fed9b.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -84,14 +84,12 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
       bundleVersion = stdout.trim();
       if (!semver.valid(bundleVersion)) {
-        throw new Error(`Invalid semver version. 'yarn --version' returned:\n${bundleVersion}`);
+        throw new Error(`Invalid semver version. ${formatUtils.pretty(configuration, `yarn --version`, formatUtils.Type.CODE} returned:\n${bundleVersion}`);
       }
     });
   }
 
-  const projectCwd = configuration.projectCwd
-    ? configuration.projectCwd
-    : configuration.startingCwd;
+  const projectCwd = configuration.projectCwd ?? configuration.startingCwd;
 
   const releaseFolder = ppath.resolve(projectCwd, `.yarn/releases` as PortablePath);
   const absolutePath = ppath.resolve(releaseFolder, `yarn-${bundleVersion}.cjs` as Filename);

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -72,26 +72,26 @@ export default class SetVersionCommand extends BaseCommand {
 }
 
 export async function setVersion(configuration: Configuration, bundleVersion: string | null, bundleBuffer: Buffer, {report}: {report: Report}) {
-  const projectCwd = configuration.projectCwd
-    ? configuration.projectCwd
-    : configuration.startingCwd;
-
   if (bundleVersion === null) {
     await xfs.mktempPromise(async tmpDir => {
       const temporaryPath = ppath.join(tmpDir, `yarn.cjs` as Filename);
       await xfs.writeFilePromise(temporaryPath, bundleBuffer);
 
       const {stdout} = await execUtils.execvp(process.execPath, [npath.fromPortablePath(temporaryPath), `--version`], {
-        cwd: projectCwd,
+        cwd: tmpDir,
         env: {...process.env, YARN_IGNORE_PATH: `1`},
       });
 
       bundleVersion = stdout.trim();
       if (!semver.valid(bundleVersion)) {
-        throw new Error(`Invalid semver version`);
+        throw new Error(`Invalid semver version. 'yarn --version' returned:\n${bundleVersion}`);
       }
     });
   }
+
+  const projectCwd = configuration.projectCwd
+    ? configuration.projectCwd
+    : configuration.startingCwd;
 
   const releaseFolder = ppath.resolve(projectCwd, `.yarn/releases` as PortablePath);
   const absolutePath = ppath.resolve(releaseFolder, `yarn-${bundleVersion}.cjs` as Filename);

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -84,7 +84,7 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
       bundleVersion = stdout.trim();
       if (!semver.valid(bundleVersion)) {
-        throw new Error(`Invalid semver version. ${formatUtils.pretty(configuration, `yarn --version`, formatUtils.Type.CODE} returned:\n${bundleVersion}`);
+        throw new Error(`Invalid semver version. ${formatUtils.pretty(configuration, `yarn --version`, formatUtils.Type.CODE)} returned:\n${bundleVersion}`);
       }
     });
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

- `yarn set version ...` downloads a bundle and runs `--version` on it from the cwd of the project, if the project contains a configuration the new bundle doesn't support it fails
- If the version returned by the new bundle is invalid Yarn doesn't include it in the error message making it rather vague

**How did you fix it?**

- Run the command in the temp directory
- Include the version in the error

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.