### PR TITLE
perf(plugin-pnp): devirtualize `Locator` for package data cache

### DIFF
--- a/.yarn/versions/8d7af4e6.yml
+++ b/.yarn/versions/8d7af4e6.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -108,14 +108,14 @@ export class PnpInstaller implements Installer {
     const key1 = structUtils.stringifyIdent(pkg);
     const key2 = pkg.reference;
 
-    const isWorkspace =
-      !!this.opts.project.tryWorkspaceByLocator(pkg);
+    const isWorkspace = !!this.opts.project.tryWorkspaceByLocator(pkg);
+    const isVirtual = structUtils.isVirtualLocator(pkg);
 
     const hasVirtualInstances =
       // Only packages with peer dependencies have virtual instances
       pkg.peerDependencies.size > 0 &&
       // Only packages with peer dependencies have virtual instances
-      !structUtils.isVirtualLocator(pkg);
+      !isVirtual;
 
     const mayNeedToBeBuilt =
       // Virtual instance templates don't need to be built, since they don't truly exist
@@ -133,16 +133,17 @@ export class PnpInstaller implements Installer {
     let dependencyMeta: DependencyMeta | undefined;
 
     if (mayNeedToBeBuilt || mayNeedToBeUnplugged) {
-      customPackageData = this.customData.store.get(pkg.locatorHash);
+      const devirtualizedLocator: Locator = isVirtual ? structUtils.devirtualizeLocator(pkg) : pkg;
+      customPackageData = this.customData.store.get(devirtualizedLocator.locatorHash);
 
       if (typeof customPackageData === `undefined`) {
-        customPackageData = await extractCustomPackageData(pkg, fetchResult);
+        customPackageData = await extractCustomPackageData(fetchResult);
         if (pkg.linkType === LinkType.HARD) {
-          this.customData.store.set(pkg.locatorHash, customPackageData);
+          this.customData.store.set(devirtualizedLocator.locatorHash, customPackageData);
         }
       }
 
-      dependencyMeta = this.opts.project.getDependencyMeta(pkg, pkg.version);
+      dependencyMeta = this.opts.project.getDependencyMeta(devirtualizedLocator, pkg.version);
     }
 
     const buildScripts = mayNeedToBeBuilt
@@ -166,13 +167,13 @@ export class PnpInstaller implements Installer {
     // workspaces are a special case because the original packages are kept in
     // the dependency tree even after being virtualized; so in their case we
     // just ignore their declared peer dependencies.
-    if (structUtils.isVirtualLocator(pkg)) {
+    if (isVirtual) {
       for (const descriptor of pkg.peerDependencies.values()) {
         packageDependencies.set(structUtils.stringifyIdent(descriptor), null);
         packagePeers.add(structUtils.stringifyIdent(descriptor));
       }
 
-      if (!this.opts.project.tryWorkspaceByLocator(pkg)) {
+      if (!isWorkspace) {
         const devirtualized = structUtils.devirtualizeLocator(pkg);
         this.virtualTemplates.set(devirtualized.locatorHash, {
           location: normalizeDirectoryPath(this.opts.project.cwd, VirtualFS.resolveVirtual(packageRawLocation)),
@@ -445,7 +446,7 @@ function normalizeDirectoryPath(root: PortablePath, folder: PortablePath) {
 type UnboxPromise<T extends Promise<any>> = T extends Promise<infer U> ? U: never;
 type CustomPackageData = UnboxPromise<ReturnType<typeof extractCustomPackageData>>;
 
-async function extractCustomPackageData(pkg: Package, fetchResult: FetchResult) {
+async function extractCustomPackageData(fetchResult: FetchResult) {
   const manifest = await Manifest.tryFind(fetchResult.prefixPath, {baseFs: fetchResult.packageFs}) ?? new Manifest();
 
   const preservedScripts = new Set([`preinstall`, `install`, `postinstall`]);


### PR DESCRIPTION
**What's the problem this PR addresses?**

When a `Package` has multiple virtual instances the `PnpInstaller` will fetch the same data about all of them instead of fetching it once and reusing it.

**How did you fix it?**

Devirtualize the `Locator` and use its `LocatorHash` instead of the virtual one

**Result**

Tested on the Storybook repo using PnP
```
YARN_IGNORE_PATH=1 hyperfine -w 1 --prepare="rm -rf .yarn/install-state.gz" \
                                                    "node ./master.cjs --mode skip-build" \
                                                    "node ./after.cjs --mode skip-build"
Benchmark #1: node ./master.cjs --mode skip-build
  Time (mean ± σ):      6.724 s ±  0.108 s    [User: 8.198 s, System: 1.216 s]
  Range (min … max):    6.594 s …  6.981 s    10 runs

Benchmark #2: node ./after.cjs --mode skip-build
  Time (mean ± σ):      6.328 s ±  0.079 s    [User: 7.864 s, System: 1.085 s]
  Range (min … max):    6.239 s …  6.523 s    10 runs

Summary
  'node ./after.cjs --mode skip-build' ran
    1.06 ± 0.02 times faster than 'node ./master.cjs --mode skip-build'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.