### PR TITLE
fix(esbuild-plugin-pnp): respect `external` field

### DIFF
--- a/.yarn/versions/7fbc3933.yml
+++ b/.yarn/versions/7fbc3933.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`esbuild-plugin-pnp` didn't take into account the `external` field.

Fixes #2838.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The plugin will now support both simple module identifiers (`clipanion`) and wildcards (`cli*anion`). We don't need to implement support for absolute paths as, from my testing, they don't affect modules at all.

I implemented support for wildcards using a very similar implementation to the one in ESBuild (which we can't use because it's internal).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
