### PR TITLE
fix: root workspace without dependencies in pnp loose mode

### DIFF
--- a/.yarn/versions/68a43f48.yml
+++ b/.yarn/versions/68a43f48.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpLoose.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpLoose.test.ts
@@ -132,5 +132,31 @@ describe(`Features`, () => {
         },
       ),
     );
+
+    test(
+      `it should install a root workspace without any dependencies (unnamed)`,
+      makeTemporaryEnv(
+        {},
+        {
+          pnpMode: `loose`,
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`)).resolves.toBeTruthy();
+        },
+      ),
+    );
+
+    test(
+      `it should install a root workspace without any dependencies (named)`,
+      makeTemporaryEnv(
+        {name: `workspace`},
+        {
+          pnpMode: `loose`,
+        },
+        async ({path, run, source}) => {
+          await expect(run(`install`)).resolves.toBeTruthy();
+        },
+      ),
+    );
   });
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpLoose.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpLoose.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 describe(`Features`, () => {
   describe(`PnP Loose`, () => {
     test(

--- a/packages/plugin-nm/sources/PnpLooseLinker.ts
+++ b/packages/plugin-nm/sources/PnpLooseLinker.ts
@@ -51,8 +51,9 @@ class PnpLooseInstaller extends PnpInstaller {
     const root = ppath.join(this.opts.project.cwd, Filename.nodeModules);
 
     const entry = tree.get(root);
+    // If there's no root junction point, it means that there are no dependencies to add to the fallback pool
     if (typeof entry === `undefined`)
-      throw new Error(`Assertion failed: Expected a root junction point`);
+      return;
 
     if (`target` in entry)
       throw new Error(`Assertion failed: Expected the root junction point to be a directory`);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

PnP loose mode always expected a junction point, but there's no junction point when the root workspace doesn't depend on anything.

Fixes #3126.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Early return if there's no junction point.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
