### PR TITLE
fix: support `yarn version decline --immediate` on top of stored version

### DIFF
--- a/.yarn/versions/9c706891.yml
+++ b/.yarn/versions/9c706891.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
@@ -282,5 +282,26 @@ describe(`Commands`, () => {
         await expect(run(`version`, `invalid`, `--deferred`)).rejects.toThrow(`Invalid value for enumeration: "invalid"`);
       }),
     );
+
+    test(
+      `it should successfully apply "decline" on top of the stored version`,
+      makeTemporaryEnv({
+        version: `1.0.0`,
+      }, {
+        plugins: [
+          require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+        ],
+      }, async ({path, run, source}) => {
+        await run(`version`, `major`, `--deferred`);
+
+        await expect(run(`version`, `decline`)).resolves.toMatchObject({
+          code: 0,
+        });
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          version: `2.0.0`,
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -95,7 +95,7 @@ export default class VersionCommand extends BaseCommand {
       const releases = await versionUtils.resolveVersionFiles(project);
       const storedVersion = releases.get(workspace);
 
-      if (typeof storedVersion !== `undefined`) {
+      if (typeof storedVersion !== `undefined` && releaseStrategy !== versionUtils.Decision.DECLINE) {
         const thisVersion = versionUtils.applyStrategy(workspace.manifest.version, releaseStrategy);
         if (semver.lt(thisVersion, storedVersion)) {
           throw new UsageError(`Can't bump the version to one that would be lower than the current deferred one (${storedVersion})`);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

What the title says, it's a small edge case I forgot to handle in #3158.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
