### PR TITLE
docs: add semver up plugin to contrib plugins page

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -65,6 +65,8 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**licenses**](https://github.com/tophat/yarn-plugin-licenses) by [**Noah Negin-Ulster**](https://noahnu.com/) - audit direct and indirect dependency licenses to ensure compliance
 
+- [**semver-up**](https://github.com/tophat/yarn-plugin-semver-up) by [**Noah Negin-Ulster**](https://noahnu.com/) - configurable `yarn up` command that preserves semantic version ranges and update groups
+
 - [**conditions**](https://github.com/nicolo-ribaudo/yarn-plugin-conditions) by [**Nicolò Ribaudo**](https://twitter.com/NicoloRibaudo) - allow choosing between different dependency versions via install-time (during development) and publish-time flags
 
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Adds "yarn semver up" plugin: https://github.com/tophat/yarn-plugin-semver-up to contrib page.

Note: the "preserve semver" functionality would actually be nice as an option in yarn's built-in "up" command. The group config that semver up supports doesn't make sense as a builtin though.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
