### PR TITLE
chore: remove outdated bigint comment

### DIFF
--- a/.yarn/versions/62765bae.yml
+++ b/.yarn/versions/62765bae.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/fslib"

--- a/packages/yarnpkg-fslib/sources/algorithms/watchFile/CustomStatWatcher.ts
+++ b/packages/yarnpkg-fslib/sources/algorithms/watchFile/CustomStatWatcher.ts
@@ -26,7 +26,6 @@ export function assertStatus<T extends Status>(current: Status, expected: T): as
 export type ListenerOptions = Omit<Required<WatchFileOptions>, 'bigint'>;
 
 export type CustomStatWatcherOptions = {
-  // BigInt Stats aren't currently implemented in the FS layer, so this is a no-op
   bigint?: boolean,
 };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR removes an outdated comment that I left when I first implemented the `CustomStatWatcher` that described the fact that bigint stats weren't supported.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
