### PR TITLE
fix: allow running `yarn config unset --home` from arbitrary folders

### DIFF
--- a/.yarn/versions/c0a0f3db.yml
+++ b/.yarn/versions/c0a0f3db.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/unset.test.js
@@ -44,5 +44,16 @@ describe(`Commands`, () => {
         await expect(xfs.readFilePromise(`${path}/.yarnrc.yml`, `utf8`)).resolves.not.toContain(`npmAlwaysAuth`);
       }),
     );
+
+    test(
+      `it should allow running the command from arbitrary folders if the -H,--home option is set`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const tmpDir = await xfs.mktempPromise();
+
+        await expect(run(`config`, `unset`, `--home`, `pnpShebang`, {cwd: tmpDir})).resolves.toMatchObject({
+          code: 0,
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-essentials/sources/commands/config/unset.ts
+++ b/packages/plugin-essentials/sources/commands/config/unset.ts
@@ -35,8 +35,13 @@ export default class ConfigUnsetCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    if (!configuration.projectCwd)
-      throw new UsageError(`This command must be run from within a project folder`);
+
+    const assertProjectCwd = () => {
+      if (!configuration.projectCwd)
+        throw new UsageError(`This command must be run from within a project folder`);
+
+      return configuration.projectCwd;
+    };
 
     const name = this.name.replace(/[.[].*$/, ``);
     const path = this.name.replace(/^[^.[]*\.?/, ``);
@@ -48,7 +53,7 @@ export default class ConfigUnsetCommand extends BaseCommand {
     const updateConfiguration: (patch: ((current: any) => any)) => Promise<void> =
       this.home
         ? patch => Configuration.updateHomeConfiguration(patch)
-        : patch => Configuration.updateConfiguration(configuration.projectCwd!, patch);
+        : patch => Configuration.updateConfiguration(assertProjectCwd(), patch);
 
     await updateConfiguration(current => {
       if (path) {


### PR DESCRIPTION
Note: This is #3014 but for `yarn config unset` - I completely forgot this command existed when I opened that PR.

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Running `yarn config unset --home` from a non-project folder throws an error.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I made it skip throwing the error when the `-H,--home` flag is used.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
