### PR TITLE
fix(core): let `semver` try to match first in `satisfiesWithPrereleases`

### DIFF
--- a/.yarn/versions/6b06cd35.yml
+++ b/.yarn/versions/6b06cd35.yml
@@ -1,0 +1,30 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-node-modules"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -38,12 +38,15 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
   let semverVersion: semver.SemVer;
   try {
     semverVersion = new semver.SemVer(version, semverRange);
-    if (semverVersion.prerelease) {
-      semverVersion.prerelease = [];
-    }
   } catch (err) {
     return false;
   }
+
+  if (semverRange.test(semverVersion))
+    return true;
+
+  if (semverVersion.prerelease)
+    semverVersion.prerelease = [];
 
   // A range has multiple sets of comparators. A version must satisfy all
   // comparators in a set and at least one set to satisfy the range.

--- a/packages/yarnpkg-core/tests/semverUtils.test.ts
+++ b/packages/yarnpkg-core/tests/semverUtils.test.ts
@@ -43,6 +43,9 @@ const SPECS: Specs = [
   [`1.0.0-rc2`, `1.0.0-rc4`, false],
   [`1.0.0-rc4`, `1.0.0-rc2`, false],
   [`1.0.0-beta.1`, `1.0.0-beta.2`, false],
+
+  // These don't match with our patch but do without it
+  [`<=5.0.0-beta.0`, `5.0.0-alpha.7`, true],
 ];
 
 describe(`semverUtils`, () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some of the extensions added in https://github.com/yarnpkg/berry/pull/3082 didn't get applied since `satisfiesWithPrereleases` didn't match them correctly

**How did you fix it?**

Let `semver` see if the version satisfies the range and if it doesn't run our loose check

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.