### PR TITLE
refactor(pkg-tests-core): strongly typed run option bag

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -536,7 +536,7 @@ export type RunFunction = (
   {path, run, source}:
   {
     path: PortablePath,
-    run: (...args: Array<any>) => Promise<ExecResult>,
+    run: (...args: Array<string> | [...Array<string>, Partial<RunDriverOptions>]) => Promise<ExecResult>,
     source: (script: string, callDefinition?: Record<string, any>) => Promise<Record<string, any>>
   }
 ) => void;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/initFields.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/initFields.test.ts
@@ -20,7 +20,7 @@ describe(`Features`, () => {
           await xfs.mkdirpPromise(`${tmp}/my-package` as PortablePath);
 
           await run(`init`, {
-            cwd: `${tmp}/my-package`,
+            cwd: `${tmp}/my-package` as PortablePath,
           });
 
           await expect(xfs.readJsonPromise(`${tmp}/my-package/package.json` as PortablePath)).resolves.toMatchObject({
@@ -50,7 +50,7 @@ describe(`Features`, () => {
           await xfs.mkdirpPromise(`${tmp}/my-package` as PortablePath);
 
           await run(`init`, {
-            cwd: `${tmp}/my-package`,
+            cwd: `${tmp}/my-package` as PortablePath,
           });
 
           await expect(xfs.readJsonPromise(`${tmp}/my-package/package.json` as PortablePath)).resolves.toMatchObject({
@@ -82,7 +82,7 @@ describe(`Features`, () => {
           await xfs.mkdirpPromise(`${tmp}/my-package` as PortablePath);
 
           await run(`init`, {
-            cwd: `${tmp}/my-package`,
+            cwd: `${tmp}/my-package` as PortablePath,
           });
 
           await expect(xfs.readJsonPromise(`${tmp}/my-package/package.json` as PortablePath)).resolves.toMatchObject({
@@ -109,7 +109,7 @@ describe(`Features`, () => {
           await xfs.mkdirpPromise(`${tmp}/my-package` as PortablePath);
 
           await run(`init`, {
-            cwd: `${tmp}/my-package`,
+            cwd: `${tmp}/my-package` as PortablePath,
           });
 
           await expect(xfs.readJsonPromise(`${tmp}/my-package/package.json` as PortablePath)).resolves.toMatchObject({

--- a/packages/acceptance-tests/pkg-tests-specs/sources/workspace.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/workspace.test.ts
@@ -242,7 +242,7 @@ describe(`Workspaces tests`, () => {
 
         await expect(
           run(`run`, `has-bin-entries`, `foo`, {
-            cwd: `${path}/packages/workspace`,
+            cwd: `${path}/packages/workspace` as PortablePath,
           }),
         ).resolves.toMatchObject({stdout: `foo\n`});
       },


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Something that has been bothering me for a long time: the lack of editor completions when using the `run` function in tests.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By strongly typing it.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
