### PR TITLE
feat(core): Asynchronous plugin loading

### DIFF
--- a/.yarn/versions/ce61ee0a.yml
+++ b/.yarn/versions/ce61ee0a.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/__snapshots__/mergeConflictResolution.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/__snapshots__/mergeConflictResolution.test.js.snap
@@ -75,7 +75,7 @@ no-deps@*:
   resolution: \\"root-workspace-0b6124@workspace:.\\"
   dependencies:
     no-deps: \\"*\\"
-  languageName: node
+  languageName: unknown
   linkType: soft
 >>>>>>> yarn2
 "

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.js
@@ -1,50 +1,84 @@
 import {xfs}           from '@yarnpkg/fslib';
 import {stringifySyml} from '@yarnpkg/parsers';
 
-const PLUGIN_A = `
-const factory = () => { console.log('Hello world A'); return {default:{}}; };
-const name = '@yarnpkg/plugin-a';
-module.exports = {factory, name};
-`;
+const PLUGIN = (name, {async = false, printOnBoot = false} = {}) => `
+const factory = ${async ? `async` : ``} r => {
+  const {Command} = r('clipanion');
 
-const PLUGIN_B = `
-const factory = () => { console.log('Hello world B'); return {default:{}}; };
-const name = '@yarnpkg/plugin-b';
+  if (${printOnBoot})
+    console.log('Booting ${name.toUpperCase()}');
+
+  return {
+    default: {
+      commands: [
+        class MyCommand extends Command {
+          static paths = [['${name}']];
+
+          async execute() {
+            this.context.stdout.write('Executing ${name.toUpperCase()}\\n');
+          }
+        },
+      ],
+    },
+  };
+};
+
+const name = '@yarnpkg/plugin-${name}';
 module.exports = {factory, name};
 `;
 
 describe(`Features`, () => {
   describe(`Plugins`, () => {
     test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
-      scripts: {
-        nothing: ``,
-      },
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN_A);
+      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`a`, {printOnBoot: true}));
 
       await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
       await expect(run(`node`, `-e`, ``)).resolves.toMatchObject({
-        stdout: `Hello world A\nHello world A\n`,
+        stdout: `Booting A\nBooting A\n`,
+      });
+    }));
+
+    test(`it should accept asynchronous plugins`, makeTemporaryEnv({
+    }, async ({path, run, source}) => {
+      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`a`, {async: true}));
+
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+        plugins: [`./plugin-a.js`],
+      }));
+
+      await expect(run(`a`)).resolves.toMatchObject({
+        stdout: `Executing A\n`,
+      });
+    }));
+
+    test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
+    }, async ({path, run, source}) => {
+      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`A`, {printOnBoot: true}));
+
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+        plugins: [`./plugin-a.js`],
+      }));
+
+      await expect(run(`node`, `-e`, ``)).resolves.toMatchObject({
+        stdout: `Booting A\nBooting A\n`,
       });
     }));
 
     test(`it should properly load multiple plugins via the local rc file, in the right order`, makeTemporaryEnv({
-      scripts: {
-        nothing: ``,
-      },
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN_A);
-      await xfs.writeFilePromise(`${path}/plugin-b.js`, PLUGIN_B);
+      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`A`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-b.js`, PLUGIN(`B`, {printOnBoot: true}));
 
       await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
         plugins: [`./plugin-a.js`, `./plugin-b.js`],
       }));
 
       await expect(run(`node`, `-e`, ``)).resolves.toMatchObject({
-        stdout: `Hello world A\nHello world B\nHello world A\nHello world B\n`,
+        stdout: `Booting A\nBooting B\nBooting A\nBooting B\n`,
       });
     }));
   });

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1056,7 +1056,7 @@ export class Configuration {
             : userPluginEntry;
 
           const pluginPath = ppath.resolve(cwd, npath.toPortablePath(userProvidedPath));
-          importPlugin(pluginPath, path);
+          await importPlugin(pluginPath, path);
         }
       }
     }

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1008,7 +1008,7 @@ export class Configuration {
 
       const dynamicPlugins = new Set();
 
-      const importPlugin = (pluginPath: PortablePath, source: string) => {
+      const importPlugin = async (pluginPath: PortablePath, source: string) => {
         const {factory, name} = miscUtils.dynamicRequire(npath.fromPortablePath(pluginPath));
 
         // Prevent plugin redefinition so that the ones declared deeper in the
@@ -1025,8 +1025,8 @@ export class Configuration {
           }
         };
 
-        const plugin = miscUtils.prettifySyncErrors(() => {
-          return getDefault(factory(pluginRequire));
+        const plugin = await miscUtils.prettifyAsyncErrors(async () => {
+          return getDefault(await factory(pluginRequire));
         }, message => {
           return `${message} (when initializing ${name}, defined in ${source})`;
         });
@@ -1040,7 +1040,7 @@ export class Configuration {
       if (environmentSettings.plugins) {
         for (const userProvidedPath of environmentSettings.plugins.split(`;`)) {
           const pluginPath = ppath.resolve(startingCwd, npath.toPortablePath(userProvidedPath));
-          importPlugin(pluginPath, `<environment>`);
+          await importPlugin(pluginPath, `<environment>`);
         }
       }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some use cases need to access the configuration in order to extract information necessary to setup the CLI (https://github.com/yarnpkg/berry/issues/3077). This isn't possible at the moment (at least not without reimplementing some of the configuration loading).

**How did you fix it?**

Plugins can now be loaded asynchronously. Note that it shouldn't affect much the boot time, because this only affects the plugins loaded from the environment or rc files - the builtin ones are always injected synchronously.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
