### PR TITLE
docs: fully document `networkSettings`

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -342,7 +342,7 @@
               "$ref": "#/properties/httpsProxy"
             }
           },
-          "_exampleKeys": ["caFilePath"]
+          "_exampleKeys": ["caFilePath", "enableNetwork", "httpProxy", "httpsProxy"]
         }
       },
       "_exampleKeys": ["*.example.com"]


### PR DESCRIPTION
**What's the problem this PR addresses?**

I forgot to add example keys when I implemented `networkSettings.foo.enableNetwork` in https://github.com/yarnpkg/berry/pull/2030 and `networkSettings.foo.http(s)Proxy` in https://github.com/yarnpkg/berry/pull/2156 so they're not visible on the website

**How did you fix it?**

Added the missing `_exampleKeys` values

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.