### PR TITLE
perf(core): handle Buffer allocation in `hashUtils.checksumFile`

### DIFF
--- a/.yarn/versions/f0d52d1c.yml
+++ b/.yarn/versions/f0d52d1c.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"


### PR DESCRIPTION
**What's the problem this PR addresses?**

`fs.createReadStream` has to allocate a new Buffer for each read operation because it can't safely reuse the Buffer from the previous read.

**How did you fix it?**

Allocate a Buffer once in `hashUtils.checksumFile` and reuse it for each read operation on a file.

**Result**

Storybook repo
```diff
  ➤ YN0000: ┌ Fetch step
  ➤ YN0013: │ 4288 packages were already cached
- ➤ YN0000: └ Completed in 1s 118ms
+ ➤ YN0000: └ Completed in 0s 863ms
```

Gatsby benchmark
```diff
 bash scripts/bench-run.sh yarn gatsby (mktemp -d)
 Reflink aren't supported! Installs may be quite slower than necessary
 Testing install-ready
 Benchmark #1: yarn add dummy-pkg@link:./dummy-pkg
-  Time (mean ± σ):      2.771 s ±  0.076 s    [User: 2.577 s, System: 0.452 s]
+  Time (mean ± σ):      2.653 s ±  0.033 s    [User: 2.392 s, System: 0.455 s]
-  Range (min … max):    2.675 s …  2.924 s    10 runs
+  Range (min … max):    2.613 s …  2.711 s    10 runs
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.