### PR TITLE
fix: validate strategies in version plugin and support ": decline"

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -14742,6 +14742,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./packages/plugin-version/",
           "packageDependencies": [
             ["@yarnpkg/plugin-version", "workspace:packages/plugin-version"],
+            ["@types/lodash", "npm:4.14.168"],
             ["@types/react", "npm:16.9.2"],
             ["@types/semver", "npm:7.1.0"],
             ["@yarnpkg/builder", "virtual:c44c4b6360dc34d25da6d32e39622e7e40f36f37b99dc66b6ebbd615fdd49465f496bf10f81b6fa5f71b95443fda61174ad51d2799fc7ca433af9a9666cd0f37#workspace:packages/yarnpkg-builder"],
@@ -14752,6 +14753,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["ink", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#npm:3.0.8"],
+            ["lodash", "npm:4.17.21"],
             ["react", "npm:16.13.1"],
             ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"],

--- a/.yarn/versions/1299405d.yml
+++ b/.yarn/versions/1299405d.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
@@ -1,4 +1,4 @@
-import {xfs, ppath, PortablePath} from '@yarnpkg/fslib';
+import {xfs, ppath, PortablePath, Filename} from '@yarnpkg/fslib';
 
 const {
   fs: {readJson},
@@ -217,7 +217,7 @@ describe(`Commands`, () => {
           // Create the primary package.
           const pkgPrimary = ppath.join(path, `packages/pkg-primary` as PortablePath);
           await xfs.mkdirpPromise(pkgPrimary);
-          await xfs.writeJsonPromise(ppath.join(pkgPrimary, `package.json` as PortablePath), {
+          await xfs.writeJsonPromise(ppath.join(pkgPrimary, Filename.manifest), {
             name: `pkg-primary`,
             version: `1.0.0`,
           });
@@ -225,7 +225,7 @@ describe(`Commands`, () => {
           // Create the dependant package.
           const pkgDependant = ppath.join(path, `packages/pkg-dependant` as PortablePath);
           await xfs.mkdirpPromise(pkgDependant);
-          await xfs.writeJsonPromise(ppath.join(pkgDependant, `package.json` as PortablePath), {
+          await xfs.writeJsonPromise(ppath.join(pkgDependant, Filename.manifest), {
             name: `pkg-dependant`,
             version: `1.0.0`,
             dependencies: {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
@@ -1,4 +1,4 @@
-import {xfs, ppath} from '@yarnpkg/fslib';
+import {xfs, ppath, PortablePath} from '@yarnpkg/fslib';
 
 const {
   fs: {readJson},
@@ -215,17 +215,17 @@ describe(`Commands`, () => {
         },
         async ({path, run, source}) => {
           // Create the primary package.
-          const pkgPrimary = ppath.join(path, `packages/pkg-primary`);
+          const pkgPrimary = ppath.join(path, `packages/pkg-primary` as PortablePath);
           await xfs.mkdirpPromise(pkgPrimary);
-          await xfs.writeJsonPromise(ppath.join(pkgPrimary, `package.json`), {
+          await xfs.writeJsonPromise(ppath.join(pkgPrimary, `package.json` as PortablePath), {
             name: `pkg-primary`,
             version: `1.0.0`,
           });
 
           // Create the dependant package.
-          const pkgDependant = ppath.join(path, `packages/pkg-dependant`);
+          const pkgDependant = ppath.join(path, `packages/pkg-dependant` as PortablePath);
           await xfs.mkdirpPromise(pkgDependant);
-          await xfs.writeJsonPromise(ppath.join(pkgDependant, `package.json`), {
+          await xfs.writeJsonPromise(ppath.join(pkgDependant, `package.json` as PortablePath), {
             name: `pkg-dependant`,
             version: `1.0.0`,
             dependencies: {
@@ -240,6 +240,47 @@ describe(`Commands`, () => {
             stdout: expect.stringContaining(`Couldn't auto-upgrade range * (in pkg-dependant@workspace:packages/pkg-dependant)`),
           });
         }),
+    );
+
+    test(
+      `it should throw when applying an invalid strategy`,
+      makeTemporaryEnv({
+        version: `1.0.0`,
+      }, {
+        plugins: [
+          require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+        ],
+      }, async ({path, run, source}) => {
+        await expect(run(`version`, `invalid`)).rejects.toThrow(`Invalid value for enumeration: "invalid"`);
+      }),
+    );
+
+    test(
+      `it should throw when applying an invalid strategy on top of the stored version`,
+      makeTemporaryEnv({
+        version: `1.0.0`,
+      }, {
+        plugins: [
+          require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+        ],
+      }, async ({path, run, source}) => {
+        await run(`version`, `major`, `--deferred`);
+
+        await expect(run(`version`, `invalid`)).rejects.toThrow(`Invalid value for enumeration: "invalid"`);
+      }),
+    );
+
+    test(
+      `it should throw when applying an invalid strategy (deferred)`,
+      makeTemporaryEnv({
+        version: `1.0.0`,
+      }, {
+        plugins: [
+          require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+        ],
+      }, async ({path, run, source}) => {
+        await expect(run(`version`, `invalid`, `--deferred`)).rejects.toThrow(`Invalid value for enumeration: "invalid"`);
+      }),
     );
   });
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.ts
@@ -1,4 +1,4 @@
-import {xfs, ppath, PortablePath} from '@yarnpkg/fslib';
+import {xfs, ppath, PortablePath, Filename} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
   describe(`version apply`, () => {
@@ -16,13 +16,13 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await run(`version`, `patch`, `--deferred`);
 
-          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
             version: `0.0.0`,
           });
 
           await run(`version`, `apply`);
 
-          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
             version: `0.0.1`,
           });
         }
@@ -50,12 +50,12 @@ describe(`Commands`, () => {
           await xfs.mkdirpPromise(pkgA);
           await xfs.mkdirpPromise(pkgB);
 
-          await xfs.writeJsonPromise(ppath.join(pkgA, `package.json` as PortablePath), {
+          await xfs.writeJsonPromise(ppath.join(pkgA, Filename.manifest), {
             name: `pkg-a`,
             version: `1.0.0`,
           });
 
-          await xfs.writeJsonPromise(ppath.join(pkgB, `package.json` as PortablePath), {
+          await xfs.writeJsonPromise(ppath.join(pkgB, Filename.manifest), {
             name: `pkg-b`,
             version: `1.0.0`,
           });
@@ -66,11 +66,11 @@ describe(`Commands`, () => {
 
           await run(`version`, `apply`, `--all`);
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgA, Filename.manifest))).resolves.toMatchObject({
             version: `1.0.0`,
           });
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgB, Filename.manifest))).resolves.toMatchObject({
             version: `1.0.1`,
           });
         }
@@ -98,12 +98,12 @@ describe(`Commands`, () => {
           await xfs.mkdirpPromise(pkgA);
           await xfs.mkdirpPromise(pkgB);
 
-          await xfs.writeJsonPromise(ppath.join(pkgA, `package.json` as PortablePath), {
+          await xfs.writeJsonPromise(ppath.join(pkgA, Filename.manifest), {
             name: `pkg-a`,
             version: `1.0.0`,
           });
 
-          await xfs.writeJsonPromise(ppath.join(pkgB, `package.json` as PortablePath), {
+          await xfs.writeJsonPromise(ppath.join(pkgB, Filename.manifest), {
             name: `pkg-b`,
             version: `1.0.0`,
           });
@@ -118,11 +118,11 @@ describe(`Commands`, () => {
 
           await run(`version`, `apply`, `--all`);
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgA, Filename.manifest))).resolves.toMatchObject({
             version: `1.0.1`,
           });
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgB, Filename.manifest))).resolves.toMatchObject({
             version: `1.0.1`,
           });
         }
@@ -143,13 +143,13 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await run(`version`, `decline`, `--deferred`);
 
-          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
             version: `0.0.0`,
           });
 
           await run(`version`, `apply`);
 
-          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
             version: `0.0.0`,
           });
         }
@@ -185,7 +185,7 @@ describe(`Commands`, () => {
             await xfs.mkdirpPromise(pkgA);
             await xfs.mkdirpPromise(pkgB);
 
-            await xfs.writeJsonPromise(ppath.join(pkgA, `package.json` as PortablePath), {
+            await xfs.writeJsonPromise(ppath.join(pkgA, Filename.manifest), {
               name: `pkg-a`,
               version: `1.0.0`,
               dependencies: {
@@ -193,7 +193,7 @@ describe(`Commands`, () => {
               },
             });
 
-            await xfs.writeJsonPromise(ppath.join(pkgB, `package.json` as PortablePath), {
+            await xfs.writeJsonPromise(ppath.join(pkgB, Filename.manifest), {
               name: `pkg-b`,
               version: `1.0.0`,
             });
@@ -204,14 +204,14 @@ describe(`Commands`, () => {
 
             await run(`version`, `apply`, `--all`);
 
-            await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json` as PortablePath))).resolves.toMatchObject({
+            await expect(xfs.readJsonPromise(ppath.join(pkgA, Filename.manifest))).resolves.toMatchObject({
               version: `1.0.0`,
               dependencies: {
                 [`pkg-b`]: dependency.replace(/1\.0\.0/, `1.0.1`),
               },
             });
 
-            await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json` as PortablePath))).resolves.toMatchObject({
+            await expect(xfs.readJsonPromise(ppath.join(pkgB, Filename.manifest))).resolves.toMatchObject({
               version: `1.0.1`,
             });
           }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.ts
@@ -1,4 +1,4 @@
-import {xfs, ppath} from '@yarnpkg/fslib';
+import {xfs, ppath, PortablePath} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
   describe(`version apply`, () => {
@@ -16,13 +16,13 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await run(`version`, `patch`, `--deferred`);
 
-          await expect(xfs.readJsonPromise(ppath.join(path, `package.json`))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
             version: `0.0.0`,
           });
 
           await run(`version`, `apply`);
 
-          await expect(xfs.readJsonPromise(ppath.join(path, `package.json`))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
             version: `0.0.1`,
           });
         }
@@ -44,18 +44,18 @@ describe(`Commands`, () => {
           ],
         },
         async ({path, run}) => {
-          const pkgA = ppath.join(path, `packages/pkg-a`);
-          const pkgB = ppath.join(path, `packages/pkg-b`);
+          const pkgA = ppath.join(path, `packages/pkg-a` as PortablePath);
+          const pkgB = ppath.join(path, `packages/pkg-b` as PortablePath);
 
           await xfs.mkdirpPromise(pkgA);
           await xfs.mkdirpPromise(pkgB);
 
-          await xfs.writeJsonPromise(ppath.join(pkgA, `package.json`), {
+          await xfs.writeJsonPromise(ppath.join(pkgA, `package.json` as PortablePath), {
             name: `pkg-a`,
             version: `1.0.0`,
           });
 
-          await xfs.writeJsonPromise(ppath.join(pkgB, `package.json`), {
+          await xfs.writeJsonPromise(ppath.join(pkgB, `package.json` as PortablePath), {
             name: `pkg-b`,
             version: `1.0.0`,
           });
@@ -66,11 +66,11 @@ describe(`Commands`, () => {
 
           await run(`version`, `apply`, `--all`);
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json`))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json` as PortablePath))).resolves.toMatchObject({
             version: `1.0.0`,
           });
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json`))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json` as PortablePath))).resolves.toMatchObject({
             version: `1.0.1`,
           });
         }
@@ -92,18 +92,18 @@ describe(`Commands`, () => {
           ],
         },
         async ({path, run}) => {
-          const pkgA = ppath.join(path, `packages/pkg-a`);
-          const pkgB = ppath.join(path, `packages/pkg-b`);
+          const pkgA = ppath.join(path, `packages/pkg-a` as PortablePath);
+          const pkgB = ppath.join(path, `packages/pkg-b` as PortablePath);
 
           await xfs.mkdirpPromise(pkgA);
           await xfs.mkdirpPromise(pkgB);
 
-          await xfs.writeJsonPromise(ppath.join(pkgA, `package.json`), {
+          await xfs.writeJsonPromise(ppath.join(pkgA, `package.json` as PortablePath), {
             name: `pkg-a`,
             version: `1.0.0`,
           });
 
-          await xfs.writeJsonPromise(ppath.join(pkgB, `package.json`), {
+          await xfs.writeJsonPromise(ppath.join(pkgB, `package.json` as PortablePath), {
             name: `pkg-b`,
             version: `1.0.0`,
           });
@@ -118,12 +118,39 @@ describe(`Commands`, () => {
 
           await run(`version`, `apply`, `--all`);
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json`))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json` as PortablePath))).resolves.toMatchObject({
             version: `1.0.1`,
           });
 
-          await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json`))).resolves.toMatchObject({
+          await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json` as PortablePath))).resolves.toMatchObject({
             version: `1.0.1`,
+          });
+        }
+      )
+    );
+
+    test(
+      `it should apply "decline"`,
+      makeTemporaryEnv(
+        {
+          version: `0.0.0`,
+        },
+        {
+          plugins: [
+            require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+          ],
+        },
+        async ({path, run}) => {
+          await run(`version`, `decline`, `--deferred`);
+
+          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
+            version: `0.0.0`,
+          });
+
+          await run(`version`, `apply`);
+
+          await expect(xfs.readJsonPromise(ppath.join(path, `package.json` as PortablePath))).resolves.toMatchObject({
+            version: `0.0.0`,
           });
         }
       )
@@ -134,7 +161,7 @@ describe(`Commands`, () => {
       [`implicit range`, `^1.0.0`, true],
       [`explicit`, `workspace:1.0.0`, true],
       [`explicit range`, `workspace:^1.0.0`, true],
-    ];
+    ] as const;
 
     for (const [name, dependency] of alternatives) {
       test(
@@ -152,13 +179,13 @@ describe(`Commands`, () => {
             ],
           },
           async ({path, run}) => {
-            const pkgA = ppath.join(path, `packages/pkg-a`);
-            const pkgB = ppath.join(path, `packages/pkg-b`);
+            const pkgA = ppath.join(path, `packages/pkg-a` as PortablePath);
+            const pkgB = ppath.join(path, `packages/pkg-b` as PortablePath);
 
             await xfs.mkdirpPromise(pkgA);
             await xfs.mkdirpPromise(pkgB);
 
-            await xfs.writeJsonPromise(ppath.join(pkgA, `package.json`), {
+            await xfs.writeJsonPromise(ppath.join(pkgA, `package.json` as PortablePath), {
               name: `pkg-a`,
               version: `1.0.0`,
               dependencies: {
@@ -166,7 +193,7 @@ describe(`Commands`, () => {
               },
             });
 
-            await xfs.writeJsonPromise(ppath.join(pkgB, `package.json`), {
+            await xfs.writeJsonPromise(ppath.join(pkgB, `package.json` as PortablePath), {
               name: `pkg-b`,
               version: `1.0.0`,
             });
@@ -177,14 +204,14 @@ describe(`Commands`, () => {
 
             await run(`version`, `apply`, `--all`);
 
-            await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json`))).resolves.toMatchObject({
+            await expect(xfs.readJsonPromise(ppath.join(pkgA, `package.json` as PortablePath))).resolves.toMatchObject({
               version: `1.0.0`,
               dependencies: {
                 [`pkg-b`]: dependency.replace(/1\.0\.0/, `1.0.1`),
               },
             });
 
-            await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json`))).resolves.toMatchObject({
+            await expect(xfs.readJsonPromise(ppath.join(pkgB, `package.json` as PortablePath))).resolves.toMatchObject({
               version: `1.0.1`,
             });
           }

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -9,6 +9,7 @@
     "@yarnpkg/parsers": "workspace:^2.4.0-rc.10",
     "clipanion": "^3.0.1",
     "ink": "^3.0.8",
+    "lodash": "^4.17.15",
     "react": "^16.13.1",
     "semver": "^7.1.2",
     "tslib": "^1.13.0"
@@ -18,6 +19,7 @@
     "@yarnpkg/core": "^3.0.0-rc.12"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.136",
     "@types/react": "^16.8.0",
     "@types/semver": "^7.1.0",
     "@yarnpkg/builder": "workspace:*",

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -88,7 +88,7 @@ export default class VersionCommand extends BaseCommand {
         }
       }
 
-      releaseStrategy = this.strategy;
+      releaseStrategy = versionUtils.validateReleaseDecision(this.strategy);
     }
 
     if (!deferred) {

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -23,8 +23,10 @@ export function assertNever(arg: never): never {
 }
 
 export function validateEnum<T>(def: {[key: string]: T}, value: string): T {
-  if (!Object.values(def).includes(value as any))
-    throw new Error(`Assertion failed: Invalid value for enumeration`);
+  const values = Object.values(def);
+
+  if (!values.includes(value as any))
+    throw new UsageError(`Invalid value for enumeration: ${JSON.stringify(value)} (expected one of ${values.map(value => JSON.stringify(value)).join(`, `)})`);
 
   return value as any as T;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,6 +5991,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-version@workspace:packages/plugin-version"
   dependencies:
+    "@types/lodash": ^4.14.136
     "@types/react": ^16.8.0
     "@types/semver": ^7.1.0
     "@yarnpkg/builder": "workspace:*"
@@ -6001,6 +6002,7 @@ __metadata:
     "@yarnpkg/parsers": "workspace:^2.4.0-rc.10"
     clipanion: ^3.0.1
     ink: ^3.0.8
+    lodash: ^4.17.15
     react: ^16.13.1
     semver: ^7.1.2
     tslib: ^1.13.0


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- The version plugin didn't validate the versions from the release files / applied by `yarn version`.
- The version plugin didn't support applying releases using the `: decline` syntax

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I also wanted to add tests testing manual modifications to the version files but I haven't managed to get them to work.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
