### PR TITLE
fix(builder): pass full request path to isDynamicLib

### DIFF
--- a/.yarn/versions/062c5159.yml
+++ b/.yarn/versions/062c5159.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -80,7 +80,7 @@ export default class BuildPluginCommand extends Command {
                 return undefined;
 
               const [, dependencyName] = dependencyNameMatch;
-              if (dependencyName === name || !isDynamicLib(dependencyName))
+              if (dependencyName === name || !isDynamicLib(args.path))
                 return undefined;
 
               return {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
Plugins can't bundle deep imports to dynamic libs where they could before. I have some Yarn 2 plugins that depend on some of `@yarnpkg/core`'s internals.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
This appears to be a regression from the refactoring in #2717. Previously, `isDynamicLib` was passed the full request path, but now it only receives the package ident. I think the old behavior was more desirable as Yarn would bundle the internal code into the plugin bundle, now it just prints this at runtime:
```
This plugin cannot access the package referenced via @yarnpkg/core/... which is neither a builtin, nor an exposed entry
```


...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
