### PR TITLE
fix: use real sdk versions again

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "0.0.0-sdk",
+  "version": "6.8.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "0.0.0-sdk",
+  "version": "4.3.2-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/.yarn/versions/d9194fbe.yml
+++ b/.yarn/versions/d9194fbe.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -221,7 +221,7 @@ export class Wrapper {
     await xfs.mkdirPromise(ppath.dirname(absWrapperPath), {recursive: true});
     await xfs.writeJsonPromise(absWrapperPath, {
       name: this.name,
-      version: `0.0.0-sdk`,
+      version: `${manifest.version}-sdk`,
       main: manifest.main,
       type: `commonjs`,
     });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We changed the sdk versions to be fixed to `0.0.0-sdk` in https://github.com/yarnpkg/berry/pull/3069 thinking it wouldn't affect VSCode's behavior, but apparently VSCode uses it for TS feature detection: https://github.com/yarnpkg/berry/pull/3069#issuecomment-886107112.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use the real version again.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
