### PR TITLE
perf(core): only devirtualize when ident matches a workspace

### DIFF
--- a/.yarn/versions/bd18fea1.yml
+++ b/.yarn/versions/bd18fea1.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -454,12 +454,15 @@ export class Project {
   }
 
   tryWorkspaceByDescriptor(descriptor: Descriptor) {
+    const workspace = this.tryWorkspaceByIdent(descriptor);
+
+    if (workspace === null)
+      return null;
+
     if (structUtils.isVirtualDescriptor(descriptor))
       descriptor = structUtils.devirtualizeDescriptor(descriptor);
 
-    const workspace = this.tryWorkspaceByIdent(descriptor);
-
-    if (workspace === null || !workspace.accepts(descriptor.range))
+    if (!workspace.accepts(descriptor.range))
       return null;
 
     return workspace;
@@ -475,11 +478,14 @@ export class Project {
   }
 
   tryWorkspaceByLocator(locator: Locator) {
+    const workspace = this.tryWorkspaceByIdent(locator);
+    if (workspace === null)
+      return null;
+
     if (structUtils.isVirtualLocator(locator))
       locator = structUtils.devirtualizeLocator(locator);
 
-    const workspace = this.tryWorkspaceByIdent(locator);
-    if (workspace === null || (workspace.locator.locatorHash !== locator.locatorHash && workspace.anchoredLocator.locatorHash !== locator.locatorHash))
+    if (workspace.locator.locatorHash !== locator.locatorHash && workspace.anchoredLocator.locatorHash !== locator.locatorHash)
       return null;
 
     return workspace;

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -455,7 +455,6 @@ export class Project {
 
   tryWorkspaceByDescriptor(descriptor: Descriptor) {
     const workspace = this.tryWorkspaceByIdent(descriptor);
-
     if (workspace === null)
       return null;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`Project.tryWorkspaceByDescriptor` and `Project.tryWorkspaceByLocator` devirtualizes the descriptor/locator even if the ident doesn't match a workspace.

**How did you fix it?**

Check if the descriptor/locator matches a workspace before devirtualizing them

**Result**

Tested on the Storybook repo using PnP
```
$ YARN_IGNORE_PATH=1 hyperfine -w 5 'nodejs before.js' 'nodejs after.js'
Benchmark #1: nodejs before.js
  Time (mean ± σ):      5.217 s ±  0.047 s    [User: 5.538 s, System: 1.219 s]
  Range (min … max):    5.179 s …  5.339 s    10 runs

Benchmark #2: nodejs after.js
  Time (mean ± σ):      5.156 s ±  0.013 s    [User: 5.535 s, System: 1.194 s]
  Range (min … max):    5.137 s …  5.176 s    10 runs

Summary
  'nodejs after.js' ran
    1.01 ± 0.01 times faster than 'nodejs before.js'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.