### PR TITLE
Improvements to `yarn init` / `yarn set version`

### DIFF
--- a/.yarn/versions/2a5b0f44.yml
+++ b/.yarn/versions/2a5b0f44.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-essentials": major
+  "@yarnpkg/plugin-init": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,9 +1,9 @@
-import {BaseCommand}                                      from '@yarnpkg/cli';
-import {Configuration, StreamReport, MessageName, Report} from '@yarnpkg/core';
-import {execUtils, formatUtils, httpUtils, semverUtils}   from '@yarnpkg/core';
-import {Filename, PortablePath, ppath, xfs, npath}        from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}               from 'clipanion';
-import semver                                             from 'semver';
+import {BaseCommand}                                                from '@yarnpkg/cli';
+import {Configuration, StreamReport, MessageName, Report, Manifest} from '@yarnpkg/core';
+import {execUtils, formatUtils, httpUtils, semverUtils}             from '@yarnpkg/core';
+import {Filename, PortablePath, ppath, xfs, npath}                  from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                         from 'clipanion';
+import semver                                                       from 'semver';
 
 // eslint-disable-next-line arca/no-default-export
 export default class SetVersionCommand extends BaseCommand {
@@ -46,11 +46,13 @@ export default class SetVersionCommand extends BaseCommand {
 
     let bundleUrl: string;
     if (this.version === `latest` || this.version === `berry`)
-      bundleUrl = `https://github.com/yarnpkg/berry/raw/master/packages/yarnpkg-cli/bin/yarn.js`;
+      bundleUrl = `https://repo.yarnpkg.com/${await findVersion(configuration, `stable`)}/packages/yarnpkg-cli/bin/yarn.js`;
+    else if (this.version === `canary`)
+      bundleUrl = `https://repo.yarnpkg.com/${await findVersion(configuration, `canary`)}/packages/yarnpkg-cli/bin/yarn.js`;
     else if (this.version === `classic`)
       bundleUrl = `https://nightly.yarnpkg.com/latest.js`;
     else if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`))
-      bundleUrl = `https://github.com/yarnpkg/berry/raw/%40yarnpkg/cli/${this.version}/packages/yarnpkg-cli/bin/yarn.js`;
+      bundleUrl = `https://repo.yarnpkg.com/${this.version}/packages/yarnpkg-cli/bin/yarn.js`;
     else if (semverUtils.satisfiesWithPrereleases(this.version, `^0.x || ^1.x`))
       bundleUrl = `https://github.com/yarnpkg/yarn/releases/download/v${this.version}/yarn-${this.version}.js`;
     else if (semverUtils.validRange(this.version))
@@ -69,6 +71,14 @@ export default class SetVersionCommand extends BaseCommand {
 
     return report.exitCode();
   }
+}
+
+export async function findVersion(configuration: Configuration, request: `stable` | `canary`) {
+  const data = await httpUtils.get(`https://repo.yarnpkg.com/tags`, {configuration, jsonResponse: true});
+  if (!data.latest[request])
+    throw new UsageError(`Tag '${request}' not found`);
+
+  return data.latest[request];
 }
 
 export async function setVersion(configuration: Configuration, bundleVersion: string | null, bundleBuffer: Buffer, {report}: {report: Report}) {
@@ -112,5 +122,20 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
     await Configuration.updateConfiguration(projectCwd, {
       yarnPath: projectPath,
     });
+
+    if (bundleVersion!.match(/^[^-]+(-rc\.[0-9]+)?$/)) {
+      const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
+      manifest.packageManager = bundleVersion;
+
+      const data = {};
+      manifest.exportTo(data);
+
+      const path = ppath.join(projectCwd, Manifest.fileName);
+      const content = `${JSON.stringify(data, null, manifest.indent)}\n`;
+
+      await xfs.changeFilePromise(path, content, {
+        automaticNewlines: true,
+      });
+    }
   }
 }

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -125,9 +125,8 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
     const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
 
-    manifest.packageManager = bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion)
-      ? bundleVersion
-      : null;
+    if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion))
+      manifest.packageManager = bundleVersion;
 
     const data = {};
     manifest.exportTo(data);

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,6 +1,6 @@
 import {BaseCommand}                                                from '@yarnpkg/cli';
 import {Configuration, StreamReport, MessageName, Report, Manifest} from '@yarnpkg/core';
-import {execUtils, formatUtils, httpUtils, semverUtils}             from '@yarnpkg/core';
+import {execUtils, formatUtils, httpUtils, miscUtils, semverUtils}  from '@yarnpkg/core';
 import {Filename, PortablePath, ppath, xfs, npath}                  from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                         from 'clipanion';
 import semver                                                       from 'semver';
@@ -123,19 +123,20 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
       yarnPath: projectPath,
     });
 
-    if (bundleVersion!.match(/^[^-]+(-rc\.[0-9]+)?$/)) {
-      const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
-      manifest.packageManager = bundleVersion;
+    const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
 
-      const data = {};
-      manifest.exportTo(data);
+    manifest.packageManager = bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion)
+      ? bundleVersion
+      : null;
 
-      const path = ppath.join(projectCwd, Manifest.fileName);
-      const content = `${JSON.stringify(data, null, manifest.indent)}\n`;
+    const data = {};
+    manifest.exportTo(data);
 
-      await xfs.changeFilePromise(path, content, {
-        automaticNewlines: true,
-      });
-    }
+    const path = ppath.join(projectCwd, Manifest.fileName);
+    const content = `${JSON.stringify(data, null, manifest.indent)}\n`;
+
+    await xfs.changeFilePromise(path, content, {
+      automaticNewlines: true,
+    });
   }
 }

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -1,10 +1,10 @@
-import {BaseCommand}                                   from '@yarnpkg/cli';
-import {Configuration, Manifest, Project, YarnVersion} from '@yarnpkg/core';
-import {execUtils, scriptUtils, structUtils}           from '@yarnpkg/core';
-import {xfs, ppath, Filename}                          from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}            from 'clipanion';
-import merge                                           from 'lodash/merge';
-import {inspect}                                       from 'util';
+import {BaseCommand}                                              from '@yarnpkg/cli';
+import {Configuration, Manifest, miscUtils, Project, YarnVersion} from '@yarnpkg/core';
+import {execUtils, scriptUtils, structUtils}                      from '@yarnpkg/core';
+import {xfs, ppath, Filename}                                     from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                       from 'clipanion';
+import merge                                                      from 'lodash/merge';
+import {inspect}                                                  from 'util';
 
 // eslint-disable-next-line arca/no-default-export
 export default class InitCommand extends BaseCommand {
@@ -133,8 +133,9 @@ export default class InitCommand extends BaseCommand {
     manifest.name = manifest.name
       ?? structUtils.makeIdent(configuration.get(`initScope`), ppath.basename(this.context.cwd));
 
-    manifest.packageManager = manifest.packageManager
-      ?? YarnVersion;
+    manifest.packageManager = YarnVersion && miscUtils.isTaggedYarnVersion(YarnVersion)
+      ? YarnVersion
+      : null;
 
     if (typeof manifest.raw.private === `undefined` && (this.private || (this.workspace && manifest.workspaceDefinitions.length === 0)))
       manifest.private = true;

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -1,10 +1,10 @@
-import {BaseCommand}                         from '@yarnpkg/cli';
-import {Configuration, Manifest, Project}    from '@yarnpkg/core';
-import {execUtils, scriptUtils, structUtils} from '@yarnpkg/core';
-import {xfs, ppath, Filename}                from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}  from 'clipanion';
-import merge                                 from 'lodash/merge';
-import {inspect}                             from 'util';
+import {BaseCommand}                                   from '@yarnpkg/cli';
+import {Configuration, Manifest, Project, YarnVersion} from '@yarnpkg/core';
+import {execUtils, scriptUtils, structUtils}           from '@yarnpkg/core';
+import {xfs, ppath, Filename}                          from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}            from 'clipanion';
+import merge                                           from 'lodash/merge';
+import {inspect}                                       from 'util';
 
 // eslint-disable-next-line arca/no-default-export
 export default class InitCommand extends BaseCommand {
@@ -57,17 +57,16 @@ export default class InitCommand extends BaseCommand {
   usev2 = Option.Boolean(`-2`, false, {hidden: true});
   yes = Option.Boolean(`-y,--yes`, {hidden: true});
 
-  // Used internally to avoid issues when using `-i`
+  // Deprecated; doesn't have any effect anymore, but we can't removing it for
+  // some time as it has some risks of breaking a few special setups. Probably
+  // good for removal in 4.x.
   assumeFreshProject = Option.Boolean(`--assume-fresh-project`, false, {hidden: true});
 
   async execute() {
-    if (xfs.existsSync(ppath.join(this.context.cwd, Manifest.fileName)))
-      throw new UsageError(`A package.json already exists in the specified directory`);
-
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
     const install = this.install
-      ? this.install === true ? `latest` : this.install
+      ? this.usev2 || this.install === true ? `latest` : this.install
       : null;
 
     if (install !== null) {
@@ -78,11 +77,8 @@ export default class InitCommand extends BaseCommand {
   }
 
   async executeProxy(configuration: Configuration, version: string) {
-    if (configuration.get(`yarnPath`) !== null)
-      throw new UsageError(`Cannot use the --install flag when the current directory already uses yarnPath (from ${configuration.sources.get(`yarnPath`)})`);
-
-    if (configuration.projectCwd !== null)
-      throw new UsageError(`Cannot use the --install flag when the current directory is already part of a project`);
+    if (configuration.projectCwd !== null && configuration.projectCwd !== this.context.cwd)
+      throw new UsageError(`Cannot use the --install flag from within a project subdirectory`);
 
     if (!xfs.existsSync(this.context.cwd))
       await xfs.mkdirPromise(this.context.cwd, {recursive: true});
@@ -97,7 +93,7 @@ export default class InitCommand extends BaseCommand {
 
     this.context.stdout.write(`\n`);
 
-    const args: Array<string> = [`--assume-fresh-project`];
+    const args: Array<string> = [];
     if (this.private)
       args.push(`-p`);
     if (this.workspace)
@@ -119,27 +115,31 @@ export default class InitCommand extends BaseCommand {
   }
 
   async executeRegular(configuration: Configuration) {
-    let existingProject: {project: Project} | null = null;
-    if (!this.assumeFreshProject) {
-      try {
-        existingProject = await Project.find(configuration, this.context.cwd);
-      } catch {
-        existingProject = null;
-      }
+    let existingProject: Project | null = null;
+    try {
+      existingProject = (await Project.find(configuration, this.context.cwd)).project;
+    } catch {
+      existingProject = null;
     }
 
     if (!xfs.existsSync(this.context.cwd))
       await xfs.mkdirPromise(this.context.cwd, {recursive: true});
 
-    const manifest = new Manifest();
+    const manifest = (await Manifest.tryFind(this.context.cwd)) || new Manifest();
 
     const fields = Object.fromEntries(configuration.get(`initFields`).entries());
     manifest.load(fields);
 
-    manifest.name = structUtils.makeIdent(configuration.get(`initScope`), ppath.basename(this.context.cwd));
-    manifest.private = this.private || this.workspace;
+    manifest.name = manifest.name
+      ?? structUtils.makeIdent(configuration.get(`initScope`), ppath.basename(this.context.cwd));
 
-    if (this.workspace) {
+    manifest.packageManager = manifest.packageManager
+      ?? YarnVersion;
+
+    if (typeof manifest.raw.private === `undefined` && (this.private || (this.workspace && manifest.workspaceDefinitions.length === 0)))
+      manifest.private = true;
+
+    if (this.workspace && manifest.workspaceDefinitions.length === 0) {
       await xfs.mkdirPromise(ppath.join(this.context.cwd, `packages` as Filename), {recursive: true});
       manifest.workspaceDefinitions = [{
         pattern: `packages/*`,
@@ -159,15 +159,18 @@ export default class InitCommand extends BaseCommand {
     })}\n`);
 
     const manifestPath = ppath.join(this.context.cwd, Manifest.fileName);
-    await xfs.changeFilePromise(manifestPath, `${JSON.stringify(serialized, null, 2)}\n`);
+    await xfs.changeFilePromise(manifestPath, `${JSON.stringify(serialized, null, 2)}\n`, {
+      automaticNewlines: true,
+    });
 
     const readmePath = ppath.join(this.context.cwd, `README.md` as Filename);
     if (!xfs.existsSync(readmePath))
       await xfs.writeFilePromise(readmePath, `# ${structUtils.stringifyIdent(manifest.name)}\n`);
 
-    if (!existingProject) {
+    if (!existingProject || existingProject.cwd === this.context.cwd) {
       const lockfilePath = ppath.join(this.context.cwd, Filename.lockfile);
-      await xfs.writeFilePromise(lockfilePath, ``);
+      if (!xfs.existsSync(lockfilePath))
+        await xfs.writeFilePromise(lockfilePath, ``);
 
       const gitignoreLines = [
         `/.yarn/*`,
@@ -217,9 +220,11 @@ export default class InitCommand extends BaseCommand {
       if (!xfs.existsSync(editorConfigPath))
         await xfs.writeFilePromise(editorConfigPath, editorConfigBody);
 
-      await execUtils.execvp(`git`, [`init`], {
-        cwd: this.context.cwd,
-      });
+      if (!xfs.existsSync(ppath.join(this.context.cwd, `.git` as Filename))) {
+        await execUtils.execvp(`git`, [`init`], {
+          cwd: this.context.cwd,
+        });
+      }
     }
   }
 }

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -57,7 +57,7 @@ export default class InitCommand extends BaseCommand {
   usev2 = Option.Boolean(`-2`, false, {hidden: true});
   yes = Option.Boolean(`-y,--yes`, {hidden: true});
 
-  // Deprecated; doesn't have any effect anymore, but we can't removing it for
+  // Deprecated; doesn't have any effect anymore, but we can't remove it for
   // some time as it has some risks of breaking a few special setups. Probably
   // good for removal in 4.x.
   assumeFreshProject = Option.Boolean(`--assume-fresh-project`, false, {hidden: true});

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -58,8 +58,8 @@ export default class InitCommand extends BaseCommand {
   yes = Option.Boolean(`-y,--yes`, {hidden: true});
 
   // Deprecated; doesn't have any effect anymore, but we can't remove it for
-  // some time as it has some risks of breaking a few special setups. Probably
-  // good for removal in 4.x.
+  // some time as it has some risks of breaking a few special setups.
+  // TODO: Remove it in 4.x.
   assumeFreshProject = Option.Boolean(`--assume-fresh-project`, false, {hidden: true});
 
   async execute() {

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -49,6 +49,7 @@ export class Manifest {
 
   public type: string | null = null;
 
+  public packageManager: string | null = null;
   public ["private"]: boolean = false;
   public license: string | null = null;
 
@@ -232,6 +233,11 @@ export class Manifest {
       this.type = data.type;
     else
       this.type = null;
+
+    if (typeof data.packageManager === `string`)
+      this.packageManager = data.packageManager;
+    else
+      this.packageManager = null;
 
     if (typeof data.private === `boolean`)
       this.private = data.private;
@@ -747,6 +753,11 @@ export class Manifest {
       data.type = this.type;
     else
       delete data.type;
+
+    if (this.packageManager !== null)
+      data.packageManager = this.packageManager;
+    else
+      delete data.packageManager;
 
     if (this.private)
       data.private = true;

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -3,6 +3,13 @@ import {UsageError}          from 'clipanion';
 import micromatch            from 'micromatch';
 import {Readable, Transform} from 'stream';
 
+/**
+ * @internal
+ */
+export function isTaggedYarnVersion(version: string) {
+  return version.match(/^[^-]+(-rc\.[0-9]+)?$/);
+}
+
 export function escapeRegExp(str: string) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`);
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

This commit improves the workflows around `yarn init` and `yarn set version` in various ways:

- It's now possible to run `yarn init` on a folder that already exists. It'll simply add the missing baseline files and fields.
- Running `yarn init` will set the `packageManager` field from Corepack.
- Similarly, `yarn set version` will set the field, ~~and `yarn set version from sources` will remove it~~.
- If Yarn detects that `yarnPath` points to the same binary content as the current one, it'll ignore it.
- The URLs used for `yarn set version` now come from our own website (cached behind Cloudflare).
- If operating within Corepack, the shims we add to the environment will point to it (rather than the current binary).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
