### PR TITLE
fix: normalize registry when indexing into registry config

### DIFF
--- a/.yarn/versions/816bc982.yml
+++ b/.yarn/versions/816bc982.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -46,12 +46,13 @@ export function getDefaultRegistry({configuration, type = RegistryType.FETCH_REG
 
 export function getRegistryConfiguration(registry: string, {configuration}: {configuration: Configuration}): MapLike | null {
   const registryConfigurations = configuration.get(`npmRegistries`);
+  const normalizedRegistry = normalizeRegistry(registry);
 
-  const exactEntry = registryConfigurations.get(registry);
+  const exactEntry = registryConfigurations.get(normalizedRegistry);
   if (typeof exactEntry !== `undefined`)
     return exactEntry;
 
-  const noProtocolEntry = registryConfigurations.get(registry.replace(/^[a-z]+:/, ``));
+  const noProtocolEntry = registryConfigurations.get(normalizedRegistry.replace(/^[a-z]+:/, ``));
   if (typeof noProtocolEntry !== `undefined`)
     return noProtocolEntry;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I am using npmHttpUtils.get in another open source project, and am passing a registry url with a trailing slash. Since Yarn normalizes the trailing slashes in the config, it doesn't match any credentials. I can normalize the url before passing it to yarn using the normalize function, however the nature of the normalization seems like an implementation detail, and we also normalize in some other functions in the config utils file.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Normalize the URL that we use to index into the npmRegistries map, so both the index and the Map keys have undergone the same transformation.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
