### PR TITLE
fix(pnpify): quote require path

### DIFF
--- a/.yarn/versions/0d41aab4.yml
+++ b/.yarn/versions/0d41aab4.yml
@@ -1,2 +1,0 @@
-undecided:
-  - "@yarnpkg/pnpify"

--- a/.yarn/versions/cf96796f.yml
+++ b/.yarn/versions/cf96796f.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 ### Bugfixes
 
 - Direct portal dependencies for `node_modules` install are given priority during hoisting now, to prevent cases when indirect regular dependencies take place in the install tree first and block the way for direct portal dependencies.
+- Usage of `pnpify` inside directories containing spaces is now possible.
 
 ### Installs
 
@@ -65,7 +66,6 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 ### Bugfixes
 
 - Yarn now has a proper [governance model](https://github.com/yarnpkg/berry/blob/master/GOVERNANCE.md).
-- Usage of `pnpify` inside directories containing spaces is now possible.
 - The `node-modules` linker will now ensure that the generated install layouts are terminal, by doing several rounds when needed.
 - The `node-modules` linker will no longer print warnings about postinstall scripts when a workspace depends on another workspace listing install scripts.
 - Peer dependencies depending on their own parent are now properly hoisted by the node-modules linker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 ### Bugfixes
 
 - Yarn now has a proper [governance model](https://github.com/yarnpkg/berry/blob/master/GOVERNANCE.md).
+- Paths resolution using spaces will no longer throw when using `pnpify`.
 - The `node-modules` linker will now ensure that the generated install layouts are terminal, by doing several rounds when needed.
 - The `node-modules` linker will no longer print warnings about postinstall scripts when a workspace depends on another workspace listing install scripts.
 - Peer dependencies depending on their own parent are now properly hoisted by the node-modules linker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 ### Bugfixes
 
 - Yarn now has a proper [governance model](https://github.com/yarnpkg/berry/blob/master/GOVERNANCE.md).
-- Paths resolution using spaces will no longer throw when using `pnpify`.
+- Usage of `pnpify` inside directories containing spaces is now possible.
 - The `node-modules` linker will now ensure that the generated install layouts are terminal, by doing several rounds when needed.
 - The `node-modules` linker will no longer print warnings about postinstall scripts when a workspace depends on another workspace listing install scripts.
 - Peer dependencies depending on their own parent are now properly hoisted by the node-modules linker.

--- a/packages/yarnpkg-pnpify/sources/commands/RunCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/RunCommand.ts
@@ -33,7 +33,7 @@ export default class RunCommand extends Command {
 
   async execute() {
     let {NODE_OPTIONS} = process.env;
-    NODE_OPTIONS = `${NODE_OPTIONS || ``} --require ${dynamicRequire.resolve(`@yarnpkg/pnpify`)}`.trim();
+    NODE_OPTIONS = `${NODE_OPTIONS || ``} --require "${dynamicRequire.resolve(`@yarnpkg/pnpify`)}"`.trim();
 
     const {code} = await execUtils.pipevp(this.commandName, this.args, {
       cwd: npath.toPortablePath(this.cwd),


### PR DESCRIPTION
**What's the problem this PR addresses?**

Closes https://github.com/yarnpkg/berry/issues/3225

**How did you fix it?**

Added double quotation marks to path so that paths containing spaces will no longer throw an error when using pnpify.
This is now possible since Node version 10 is no longer supported (double quotation marks are supported in Node as of version 12).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.
Not sure if it's considered a patch or not so put `undecided`.
<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
I think so. 