### PR TITLE
perf(plugin-pnp): only load package data when needed

### DIFF
--- a/.yarn/versions/a32be810.yml
+++ b/.yarn/versions/a32be810.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `PnpInstaller` fetches data about packages even if it isn't going to use it which slows down installs in monorepos

Depends on https://github.com/yarnpkg/berry/pull/2904

**How did you fix it?**

Only fetch the data if it will be used

**Result**

Tested on the Storybook repo using PnP

```
YARN_IGNORE_PATH=1 hyperfine -w 5 'node master.cjs' 'node PR-2904.cjs' 'node after.cjs'
Benchmark #1: node master.cjs
  Time (mean ± σ):      4.394 s ±  0.069 s    [User: 5.542 s, System: 1.059 s]
  Range (min … max):    4.284 s …  4.510 s    10 runs

Benchmark #2: node PR-2904.cjs
  Time (mean ± σ):      3.986 s ±  0.025 s    [User: 5.049 s, System: 0.976 s]
  Range (min … max):    3.955 s …  4.041 s    10 runs

Benchmark #3: node after.cjs
  Time (mean ± σ):      3.758 s ±  0.014 s    [User: 4.800 s, System: 0.887 s]
  Range (min … max):    3.736 s …  3.782 s    10 runs

Summary
  'node after.cjs' ran
    1.06 ± 0.01 times faster than 'node PR-2904.cjs'
    1.17 ± 0.02 times faster than 'node master.cjs'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.