### PR TITLE
fix: respect preferInteractive in yarn add

### DIFF
--- a/.yarn/versions/cf905fb9.yml
+++ b/.yarn/versions/cf905fb9.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -98,7 +98,7 @@ export default class AddCommand extends BaseCommand {
     description: `Add / upgrade a package to a dev dependency`,
   });
 
-  interactive = Option.Boolean(`-i,--interactive`, false, {
+  interactive = Option.Boolean(`-i,--interactive`, {
     description: `Reuse the specified package from other workspaces in the project`,
   });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn add` didn't respect `preferInteractive` anymore.

I added support for it in #1568 but it was accidentally regressed in https://github.com/yarnpkg/berry/pull/2370/files#diff-25c3769b5d919544ba1e2f3dd148d8ce448cd2af68363a129aec641d641c1c6dR94.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed the default value so that the `??` fallback can kick in when the `--interactive` / `--no-interactive` flag isn't used. 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
