### PR TITLE
fix(pnpify): include wrapper for `tsserverlibrary.js` and return the entire `tsserver`

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -136,10 +136,10 @@ const moduleWrapper = tsserver => {
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require typescript/lib/tsserver.js
+    // Setup the environment to be able to require typescript/lib/tsserverlibrary.js
     require(absPnpApiPath).setup();
   }
 }
 
-// Defer to the real typescript/lib/tsserver.js your application uses
-module.exports = moduleWrapper(absRequire(`typescript/lib/tsserver.js`));
+// Defer to the real typescript/lib/tsserverlibrary.js your application uses
+module.exports = moduleWrapper(absRequire(`typescript/lib/tsserverlibrary.js`));

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "4.3.0-beta-pnpify",
+  "version": "4.3.2-pnpify",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/.yarn/versions/230b05c5.yml
+++ b/.yarn/versions/230b05c5.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -133,7 +133,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       const {onMessage: originalOnMessage, send: originalSend} = Session.prototype;
       let hostInfo = \`unknown\`;
 
-      return Object.assign(Session.prototype, {
+      Object.assign(Session.prototype, {
         onMessage(/** @type {string} */ message) {
           const parsedMessage = JSON.parse(message)
 
@@ -157,6 +157,8 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           })));
         }
       });
+
+      return tsserver;
     };
   `;
 
@@ -170,6 +172,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
   await wrapper.writeFile(`lib/tsc.js` as PortablePath);
   await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
   await wrapper.writeFile(`lib/typescript.js` as PortablePath);
+  await wrapper.writeFile(`lib/tsserverlibrary.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
 
   return wrapper;
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**

The TypeScript SDK doesn't include a wrapper around the `tsserverlibrary.js` file and only returns the Session instead of the entire lib in `tsserver`

Fixes https://github.com/yarnpkg/berry/issues/2986

**How did you fix it?**

Generate a wrapper for it and return the entire tsserver

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.