### PR TITLE
fix: don't set packageManager field when bundleVersion isn't semver

### DIFF
--- a/.yarn/versions/e704a693.yml
+++ b/.yarn/versions/e704a693.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/e704a693.yml
+++ b/.yarn/versions/e704a693.yml
@@ -1,14 +1,22 @@
 releases:
   "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
   "@yarnpkg/plugin-essentials": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
   - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
@@ -18,5 +26,7 @@ declined:
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
-  - "@yarnpkg/core"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -189,7 +189,7 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
     const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
 
-    if (bundleVersion && semver.valid(bundleVersion) && miscUtils.isTaggedYarnVersion(bundleVersion))
+    if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion))
       manifest.packageManager = `yarn@${bundleVersion}`;
 
     const data = {};

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -189,7 +189,7 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
     const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
 
-    if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion))
+    if (bundleVersion && semver.valid(bundleVersion) && miscUtils.isTaggedYarnVersion(bundleVersion))
       manifest.packageManager = `yarn@${bundleVersion}`;
 
     const data = {};

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -1,13 +1,14 @@
 import {PortablePath, npath, xfs} from '@yarnpkg/fslib';
 import {UsageError}               from 'clipanion';
 import micromatch                 from 'micromatch';
+import semver                     from 'semver';
 import {Readable, Transform}      from 'stream';
 
 /**
  * @internal
  */
 export function isTaggedYarnVersion(version: string) {
-  return version.match(/^[^-]+(-rc\.[0-9]+)?$/);
+  return semver.valid(version) && version.match(/^[^-]+(-rc\.[0-9]+)?$/);
 }
 
 export function escapeRegExp(str: string) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When running `yarn set version from sources`, `bundleVersion` is `sources` and Yarn tries to set corepack's `packageManager` field to `yarn@sources` which isn't valid.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Check if the `bundleVersion` is valid semver before setting the field.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
