### PR TITLE
fix(node-modules) Exclude unresolved peer deps from portal compatibility check

### DIFF
--- a/.yarn/versions/06f8d539.yml
+++ b/.yarn/versions/06f8d539.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-node-modules": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-pnpify/sources/buildNodeModulesTree.ts
@@ -312,38 +312,40 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
               preserveSymlinksRequired = true;
 
             for (const [name, referencish] of depPkg.packageDependencies) {
-              const portalDependencyLocator = structUtils.parseLocator(Array.isArray(referencish) ? `${referencish[0]}@${referencish[1]}` : `${name}@${referencish}`);
-              // Ignore self-references during portal hoistability check
-              if (stringifyLocator(portalDependencyLocator) !== stringifyLocator(depLocator)) {
-                const parentDependencyReferencish = allDependencies.get(name);
-                if (parentDependencyReferencish) {
-                  const parentDependencyLocator = structUtils.parseLocator(Array.isArray(parentDependencyReferencish) ? `${parentDependencyReferencish[0]}@${parentDependencyReferencish[1]}` : `${name}@${parentDependencyReferencish}`);
-                  if (!areRealLocatorsEqual(parentDependencyLocator, portalDependencyLocator)) {
-                    errors.push({
-                      messageName: MessageName.NM_CANT_INSTALL_EXTERNAL_SOFT_LINK,
-                      text: `Cannot link ${structUtils.prettyIdent(options.project.configuration, structUtils.parseIdent(depLocator.name))} ` +
-                        `into ${structUtils.prettyLocator(options.project.configuration, structUtils.parseLocator(`${locator.name}@${locator.reference}`))} ` +
-                        `dependency ${structUtils.prettyLocator(options.project.configuration, portalDependencyLocator)} ` +
-                        `conflicts with parent dependency ${structUtils.prettyLocator(options.project.configuration, parentDependencyLocator)}`,
-                    });
-                  }
-                } else {
-                  const siblingPortalDependency = siblingPortalDependencyMap.get(name);
-                  if (siblingPortalDependency) {
-                    const siblingReferncish = siblingPortalDependency.target;
-                    const siblingPortalDependencyLocator = structUtils.parseLocator(Array.isArray(siblingReferncish) ? `${siblingReferncish[0]}@${siblingReferncish[1]}` : `${name}@${siblingReferncish}`);
-                    if (!areRealLocatorsEqual(siblingPortalDependencyLocator, portalDependencyLocator)) {
+              if (referencish !== null) {
+                const portalDependencyLocator = structUtils.parseLocator(Array.isArray(referencish) ? `${referencish[0]}@${referencish[1]}` : `${name}@${referencish}`);
+                // Ignore self-references during portal hoistability check
+                if (stringifyLocator(portalDependencyLocator) !== stringifyLocator(depLocator)) {
+                  const parentDependencyReferencish = allDependencies.get(name);
+                  if (parentDependencyReferencish) {
+                    const parentDependencyLocator = structUtils.parseLocator(Array.isArray(parentDependencyReferencish) ? `${parentDependencyReferencish[0]}@${parentDependencyReferencish[1]}` : `${name}@${parentDependencyReferencish}`);
+                    if (!areRealLocatorsEqual(parentDependencyLocator, portalDependencyLocator)) {
                       errors.push({
                         messageName: MessageName.NM_CANT_INSTALL_EXTERNAL_SOFT_LINK,
                         text: `Cannot link ${structUtils.prettyIdent(options.project.configuration, structUtils.parseIdent(depLocator.name))} ` +
+                        `into ${structUtils.prettyLocator(options.project.configuration, structUtils.parseLocator(`${locator.name}@${locator.reference}`))} ` +
+                        `dependency ${structUtils.prettyLocator(options.project.configuration, portalDependencyLocator)} ` +
+                        `conflicts with parent dependency ${structUtils.prettyLocator(options.project.configuration, parentDependencyLocator)}`,
+                      });
+                    }
+                  } else {
+                    const siblingPortalDependency = siblingPortalDependencyMap.get(name);
+                    if (siblingPortalDependency) {
+                      const siblingReferncish = siblingPortalDependency.target;
+                      const siblingPortalDependencyLocator = structUtils.parseLocator(Array.isArray(siblingReferncish) ? `${siblingReferncish[0]}@${siblingReferncish[1]}` : `${name}@${siblingReferncish}`);
+                      if (!areRealLocatorsEqual(siblingPortalDependencyLocator, portalDependencyLocator)) {
+                        errors.push({
+                          messageName: MessageName.NM_CANT_INSTALL_EXTERNAL_SOFT_LINK,
+                          text: `Cannot link ${structUtils.prettyIdent(options.project.configuration, structUtils.parseIdent(depLocator.name))} ` +
                           `into ${structUtils.prettyLocator(options.project.configuration, structUtils.parseLocator(`${locator.name}@${locator.reference}`))} ` +
                           `dependency ${structUtils.prettyLocator(options.project.configuration, portalDependencyLocator)} ` +
                           `conflicts with dependency ${structUtils.prettyLocator(options.project.configuration, siblingPortalDependencyLocator)} ` +
                           `from sibling portal ${structUtils.prettyIdent(options.project.configuration, structUtils.parseIdent(siblingPortalDependency.portal.name))}`,
-                      });
+                        });
+                      }
+                    } else {
+                      siblingPortalDependencyMap.set(name, {target: portalDependencyLocator.reference, portal: depLocator});
                     }
-                  } else {
-                    siblingPortalDependencyMap.set(name, {target: portalDependencyLocator.reference, portal: depLocator});
                   }
                 }
               }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The portal compatiblity check currently thinks that portal having unresolved peer dependency conflicts with the parent that has resolved peer dependency with the same name. They are compatible indeed, because when the peer dep is unresolved all bets are off and install should not stop because of this.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Ignores unresolved peer dependencies during portal compatibility check

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
