### PR TITLE
Restores the fds after builtins finish executing

### DIFF
--- a/.yarn/versions/8e84815d.yml
+++ b/.yarn/versions/8e84815d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -632,11 +632,23 @@ function makeCommandAction(args: Array<string>, opts: ShellOptions, state: Shell
     throw new Error(`Assertion failed: A builtin should exist for "${name}"`);
 
   return makeBuiltin(async ({stdin, stdout, stderr}) => {
+    const {
+      stdin: initialStdin,
+      stdout: initialStdout,
+      stderr: initialStderr,
+    } = state;
+
     state.stdin = stdin;
     state.stdout = stdout;
     state.stderr = stderr;
 
-    return await builtin(rest, opts, state);
+    try {
+      return await builtin(rest, opts, state);
+    } finally {
+      state.stdin = initialStdin;
+      state.stdout = initialStdout;
+      state.stderr = initialStderr;
+    }
   });
 }
 

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -739,6 +739,32 @@ describe(`Shell`, () => {
         });
       });
 
+      it(`shouldn't affect unrelated commands`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+
+          await expect(bufferResult(
+            `echo "hello world" > "${file}"; echo foo`,
+          )).resolves.toMatchObject({
+            stdout: `foo\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`hello world\n`);
+        });
+
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+
+          await expect(bufferResult(
+            `echo "hello world" > "${file}" && echo foo`,
+          )).resolves.toMatchObject({
+            stdout: `foo\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`hello world\n`);
+        });
+      });
+
       it(`should support output redirections from fd (stdout)`, async () => {
         await xfs.mktempPromise(async tmpDir => {
           const file = ppath.join(tmpDir, `file` as Filename);

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -765,6 +765,34 @@ describe(`Shell`, () => {
         });
       });
 
+      it(`shouldn't do weird stuff when piping a builtin redirection`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          const file1 = ppath.join(tmpDir, `file1` as Filename);
+          const file2 = ppath.join(tmpDir, `file2` as Filename);
+
+          await expect(bufferResult(
+            `echo "hello world" > "${file1}" | echo "foo bar" > "${file2}"; echo test`,
+          )).resolves.toMatchObject({
+            stdout: `test\n`,
+          });
+
+          await expect(xfs.readFilePromise(file1, `utf8`)).resolves.toEqual(`hello world\n`);
+          await expect(xfs.readFilePromise(file2, `utf8`)).resolves.toEqual(`foo bar\n`);
+        });
+
+        await xfs.mktempPromise(async tmpDir => {
+          const file = ppath.join(tmpDir, `file` as Filename);
+
+          await expect(bufferResult(
+            `echo "hello world" > "${file}" && echo foo`,
+          )).resolves.toMatchObject({
+            stdout: `foo\n`,
+          });
+
+          await expect(xfs.readFilePromise(file, `utf8`)).resolves.toEqual(`hello world\n`);
+        });
+      });
+
       it(`should support output redirections from fd (stdout)`, async () => {
         await xfs.mktempPromise(async tmpDir => {
           const file = ppath.join(tmpDir, `file` as Filename);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The shell was overriding the file descriptors when applying a file redirection to a builtin. I don't exactly remember why, but I think it has to do with having to setup the new file descriptors while still preserving the context (since things like `cd > foo` should still update the cwd; they don't operate in a separate context). As a result, something like `echo foo > x; echo bar` was causing the `echo bar` to be written into the redirection (but after it closed, so it wasn't actually written).

**How did you fix it?**

I made the shell restore the streams after the builtin finishes executing. Some note:

- I got the idea from [this SO answer](https://unix.stackexchange.com/a/266824/24106), which seems to point out it's what shells do
- It means that our builtins may exhibit strange behaviors when executing in parallel (which may happen when using pipes). I've added a test to cover this case, and it seems to work, but I'm not super confortable ... still, this edge case (`a > b | c`) should be far less common than `a > b; c`, so it'll good enough for now.

Overall however, I'm worried our shell implementation is starting to become quite complicated. I wonder if perhaps trying to fit the native streams isn't a mistake, and we'd be better of with writing our own indirection + emulating a closer dup2/fork model (rather than the Node-specific execution model we currently follow).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
