### PR TITLE
feat(builder): use `main` field as entry point when building plugins

### DIFF
--- a/.yarn/versions/6003d3e1.yml
+++ b/.yarn/versions/6003d3e1.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": minor
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -57,7 +57,7 @@ export default class BuildPluginCommand extends Command {
     const portableBaseDir = npath.toPortablePath(basedir);
     const configuration = Configuration.create(portableBaseDir);
 
-    const {name: rawName} = require(`${basedir}/package.json`);
+    const {name: rawName, main} = require(`${basedir}/package.json`);
     const name = getNormalizedName(rawName);
     const prettyName = structUtils.prettyIdent(configuration, structUtils.parseIdent(name));
     const output = path.join(basedir, `bundles/${name}.js`);
@@ -109,7 +109,7 @@ export default class BuildPluginCommand extends Command {
               `};`,
             ].join(`\n`),
           },
-          entryPoints: [path.join(basedir, `sources/index`)],
+          entryPoints: [path.resolve(basedir, main ?? `sources/index`)],
           bundle: true,
           outfile: output,
           logLevel: `silent`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

It wasn't possible to configure the entry point of the builder when building plugins.

Closes #3114.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Use `main` as the entry point.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
