### PR TITLE
fix(core): only call `installPackage` if the `Linker` supports it

### DIFF
--- a/.yarn/versions/deebfe02.yml
+++ b/.yarn/versions/deebfe02.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/core` is calling `Installer.installPackage` for workspaces without checking if the `Linker` supports it

**How did you fix it?**

Check `Linker.supportsPackage` before calling `Installer.installPackage` for workspaces

**Result**

Tested on the Storybook repo using PnP

```
$ YARN_IGNORE_PATH=1 hyperfine -w 5 './nodejs before.cjs' './nodejs after.cjs'
Benchmark #1: ./nodejs before.cjs
  Time (mean ± σ):      4.279 s ±  0.036 s    [User: 5.421 s, System: 0.975 s]
  Range (min … max):    4.253 s …  4.374 s    10 runs

Benchmark #2: ./nodejs after.cjs
  Time (mean ± σ):      3.930 s ±  0.048 s    [User: 5.028 s, System: 0.863 s]
  Range (min … max):    3.891 s …  4.054 s    10 runs

Summary
  './nodejs after.cjs' ran
    1.09 ± 0.02 times faster than './nodejs before.cjs'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.