### PR TITLE
docs: make usage of the patch protocol clearer

### DIFF
--- a/packages/gatsby/content/features/protocols.md
+++ b/packages/gatsby/content/features/protocols.md
@@ -65,11 +65,11 @@ The `patch:` protocol is meant to be used with [`yarn patch`](/cli/patch) and [`
 1. Find a package you want to patch (let's say `lodash@^1.0.0`)
 2. Run `yarn patch lodash`
 3. Edit the folder the command generated
-4. Once you're done, run `yarn patch-commit <path> > my-patch.diff`
+4. Once you're done, run `yarn patch-commit -s <path>`
 5. In your manifest, change the dependency from `^1.0.0` to:
 
 ```
-patch:lodash@^1.0.0#./my-patch.diff
+patch:lodash@^1.0.0#path/to/generated/file.patch
 ```
 
 Note that if you wish to update a transitive dependency (ie not directly yours), it's perfectly possible to use the [`resolutions` field](/configuration/manifest#resolutions).

--- a/packages/plugin-patch/README.md
+++ b/packages/plugin-patch/README.md
@@ -10,7 +10,7 @@ This plugin is included by default in Yarn.
 
 1. Run `yarn patch <package name>` and edit the resulting folder.
 
-2. Once you're ready, run `yarn patch-commit <patch folder> > mypatch.patch` to store the result inside a `.patch` file.
+2. Once you're ready, run `yarn patch-commit -s <patch folder>` to store the result inside a `.patch` file.
 
 3. Add the `patch:` protocol to your dependencies as such:
 

--- a/packages/plugin-patch/README.md
+++ b/packages/plugin-patch/README.md
@@ -10,7 +10,7 @@ This plugin is included by default in Yarn.
 
 1. Run `yarn patch <package name>` and edit the resulting folder.
 
-2. Once you're ready, run `yarn patch-commit <patch folder>`, and store the result inside a `.patch` file.
+2. Once you're ready, run `yarn patch-commit <patch folder> > mypatch.patch` to store the result inside a `.patch` file.
 
 3. Add the `patch:` protocol to your dependencies as such:
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
This PR is a documentation fix and makes the usage of the `patch-commit` command a bit clearer.

**How did you fix it?**
This is now more in line with the official [protocols documentation](https://yarnpkg.com/features/protocols).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
