### PR TITLE
fix: make all cli commands extend BaseCommand

### DIFF
--- a/.yarn/versions/3ea30064.yml
+++ b/.yarn/versions/3ea30064.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/entries/clipanion.ts
+++ b/packages/plugin-essentials/sources/commands/entries/clipanion.ts
@@ -1,5 +1,6 @@
-import {CommandContext, Configuration}                   from '@yarnpkg/core';
-import {Command, Cli, Definition as ClipanionDefinition} from 'clipanion';
+import {BaseCommand}                            from '@yarnpkg/cli';
+import {Configuration}                          from '@yarnpkg/core';
+import {Cli, Definition as ClipanionDefinition} from 'clipanion';
 
 type ExtendedDefinition = ClipanionDefinition & {
   plugin: {
@@ -9,7 +10,7 @@ type ExtendedDefinition = ClipanionDefinition & {
 };
 
 // eslint-disable-next-line arca/no-default-export
-export default class ClipanionCommand extends Command<CommandContext> {
+export default class ClipanionCommand extends BaseCommand {
   static paths = [
     [`--clipanion=definitions`],
   ];

--- a/packages/plugin-essentials/sources/commands/entries/help.ts
+++ b/packages/plugin-essentials/sources/commands/entries/help.ts
@@ -1,8 +1,7 @@
-import {CommandContext} from '@yarnpkg/core';
-import {Command}        from 'clipanion';
+import {BaseCommand} from "@yarnpkg/cli";
 
 // eslint-disable-next-line arca/no-default-export
-export default class HelpCommand extends Command<CommandContext> {
+export default class HelpCommand extends BaseCommand {
   static paths = [
     [`help`],
     [`--help`],

--- a/packages/plugin-essentials/sources/commands/entries/run.ts
+++ b/packages/plugin-essentials/sources/commands/entries/run.ts
@@ -1,9 +1,10 @@
-import {CommandContext, structUtils} from '@yarnpkg/core';
-import {npath, ppath}                from '@yarnpkg/fslib';
-import {Command, Option}             from 'clipanion';
+import {BaseCommand}  from '@yarnpkg/cli';
+import {structUtils}  from '@yarnpkg/core';
+import {npath, ppath} from '@yarnpkg/fslib';
+import {Option}       from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
-export default class EntryCommand extends Command<CommandContext> {
+export default class EntryCommand extends BaseCommand {
   leadingArgument = Option.String();
   args = Option.Proxy();
 

--- a/packages/plugin-essentials/sources/commands/entries/version.ts
+++ b/packages/plugin-essentials/sources/commands/entries/version.ts
@@ -1,8 +1,8 @@
-import {CommandContext, YarnVersion} from '@yarnpkg/core';
-import {Command}                     from 'clipanion';
+import {BaseCommand} from '@yarnpkg/cli';
+import {YarnVersion} from '@yarnpkg/core';
 
 // eslint-disable-next-line arca/no-default-export
-export default class VersionCommand extends Command<CommandContext> {
+export default class VersionCommand extends BaseCommand {
   static paths = [
     [`-v`],
     [`--version`],

--- a/packages/plugin-essentials/sources/commands/workspace.ts
+++ b/packages/plugin-essentials/sources/commands/workspace.ts
@@ -1,10 +1,10 @@
-import {WorkspaceRequiredError}                            from "@yarnpkg/cli";
-import {CommandContext, Configuration, Project, Workspace} from "@yarnpkg/core";
-import {structUtils}                                       from "@yarnpkg/core";
-import {Command, Option, Usage, UsageError}                from "clipanion";
+import {WorkspaceRequiredError, BaseCommand} from "@yarnpkg/cli";
+import {Configuration, Project, Workspace}   from "@yarnpkg/core";
+import {structUtils}                         from "@yarnpkg/core";
+import {Command, Option, Usage, UsageError}  from "clipanion";
 
 // eslint-disable-next-line arca/no-default-export
-export default class WorkspaceCommand extends Command<CommandContext> {
+export default class WorkspaceCommand extends BaseCommand {
   static paths = [
     [`workspace`],
   ];

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -1,22 +1,22 @@
-import {WorkspaceRequiredError}                                                                                 from '@yarnpkg/cli';
-import {CommandContext, Configuration, MessageName, Project, StreamReport, Workspace, formatUtils, structUtils} from '@yarnpkg/core';
-import {npath}                                                                                                  from '@yarnpkg/fslib';
-import {Gem}                                                                                                    from '@yarnpkg/libui/sources/components/Gem';
-import {ScrollableItems}                                                                                        from '@yarnpkg/libui/sources/components/ScrollableItems';
-import {FocusRequest}                                                                                           from '@yarnpkg/libui/sources/hooks/useFocusRequest';
-import {useListInput}                                                                                           from '@yarnpkg/libui/sources/hooks/useListInput';
-import {renderForm}                                                                                             from '@yarnpkg/libui/sources/misc/renderForm';
-import {Command, Option, Usage, UsageError}                                                                     from 'clipanion';
-import {Box, Text}                                                                                              from 'ink';
-import React, {useCallback, useState}                                                                           from 'react';
-import semver                                                                                                   from 'semver';
+import {BaseCommand, WorkspaceRequiredError}                                                    from '@yarnpkg/cli';
+import {Configuration, MessageName, Project, StreamReport, Workspace, formatUtils, structUtils} from '@yarnpkg/core';
+import {npath}                                                                                  from '@yarnpkg/fslib';
+import {Gem}                                                                                    from '@yarnpkg/libui/sources/components/Gem';
+import {ScrollableItems}                                                                        from '@yarnpkg/libui/sources/components/ScrollableItems';
+import {FocusRequest}                                                                           from '@yarnpkg/libui/sources/hooks/useFocusRequest';
+import {useListInput}                                                                           from '@yarnpkg/libui/sources/hooks/useListInput';
+import {renderForm}                                                                             from '@yarnpkg/libui/sources/misc/renderForm';
+import {Command, Option, Usage, UsageError}                                                     from 'clipanion';
+import {Box, Text}                                                                              from 'ink';
+import React, {useCallback, useState}                                                           from 'react';
+import semver                                                                                   from 'semver';
 
-import * as versionUtils                                                                                        from '../../versionUtils';
+import * as versionUtils                                                                        from '../../versionUtils';
 
 type Releases = Map<Workspace, Exclude<versionUtils.Decision, versionUtils.Decision.UNDECIDED>>;
 
 // eslint-disable-next-line arca/no-default-export
-export default class VersionCheckCommand extends Command<CommandContext> {
+export default class VersionCheckCommand extends BaseCommand {
   static paths = [
     [`version`, `check`],
   ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

A few CLI commands weren't extending `BaseCommand` which meant that they weren't supporting the `--cwd` flag.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made them extend `BaseCommand`.

Now it's possible to run commands such as:
- `yarn --cwd /another/project workspace ...`
- `yarn --cwd ./workspace build:cli`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
