### PR TITLE
chore(compat): update extensions list

### DIFF
--- a/.yarn/versions/666c24a1.yml
+++ b/.yarn/versions/666c24a1.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -375,4 +375,13 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       underscore: `^1.9.2`,
     },
   }],
+  // https://github.com/creationix/git-node-fs/pull/8
+  [`git-node-fs@*`, {
+    peerDependencies: {
+      'js-git': `^0.7.8`,
+    },
+    peerDependenciesMeta: {
+      'js-git': optionalPeerDep,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -363,4 +363,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'vue-template-compiler': optionalPeerDep,
     },
   }],
+  // https://github.com/apache/cordova-ios/pull/1105
+  [`cordova-ios@<=6.3.0`, {
+    dependencies: {
+      underscore: `^1.9.2`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -314,4 +314,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       react: `>=16.0.0`,
     },
   }],
+  // https://github.com/mqttjs/MQTT.js/pull/1266
+  [`mqtt@<4.2.7`, {
+    dependencies: {
+      duplexify: `^4.1.1`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -345,4 +345,22 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'sass-loader': optionalPeerDep,
     },
   }],
+  // https://github.com/vuejs/vue-cli/pull/6060/files#diff-857cfb6f3e9a676b0de4a00c2c712297068c038a7d5820c133b8d6aa8cceb146R28
+  [`@vue/cli-plugin-typescript@<=5.0.0-alpha.0`, {
+    dependencies: {
+      'babel-loader': `^8.1.0`,
+    },
+  }],
+  // https://github.com/vuejs/vue-cli/pull/6456
+  [`@vue/cli-plugin-typescript@<=5.0.0-beta.0`, {
+    dependencies: {
+      '@babel/core': `^7.12.16`,
+    },
+    peerDependencies: {
+      'vue-template-compiler': `^2.0.0`,
+    },
+    peerDependenciesMeta: {
+      'vue-template-compiler': optionalPeerDep,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -336,4 +336,13 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'null-loader': `^3.0.0`,
     },
   }],
+  // https://github.com/vuetifyjs/vue-cli-plugins/pull/155
+  [`@vuetify/cli-plugin-utils@<=0.0.4`, {
+    dependencies: {
+      semver: `^6.3.0`,
+    },
+    peerDependenciesMeta: {
+      'sass-loader': optionalPeerDep,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -102,7 +102,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/xz64/license-webpack-plugin/pull/100
-  [`license-webpack-plugin@*`, {
+  [`license-webpack-plugin@<2.3.18`, {
     peerDependenciesMeta: {
       [`webpack`]: optionalPeerDep,
     },

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -320,4 +320,20 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       duplexify: `^4.1.1`,
     },
   }],
+  // https://github.com/vuetifyjs/vue-cli-plugins/pull/155
+  [`vue-cli-plugin-vuetify@<=2.0.3`, {
+    dependencies: {
+      semver: `^6.3.0`,
+    },
+    peerDependenciesMeta: {
+      'sass-loader': optionalPeerDep,
+      'vuetify-loader': optionalPeerDep,
+    },
+  }],
+  // https://github.com/vuetifyjs/vue-cli-plugins/pull/152
+  [`vue-cli-plugin-vuetify@<=2.0.4`, {
+    dependencies: {
+      'null-loader': `^3.0.0`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -369,4 +369,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       underscore: `^1.9.2`,
     },
   }],
+  // https://github.com/apache/cordova-lib/pull/871
+  [`cordova-lib@<=10.0.1`, {
+    dependencies: {
+      underscore: `^1.9.2`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Updates the extensions list to include
- https://github.com/mqttjs/MQTT.js/pull/1266
- https://github.com/vuetifyjs/vue-cli-plugins/pull/152
- https://github.com/vuetifyjs/vue-cli-plugins/pull/155
- https://github.com/vuejs/vue-cli/pull/6060
- https://github.com/vuejs/vue-cli/pull/6456
- https://github.com/apache/cordova-ios/pull/1105
- https://github.com/apache/cordova-lib/pull/871
- https://github.com/creationix/git-node-fs/pull/8

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.