### PR TITLE
fix(builder): create output directory before building

### DIFF
--- a/.yarn/versions/04e0bcd3.yml
+++ b/.yarn/versions/04e0bcd3.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -1,6 +1,6 @@
 import {StreamReport, MessageName, Configuration, formatUtils, structUtils} from '@yarnpkg/core';
 import {pnpPlugin}                                                          from '@yarnpkg/esbuild-plugin-pnp';
-import {npath}                                                              from '@yarnpkg/fslib';
+import {npath, xfs}                                                         from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                                 from 'clipanion';
 import {build, Plugin}                                                      from 'esbuild-wasm';
 import fs                                                                   from 'fs';
@@ -61,6 +61,8 @@ export default class BuildPluginCommand extends Command {
     const name = getNormalizedName(rawName);
     const prettyName = structUtils.prettyIdent(configuration, structUtils.parseIdent(name));
     const output = path.join(basedir, `bundles/${name}.js`);
+
+    await xfs.mkdirPromise(npath.toPortablePath(path.dirname(output)), {recursive: true});
 
     const report = await StreamReport.start({
       configuration,


### PR DESCRIPTION
**What's the problem this PR addresses?**

On Windows esbuild doesn't create the output directory recursively

**How did you fix it?**

Create the directory before running the build

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.