### PR TITLE
fix(builder): alias `esbuild-wasm` to `esbuild`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -9459,7 +9459,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -9497,7 +9500,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -9535,7 +9541,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -9572,7 +9581,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-loader", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:8.2.2"],
             ["chalk", "npm:3.0.0"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
-            ["esbuild-wasm", "npm:0.11.20"],
+            ["esbuild", [
+              "esbuild-wasm",
+              "npm:0.11.20"
+            ]],
             ["filesize", "npm:4.1.2"],
             ["fork-ts-checker-webpack-plugin", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#npm:5.0.0"],
             ["semver", "npm:7.3.5"],
@@ -10290,7 +10302,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
-            "@types/esbuild"
+            "@types/esbuild",
+            "esbuild"
           ],
           "linkType": "SOFT",
         }],

--- a/.yarn/versions/0326a790.yml
+++ b/.yarn/versions/0326a790.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -13,7 +13,7 @@
     "babel-loader": "^8.1.0",
     "chalk": "^3.0.0",
     "clipanion": "^3.0.1",
-    "esbuild-wasm": "^0.11.20",
+    "esbuild": "npm:esbuild-wasm@^0.11.20",
     "filesize": "^4.1.2",
     "fork-ts-checker-webpack-plugin": "^5.0.0",
     "semver": "^7.1.2",

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -5,7 +5,7 @@ import {npath}                                                              from
 import chalk                                                                from 'chalk';
 import cp                                                                   from 'child_process';
 import {Command, Option, Usage}                                             from 'clipanion';
-import {build, Plugin}                                                      from 'esbuild-wasm';
+import {build, Plugin}                                                      from 'esbuild';
 import fs                                                                   from 'fs';
 import {createRequire}                                                      from 'module';
 import path                                                                 from 'path';

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -2,7 +2,7 @@ import {StreamReport, MessageName, Configuration, formatUtils, structUtils} from
 import {pnpPlugin}                                                          from '@yarnpkg/esbuild-plugin-pnp';
 import {npath, xfs}                                                         from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                                 from 'clipanion';
-import {build, Plugin}                                                      from 'esbuild-wasm';
+import {build, Plugin}                                                      from 'esbuild';
 import fs                                                                   from 'fs';
 import path                                                                 from 'path';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5227,7 +5227,7 @@ __metadata:
     babel-loader: ^8.1.0
     chalk: ^3.0.0
     clipanion: ^3.0.1
-    esbuild-wasm: ^0.11.20
+    esbuild: "npm:esbuild-wasm@^0.11.20"
     filesize: ^4.1.2
     fork-ts-checker-webpack-plugin: ^5.0.0
     semver: ^7.1.2
@@ -10875,7 +10875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-wasm@npm:^0.11.20, esbuild@npm:esbuild-wasm@^0.11.20":
+"esbuild@npm:esbuild-wasm@^0.11.20":
   version: 0.11.20
   resolution: "esbuild-wasm@npm:0.11.20"
   bin:


### PR DESCRIPTION
**What's the problem this PR addresses?**

There is a missing peer dependency warning from `@yarnpkg/builder` since we're depending on `esbuild-wasm` instead of `esbuild`

Extracted from https://github.com/yarnpkg/berry/pull/2919
Fixes https://github.com/yarnpkg/berry/pull/2919#discussion_r638478601

**How did you fix it?**

Alias `esbuild-wasm` to `esbuild`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.