### PR TITLE
fix(unset): correctly unset non-nested properties

### DIFF
--- a/.yarn/versions/6601a028.yml
+++ b/.yarn/versions/6601a028.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 - The PnP linker now schedules packages to be rebuilt if their unplugged folder is removed
 - Plugins can now access `yup` again to make migration easier - will be removed again in the future
+- `yarn config unset` will now correctly unset non-nested properties
 
 ### Shell
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
@@ -24,7 +24,7 @@ describe(`Commands`, () => {
         await expect(run(`config`, `unset`, `npmScopes`)).resolves.toMatchObject({
           stdout: expect.stringContaining(`Successfully unset`),
         });
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.not.toContain(`npmScopes`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toStrictEqual(``);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
@@ -10,7 +10,7 @@ describe(`Commands`, () => {
         await expect(run(`config`, `unset`, `pnpShebang`)).resolves.toMatchObject({
           stdout: expect.stringContaining(`Successfully unset`),
         });
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.not.toContain(`pnpShebang`);
+        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.toStrictEqual(``);
       }),
     );
 

--- a/packages/plugin-essentials/sources/commands/config/unset.ts
+++ b/packages/plugin-essentials/sources/commands/config/unset.ts
@@ -51,15 +51,12 @@ export default class ConfigUnsetCommand extends BaseCommand {
         : patch => Configuration.updateConfiguration(configuration.projectCwd!, patch);
 
     await updateConfiguration(current => {
-      if (path) {
-        const clone = cloneDeep(current);
-        unsetPath(clone, this.name);
-        return clone;
-      } else {
-        const clone = {...current};
-        unsetPath(clone, name);
-        return clone;
-      }
+      const clone = path
+        ? cloneDeep(current)
+        : {...current};
+
+      unsetPath(clone, this.name);
+      return clone;
     });
 
     const report = await StreamReport.start({

--- a/packages/plugin-essentials/sources/commands/config/unset.ts
+++ b/packages/plugin-essentials/sources/commands/config/unset.ts
@@ -56,8 +56,9 @@ export default class ConfigUnsetCommand extends BaseCommand {
         unsetPath(clone, this.name);
         return clone;
       } else {
-        const next = unsetPath({...current}, name);
-        return next;
+        const clone = {...current};
+        unsetPath(clone, name);
+        return clone;
       }
     });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn config unset` didn't unset non-nested properties correctly, as it was returning the result of `unsetPath` which was always a boolean.

Fixes #3072.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Return the clone mutated by `unsetPath` instead.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
