### PR TITLE
chore: enforce using `@ts-expect-error` instead of `@ts-ignore`

### DIFF
--- a/.yarn/versions/27b1a1ae.yml
+++ b/.yarn/versions/27b1a1ae.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/eslint-config": patch

--- a/.yarn/versions/27b1a1ae.yml
+++ b/.yarn/versions/27b1a1ae.yml
@@ -1,2 +1,2 @@
 releases:
-  "@yarnpkg/eslint-config": patch
+  "@yarnpkg/eslint-config": minor

--- a/packages/eslint-config/rules/best-practices.js
+++ b/packages/eslint-config/rules/best-practices.js
@@ -13,6 +13,8 @@ module.exports = {
       ignoreRestSiblings: true,
     }],
 
+    '@typescript-eslint/prefer-ts-expect-error': 2,
+
     'arca/no-default-export': 2,
 
     'consistent-return': 2,

--- a/packages/gatsby/src/utils/schemaUtils.tsx
+++ b/packages/gatsby/src/utils/schemaUtils.tsx
@@ -158,7 +158,7 @@ export const renderArrayProperty = (name: string, definition: JSONSchema7, state
     if (typeof arrayProperty === `object` && arrayProperty !== null) {
       const subDefinition = definition.items! as JSONSchema7;
       return <>{Object.keys(arrayProperty).map(name => {
-        // @ts-ignore
+        // @ts-expect-error
         return renderProperty(name, subDefinition.properties[name], {...state, pathSegments: [...state.pathSegments, `${index}`, name]});
       })}</>;
     } else {

--- a/packages/yarnpkg-fslib/sources/ProxiedFS.test.ts
+++ b/packages/yarnpkg-fslib/sources/ProxiedFS.test.ts
@@ -5,10 +5,10 @@ import {PortablePath, ppath} from './path';
 describe(`ProxiedFS`, () => {
   it(`should resolve relative symlinks after remapping`, async () => {
     class SpyFS extends NoFS {
-      // @ts-ignore
+      // @ts-expect-error
       symlinkPromise = jest.fn(async () => {});
 
-      // @ts-ignore
+      // @ts-expect-error
       symlinkSync = jest.fn(() => {});
     }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

#1729 replaced all instances of `@ts-ignore` (at that time) with `@ts-expect-error`, but since then a few others were introduced in the codebase because ESLint didn't report them as linting errors.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Enabled `@typescript-eslint/prefer-ts-expect-error` and autofixed things.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
