### PR TITLE
fix(essentials): disallow linking a project to itself

### DIFF
--- a/.yarn/versions/31b9bbb3.yml
+++ b/.yarn/versions/31b9bbb3.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/link.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/link.test.js
@@ -190,5 +190,20 @@ describe(`Commands`, () => {
         });
       }),
     );
+
+    test(
+      `it should not allow linking a project to itself`,
+      makeTemporaryEnv(
+        {
+          name: `foo`,
+        },
+        async ({path, run, source}) => {
+          await expect(run(`link`, path)).rejects.toMatchObject({
+            code: 1,
+            stdout: expect.stringContaining(`Can't link the project to itself`),
+          });
+        }
+      )
+    );
   });
 });

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -54,6 +54,9 @@ export default class LinkCommand extends BaseCommand {
     const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
     const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
 
+    if (project.cwd === project2.cwd)
+      throw new UsageError(`Invalid destination; Can't link the project to itself`);
+
     if (!workspace2)
       throw new WorkspaceRequiredError(project2.cwd, absoluteDestination);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running `yarn link -Ap ~/foo` in PowerShell on Windows will link the current project to itself which most likely isn't what the user wanted to do.

**How did you fix it?**

Disallow linking a Project to itself

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.