### PR TITLE
fix(pnpify): only wrap `tsserver` if PnP is enabled

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -10,6 +10,10 @@ const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 const moduleWrapper = tsserver => {
+  if (!process.versions.pnp) {
+    return tsserver;
+  }
+
   const {isAbsolute} = require(`path`);
   const pnpApi = require(`pnpapi`);
 

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -10,6 +10,10 @@ const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
 
 const moduleWrapper = tsserver => {
+  if (!process.versions.pnp) {
+    return tsserver;
+  }
+
   const {isAbsolute} = require(`path`);
   const pnpApi = require(`pnpapi`);
 

--- a/.yarn/versions/137f9f5f.yml
+++ b/.yarn/versions/137f9f5f.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-node-modules"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/sdks/base.ts
+++ b/packages/yarnpkg-pnpify/sources/sdks/base.ts
@@ -37,6 +37,10 @@ export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = 
 export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const tsServerMonkeyPatch = `
     tsserver => {
+      if (!process.versions.pnp) {
+        return tsserver;
+      }
+
       const {isAbsolute} = require(\`path\`);
       const pnpApi = require(\`pnpapi\`);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The TypeScript SDK's `tsserver` crashes if the project uses the `node-modules` linker instead of PnP

**How did you fix it?**

Disable the `moduleWrapper` if PnP isn't enabled

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.