### PR TITLE
docs(builder): add note about v3.0 vs v2.0 plugins

### DIFF
--- a/.yarn/versions/939a73e5.yml
+++ b/.yarn/versions/939a73e5.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -2,7 +2,7 @@
 
 A CLI tool designed for creating, building, and managing complex plugins.
 
-This version of the builder is for creating plugins for Yarn 3.x. Yarn 3 plugins are not compatible with Yarn 2 installations, however Yarn 2 plugins are usually compatible with Yarn 3. If you wish to create plugins for Yarn 2, please use v2.x of the builder (`yarn add @yarnpkg/builder@^2`).
+> This version of the builder is for creating plugins for Yarn 3.x. Yarn 3 plugins are not compatible with Yarn 2 installations, however Yarn 2 plugins are usually compatible with Yarn 3. If you wish to create plugins for Yarn 2, please use v2.x of the builder (`yarn add @yarnpkg/builder@^2`).
 
 ## Features
 

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -2,6 +2,8 @@
 
 A CLI tool designed for creating, building, and managing complex plugins.
 
+This version of the builder is for creating plugins for Yarn 3.x. Yarn 3 plugins are not compatible with Yarn 2 installations, however Yarn 2 plugins are usually compatible with Yarn 3. If you wish to create plugins for Yarn 2, please use v2.x of the builder (`npm install @yarnpkg/builder@^2`).
+
 ## Features
 
 - `builder new plugin` command for scaffolding new plugins

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -2,7 +2,7 @@
 
 A CLI tool designed for creating, building, and managing complex plugins.
 
-This version of the builder is for creating plugins for Yarn 3.x. Yarn 3 plugins are not compatible with Yarn 2 installations, however Yarn 2 plugins are usually compatible with Yarn 3. If you wish to create plugins for Yarn 2, please use v2.x of the builder (`npm install @yarnpkg/builder@^2`).
+This version of the builder is for creating plugins for Yarn 3.x. Yarn 3 plugins are not compatible with Yarn 2 installations, however Yarn 2 plugins are usually compatible with Yarn 3. If you wish to create plugins for Yarn 2, please use v2.x of the builder (`yarn add @yarnpkg/builder@^2`).
 
 ## Features
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Related to: #2872.

Fixes confusion relating to usage of the plugin builder, as the current version is for building Yarn 3 plugins, but this is not obvious. This is compounded by the fact that the [Yarn 2.0 docs recommend usage of the builder](https://yarnpkg.com/advanced/plugin-tutorial/#gatsby-focus-wrapper) without mentioning that you must use v2.x of the builder to make plugins compatible with Yarn 2.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added a note to the builder readme explaining that the current version is for building Yarn 3 plugins, and recommending usage of `@yarnpkg/builder@^2` if the user wants to build plugins for 2.x.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
