### PR TITLE
docs: PnP is supported with Gatsby 3.7.0+

### DIFF
--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -127,7 +127,7 @@ A lot of very common frontend tools now support Plug'n'Play natively!
 | Babel | Starting from `resolve` 1.9 |
 | Create-React-App | Starting from 2.0+ |
 | ESLint | Some compatibility issues w/ shared configs |
-| Gatsby | Starting from 2.15.0+ |
+| Gatsby | Supported with version ≥2.15.0, <3 |
 | Husky | Starting from 4.0.0-1+ |
 | Jest | Starting from 24.1+ |
 | Next.js | Starting from 9.1.2+ |

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -127,7 +127,7 @@ A lot of very common frontend tools now support Plug'n'Play natively!
 | Babel | Starting from `resolve` 1.9 |
 | Create-React-App | Starting from 2.0+ |
 | ESLint | Some compatibility issues w/ shared configs |
-| Gatsby | Supported with version ≥2.15.0, <3 |
+| Gatsby | Supported with version ≥2.15.0, ≥3.7.0 |
 | Husky | Starting from 4.0.0-1+ |
 | Jest | Starting from 24.1+ |
 | Next.js | Starting from 9.1.2+ |


### PR DESCRIPTION
**What's the problem this PR addresses?**
Gatsby's Yarn PnP version support information is misleading

**How did you fix it?**
I explicitly stated the fact that Gatsby v3 does not support Yarn PnP

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

**References**
- https://www.gatsbyjs.com/docs/reference/release-notes/v3.7/#yarn-2-pnp-support