### PR TITLE
feat: add better error message to pnpify --sdk

### DIFF
--- a/.yarn/versions/60c8888c.yml
+++ b/.yarn/versions/60c8888c.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-pnpify/sources/cli.ts
+++ b/packages/yarnpkg-pnpify/sources/cli.ts
@@ -3,6 +3,7 @@
 import {Cli, Builtins} from 'clipanion';
 
 import RunCommand      from './commands/RunCommand';
+import SdkCommand      from './commands/SdkCommand';
 
 const cli = new Cli({
   binaryLabel: `Yarn PnPify`,
@@ -11,6 +12,7 @@ const cli = new Cli({
 });
 
 cli.register(RunCommand);
+cli.register(SdkCommand);
 
 cli.register(Builtins.DefinitionsCommand);
 cli.register(Builtins.HelpCommand);

--- a/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/SdkCommand.ts
@@ -1,0 +1,16 @@
+import {Command, Option, UsageError} from 'clipanion';
+
+// TODO: remove error message in next major
+
+// eslint-disable-next-line arca/no-default-export
+export default class SdkCommand extends Command {
+  static paths = [
+    [`--sdk`],
+  ];
+
+  args = Option.Proxy();
+
+  async execute() {
+    throw new UsageError(`The 'pnpify --sdk ...' command has been moved to the '@yarnpkg/sdks' package - use 'yarn dlx @yarnpkg/sdks ...' instead`);
+  }
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We've refactored `@yarnpkg/pnpify` into 3 packages and moved the `pnpify --sdk` command to `@yarnpkg/sdks`, but there's no user-friendly error stating this.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added a better error message when somebody uses `pnpify --sdk`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
