### PR TITLE
docs(plugin-version): update the usage details to point to the correct docs

### DIFF
--- a/.yarn/versions/2b43493b.yml
+++ b/.yarn/versions/2b43493b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -26,7 +26,7 @@ export default class VersionCommand extends BaseCommand {
       - If a valid semver range, it will be used as new version.
       - If unspecified, Yarn will ask you for guidance.
 
-      For more information about the \`--deferred\` flag, consult our documentation ("Managing Releases").
+      For more information about the \`--deferred\` flag, consult our documentation ("https://yarnpkg.com/features/release-workflow#deferred-versioning").
     `,
     examples: [[
       `Immediately bump the version to the next major`,

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -26,7 +26,7 @@ export default class VersionCommand extends BaseCommand {
       - If a valid semver range, it will be used as new version.
       - If unspecified, Yarn will ask you for guidance.
 
-      For more information about the \`--deferred\` flag, consult our documentation ("https://yarnpkg.com/features/release-workflow#deferred-versioning").
+      For more information about the \`--deferred\` flag, consult our documentation (https://yarnpkg.com/features/release-workflow#deferred-versioning).
     `,
     examples: [[
       `Immediately bump the version to the next major`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Usage details for `--deferred` told the user to consult documentation for "Managing Releases", which when searched for, returned no results.

Found no open issues referring to this.

...

**How did you fix it?**

Direct the user directly to the intended place in the documentation via a link.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
