### PR TITLE
ci: use pnpify from sources in e2e test

### DIFF
--- a/.github/workflows/e2e-pnpify-workflow.yml
+++ b/.github/workflows/e2e-pnpify-workflow.yml
@@ -37,7 +37,7 @@ jobs:
 
         cd berry-angular
 
-        yarn add @yarnpkg/pnpify @angular-devkit/core@next @babel/preset-env @babel/core -D
+        yarn add @yarnpkg/pnpify@portal:"$HERE_DIR/../packages/yarnpkg-pnpify" @angular-devkit/core@next @babel/preset-env @babel/core -D
 
         yarn unplug -AR @angular/platform-browser @angular/core @angular/common @angular/compiler-cli
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The "Angular over PnPify" E2E test was using the latest pnpify from the registry instead of using the one from sources.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use the one from sources since it's better at highlighting issues.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
