### PR TITLE
feat(esbuild): watch support

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -9449,7 +9449,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:3.0.0"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -9487,7 +9490,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:3.0.0"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -9525,7 +9531,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:3.0.0"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -9562,7 +9571,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:3.0.0"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -10280,7 +10292,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
-            "@types/esbuild"
+            "@types/esbuild",
+            "esbuild"
           ],
           "linkType": "SOFT",
         }],

--- a/.yarn/versions/2ae85504.yml
+++ b/.yarn/versions/2ae85504.yml
@@ -1,0 +1,15 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/esbuild-plugin-pnp": major
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/pnp"

--- a/packages/esbuild-plugin-pnp/package.json
+++ b/packages/esbuild-plugin-pnp/package.json
@@ -7,7 +7,7 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "esbuild": ">=0.8.36"
+    "esbuild": ">=0.10.0"
   },
   "devDependencies": {
     "@yarnpkg/pnp": "workspace:*",

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -76,7 +76,7 @@ async function defaultOnResolve(args: OnResolveArgs, {resolvedPath, error, watch
   if (resolvedPath !== null) {
     return {namespace: `pnp`, path: resolvedPath, watchFiles};
   } else {
-    return {external: true, ...mergeWith};
+    return {external: true, ...mergeWith, watchFiles};
   }
 }
 

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -49,10 +49,11 @@ async function defaultOnLoad(args: OnLoadArgs): Promise<OnLoadResult> {
 
 type OnResolveParams = {
   resolvedPath: string | null;
+  watchFiles: Array<string>
   error?: Error;
 };
 
-async function defaultOnResolve(args: OnResolveArgs, {resolvedPath, error}: OnResolveParams): Promise<OnResolveResult> {
+async function defaultOnResolve(args: OnResolveArgs, {resolvedPath, error, watchFiles}: OnResolveParams): Promise<OnResolveResult> {
   const problems = error ? [{text: error.message}] : [];
 
   // Sometimes dynamic resolve calls might be wrapped in a try / catch,
@@ -73,7 +74,7 @@ async function defaultOnResolve(args: OnResolveArgs, {resolvedPath, error}: OnRe
   }
 
   if (resolvedPath !== null) {
-    return {namespace: `pnp`, path: resolvedPath};
+    return {namespace: `pnp`, path: resolvedPath, watchFiles};
   } else {
     return {external: true, ...mergeWith};
   }
@@ -128,7 +129,20 @@ export function pnpPlugin({
           error = e;
         }
 
-        return onResolve(args, {resolvedPath: path, error});
+        const watchFiles: Array<string> = [pnpApi.resolveRequest(`pnpapi`, null)!];
+
+        if (path) {
+          const locator = pnpApi.findPackageLocator(path);
+          if (locator) {
+            const info = pnpApi.getPackageInformation(locator);
+
+            if (info?.linkType === `SOFT`) {
+              watchFiles.push(pnpApi.resolveVirtual?.(path) ?? path);
+            }
+          }
+        }
+
+        return onResolve(args, {resolvedPath: path, error, watchFiles});
       });
 
       // We register on the build to prevent ESBuild from reading the files

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -13,7 +13,7 @@
     "babel-loader": "^8.1.0",
     "chalk": "^3.0.0",
     "clipanion": "^3.0.0",
-    "esbuild-wasm": "^0.11.20",
+    "esbuild": "npm:esbuild-wasm@^0.11.20",
     "filesize": "^4.1.2",
     "fork-ts-checker-webpack-plugin": "^5.0.0",
     "semver": "^7.1.2",

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -5,7 +5,7 @@ import {npath}                                                              from
 import chalk                                                                from 'chalk';
 import cp                                                                   from 'child_process';
 import {Command, Option, Usage}                                             from 'clipanion';
-import {build, Plugin}                                                      from 'esbuild-wasm';
+import {build, Plugin}                                                      from 'esbuild';
 import fs                                                                   from 'fs';
 import {createRequire}                                                      from 'module';
 import path                                                                 from 'path';

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -2,7 +2,7 @@ import {StreamReport, MessageName, Configuration, formatUtils, structUtils} from
 import {pnpPlugin}                                                          from '@yarnpkg/esbuild-plugin-pnp';
 import {npath, xfs}                                                         from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                                 from 'clipanion';
-import {build, Plugin}                                                      from 'esbuild-wasm';
+import {build, Plugin}                                                      from 'esbuild';
 import fs                                                                   from 'fs';
 import path                                                                 from 'path';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,7 +5373,7 @@ __metadata:
     esbuild: "npm:esbuild-wasm@^0.11.20"
     tslib: ^1.13.0
   peerDependencies:
-    esbuild: ">=0.8.36"
+    esbuild: ">=0.10.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5227,7 +5227,7 @@ __metadata:
     babel-loader: ^8.1.0
     chalk: ^3.0.0
     clipanion: ^3.0.0
-    esbuild-wasm: ^0.11.20
+    esbuild: "npm:esbuild-wasm@^0.11.20"
     filesize: ^4.1.2
     fork-ts-checker-webpack-plugin: ^5.0.0
     semver: ^7.1.2
@@ -10855,7 +10855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-wasm@npm:^0.11.20, esbuild@npm:esbuild-wasm@^0.11.20":
+"esbuild@npm:esbuild-wasm@^0.11.20":
   version: 0.11.20
   resolution: "esbuild-wasm@npm:0.11.20"
   bin:


### PR DESCRIPTION
**What's the problem this PR addresses?**

esbuild's watch mode doesn't work with PnP as it only watches the `file` namespace by default

Fixes https://github.com/yarnpkg/berry/issues/2916

**How did you fix it?**

Return `watchFiles` from the resolve callback which was introduced in [`esbuild@0.10.0`](https://github.com/evanw/esbuild/blob/e76b49fa3c9d8ef4dc13b4d7a3eb04b524ff4626/CHANGELOG.md#0100)

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.