### PR TITLE
Fix nested list indentation in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,9 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
   - Because Yarn installs will never modify files outside of the project due to security reasons, sub-dependencies of packages with `portal:` must be hoisted outside of the portal. Failing that (for example if the portal package depends on something incompatible with the version hoisted via another package), the linker will produce an error and abandon the install.
 
 - The node-modules linker can now utilize hardlinks. The new setting `nmMode: classic | hardlinks-local | hardlinks-global` specifies which `node_modules` strategy should be used:
- - `classic` - standard `node_modules` layout, without hardlinks
- - `hardlinks-local` - standard `node_modules` layout with hardlinks inside the project only
- - `hardlinks-global` - standard `node_modules` layout with hardlinks pointing to global content storage across all the projects using this option
+  - `classic` - standard `node_modules` layout, without hardlinks
+  - `hardlinks-local` - standard `node_modules` layout with hardlinks inside the project only
+  - `hardlinks-global` - standard `node_modules` layout with hardlinks pointing to global content storage across all the projects using this option
 
 ### Bugfixes
 


### PR DESCRIPTION
Small fix in Markdown.

[Before](https://github.com/yarnpkg/berry/blob/f8561e3f6c6a7442186c5233c621b28aeefe53ae/CHANGELOG.md#installs):

<img width="1084" alt="Screen Shot 2021-07-23 at 9 16 18" src="https://user-images.githubusercontent.com/101152/126749062-27aff54c-63dc-469b-b809-011f1319b039.png">

[After](https://github.com/yarnpkg/berry/blob/64260d74ea9a3b191ff28fcfeac4afa213b00df8/CHANGELOG.md):

<img width="1084" alt="Screen Shot 2021-07-23 at 9 17 50" src="https://user-images.githubusercontent.com/101152/126749167-7253e72c-2156-4429-911c-aa10d80fd114.png">
