### PR TITLE
docs: document `packageExtensions.<package>.peerDependenciesMeta`

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -535,13 +535,15 @@
                       "type": "boolean",
                       "examples": [true]
                     }
-                  }
+                  },
+                  "_exampleKeys": ["optional"]
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": false,
+              "_exampleKeys": ["webpack-cli"]
             }
           },
-          "_exampleKeys": ["dependencies", "peerDependencies"],
+          "_exampleKeys": ["dependencies", "peerDependencies", "peerDependenciesMeta"],
           "_margin": false
         }
       },

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -490,29 +490,6 @@
               "additionalProperties": false,
               "_exampleKeys": ["lodash"]
             },
-            "dependenciesMeta": {
-              "type": "object",
-              "patternProperties": {
-                "^(?:@([^/]+?)/)?([^/]+?)$": {
-                  "type": "object",
-                  "properties": {
-                    "built": {
-                      "type": "boolean",
-                      "examples": [false]
-                    },
-                    "optional": {
-                      "type": "boolean",
-                      "examples": [false]
-                    },
-                    "unplugged": {
-                      "type": "boolean",
-                      "examples": [true]
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            },
             "peerDependencies": {
               "type": "object",
               "patternProperties": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

- `packageExtensions.<package>.peerDependenciesMeta` isn't documented on the website
- `packageExtensions.<package>.dependenciesMeta` is in the yaml manifest but isn't a valid setting

Fixes https://github.com/yarnpkg/berry/issues/1658

**How did you fix it?**

- Added some example keys so its visible
- Removed it

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.