### PR TITLE
fix(essentials): document `yarn run`'s `-T` and `-B` flags

### DIFF
--- a/.yarn/versions/6d93bfff.yml
+++ b/.yarn/versions/6d93bfff.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/gatsby/content/getting-started/questions-and-answers.md
+++ b/packages/gatsby/content/getting-started/questions-and-answers.md
@@ -133,12 +133,22 @@ Then, from any workspace that contains its own `tsconfig.json`, you'll be able t
 }
 ```
 
+or if you only want to use `tsc` from the root workspace:
+
+```json
+{
+  "scripts": {
+    "build": "run -T tsc"
+  }
+}
+```
+
 Should you want to run a script in the base of your project:
 
 ```json
 {
   "scripts": {
-    "build": "run node ${PROJECT_CWD}/scripts/update-contributors.js"
+    "build": "node ${PROJECT_CWD}/scripts/update-contributors.js"
   }
 }
 ```

--- a/packages/plugin-essentials/sources/commands/run.ts
+++ b/packages/plugin-essentials/sources/commands/run.ts
@@ -44,13 +44,13 @@ export default class RunCommand extends BaseCommand {
     description: `Forwarded to the underlying Node process when executing a binary`,
   });
 
-  // This flag is mostly used to give users a way to configure node-gyp. They
-  // just have to add it as a top-level workspace.
-  topLevel = Option.Boolean(`-T,--top-level`, false, {hidden: true});
+  topLevel = Option.Boolean(`-T,--top-level`, false, {
+    description: `Check the root workspace for scripts and/or binaries instead of the current one`,
+  });
 
-  // Some tools (for example text editors) want to call the real binaries, not
-  // what their users might have remapped them to in their `scripts` field.
-  binariesOnly = Option.Boolean(`-B,--binaries-only`, false, {hidden: true});
+  binariesOnly = Option.Boolean(`-B,--binaries-only`, false, {
+    description: `Ignore any user defined scripts and only check for binaries`,
+  });
 
   // The v1 used to print the Yarn version header when using "yarn run", which
   // was messing with the output of things like `--version` & co. We don't do


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `-T` and `-B` flags for `yarn run` are currently hidden but are really useful so we should document them

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.