### PR TITLE
ci: add preact cli e2e test

### DIFF
--- a/.github/workflows/e2e-preact-cli-workflow.yml
+++ b/.github/workflows/e2e-preact-cli-workflow.yml
@@ -1,0 +1,48 @@
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/workflows/e2e-preact-cli-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Preact CLI'
+jobs:
+  chore:
+    name: 'Validating Preact CLI'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: 'Install Node'
+      uses: actions/setup-node@master
+      with:
+        node-version: 14.x
+
+    - name: 'Build the standard bundle'
+      run: |
+        node ./scripts/run-yarn.js build:cli
+
+    - name: 'Running the integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        git clone https://github.com/preactjs-templates/default.git default
+        cd default/template
+        touch yarn.lock
+        echo $(cat package.json | jq '.name = "pnp-test"') > package.json
+        yarn
+        yarn build
+
+    - name: 'Running the TypeScript integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        git clone https://github.com/preactjs-templates/typescript.git default
+        cd default/template
+        touch yarn.lock
+        echo $(cat package.json | jq '.name = "pnp-test"') > package.json
+        yarn
+        yarn build

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ On top of our classic integration tests, we also run Yarn every day against the 
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Gatsby/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gatsby-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Next/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-next-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Vue-CLI/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-vue-cli-workflow.yml)<br/>
+[![](https://github.com/yarnpkg/berry/workflows/E2E%20Preact-CLI/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-preact-cli-workflow.yml)<br/>
 </td><td valign="top">
 
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20ESBuild/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-esbuild-workflow.yml)<br/>

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -132,6 +132,7 @@ A lot of very common frontend tools now support Plug'n'Play natively!
 | Jest | Starting from 24.1+ |
 | Next.js | Starting from 9.1.2+ |
 | Parcel | Starting from 2.0.0-nightly.212+ |
+| Preact CLI | Starting from 3.1.0+ |
 | Prettier | Starting from 1.17+ |
 | Rollup | Starting from `resolve` 1.9+ |
 | Storybook | Starting from 6.0+ |


### PR DESCRIPTION
**What's the problem this PR addresses?**

Preact CLI has PnP support now so we should have an e2e test to cover it
https://github.com/preactjs/preact-cli/pull/1418

**How did you fix it?**

Added a test

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.