### PR TITLE
docs: make explicit base64 encoding of auth ident

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -376,9 +376,9 @@
     },
     "npmAuthIdent": {
       "_package": "@yarnpkg/plugin-npm",
-      "description": "Defines the authentication credentials to use by default when accessing your registries (equivalent to `_auth` in the v1). This settings is strongly discouraged in favor of `npmAuthToken`.",
+      "description": "Defines the authentication credentials to use by default when accessing your registries (equivalent to `_auth` in the v1). This setting is strongly discouraged in favor of `npmAuthToken`.",
       "type": "string",
-      "examples": ["username:password"]
+      "examples": ["base64(username:password)"]
     },
     "npmAuthToken": {
       "_package": "@yarnpkg/plugin-npm",


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Docs seem to imply you can just pass `username:password` into npmAuthIdent, however this is typically sent via Basic HTTP which expects the value to be base64 encoded.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated docs to call out it should be base64 encoded. I was debating whether this is clear enough. Maybe readers will think you need to add the literal base64 prefix? in which case we can call this out in the description instead

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
