### PR TITLE
fix(core): use dependencies if peer dependency wasn't provided

### DIFF
--- a/.yarn/versions/570544e2.yml
+++ b/.yarn/versions/570544e2.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1936,7 +1936,8 @@ function applyVirtualResolutionMutations({
             volatileDescriptors.delete(peerDescriptor.descriptorHash);
           }
 
-          if (!peerDescriptor && virtualizedPackage.dependencies.has(peerRequest.identHash)) {
+          // If the peerRequest isn't provided by the parent then fall back to dependencies
+          if ((!peerDescriptor || peerDescriptor.range === `missing:`) && virtualizedPackage.dependencies.has(peerRequest.identHash)) {
             virtualizedPackage.peerDependencies.delete(peerRequest.identHash);
             continue;
           }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Peer dependencies with a fallback doesn't work if the parent has an unmet peer dependency on the same dependency. In the following dependency tree `lib-2` should have access to `lodash` but doesn't
```
.
├── root
│   └── dependencies
│       └── lib-1
├── lib-1
│   ├── dependencies
│   │   └── lib-2
│   └── peerDependencies
│       └── lodash
└── lib-2
    ├── dependencies
    │   └── lodash
    └── peerDependencies
        └── lodash
```

**How did you fix it?**

When the descriptor from the parent has a `missing:` range use the fallback instead

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.