### PR TITLE
fix(core): ignore `__esModule` and always use `default` when defined

### DIFF
--- a/.yarn/versions/10adb297.yml
+++ b/.yarn/versions/10adb297.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -983,14 +983,13 @@ export class Configuration {
       [`@@core`, CorePlugin],
     ]);
 
-    const interop =
-      (obj: any) => obj.__esModule
-        ? obj.default
-        : obj;
+    const getDefault = (object: any) => {
+      return `default` in object ? object.default : object;
+    };
 
     if (pluginConfiguration !== null) {
       for (const request of pluginConfiguration.plugins.keys())
-        plugins.set(request, interop(pluginConfiguration.modules.get(request)));
+        plugins.set(request, getDefault(pluginConfiguration.modules.get(request)));
 
       const requireEntries = new Map();
       for (const request of nodeUtils.builtinModules())
@@ -999,10 +998,6 @@ export class Configuration {
         requireEntries.set(request, () => embedModule);
 
       const dynamicPlugins = new Set();
-
-      const getDefault = (object: any) => {
-        return object.default || object;
-      };
 
       const importPlugin = (pluginPath: PortablePath, source: string) => {
         const {factory, name} = miscUtils.dynamicRequire(npath.fromPortablePath(pluginPath));


### PR DESCRIPTION
**What's the problem this PR addresses?**

[`esbuild@0.8.43`](https://github.com/evanw/esbuild/releases/tag/v0.8.43) stopped emitting the `__esModule` flag for ESM to ESM imports (I think) causing all built-in plugins to be registered incorrectly.

**How did you fix it?**

Ignore the `__esModule` flag and just use `default` if it's defined

**Extra**

I didn't update to a newer esbuild version as it consistently panics on Windows when node is about to terminate
cc @evanw

```
panic: <object>

goroutine 7 [running]:
syscall.mapJSError(0x7ff8000100000f86, 0xb956e98, 0x17080008, 0x7ff8000100000f86)
        /usr/local/go/src/syscall/fs_js.go:552 +0x1e
syscall.fsCall.func1(0x7ff8000100000005, 0xb956e88, 0x3f71480, 0x1, 0x1, 0xb956e90, 0x40000838f00)
        /usr/local/go/src/syscall/fs_js.go:507 +0xb
syscall/js.handleEvent()
        /usr/local/go/src/syscall/js/func.go:96 +0x24
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.