### PR TITLE
fix(dlx): don't print ci group markers when --quiet is used

### DIFF
--- a/.yarn/versions/375ad2da.yml
+++ b/.yarn/versions/375ad2da.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -243,7 +243,7 @@ export class StreamReport extends Report {
       this.reportInfo(null, `┌ ${what}`);
       this.indent += 1;
 
-      if (GROUP !== null && !this.json) {
+      if (GROUP !== null && !this.json && this.includeInfos) {
         this.stdout.write(GROUP.start(what));
       }
     }};
@@ -269,7 +269,7 @@ export class StreamReport extends Report {
       if (mark.committed) {
         this.indent -= 1;
 
-        if (GROUP !== null && !this.json)
+        if (GROUP !== null && !this.json && this.includeInfos)
           this.stdout.write(GROUP.end(what));
 
         if (this.configuration.get(`enableTimers`) && after - before > 200) {
@@ -291,7 +291,7 @@ export class StreamReport extends Report {
       this.reportInfo(null, `┌ ${what}`);
       this.indent += 1;
 
-      if (GROUP !== null && !this.json) {
+      if (GROUP !== null && !this.json && this.includeInfos) {
         this.stdout.write(GROUP.start(what));
       }
     }};
@@ -317,7 +317,7 @@ export class StreamReport extends Report {
       if (mark.committed) {
         this.indent -= 1;
 
-        if (GROUP !== null && !this.json)
+        if (GROUP !== null && !this.json && this.includeInfos)
           this.stdout.write(GROUP.end(what));
 
         if (this.configuration.get(`enableTimers`) && after - before > 200) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Running `yarn dlx --quiet` on CI still printed `yarn add`'s group markers.

Sherlock snippet from #3056:

```
Error: expect(received).toStrictEqual(expected) // deep equality

Expected: "2"
Received: "::group::Resolution step
::endgroup::
::group::Fetch step
::endgroup::
::group::Link step
::endgroup::
8"
```

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Don't print group markers unless `includeInfos` is `true` (the same condition for printing the header and the footer of timers).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
