### PR TITLE
fix: allow running `yarn config set --home` from arbitrary folders

### DIFF
--- a/.yarn/versions/37951b26.yml
+++ b/.yarn/versions/37951b26.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
@@ -1,5 +1,5 @@
-import {xfs} from '@yarnpkg/fslib';
-import {EOL} from 'os';
+import {PortablePath, xfs} from '@yarnpkg/fslib';
+import {EOL}               from 'os';
 
 describe(`Commands`, () => {
   describe(`config set`, () => {
@@ -10,7 +10,7 @@ describe(`Commands`, () => {
           stdout: expect.stringContaining(`#!/usr/bin/env iojs\\n`),
         });
 
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`pnpShebang`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml` as PortablePath, `utf8`)).resolves.toContain(`pnpShebang`);
       }),
     );
 
@@ -22,7 +22,7 @@ describe(`Commands`, () => {
         expect(stdout).not.toContain(`foobar`);
         expect(stdout).toContain(`********`);
 
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(`npmAuthToken: foobar`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml` as PortablePath, `utf8`)).resolves.toContain(`npmAuthToken: foobar`);
       }),
     );
 
@@ -36,11 +36,22 @@ describe(`Commands`, () => {
         expect(stdout).toContain(`npmScopes.yarnpkg`);
         expect(stdout).toContain(`npmAlwaysAuth: false`);
 
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toContain(
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml` as PortablePath, `utf8`)).resolves.toContain(
           `npmScopes:${EOL}` +
           `  yarnpkg:${EOL}` +
           `    npmAlwaysAuth: false`,
         );
+      }),
+    );
+
+    test(
+      `it should allow running the command from arbitrary folders if the -H,--home option is set`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmpDir = await xfs.mktempPromise();
+
+        await expect(run(`config`, `set`, `--home`, `pnpShebang`, `#!/usr/bin/env iojs\n`, {cwd: tmpDir})).resolves.toMatchObject({
+          code: 0,
+        });
       }),
     );
   });

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -55,8 +55,13 @@ export default class ConfigSetCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    if (!configuration.projectCwd)
-      throw new UsageError(`This command must be run from within a project folder`);
+
+    const assertProjectCwd = () => {
+      if (!configuration.projectCwd)
+        throw new UsageError(`This command must be run from within a project folder`);
+
+      return configuration.projectCwd;
+    };
 
     const name = this.name.replace(/[.[].*$/, ``);
     const path = this.name.replace(/^[^.[]*\.?/, ``);
@@ -72,7 +77,7 @@ export default class ConfigSetCommand extends BaseCommand {
     const updateConfiguration: (patch: ((current: any) => any)) => Promise<void> =
       this.home
         ? patch => Configuration.updateHomeConfiguration(patch)
-        : patch => Configuration.updateConfiguration(configuration.projectCwd!, patch);
+        : patch => Configuration.updateConfiguration(assertProjectCwd(), patch);
 
     await updateConfiguration(current => {
       if (path) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Running `yarn config set --home` from a non-project folder throws an error.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it skip throwing the error when the `-H,--home` flag is used.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
