### PR TITLE
export versionUtils from @yarnpkg/plugin-version

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -14714,7 +14714,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
             ["@yarnpkg/libui", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-libui"],
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
-            ["@yarnpkg/plugin-pack", "virtual:c44c4b6360dc34d25da6d32e39622e7e40f36f37b99dc66b6ebbd615fdd49465f496bf10f81b6fa5f71b95443fda61174ad51d2799fc7ca433af9a9666cd0f37#workspace:packages/plugin-pack"],
             ["clipanion", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:3.0.0-rc.10"],
             ["ink", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#npm:3.0.8"],
             ["react", "npm:16.13.1"],

--- a/.yarn/versions/2cb94862.yml
+++ b/.yarn/versions/2cb94862.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": minor

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -15,8 +15,7 @@
   },
   "peerDependencies": {
     "@yarnpkg/cli": "^3.0.0-rc.5",
-    "@yarnpkg/core": "^3.0.0-rc.5",
-    "@yarnpkg/plugin-pack": "^3.0.0-rc.5"
+    "@yarnpkg/core": "^3.0.0-rc.5"
   },
   "devDependencies": {
     "@types/react": "^16.8.0",
@@ -24,7 +23,6 @@
     "@yarnpkg/builder": "workspace:*",
     "@yarnpkg/cli": "workspace:*",
     "@yarnpkg/core": "workspace:*",
-    "@yarnpkg/plugin-pack": "workspace:*",
     "typescript": "^4.3.2"
   },
   "scripts": {

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -4,6 +4,9 @@ import {PortablePath}         from '@yarnpkg/fslib';
 import versionApply           from './commands/version/apply';
 import versionCheck           from './commands/version/check';
 import version                from './commands/version';
+import * as versionUtils      from './versionUtils';
+
+export {versionUtils};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5988,7 +5988,6 @@ __metadata:
     "@yarnpkg/fslib": "workspace:^2.5.0-rc.5"
     "@yarnpkg/libui": "workspace:^2.1.2-rc.5"
     "@yarnpkg/parsers": "workspace:^2.4.0-rc.3"
-    "@yarnpkg/plugin-pack": "workspace:*"
     clipanion: ^3.0.0-rc.10
     ink: ^3.0.8
     react: ^16.13.1
@@ -5998,7 +5997,6 @@ __metadata:
   peerDependencies:
     "@yarnpkg/cli": ^3.0.0-rc.5
     "@yarnpkg/core": ^3.0.0-rc.5
-    "@yarnpkg/plugin-pack": ^3.0.0-rc.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
Title is self-explanatory. I'm currently attempting to make a plugin that reuses parts of the release flow, but I can't import `versionUtils` at runtime.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
I followed the same pattern as the other plugins for exporting utils under a namespace.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
