### PR TITLE
Support PnP with Neovim native LSP

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -72,6 +72,14 @@ const moduleWrapper = tsserver => {
             str = resolve(`zipfile:${str}`);
           } break;
 
+          // Support neovim native LSP and [typescript-language-server](https://github.com/theia-ide/typescript-language-server)
+          // We have to resolve the actual file system path from virtual path,
+          // everything else is up to neovim
+          case `neovim`: {
+            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+            str = `zipfile:${str}`;
+          } break;
+
           default: {
             str = `zip:${str}`;
           } break;

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -72,6 +72,14 @@ const moduleWrapper = tsserver => {
             str = resolve(`zipfile:${str}`);
           } break;
 
+          // Support neovim native LSP and [typescript-language-server](https://github.com/theia-ide/typescript-language-server)
+          // We have to resolve the actual file system path from virtual path,
+          // everything else is up to neovim
+          case `neovim`: {
+            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+            str = `zipfile:${str}`;
+          } break;
+
           default: {
             str = `zip:${str}`;
           } break;

--- a/.yarn/versions/ac97a50e.yml
+++ b/.yarn/versions/ac97a50e.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -78,6 +78,49 @@ yarn dlx @yarnpkg/pnpify --sdk base
 
 With the `.yarn/sdks` in place TypeScript support should work out of the box with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) and [theia-ide/typescript-language-server](https://github.com/theia-ide/typescript-language-server).
 
+##### Supporting go-to-definition et al.
+
+As well as the [vim-rzip](https://github.com/lbrayner/vim-rzip) plugin you'll also need the following snippet to handle Yarn PnP's URIs emitted from [theia-ide/typescript-language-server](https://github.com/theia-ide/typescript-language-server). See [lbrayner/vim-rzip#15](https://github.com/lbrayner/vim-rzip/issues/15) for further details.
+
+```vim
+" Decode URI encoded characters
+function! DecodeURI(uri)
+    return substitute(a:uri, '%\([a-fA-F0-9][a-fA-F0-9]\)', '\=nr2char("0x" . submatch(1))', "g")
+endfunction
+
+" Attempt to clear non-focused buffers with matching name
+function! ClearDuplicateBuffers(uri)
+    " if our filename has URI encoded characters
+    if DecodeURI(a:uri) !=# a:uri
+        " wipeout buffer with URI decoded name - can print error if buffer in focus
+        sil! exe "bwipeout " . fnameescape(DecodeURI(a:uri))
+        " change the name of the current buffer to the URI decoded name
+        exe "keepalt file " . fnameescape(DecodeURI(a:uri))
+        " ensure we don't have any open buffer matching non-URI decoded name
+        sil! exe "bwipeout " . fnameescape(a:uri)
+    endif
+endfunction
+
+function! RzipOverride()
+    " Disable vim-rzip's autocommands
+    autocmd! zip BufReadCmd   zipfile:*,zipfile:*/*
+    exe "au! zip BufReadCmd ".g:zipPlugin_ext
+
+    " order is important here, setup name of new buffer correctly then fallback to vim-rzip's handling
+    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<amatch>"))
+    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+
+    if has("unix")
+        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<amatch>"))
+        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+    endif
+
+    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<amatch>')))"
+endfunction
+
+autocmd VimEnter * call RzipOverride()
+```
+
 ### Emacs
 
 The SDK comes with a typescript-language-server wrapper which enables you to use the ts-ls LSP client.

--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -56,13 +56,27 @@ Your VSCode project is now configured to use the exact same version of TypeScrip
 
 Note that VSCode might ask you to do Step 3 again from time to time, but apart from that your experience should be mostly the same as usual. Happy development!
 
-### VIM / coc.nvim
+### VIM
 
-Run the following command, which will generate a new directory called `.yarn/sdks`:
+To support features like go-to-definition a plugin like [vim-rzip](https://github.com/lbrayner/vim-rzip) is needed.
+
+#### coc.nvim
+
+Run the following command, which will generate a new directory called `.yarn/sdks` and create a `.vim/coc-settings.json` file:
 
 ```bash
 yarn dlx @yarnpkg/pnpify --sdk vim
 ```
+
+#### Neovim Native LSP
+
+Run the following command, which will generate a new directory called `.yarn/sdks`:
+
+```bash
+yarn dlx @yarnpkg/pnpify --sdk base
+```
+
+With the `.yarn/sdks` in place TypeScript support should work out of the box with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) and [theia-ide/typescript-language-server](https://github.com/theia-ide/typescript-language-server).
 
 ### Emacs
 

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -99,6 +99,14 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
                 str = resolve(\`zipfile:\${str}\`);
               } break;
 
+              // Support neovim native LSP and [typescript-language-server](https://github.com/theia-ide/typescript-language-server)
+              // We have to resolve the actual file system path from virtual path,
+              // everything else is up to neovim
+              case \`neovim\`: {
+                str = normalize(resolved).replace(/\\.zip\\//, \`.zip::\`);
+                str = \`zipfile:\${str}\`;
+              } break;
+
               default: {
                 str = \`zip:\${str}\`;
               } break;


### PR DESCRIPTION
Linked to https://github.com/theia-ide/typescript-language-server/pull/220

**What's the problem this PR addresses?**
Neovim's native LSP client uses [theia-ide/typescript-language-server](https://github.com/theia-ide/typescript-language-server) to wrap `tsserver`. For go-to-definition to work yarn needs to resolve virtual filepaths to on-disk paths for neovim to open.

**How did you fix it?**
Followed example of how the issues was fixed for other editor implementations
https://github.com/yarnpkg/berry/pull/2598

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
