### PR TITLE
fix(core): handle case when os.cpus().length is 0

### DIFF
--- a/.yarn/versions/591061ea.yml
+++ b/.yarn/versions/591061ea.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/WorkerPool.ts
+++ b/packages/yarnpkg-core/sources/WorkerPool.ts
@@ -5,7 +5,7 @@ import {Worker} from 'worker_threads';
 export class WorkerPool<TIn, TOut> {
   private pool: Array<Worker> = [];
   private queue = new PQueue({
-    concurrency: cpus().length,
+    concurrency: Math.max(1, cpus().length),
   });
 
   constructor(private source: string) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When libuv's code that retrieves the cpus fails, [Node falls back to `[]` as the return value for `os.cpus()`](https://github.com/nodejs/node/blob/6dfdb0a37cf0bf2bf08f50727d698699c3b8d105/lib/os.js#L135).

This causes Yarn to try to create a pool with 0 concurrent workers (which causes `p-queue` to throw) on unsupported platforms such as Android.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Use `Math.max(1, cpus.length())`.

The `yarn workspaces foreach` command [doesn't suffer from this issue because it already uses `1` as a fallback](https://github.com/yarnpkg/berry/blob/fce9eb661522bb3989a5eb0c1b3f87027f8a3970/packages/plugin-workspace-tools/sources/commands/foreach.ts#L155).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
