### PR TITLE
fix(patch): ignore global git config

### DIFF
--- a/.yarn/versions/56bdc806.yml
+++ b/.yarn/versions/56bdc806.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -207,6 +207,17 @@ export async function diffFolders(folderA: PortablePath, folderB: PortablePath) 
 
   const {stdout, stderr} = await execUtils.execvp(`git`, [`-c`, `core.safecrlf=false`, `diff`, `--src-prefix=a/`, `--dst-prefix=b/`, `--ignore-cr-at-eol`, `--full-index`, `--no-index`, `--text`, folderAN, folderBN], {
     cwd: npath.toPortablePath(process.cwd()),
+    env: {
+      ...process.env,
+      //#region Predictable output
+      // These variables aim to ignore the global git config so we get predictable output
+      // https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGNOSYSTEMcode
+      GIT_CONFIG_NOSYSTEM: `1`,
+      HOME: ``,
+      XDG_CONFIG_HOME: ``,
+      USERPROFILE: ``,
+      //#endregion
+    },
   });
 
   // we cannot rely on exit code, because --no-index implies --exit-code


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn patch-commit` (`patchUtils.diffFolders`) can end up with different output on different systems depending on their global config.

Guessing this is the issue in https://github.com/yarnpkg/berry/issues/2852 since whitespace changes isn't visible in their diff.

**How did you fix it?**

Ignore the global git config

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.