### PR TITLE
fix(nm): Maximizes chances to end-up with only top-level node_modules

### DIFF
--- a/.yarn/versions/9d048c9b.yml
+++ b/.yarn/versions/9d048c9b.yml
@@ -19,5 +19,7 @@ declined:
   - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"

--- a/.yarn/versions/9d048c9b.yml
+++ b/.yarn/versions/9d048c9b.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 ### Installs
 
 - `hardlinks-global` node modules mode is automatically downgraded to `hardlinks-local` when global cache and install folder are on a different devices and the install continues normally. Warning is produced to the user with mitigation steps provided in documentation.
+- The nm linker maximizes chances to end-up with only one top-level node_modules in the case of using workspaces
 
 ## 3.0.0
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1302,4 +1302,38 @@ describe(`Node_Modules`, () => {
       }
     )
   );
+
+  test(`should give priority to direct workspace dependencies over indirect regular dependencies`,
+    // Despite 'one-fixed-dep' and 'has-bin-entries' depend on 'no-deps:1.0.0',
+    // the 'no-deps:2.0.0' should be hoisted to the top-level
+    makeTemporaryEnv(
+      {
+        workspaces: [`ws1`, `ws2`],
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await writeJson(`${path}/ws1/package.json`, {
+          dependencies: {
+            [`no-deps`]: `2.0.0`,
+          },
+        });
+        await writeJson(`${path}/ws2/package.json`, {
+          dependencies: {
+            [`has-bin-entries`]: `1.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+          version: `2.0.0`,
+        });
+      }
+    )
+  );
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1310,7 +1310,7 @@ describe(`Node_Modules`, () => {
       {
         workspaces: [`ws1`, `ws2`],
         dependencies: {
-          [`one-fixed-dep`]: `1.0.0`
+          [`one-fixed-dep`]: `1.0.0`,
         },
       },
       {

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -248,8 +248,20 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
       nodes.set(nodeKey, packageTree);
     }
 
-    const isExternalSoftLinkPackage = isExternalSoftLink(pkg, locator);
+    if (!node) {
+      node = {
+        name,
+        identName: locator.name,
+        reference: locator.reference,
+        dependencies: new Set(),
+        peerNames: pkg.packagePeers,
+      };
+
+      nodes.set(nodeKey, node);
+    }
+
     let hoistPriority;
+    const isExternalSoftLinkPackage = isExternalSoftLink(pkg, locator);
     if (isExternalSoftLinkPackage)
       // External soft link dependencies have the highest priority - we don't want to install inside them
       hoistPriority = 2;
@@ -258,19 +270,7 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
       hoistPriority = 1;
     else
       hoistPriority = 0;
-
-    if (!node) {
-      node = {
-        name,
-        identName: locator.name,
-        reference: locator.reference,
-        dependencies: new Set(),
-        peerNames: pkg.packagePeers,
-        hoistPriority,
-      };
-
-      nodes.set(nodeKey, node);
-    }
+    node.hoistPriority = Math.max(node.hoistPriority || 0, hoistPriority);
 
     if (isHoistBorder && !isExternalSoftLinkPackage) {
       const parentLocatorKey = stringifyLocator({name: parent.identName, reference: parent.reference});

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -259,7 +259,6 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
     else
       hoistPriority = 0;
 
-
     if (!node) {
       node = {
         name,

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -250,15 +250,15 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
 
     const isExternalSoftLinkPackage = isExternalSoftLink(pkg, locator);
     let hoistPriority;
-    if (isExternalSoftLinkPackage) {
+    if (isExternalSoftLinkPackage)
       // External soft link dependencies have the highest priority - we don't want to install inside them
       hoistPriority = 2;
-    } else if (parentPkg.linkType === LinkType.SOFT) {
+    else if (parentPkg.linkType === LinkType.SOFT)
       // Internal soft link dependencies should have priority over transitive dependencies - to maximize chances having only one top-level node_modules
       hoistPriority = 1;
-    } else {
+    else
       hoistPriority = 0;
-    }
+
 
     if (!node) {
       node = {

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -875,7 +875,7 @@ const buildPreferenceMap = (rootNode: HoisterWorkTree): PreferenceMap => {
       seenNodes.add(node);
       for (const dep of node.dependencies.values()) {
         const entry = getOrCreatePreferenceEntry(dep);
-        entry.hoistPriority = Math.max(entry.hoistPriority, node.hoistPriority);
+        entry.hoistPriority = Math.max(entry.hoistPriority, dep.hoistPriority);
         if (node.peerNames.has(dep.name)) {
           entry.peerDependents.add(node.ident);
         } else {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The problem - Yarn 1.x maximized chances to end up with only one node_modules in the case of workspaces by giving priority to direct workspace dependencies. The users expect now the same behaviour in 2+. The other consideration is that its a universally the best layout for node_modules when there is only one top-level node_modules folder - it has the best compatibility with the tools and packages, so it makes sense to do the same.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I gave hoisting priority to direct workspace dependencies above priority for other dependencies. Note, that direct portal dependencies have the highest priority. Fixes: #3266 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
