### PR TITLE
fix(core): handle UNC path on Windows when locating workspaces

### DIFF
--- a/.yarn/versions/69f77a2e.yml
+++ b/.yarn/versions/69f77a2e.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -64,7 +64,6 @@ export class Workspace {
     const patterns = this.manifest.workspaceDefinitions.map(({pattern}) => pattern);
 
     const relativeCwds = await globby(patterns, {
-      absolute: true,
       cwd: npath.fromPortablePath(this.cwd),
       expandDirectories: false,
       onlyDirectories: true,


### PR DESCRIPTION
**What's the problem this PR addresses?**

When `globby` returns absolute paths from a UNC directory it returns the paths with forward slashes which isn't valid making Yarn unable to locate workspaces.

**How did you fix it?**

Use relative paths so they can be joined with the cwd correctly

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.