### PR TITLE
feat(shell): implement redirection from file descriptors

### DIFF
--- a/.yarn/versions/0467df86.yml
+++ b/.yarn/versions/0467df86.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/parsers": minor
+  "@yarnpkg/plugin-essentials": minor
+  "@yarnpkg/shell": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-parsers/sources/grammars/shell.d.ts
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.d.ts
@@ -20,6 +20,7 @@ export type Argument =
 export type RedirectArgument = {
   type: `redirection`,
   subtype: `>` | `<` | '>&' | '<&' | `>>` | `<<<`,
+  fd: number | null,
   args: Array<ValueArgument>
 };
 

--- a/packages/yarnpkg-parsers/sources/grammars/shell.js
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.js
@@ -179,50 +179,50 @@ function peg$parse(input, options) {
       peg$c35 = function(envs) { return { type: `envs`, envs } },
       peg$c36 = function(args) { return args },
       peg$c37 = function(arg) { return arg },
-      peg$c38 = function(redirect, arg) { return { type: `redirection`, subtype: redirect, args: [arg] } },
-      peg$c39 = ">>",
-      peg$c40 = peg$literalExpectation(">>", false),
-      peg$c41 = ">&",
-      peg$c42 = peg$literalExpectation(">&", false),
-      peg$c43 = ">",
-      peg$c44 = peg$literalExpectation(">", false),
-      peg$c45 = "<<<",
-      peg$c46 = peg$literalExpectation("<<<", false),
-      peg$c47 = "<&",
-      peg$c48 = peg$literalExpectation("<&", false),
-      peg$c49 = "<",
-      peg$c50 = peg$literalExpectation("<", false),
-      peg$c51 = function(segments) { return { type: `argument`, segments: [].concat(... segments) } },
-      peg$c52 = function(string) { return string },
-      peg$c53 = "'",
-      peg$c54 = peg$literalExpectation("'", false),
-      peg$c55 = function(text) { return [ { type: `text`, text } ] },
-      peg$c56 = "\"",
-      peg$c57 = peg$literalExpectation("\"", false),
-      peg$c58 = function(segments) { return segments },
-      peg$c59 = function(arithmetic) { return { type: `arithmetic`, arithmetic, quoted: true} },
-      peg$c60 = function(shell) { return { type: `shell`, shell, quoted: true } },
-      peg$c61 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
-      peg$c62 = function(text) { return { type: `text`, text } },
-      peg$c63 = function(arithmetic) { return { type: `arithmetic`, arithmetic, quoted: false} },
-      peg$c64 = function(shell) { return { type: `shell`, shell, quoted: false } },
-      peg$c65 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
-      peg$c66 = function(pattern) { return { type: `glob`, pattern } },
-      peg$c67 = "\\",
-      peg$c68 = peg$literalExpectation("\\", false),
-      peg$c69 = peg$anyExpectation(),
-      peg$c70 = function(c) { return c },
-      peg$c71 = /^[^']/,
-      peg$c72 = peg$classExpectation(["'"], true, false),
-      peg$c73 = function(chars) { return chars.join(``) },
-      peg$c74 = /^[^$"]/,
-      peg$c75 = peg$classExpectation(["$", "\""], true, false),
-      peg$c76 = "-",
-      peg$c77 = peg$literalExpectation("-", false),
-      peg$c78 = "+",
-      peg$c79 = peg$literalExpectation("+", false),
-      peg$c80 = /^[0-9]/,
-      peg$c81 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c38 = /^[0-9]/,
+      peg$c39 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c40 = function(fd, redirect, arg) { return { type: `redirection`, subtype: redirect, fd: fd !== null ? parseInt(fd) : null, args: [arg] } },
+      peg$c41 = ">>",
+      peg$c42 = peg$literalExpectation(">>", false),
+      peg$c43 = ">&",
+      peg$c44 = peg$literalExpectation(">&", false),
+      peg$c45 = ">",
+      peg$c46 = peg$literalExpectation(">", false),
+      peg$c47 = "<<<",
+      peg$c48 = peg$literalExpectation("<<<", false),
+      peg$c49 = "<&",
+      peg$c50 = peg$literalExpectation("<&", false),
+      peg$c51 = "<",
+      peg$c52 = peg$literalExpectation("<", false),
+      peg$c53 = function(segments) { return { type: `argument`, segments: [].concat(... segments) } },
+      peg$c54 = function(string) { return string },
+      peg$c55 = "'",
+      peg$c56 = peg$literalExpectation("'", false),
+      peg$c57 = function(text) { return [ { type: `text`, text } ] },
+      peg$c58 = "\"",
+      peg$c59 = peg$literalExpectation("\"", false),
+      peg$c60 = function(segments) { return segments },
+      peg$c61 = function(arithmetic) { return { type: `arithmetic`, arithmetic, quoted: true} },
+      peg$c62 = function(shell) { return { type: `shell`, shell, quoted: true } },
+      peg$c63 = function(variable) { return { type: `variable`, ...variable, quoted: true } },
+      peg$c64 = function(text) { return { type: `text`, text } },
+      peg$c65 = function(arithmetic) { return { type: `arithmetic`, arithmetic, quoted: false} },
+      peg$c66 = function(shell) { return { type: `shell`, shell, quoted: false } },
+      peg$c67 = function(variable) { return { type: `variable`, ...variable, quoted: false } },
+      peg$c68 = function(pattern) { return { type: `glob`, pattern } },
+      peg$c69 = "\\",
+      peg$c70 = peg$literalExpectation("\\", false),
+      peg$c71 = peg$anyExpectation(),
+      peg$c72 = function(c) { return c },
+      peg$c73 = /^[^']/,
+      peg$c74 = peg$classExpectation(["'"], true, false),
+      peg$c75 = function(chars) { return chars.join(``) },
+      peg$c76 = /^[^$"]/,
+      peg$c77 = peg$classExpectation(["$", "\""], true, false),
+      peg$c78 = "-",
+      peg$c79 = peg$literalExpectation("-", false),
+      peg$c80 = "+",
+      peg$c81 = peg$literalExpectation("+", false),
       peg$c82 = ".",
       peg$c83 = peg$literalExpectation(".", false),
       peg$c84 = function(sign, left, right) { return { type: `number`, value: (sign === '-' ? -1 : 1) * parseFloat(left.join(``) + `.` + right.join(``)) } },
@@ -1269,7 +1269,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseRedirectArgument() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = [];
@@ -1279,13 +1279,28 @@ function peg$parse(input, options) {
       s2 = peg$parseS();
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseRedirectType();
+      if (peg$c38.test(input.charAt(peg$currPos))) {
+        s2 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseValueArgument();
+        s3 = peg$parseRedirectType();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c38(s2, s3);
-          s0 = s1;
+          s4 = peg$parseValueArgument();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c40(s2, s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1305,52 +1320,52 @@ function peg$parse(input, options) {
   function peg$parseRedirectType() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c39) {
-      s0 = peg$c39;
+    if (input.substr(peg$currPos, 2) === peg$c41) {
+      s0 = peg$c41;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c40); }
+      if (peg$silentFails === 0) { peg$fail(peg$c42); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c41) {
-        s0 = peg$c41;
+      if (input.substr(peg$currPos, 2) === peg$c43) {
+        s0 = peg$c43;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c42); }
+        if (peg$silentFails === 0) { peg$fail(peg$c44); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s0 = peg$c43;
+          s0 = peg$c45;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c45) {
-            s0 = peg$c45;
+          if (input.substr(peg$currPos, 3) === peg$c47) {
+            s0 = peg$c47;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c46); }
+            if (peg$silentFails === 0) { peg$fail(peg$c48); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c47) {
-              s0 = peg$c47;
+            if (input.substr(peg$currPos, 2) === peg$c49) {
+              s0 = peg$c49;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c48); }
+              if (peg$silentFails === 0) { peg$fail(peg$c50); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 60) {
-                s0 = peg$c49;
+                s0 = peg$c51;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                if (peg$silentFails === 0) { peg$fail(peg$c52); }
               }
             }
           }
@@ -1405,7 +1420,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c51(s1);
+      s1 = peg$c53(s1);
     }
     s0 = s1;
 
@@ -1419,7 +1434,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSglQuoteString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c52(s1);
+      s1 = peg$c54(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1427,7 +1442,7 @@ function peg$parse(input, options) {
       s1 = peg$parseDblQuoteString();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s1);
+        s1 = peg$c54(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1435,7 +1450,7 @@ function peg$parse(input, options) {
         s1 = peg$parsePlainString();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c52(s1);
+          s1 = peg$c54(s1);
         }
         s0 = s1;
       }
@@ -1449,25 +1464,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c53;
+      s1 = peg$c55;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
+      if (peg$silentFails === 0) { peg$fail(peg$c56); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSglQuoteStringText();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c53;
+          s3 = peg$c55;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c54); }
+          if (peg$silentFails === 0) { peg$fail(peg$c56); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c55(s2);
+          s1 = peg$c57(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1490,11 +1505,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c56;
+      s1 = peg$c58;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
+      if (peg$silentFails === 0) { peg$fail(peg$c59); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1505,15 +1520,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c56;
+          s3 = peg$c58;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c57); }
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c58(s2);
+          s1 = peg$c60(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1547,7 +1562,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c58(s1);
+      s1 = peg$c60(s1);
     }
     s0 = s1;
 
@@ -1561,7 +1576,7 @@ function peg$parse(input, options) {
     s1 = peg$parseArithmetic();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c59(s1);
+      s1 = peg$c61(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1569,7 +1584,7 @@ function peg$parse(input, options) {
       s1 = peg$parseSubshell();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c60(s1);
+        s1 = peg$c62(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1577,7 +1592,7 @@ function peg$parse(input, options) {
         s1 = peg$parseVariable();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c61(s1);
+          s1 = peg$c63(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -1585,7 +1600,7 @@ function peg$parse(input, options) {
           s1 = peg$parseDblQuoteStringText();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c62(s1);
+            s1 = peg$c64(s1);
           }
           s0 = s1;
         }
@@ -1602,7 +1617,7 @@ function peg$parse(input, options) {
     s1 = peg$parseArithmetic();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c63(s1);
+      s1 = peg$c65(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1610,7 +1625,7 @@ function peg$parse(input, options) {
       s1 = peg$parseSubshell();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c64(s1);
+        s1 = peg$c66(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1618,7 +1633,7 @@ function peg$parse(input, options) {
         s1 = peg$parseVariable();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c65(s1);
+          s1 = peg$c67(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -1626,7 +1641,7 @@ function peg$parse(input, options) {
           s1 = peg$parseGlob();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c66(s1);
+            s1 = peg$c68(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -1634,7 +1649,7 @@ function peg$parse(input, options) {
             s1 = peg$parsePlainStringText();
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c62(s1);
+              s1 = peg$c64(s1);
             }
             s0 = s1;
           }
@@ -1652,11 +1667,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c67;
+      s3 = peg$c69;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      if (peg$silentFails === 0) { peg$fail(peg$c70); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1664,11 +1679,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c70(s4);
+        s3 = peg$c72(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1679,23 +1694,23 @@ function peg$parse(input, options) {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$c71.test(input.charAt(peg$currPos))) {
+      if (peg$c73.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c74); }
       }
     }
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c67;
+        s3 = peg$c69;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
       }
       if (s3 !== peg$FAILED) {
         if (input.length > peg$currPos) {
@@ -1703,11 +1718,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c71); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c70(s4);
+          s3 = peg$c72(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1718,18 +1733,18 @@ function peg$parse(input, options) {
         s2 = peg$FAILED;
       }
       if (s2 === peg$FAILED) {
-        if (peg$c71.test(input.charAt(peg$currPos))) {
+        if (peg$c73.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c72); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73(s1);
+      s1 = peg$c75(s1);
     }
     s0 = s1;
 
@@ -1743,11 +1758,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c67;
+      s3 = peg$c69;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      if (peg$silentFails === 0) { peg$fail(peg$c70); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1755,11 +1770,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c70(s4);
+        s3 = peg$c72(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1770,12 +1785,12 @@ function peg$parse(input, options) {
       s2 = peg$FAILED;
     }
     if (s2 === peg$FAILED) {
-      if (peg$c74.test(input.charAt(peg$currPos))) {
+      if (peg$c76.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c75); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
     }
     if (s2 !== peg$FAILED) {
@@ -1783,11 +1798,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c67;
+          s3 = peg$c69;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c68); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1795,11 +1810,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c71); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c70(s4);
+            s3 = peg$c72(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1810,12 +1825,12 @@ function peg$parse(input, options) {
           s2 = peg$FAILED;
         }
         if (s2 === peg$FAILED) {
-          if (peg$c74.test(input.charAt(peg$currPos))) {
+          if (peg$c76.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c75); }
+            if (peg$silentFails === 0) { peg$fail(peg$c77); }
           }
         }
       }
@@ -1824,7 +1839,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73(s1);
+      s1 = peg$c75(s1);
     }
     s0 = s1;
 
@@ -1838,11 +1853,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s3 = peg$c67;
+      s3 = peg$c69;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      if (peg$silentFails === 0) { peg$fail(peg$c70); }
     }
     if (s3 !== peg$FAILED) {
       if (input.length > peg$currPos) {
@@ -1850,11 +1865,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c70(s4);
+        s3 = peg$c72(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -1882,11 +1897,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c71); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c70(s4);
+          s3 = peg$c72(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1902,11 +1917,11 @@ function peg$parse(input, options) {
         s1.push(s2);
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s3 = peg$c67;
+          s3 = peg$c69;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c68); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
         if (s3 !== peg$FAILED) {
           if (input.length > peg$currPos) {
@@ -1914,11 +1929,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c71); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c70(s4);
+            s3 = peg$c72(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -1946,11 +1961,11 @@ function peg$parse(input, options) {
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c69); }
+              if (peg$silentFails === 0) { peg$fail(peg$c71); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c70(s4);
+              s3 = peg$c72(s4);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -1967,7 +1982,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73(s1);
+      s1 = peg$c75(s1);
     }
     s0 = s1;
 
@@ -1979,19 +1994,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c76;
+      s1 = peg$c78;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c78;
+        s1 = peg$c80;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
     }
     if (s1 === peg$FAILED) {
@@ -1999,22 +2014,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c80.test(input.charAt(peg$currPos))) {
+      if (peg$c38.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c81); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c80.test(input.charAt(peg$currPos))) {
+          if (peg$c38.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c39); }
           }
         }
       } else {
@@ -2030,22 +2045,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c80.test(input.charAt(peg$currPos))) {
+          if (peg$c38.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c39); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c80.test(input.charAt(peg$currPos))) {
+              if (peg$c38.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c81); }
+                if (peg$silentFails === 0) { peg$fail(peg$c39); }
               }
             }
           } else {
@@ -2074,19 +2089,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c76;
+        s1 = peg$c78;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c77); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 43) {
-          s1 = peg$c78;
+          s1 = peg$c80;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c81); }
         }
       }
       if (s1 === peg$FAILED) {
@@ -2094,22 +2109,22 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c80.test(input.charAt(peg$currPos))) {
+        if (peg$c38.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c80.test(input.charAt(peg$currPos))) {
+            if (peg$c38.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c81); }
+              if (peg$silentFails === 0) { peg$fail(peg$c39); }
             }
           }
         } else {
@@ -2334,11 +2349,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 43) {
-          s3 = peg$c78;
+          s3 = peg$c80;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c81); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -2385,11 +2400,11 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s3 = peg$c76;
+            s3 = peg$c78;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c77); }
+            if (peg$silentFails === 0) { peg$fail(peg$c79); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -2742,11 +2757,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c70(s4);
+        s3 = peg$c72(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2776,11 +2791,11 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c71); }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c70(s4);
+            s3 = peg$c72(s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2796,7 +2811,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73(s1);
+      s1 = peg$c75(s1);
     }
     s0 = s1;
 

--- a/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
@@ -50,7 +50,7 @@ Argument
   / S* arg:ValueArgument { return arg }
 
 RedirectArgument
-  = S* redirect:RedirectType arg:ValueArgument { return { type: `redirection`, subtype: redirect, args: [arg] } }
+  = S* fd:[0-9]? redirect:RedirectType arg:ValueArgument { return { type: `redirection`, subtype: redirect, fd: fd !== null ? parseInt(fd) : null, args: [arg] } }
 
 RedirectType
   = '>>'

--- a/packages/yarnpkg-parsers/tests/shell.test.ts
+++ b/packages/yarnpkg-parsers/tests/shell.test.ts
@@ -8,6 +8,7 @@ const VALID_COMMANDS = [
   ...[
     `echo foo >& 1`,
     `echo foo >&1`,
+    `echo foo 2> bar`,
   ],
 
   // Groups
@@ -64,6 +65,38 @@ describe(`Shell parser`, () => {
         expect(() => parseShell(command)).toThrow();
       });
     }
+  });
+
+  describe(`Redirections`, () => {
+    describe(`fd`, () => {
+      it(`shouldn't parse fds that aren't single digits as part of the redirection`, () => {
+        expect(parseShell(`echo 10> /dev/null`)).toStrictEqual([expect.objectContaining({
+          command: expect.objectContaining({
+            chain: expect.objectContaining({
+              args: [
+                expect.anything(),
+                {type: `argument`, segments: [{type: `text`, text: `10`}]},
+                expect.objectContaining({fd: null}),
+              ],
+            }),
+          }),
+        })]);
+      });
+
+      it(`shouldn't parse fds that aren't directly next to the redirection as part of the redirection`, () => {
+        expect(parseShell(`echo 1 > /dev/null`)).toStrictEqual([expect.objectContaining({
+          command: expect.objectContaining({
+            chain: expect.objectContaining({
+              args: [
+                expect.anything(),
+                {type: `argument`, segments: [{type: `text`, text: `1`}]},
+                expect.objectContaining({fd: null}),
+              ],
+            }),
+          }),
+        })]);
+      });
+    });
   });
 });
 

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -641,6 +641,19 @@ describe(`Shell`, () => {
         });
       });
 
+      it(`should support input redirections to fd (file)`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+          await xfs.writeFilePromise(file, `hello world\n`);
+
+          await expect(bufferResult(
+            `cat 0< "${file}"`,
+          )).resolves.toMatchObject({
+            stdout: `hello world\n`,
+          });
+        });
+      });
+
       it(`should support multiple inputs`, async () => {
         await xfs.mktempPromise(async tmpDir => {
           const file1 = ppath.join(tmpDir, `file1` as Filename);
@@ -656,6 +669,25 @@ describe(`Shell`, () => {
           });
         });
       });
+
+      it(`should throw on input redirections to unsupported file descriptors`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+          await xfs.writeFilePromise(file, `hello world\n`);
+
+          await expect(bufferResult(
+            `cat 1< "${file}"`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "1"`);
+
+          await expect(bufferResult(
+            `cat 2< "${file}"`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "2"`);
+
+          await expect(bufferResult(
+            `cat 3< "${file}"`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
+        });
+      });
     });
 
     describe(`<<<`, () => {
@@ -664,6 +696,30 @@ describe(`Shell`, () => {
           `cat <<< "hello world"`,
         )).resolves.toMatchObject({
           stdout: `hello world\n`,
+        });
+      });
+
+      it(`should support input redirections to fd (string)`, async () => {
+        await expect(bufferResult(
+          `cat 0<<< "hello world"`,
+        )).resolves.toMatchObject({
+          stdout: `hello world\n`,
+        });
+      });
+
+      it(`should throw on input redirections to unsupported file descriptors`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `cat 1<<< "hello world"`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "1"`);
+
+          await expect(bufferResult(
+            `cat 2<<< "hello world"`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "2"`);
+
+          await expect(bufferResult(
+            `cat 3<<< "hello world"`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
         });
       });
     });
@@ -680,6 +736,34 @@ describe(`Shell`, () => {
           });
 
           await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`hello world\n`);
+        });
+      });
+
+      it(`should support output redirections from fd (stdout)`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+
+          await expect(bufferResult(
+            `node -e "console.log(\`foo\`), console.error(\`bar\`)" 1> "${file}"`,
+          )).resolves.toMatchObject({
+            stderr: `bar\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`foo\n`);
+        });
+      });
+
+      it(`should support output redirections from fd (stderr)`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+
+          await expect(bufferResult(
+            `node -e "console.log(\`foo\`), console.error(\`bar\`)" 2> "${file}"`,
+          )).resolves.toMatchObject({
+            stdout: `foo\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`bar\n`);
         });
       });
 
@@ -706,6 +790,20 @@ describe(`Shell`, () => {
           )).rejects.toThrowError(`ENOENT: no such file or directory, open`);
         });
       });
+
+      it(`should throw on output redirections from unsupported file descriptors`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" 0> /dev/null`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "0"`);
+        });
+
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" 3> /dev/null`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
+        });
+      });
     });
 
     describe(`>>`, () => {
@@ -723,10 +821,54 @@ describe(`Shell`, () => {
           await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`foo bar baz\nhello world\n`);
         });
       });
+
+      it(`should support output redirections from fd (stdout)`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+          await xfs.writeFilePromise(file, `foo bar baz\n`);
+
+          await expect(bufferResult(
+            `node -e "console.log(\`foo\`), console.error(\`bar\`)" 1>> "${file}"`,
+          )).resolves.toMatchObject({
+            stderr: `bar\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`foo bar baz\nfoo\n`);
+        });
+      });
+
+      it(`should support output redirections from fd (stderr)`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+          await xfs.writeFilePromise(file, `foo bar baz\n`);
+
+          await expect(bufferResult(
+            `node -e "console.log(\`foo\`), console.error(\`bar\`)" 2>> "${file}"`,
+          )).resolves.toMatchObject({
+            stdout: `foo\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`foo bar baz\nbar\n`);
+        });
+      });
+
+      it(`should throw on output redirections from unsupported file descriptors`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" 0>> /dev/null`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "0"`);
+        });
+
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" 3>> /dev/null`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
+        });
+      });
     });
 
     describe(`>&`, () => {
-      it(`should support stdout redirections (file descriptor)`, async () => {
+      it(`should support implicit stdout redirections (file descriptor)`, async () => {
         await expect(bufferResult(
           `echo "hello world" >& 1`,
         )).resolves.toMatchObject({
@@ -740,12 +882,54 @@ describe(`Shell`, () => {
         });
       });
 
+      it(`should support stdout redirections (file descriptor)`, async () => {
+        await expect(bufferResult(
+          `echo "hello world" 1>& 1`,
+        )).resolves.toMatchObject({
+          stdout: `hello world\n`,
+        });
+
+        await expect(bufferResult(
+          `echo "hello world" 1>& 2`,
+        )).resolves.toMatchObject({
+          stderr: `hello world\n`,
+        });
+      });
+
+      it(`should support stderr redirections (file descriptor)`, async () => {
+        await expect(bufferResult(
+          `node -e "console.error(\`hello world\`)" 2>& 1`,
+        )).resolves.toMatchObject({
+          stdout: `hello world\n`,
+        });
+
+        await expect(bufferResult(
+          `node -e "console.error(\`hello world\`)" 2>& 2`,
+        )).resolves.toMatchObject({
+          stderr: `hello world\n`,
+        });
+      });
+
       it(`should support multiple stdout redirections (file descriptor)`, async () => {
         await expect(bufferResult(
           `echo "hello world" >& 1 >& 2`,
         )).resolves.toMatchObject({
           stdout: `hello world\n`,
           stderr: `hello world\n`,
+        });
+      });
+
+      it(`should throw on output redirections from unsupported file descriptors`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" 0>& 1`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "0"`);
+        });
+
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `echo "hello world" 3>& 1`,
+          )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
         });
       });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell didn't support redirection from file descriptors (e.g. `ls 2>/dev/null`).

Fixes #2778.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By implementing fd support in both input (e.g. `cat 0< README.md`) and output (e.g. `ls 2>/dev/null`) redirections.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
