### PR TITLE
perf: reduce the amount of URL parsing

### DIFF
--- a/.yarn/versions/ee01ac4d.yml
+++ b/.yarn/versions/ee01ac4d.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -65,15 +65,8 @@ export async function get(path: string, {configuration, headers, ident, authType
   if (auth)
     headers = {...headers, authorization: auth};
 
-  let url;
   try {
-    url = new URL(path);
-  } catch (e) {
-    url = new URL(registry + path);
-  }
-
-  try {
-    return await httpUtils.get(url.href, {configuration, headers, ...rest});
+    return await httpUtils.get(path.charAt(0) === `/` ? `${registry}${path}` : path, {configuration, headers, ...rest});
   } catch (error) {
     await handleInvalidAuthenticationError(error, {registry, configuration, headers});
 

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -110,7 +110,7 @@ async function prettyNetworkError(response: Promise<Response<any>>, {configurati
 /**
  * Searches through networkSettings and returns the most specific match
  */
-export function getNetworkSettings(target: string, opts: { configuration: Configuration }) {
+export function getNetworkSettings(target: string | URL, opts: { configuration: Configuration }) {
   // Sort the config by key length to match on the most specific pattern
   const networkSettings = [...opts.configuration.get(`networkSettings`)].sort(([keyA], [keyB]) => {
     return keyB.length - keyA.length;
@@ -128,7 +128,7 @@ export function getNetworkSettings(target: string, opts: { configuration: Config
 
   const mergableKeys = Object.keys(mergedNetworkSettings) as Array<keyof NetworkSettingsType>;
 
-  const url = new URL(target);
+  const url = typeof target === `string` ? new URL(target) : target;
   for (const [glob, config] of networkSettings) {
     if (micromatch.isMatch(url.hostname, glob)) {
       for (const key of mergableKeys) {
@@ -171,12 +171,13 @@ export type Options = {
   method?: Method,
 };
 
-export async function request(target: string, body: Body, {configuration, headers, jsonRequest, jsonResponse, method = Method.GET}: Omit<Options, 'customErrorMessage'>) {
-  const networkConfig = getNetworkSettings(target, {configuration});
-  if (networkConfig.enableNetwork === false)
-    throw new Error(`Request to '${target}' has been blocked because of your configuration settings`);
+export async function request(target: string | URL, body: Body, {configuration, headers, jsonRequest, jsonResponse, method = Method.GET}: Omit<Options, 'customErrorMessage'>) {
+  const url = typeof target === `string`  ? new URL(target) : target;
 
-  const url = new URL(target);
+  const networkConfig = getNetworkSettings(url, {configuration});
+  if (networkConfig.enableNetwork === false)
+    throw new Error(`Request to '${url.href}' has been blocked because of your configuration settings`);
+
   if (url.protocol === `http:` && !micromatch.isMatch(url.hostname, configuration.get(`unsafeHttpWhitelist`)))
     throw new Error(`Unsafe http requests must be explicitly whitelisted in your configuration (${url.hostname})`);
 
@@ -227,7 +228,7 @@ export async function request(target: string, body: Body, {configuration, header
   });
 
   return configuration.getLimit(`networkConcurrency`)(() => {
-    return gotClient(target) as unknown as Response<any>;
+    return gotClient(url) as unknown as Response<any>;
   });
 }
 

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -172,7 +172,7 @@ export type Options = {
 };
 
 export async function request(target: string | URL, body: Body, {configuration, headers, jsonRequest, jsonResponse, method = Method.GET}: Omit<Options, 'customErrorMessage'>) {
-  const url = typeof target === `string`  ? new URL(target) : target;
+  const url = typeof target === `string` ? new URL(target) : target;
 
   const networkConfig = getNetworkSettings(url, {configuration});
   if (networkConfig.enableNetwork === false)


### PR DESCRIPTION
**What's the problem this PR addresses?**

Parsing URLs is expensive

**How did you fix it?**

- Reuse URL instances by making some methods accept a `string | URL` and passing the parsed URL to them
- Avoid parsing known invalid URLs

**Result**

Tested on the Gatsby benchmark with a cached registry to avoid external network latency and a hot cache to only measure the time spent on resolution

```
YARN_IGNORE_PATH=1 hyperfine -w 1 --prepare="rm -rf yarn.lock .yarn" "node before.cjs --skip-builds" "node after.cjs --skip-builds"
Benchmark #1: node before.cjs --skip-builds
  Time (mean ± σ):     10.702 s ±  0.067 s    [User: 11.845 s, System: 1.473 s]
  Range (min … max):   10.631 s … 10.856 s    10 runs

Benchmark #2: node after.cjs --skip-builds
  Time (mean ± σ):     10.609 s ±  0.056 s    [User: 11.490 s, System: 1.525 s]
  Range (min … max):   10.521 s … 10.698 s    10 runs

Summary
  'node after.cjs --skip-builds' ran
    1.01 ± 0.01 times faster than 'node before.cjs --skip-builds'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.