### PR TITLE
fix(link): handle nested portals

### DIFF
--- a/.yarn/versions/095aa322.yml
+++ b/.yarn/versions/095aa322.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-link": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/links.test.js
@@ -6,7 +6,7 @@ const {
 } = require(`pkg-tests-core`);
 
 describe(`Protocols`, () => {
-  describe(`portal:`, () => {
+  describe(`link:`, () => {
     test(
       `it should link a remote location into the current dependency tree`,
       makeTemporaryEnv({

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/portals.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/portals.test.js
@@ -123,5 +123,34 @@ describe(`Protocols`, () => {
         });
       }),
     );
+
+    test(
+      `it should support nested portals`,
+      makeTemporaryEnv({ }, async ({path, run, source}) => {
+        await xfs.mkdirPromise(`${path}/a`);
+        await xfs.writeJsonPromise(`${path}/a/package.json`, {
+          name: `a`,
+        });
+
+        await xfs.mkdirPromise(`${path}/b`);
+        await xfs.writeJsonPromise(`${path}/b/package.json`, {
+          name: `b`,
+          dependencies: {
+            a: `portal:../a`,
+          },
+        });
+
+        await xfs.writeJsonPromise(`${path}/package.json`, {
+          name: `c`,
+          dependencies: {
+            b: `portal:./b`,
+          },
+        });
+
+        await expect(run(`install`)).resolves.toMatchObject({
+          code: 0,
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-link/sources/LinkFetcher.ts
+++ b/packages/plugin-link/sources/LinkFetcher.ts
@@ -37,7 +37,7 @@ export class LinkFetcher implements Fetcher {
     // If the package fs publicized its "original location" (for example like
     // in the case of "file:" packages), we use it to derive the real location.
     const effectiveParentFetch: FetchResult = parentFetch.localPath
-      ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
+      ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath), localPath: PortablePath.root}
       : parentFetch;
 
     // Discard the parent fs unless we really need it to access the files
@@ -45,7 +45,11 @@ export class LinkFetcher implements Fetcher {
       parentFetch.releaseFs();
 
     const sourceFs = effectiveParentFetch.packageFs;
-    const sourcePath = ppath.join(effectiveParentFetch.prefixPath, path);
+    const sourcePath = ppath.resolve(
+      effectiveParentFetch.localPath ?? effectiveParentFetch.packageFs.getRealPath(),
+      effectiveParentFetch.prefixPath,
+      path
+    );
 
     if (parentFetch.localPath) {
       return {packageFs: new CwdFS(sourcePath, {baseFs: sourceFs}), releaseFs: effectiveParentFetch.releaseFs, prefixPath: PortablePath.dot, localPath: sourcePath};

--- a/packages/plugin-link/sources/RawLinkFetcher.ts
+++ b/packages/plugin-link/sources/RawLinkFetcher.ts
@@ -37,7 +37,7 @@ export class RawLinkFetcher implements Fetcher {
     // If the package fs publicized its "original location" (for example like
     // in the case of "file:" packages), we use it to derive the real location.
     const effectiveParentFetch: FetchResult = parentFetch.localPath
-      ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
+      ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath), localPath: PortablePath.root}
       : parentFetch;
 
     // Discard the parent fs unless we really need it to access the files
@@ -45,7 +45,11 @@ export class RawLinkFetcher implements Fetcher {
       parentFetch.releaseFs();
 
     const sourceFs = effectiveParentFetch.packageFs;
-    const sourcePath = ppath.join(effectiveParentFetch.prefixPath, path);
+    const sourcePath = ppath.resolve(
+      effectiveParentFetch.localPath ?? effectiveParentFetch.packageFs.getRealPath(),
+      effectiveParentFetch.prefixPath,
+      path
+    );
 
     if (parentFetch.localPath) {
       return {packageFs: new CwdFS(sourcePath, {baseFs: sourceFs}), releaseFs: effectiveParentFetch.releaseFs, prefixPath: PortablePath.dot, discardFromLookup: true, localPath: sourcePath};


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using nested portals fails with a manifest not found error since the `LinkFetcher` doesn't take the `localPath` into account when computing the `sourcePath`

Fixes https://github.com/yarnpkg/berry/issues/3091

**How did you fix it?**

Avoid making the `prefixPath` relative

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.