### PR TITLE
fix(esbuild): read file without charset

### DIFF
--- a/.yarn/versions/c4d7aa18.yml
+++ b/.yarn/versions/c4d7aa18.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -42,7 +42,7 @@ function isExternal(path: string, externals: Array<External>): boolean {
 
 async function defaultOnLoad(args: OnLoadArgs): Promise<OnLoadResult> {
   return {
-    contents: await fs.promises.readFile(args.path, `utf8`),
+    contents: await fs.promises.readFile(args.path),
     loader: `default`,
   };
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**
It changed esbuild-plugin-pnp's default loader function to not using `utf-8` charset, which leaves raw data to esbuild and takes care of binary files (like .woff, .png).

Related issue outside: evanw/esbuild#1501

Fixes #2590

**How did you fix it?**
Just remove the charset field on read file.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
