### PR TITLE
chore(compat): tailwindcss related compat extensions

### DIFF
--- a/.yarn/versions/87f3c595.yml
+++ b/.yarn/versions/87f3c595.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -21,6 +21,12 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       [`tailwindcss`]: `^2.0.2`,
     },
   }],
+  // https://github.com/FullHuman/purgecss/commit/24116f394dc54c913e4fd254cf2d78c03db971f2
+  [`@fullhuman/postcss-purgecss@3.1.3`, {
+    peerDependencies: {
+      [`postcss`]: `^8.0.0`,
+    },
+  }],
   // https://github.com/SamVerschueren/stream-to-observable/pull/5
   [`@samverschueren/stream-to-observable@<0.3.1`, {
     peerDependenciesMeta: {

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -9,6 +9,18 @@ const optionalPeerDep = {
 };
 
 export const packageExtensions: Array<[string, PackageExtensionData]> = [
+  // https://github.com/tailwindlabs/tailwindcss-aspect-ratio/pull/14
+  [`@tailwindcss/aspect-ratio@<0.2.1`, {
+    peerDependencies: {
+      [`tailwindcss`]: `^2.0.2`,
+    },
+  }],
+  // https://github.com/tailwindlabs/tailwindcss-line-clamp/pull/6
+  [`@tailwindcss/line-clamp@<0.2.1`, {
+    peerDependencies: {
+      [`tailwindcss`]: `^2.0.2`,
+    },
+  }],
   // https://github.com/SamVerschueren/stream-to-observable/pull/5
   [`@samverschueren/stream-to-observable@<0.3.1`, {
     peerDependenciesMeta: {


### PR DESCRIPTION
**What's the problem this PR addresses?**
tailwindcss currently does not work with yarn PnP due to issues with a dependency and a couple plugins. This PR adds the necessary compat data for tailwindcss and all the official plugins to work out of the box.

...

**How did you fix it?**
For the official tailwindcss extensions, I submitted PRs to add the correct peer dependencies (https://github.com/tailwindlabs/tailwindcss-aspect-ratio/pull/14, https://github.com/tailwindlabs/tailwindcss-line-clamp/pull/6) that have since been accepted, and added compat data for older versions. There is also a specific version of postcss-purgecss that was missing a peer dependency for postcss, and tailwindcss is pinned to that version for compatibility reasons, so I added compat data for the specific version in question.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.