### PR TITLE
ci(e2e): force pnp e2e tests to run with pnp linker

### DIFF
--- a/.github/workflows/e2e-nm-angular-workflow.yml
+++ b/.github/workflows/e2e-nm-angular-workflow.yml
@@ -48,12 +48,11 @@ jobs:
 
     - name: 'Running the integration test'
       run: |
-        source scripts/e2e-setup-ci.sh;
+        source scripts/e2e-setup-ci.sh nm
 
         yarn dlx -p @angular/cli@next ng new berry-angular --interactive=false
 
         cd berry-angular
-        echo 'nodeLinker: node-modules' >> .yarnrc.yml
         echo 'enableGlobalCache: true' >> .yarnrc.yml
         echo 'compressionLevel: 0' >> .yarnrc.yml
 

--- a/.github/workflows/e2e-nm-angular-workflow.yml
+++ b/.github/workflows/e2e-nm-angular-workflow.yml
@@ -53,10 +53,11 @@ jobs:
         yarn dlx -p @angular/cli@next ng new berry-angular --interactive=false
 
         cd berry-angular
-        echo 'enableGlobalCache: true' >> .yarnrc.yml
-        echo 'compressionLevel: 0' >> .yarnrc.yml
 
         yarn add @angular-devkit/core@next @babel/preset-env @babel/core -D
 
         yarn ng build --aot
       shell: bash
+      env:
+        YARN_ENABLE_GLOBAL_CACHE: true
+        YARN_COMPRESSION_LEVEL: 0

--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -48,8 +48,8 @@ jobs:
 
     - name: 'Running node_modules install with self-validation'
       run: |
-        source scripts/e2e-setup-ci.sh
+        source scripts/e2e-setup-ci.sh nm
         git clone https://github.com/babel/babel.git
         cd babel
-        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
+        NM_DEBUG_LEVEL=1 yarn
       shell: bash

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: 'Running node_modules install with self-validation'
       run: |
-        source scripts/e2e-setup-ci.sh
+        source scripts/e2e-setup-ci.sh nm
         cd -
-        NM_DEBUG_LEVEL=1 YARN_NODE_LINKER=node-modules yarn
+        NM_DEBUG_LEVEL=1 yarn
       shell: bash

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -28,12 +28,14 @@ git config --global user.name "John Doe"
 export NODE_OPTIONS="--unhandled-rejections=strict"
 
 if [[ "$1" == "nm" ]]; then
-  export YARN_NODE_LINKER="node-modules"
+  NODE_LINKER="node-modules"
 elif [[ -z "$1" || "$1" == "pnp" ]]; then
-  export YARN_NODE_LINKER="pnp"
+  NODE_LINKER="pnp"
 else
   echo "Invalid nodeLinker: $1"
   exit 1
 fi
 
-echo nodeLinker: $YARN_NODE_LINKER
+yarn config set -H nodeLinker "$NODE_LINKER"
+
+echo nodeLinker: $NODE_LINKER

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -35,3 +35,5 @@ else
   echo "Invalid nodeLinker: $1"
   exit 1
 fi
+
+echo nodeLinker: $YARN_NODE_LINKER

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -26,3 +26,12 @@ git config --global user.name "John Doe"
 
 # We want all e2e tests to fail on unhandled rejections
 export NODE_OPTIONS="--unhandled-rejections=strict"
+
+if [[ "$1" == "nm" ]]; then
+  export YARN_NODE_LINKER="node-modules"
+elif [[ -z "$1" || "$1" == "pnp" ]]; then
+  export YARN_NODE_LINKER="pnp"
+else
+  echo "Invalid nodeLinker: $1"
+  exit 1
+fi


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The gatsby e2e test has been unintentionally using the node-modules linker ever since we've started migrating projects with v1 lockfiles to v2 with nm.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Force all pnp e2e tests to use the pnp linker.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
