### PR TITLE
feat(plugin-pack): reload manifest after prepack script

### DIFF
--- a/.yarn/versions/ad4d146d.yml
+++ b/.yarn/versions/ad4d146d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-pack": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/ad4d146d.yml
+++ b/.yarn/versions/ad4d146d.yml
@@ -1,6 +1,6 @@
 releases:
-  "@yarnpkg/cli": major
-  "@yarnpkg/plugin-pack": minor
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pack": patch
 
 declined:
   - "@yarnpkg/plugin-compat"

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -1,4 +1,4 @@
-import {Report, Workspace, scriptUtils, tgzUtils}                  from '@yarnpkg/core';
+import {Manifest, Report, Workspace, scriptUtils, tgzUtils}        from '@yarnpkg/core';
 import {FakeFS, JailFS, xfs, PortablePath, ppath, Filename, npath} from '@yarnpkg/fslib';
 import {Hooks as StageHooks}                                       from '@yarnpkg/plugin-stage';
 import mm                                                          from 'micromatch';
@@ -57,6 +57,10 @@ export async function prepareForPack(workspace: Workspace, {report}: {report: Re
   await scriptUtils.maybeExecuteWorkspaceLifecycleScript(workspace, `prepack`, {report});
 
   try {
+    const manifestPath = ppath.join(workspace.cwd, Manifest.fileName);
+    if (await xfs.existsPromise(manifestPath))
+      await workspace.manifest.loadFile(manifestPath, {baseFs: xfs});
+
     await cb();
   } finally {
     await scriptUtils.maybeExecuteWorkspaceLifecycleScript(workspace, `postpack`, {report});


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Resolves #3145 - see issue for rationale.

**How did you fix it?**
<!-- A detailed description of your implementation. -->
This unconditionally reloads the active workspace's manifest during `prepareForPack` after the prepack lifecycle script exits.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
