### PR TITLE
fix(core): disable hyperlinks on circleci

### DIFF
--- a/.yarn/versions/c5e90091.yml
+++ b/.yarn/versions/c5e90091.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -1,5 +1,6 @@
 import {npath}                                                              from '@yarnpkg/fslib';
 import chalk                                                                from 'chalk';
+import {CIRCLE as isCircleCI}                                               from 'ci-info';
 import stripAnsi                                                            from 'strip-ansi';
 
 import {Configuration, ConfigurationValueMap}                               from './Configuration';
@@ -57,7 +58,7 @@ const chalkOptions = process.env.GITHUB_ACTIONS
     : {level: 0};
 
 export const supportsColor = chalkOptions.level !== 0;
-export const supportsHyperlinks = supportsColor && !process.env.GITHUB_ACTIONS;
+export const supportsHyperlinks = supportsColor && !process.env.GITHUB_ACTIONS && !isCircleCI;
 
 const chalkInstance = new chalk.Instance(chalkOptions);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

CircleCI doesn't support hyperlinks so the CLI output looks horrible

```
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0013---fetch_not_cachedYN0013]8;;: │ 5 packages were already cached, 1369 had to be fetched
➤ YN0000: └ Completed in 1m 38s
➤ YN0000: ┌ Link step
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0062---incompatible_osYN0062]8;;: │ fsevents@patch:fsevents@npm%3A2.3.2#builtin<compat/fsevents>::version=2.3.2&hash=11e9ea The platform linux is incompatible with this module, link skipped.
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0062---incompatible_osYN0062]8;;: │ fsevents@patch:fsevents@npm%3A1.2.13#builtin<compat/fsevents>::version=1.2.13&hash=11e9ea The platform linux is incompatible with this module, link skipped.
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0005---build_disabledYN0005]8;;: │ core-js@npm:2.6.11 lists build scripts, but its build has been explicitly disabled through configuration.
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0005---build_disabledYN0005]8;;: │ core-js-pure@npm:3.8.1 lists build scripts, but its build has been explicitly disabled through configuration.
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0005---build_disabledYN0005]8;;: │ core-js@npm:3.6.5 lists build scripts, but its build has been explicitly disabled through configuration.
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0007---must_buildYN0007]8;;: │ husky@npm:3.1.0 must be built because it never did before or the last one failed
➤ ]8;;https://yarnpkg.com/advanced/error-codes#yn0007---must_buildYN0007]8;;: │ uglifyjs-webpack-plugin@npm:0.4.6 [d79c4] must be built because it never did before or the last one failed
```

Copied from one of the CI runs in the Babel repo

**How did you fix it?**

Disable hyperlinks when CircleCI is detected

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.