### PR TITLE
fix(essentials): export `dedupeUtils` from `./dedupeUtils`

### DIFF
--- a/.yarn/versions/91427522.yml
+++ b/.yarn/versions/91427522.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -37,7 +37,7 @@ import up                                                       from './commands
 import why                                                      from './commands/why';
 import listWorkspaces                                           from './commands/workspaces/list';
 import workspace                                                from './commands/workspace';
-import * as dedupeUtils                                         from './suggestUtils';
+import * as dedupeUtils                                         from './dedupeUtils';
 import * as suggestUtils                                        from './suggestUtils';
 
 export {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/plugin-essentials` is exporting `suggestUtils.ts` as both `dedupeUtils` and `suggestUtils`

**How did you fix it?**

Correct the path for the `dedupeUtils` import

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.