### PR TITLE
refactor: remove outdated check and quote more `--require` arguments

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -14076,7 +14076,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/yarnpkg-cli"],
@@ -14086,7 +14085,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14102,7 +14100,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],
@@ -14112,7 +14109,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14128,7 +14124,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],
@@ -14138,7 +14133,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14154,7 +14148,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],
@@ -14164,7 +14157,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14180,7 +14172,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:83b7a14498f70e120fb6f455fa263877f0d2954cbb68f3216e842cf37532afa9fe7895f2327708b45ae12ab75df0f3b07ed6e746fa7001bc6460dba7aaf38d31#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:5d170a96e3bd35439131aba7820e7b850e9381656d638624d34e228d96fc2f134ebf73b7eb6235db8cb822a7bcd252e04750d4dfcaeb49408c4e561390950138#workspace:packages/yarnpkg-cli"],
@@ -14190,7 +14181,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14206,7 +14196,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],
@@ -14216,7 +14205,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14232,7 +14220,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],
@@ -14242,7 +14229,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14258,7 +14244,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],
@@ -14268,7 +14253,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14284,7 +14268,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:c44c4b6360dc34d25da6d32e39622e7e40f36f37b99dc66b6ebbd615fdd49465f496bf10f81b6fa5f71b95443fda61174ad51d2799fc7ca433af9a9666cd0f37#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:7bf4ad1016291a7e1c04756f55760890095421dd1b945930b62d8d0464c365d1cdce28ed812277b54dc54443922ac82afd5e98ed7f1d218ae7753d16e21541bb#workspace:packages/yarnpkg-cli"],
@@ -14294,7 +14277,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14310,7 +14292,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:cd2af72718007566941ac9f5a6def4d055c38029c95c3ac065493603e6055c1d77b2f2df752588114932973488b5a566f49b00118e7e12f48aa0798ea38cc15b#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:e04a2594c769771b96db34e7a92a8a3af1c98ae86dce662589a5c5d5209e16875506f8cb5f4c2230a2b2ae06335b14466352c4ed470d39edf9edb6c515984525#workspace:packages/yarnpkg-cli"],
@@ -14320,7 +14301,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14336,7 +14316,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],
@@ -14346,7 +14325,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14362,7 +14340,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/yarnpkg-cli"],
@@ -14372,7 +14349,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14388,7 +14364,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@types/yarnpkg__cli", null],
             ["@types/yarnpkg__core", null],
             ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],
@@ -14398,7 +14373,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "packagePeers": [
@@ -14414,7 +14388,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [
             ["@yarnpkg/plugin-pnp", "workspace:packages/plugin-pnp"],
             ["@types/micromatch", "npm:4.0.1"],
-            ["@types/semver", "npm:7.1.0"],
             ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],
             ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],
             ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],
@@ -14422,7 +14395,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],
             ["clipanion", "virtual:02f08ef8b8f3af06d08a146e8941d7fef41abbe0f441d85250a110dd2773e679dff502bd7763f42309743e1ddb33847a4bc3aab82132068c9954ae25f4c4bce5#npm:3.0.1"],
             ["micromatch", "npm:4.0.2"],
-            ["semver", "npm:7.3.5"],
             ["tslib", "npm:1.13.0"]
           ],
           "linkType": "SOFT",

--- a/.yarn/versions/9f1f893a.yml
+++ b/.yarn/versions/9f1f893a.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1472,7 +1472,7 @@ describe(`Plug'n'Play`, () => {
       await writeFile(`${path}/foo.js`, `console.log(42);`);
 
       await expect(
-        run(`node`, `-e`, `console.log(21);`, {env: {NODE_OPTIONS: `--require ${npath.fromPortablePath(path)}/foo`}}),
+        run(`node`, `-e`, `console.log(21);`, {env: {NODE_OPTIONS: `--require "${npath.fromPortablePath(path)}/foo"`}}),
       ).resolves.toMatchObject({
         // Note that '42' is present twice: the first one because Node executes Yarn, and the second one because Yarn spawns Node
         stdout: `42\n42\n21\n`,

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -62,23 +62,23 @@ Yarn generates a single `.pnp.cjs` file that needs to be installed for Node to k
 
 For some remaining edge cases, a small setup may be required:
 
-- If you need to run an arbitrary Node script, use [`yarn node`](/cli/node) as the interpreter, instead of `node`. This will be enough to register the `.pnp.cjs` file as a runtime dependency. 
+- If you need to run an arbitrary Node script, use [`yarn node`](/cli/node) as the interpreter, instead of `node`. This will be enough to register the `.pnp.cjs` file as a runtime dependency.
 
-```
+```sh
 yarn node ./server.js
 ```
 
 - If you operate on a system that automatically executes a Node script (for instance on Google Cloud Platform (--reference needed here--)), simply require the PnP file at the top of your init script and call its `setup` function.
 
-```
+```js
 require('./.pnp.cjs').setup();
 ```
 
 As a quick tip, all `yarn node` typically does is set the `NODE_OPTIONS` environment variable to use the [`--require`](https://nodejs.org/api/cli.html#cli_r_require_module) option from Node, associated with the path of the `.pnp.cjs` file. You can easily apply this operation yourself if you prefer:
 
-```
+```sh
 node -r ./.pnp.cjs ./server.js
-NODE_OPTIONS="--require $(pwd)/.pnp.cjs" node ./server.js
+NODE_OPTIONS="--require \"$(pwd)/.pnp.cjs\"" node ./server.js
 ```
 
 ## PnP `loose` mode
@@ -173,7 +173,7 @@ This list is kept up-to-date based on the latest release we've published startin
 ### Why not use import maps?
 
 Yarn Plug'n'Play provides semantic errors (explaining you the exact reason why a package isn't reachable from another) and a [sensible JS API](/advanced/pnpapi) to solve various shortcomings with `require.resolve`. These are features that import maps wouldn't solve by themselves.
-This is answered in more detail in [this thread](https://github.com/nodejs/modules/issues/477#issuecomment-578091424). 
+This is answered in more detail in [this thread](https://github.com/nodejs/modules/issues/477#issuecomment-578091424).
 
 A main reason we're in this mess today is that the original `node_modules` design tried to abstract packages away in order to provide a generic system that would work without any notion of packages. This became a challenge that prompted many implementers to come up with their own interpretations. Import maps suffer from the same flaw.
 

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -4,13 +4,11 @@
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
   "dependencies": {
-    "@types/semver": "^7.1.0",
     "@yarnpkg/fslib": "workspace:^2.5.0",
     "@yarnpkg/plugin-stage": "workspace:^3.0.0",
     "@yarnpkg/pnp": "workspace:^3.0.0",
     "clipanion": "^3.0.1",
     "micromatch": "^4.0.2",
-    "semver": "^7.1.2",
     "tslib": "^1.13.0"
   },
   "peerDependencies": {

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -1,7 +1,6 @@
 import {Hooks as CoreHooks, Plugin, Project, SettingsType} from '@yarnpkg/core';
 import {Filename, PortablePath, npath, ppath, xfs}         from '@yarnpkg/fslib';
 import {Hooks as StageHooks}                               from '@yarnpkg/plugin-stage';
-import semver                                              from 'semver';
 
 import {PnpLinker}                                         from './PnpLinker';
 import unplug                                              from './commands/unplug';
@@ -18,16 +17,9 @@ export const getPnpPath = (project: Project) => {
   };
 };
 
-export const quotePathIfNeeded = (path: string) => {
-  return /\s/.test(path) ? JSON.stringify(path) : path;
-};
-
 async function setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>) {
   const pnpPath: PortablePath = getPnpPath(project).cjs;
-  const pnpRequire = `--require ${quotePathIfNeeded(npath.fromPortablePath(pnpPath))}`;
-
-  if (pnpPath.includes(` `) && semver.lt(process.versions.node, `12.0.0`))
-    throw new Error(`Expected the build location to not include spaces when using Node < 12.0.0 (${process.versions.node})`);
+  const pnpRequire = `--require "${npath.fromPortablePath(pnpPath)}"`;
 
   if (xfs.existsSync(pnpPath)) {
     let nodeOptions = env.NODE_OPTIONS || ``;

--- a/packages/yarnpkg-doctor/sources/boot-cli-dev.js
+++ b/packages/yarnpkg-doctor/sources/boot-cli-dev.js
@@ -1,4 +1,4 @@
-process.env.NODE_OPTIONS += ` --require ${require.resolve(`@yarnpkg/monorepo/scripts/setup-ts-execution`)}`;
+process.env.NODE_OPTIONS += ` --require "${require.resolve(`@yarnpkg/monorepo/scripts/setup-ts-execution`)}"`;
 
 require(`@yarnpkg/monorepo/scripts/setup-ts-execution`);
 

--- a/packages/yarnpkg-pnpify/sources/boot-cli-dev.js
+++ b/packages/yarnpkg-pnpify/sources/boot-cli-dev.js
@@ -1,4 +1,4 @@
-process.env.NODE_OPTIONS += ` --require ${require.resolve(`@yarnpkg/monorepo/scripts/setup-ts-execution`)}`;
+process.env.NODE_OPTIONS += ` --require "${require.resolve(`@yarnpkg/monorepo/scripts/setup-ts-execution`)}"`;
 
 require(`@yarnpkg/monorepo/scripts/setup-ts-execution`);
 

--- a/packages/yarnpkg-sdks/sources/boot-cli-dev.js
+++ b/packages/yarnpkg-sdks/sources/boot-cli-dev.js
@@ -1,4 +1,4 @@
-process.env.NODE_OPTIONS += ` --require ${require.resolve(`@yarnpkg/monorepo/scripts/setup-ts-execution`)}`;
+process.env.NODE_OPTIONS += ` --require "${require.resolve(`@yarnpkg/monorepo/scripts/setup-ts-execution`)}"`;
 
 require(`@yarnpkg/monorepo/scripts/setup-ts-execution`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5932,7 +5932,6 @@ __metadata:
   resolution: "@yarnpkg/plugin-pnp@workspace:packages/plugin-pnp"
   dependencies:
     "@types/micromatch": ^4.0.1
-    "@types/semver": ^7.1.0
     "@yarnpkg/cli": "workspace:*"
     "@yarnpkg/core": "workspace:*"
     "@yarnpkg/fslib": "workspace:^2.5.0"
@@ -5940,7 +5939,6 @@ __metadata:
     "@yarnpkg/pnp": "workspace:^3.0.0"
     clipanion: ^3.0.1
     micromatch: ^4.0.2
-    semver: ^7.1.2
     tslib: ^1.13.0
   peerDependencies:
     "@yarnpkg/cli": ^3.0.1-rc.1


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- `@yarnpkg/plugin-pnp`'s `setupScriptEnvironment` was doing an unnecessary Node version check
- A few `--require` arguments in our `boot-cli-dev`s / tests / docs were missing double quotes
- `@yarnpkg/plugin-pnp`'s `setupScriptEnvironment` was doing a `quotePathIfNeeded` which isn't consistent with the way pnpify does it (always adding double quotes)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- Removed it
- Added double quotes
- Always add double quotes

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
