### PR TITLE
Adds a workflow to auto-merge master into PRs

### DIFF
--- a/.github/workflows/pr-smart-merge.yml
+++ b/.github/workflows/pr-smart-merge.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         node ./scripts/run-yarn.js build:cli
 
-    - name: 'Build the standard bundle'
+    - name: 'Update, commit, and upload the hook'
       run: |
         git fetch origin pull/'${{github.event.inputs.branch}}'/head:local
         git checkout local
@@ -40,7 +40,7 @@ jobs:
 
         if git diff --name-only --diff-filter=U | grep packages/yarnpkg-pnp/sources/hook.js; then
           git checkout --theirs packages/yarnpkg-pnp/sources/hook.js
-          yarn build:pnp:hook && yarn
+          yarn update:pnp:hook
         fi
 
         git config user.name "Yarn Bot"

--- a/.github/workflows/pr-smart-merge.yml
+++ b/.github/workflows/pr-smart-merge.yml
@@ -8,7 +8,7 @@ on:
 name: 'Smart master merge'
 jobs:
   merge:
-    name: 'Validating Rollup'
+    name: 'Merge master into the PR'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-smart-merge.yml
+++ b/.github/workflows/pr-smart-merge.yml
@@ -1,0 +1,52 @@
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'The pull request to update'
+        required: true
+
+name: 'Smart master merge'
+jobs:
+  merge:
+    name: 'Validating Rollup'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+      with:
+        ref: master
+        token: ${{secrets.YARNBOT_TOKEN}}
+
+    - name: 'Install Node'
+      uses: actions/setup-node@master
+      with:
+        node-version: 14.x
+
+    - name: 'Build the standard bundle'
+      run: |
+        node ./scripts/run-yarn.js build:cli
+
+    - name: 'Build the standard bundle'
+      run: |
+        git fetch origin pull/'${{github.event.inputs.branch}}'/head:local
+        git checkout local
+
+        git merge origin/master
+
+        if git diff --name-only --diff-filter=U | grep .pnp.cjs; then
+          # We use a prebuilt binary so that we don't have to deal with new/removed dependencies
+          YARN_ENABLE_STRICT_SETTINGS=0 YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js
+        fi
+
+        if git diff --name-only --diff-filter=U | grep packages/yarnpkg-pnp/sources/hook.js; then
+          git checkout --theirs packages/yarnpkg-pnp/sources/hook.js
+          yarn build:pnp:hook && yarn
+        fi
+
+        git config user.name "Yarn Bot"
+        git config user.email nison.mael+yarnbot@gmail.com
+
+        git add .pnp.cjs packages/yarnpkg-pnp/sources/hook.js
+        git commit -m 'Auto-merge with master'
+
+        git push origin local

--- a/.yarn/versions/d6f917f2.yml
+++ b/.yarn/versions/d6f917f2.yml
@@ -1,12 +1,12 @@
 releases:
   "@yarnpkg/cli": minor
   "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
-  - "@yarnpkg/plugin-essentials"
   - "@yarnpkg/plugin-exec"
   - "@yarnpkg/plugin-file"
   - "@yarnpkg/plugin-git"

--- a/.yarn/versions/d6f917f2.yml
+++ b/.yarn/versions/d6f917f2.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/.yarn/versions/e959dc6e.yml
+++ b/.yarn/versions/e959dc6e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-essentials": patch

--- a/.yarn/versions/e959dc6e.yml
+++ b/.yarn/versions/e959dc6e.yml
@@ -1,2 +1,0 @@
-releases:
-  "@yarnpkg/plugin-essentials": patch

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -66,6 +66,10 @@ export default class ConfigSetCommand extends BaseCommand {
     const name = this.name.replace(/[.[].*$/, ``);
     const path = this.name.replace(/^[^.[]*\.?/, ``);
 
+
+    if (name === `enableStrictSettings`)
+      throw new UsageError(`This setting only affects the file it's in, and thus cannot be set from the CLI`);
+
     const setting = configuration.settings.get(name);
     if (typeof setting === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${name}"`);

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -66,13 +66,12 @@ export default class ConfigSetCommand extends BaseCommand {
     const name = this.name.replace(/[.[].*$/, ``);
     const path = this.name.replace(/^[^.[]*\.?/, ``);
 
-
-    if (name === `enableStrictSettings`)
-      throw new UsageError(`This setting only affects the file it's in, and thus cannot be set from the CLI`);
-
     const setting = configuration.settings.get(name);
     if (typeof setting === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${name}"`);
+
+    if (name === `enableStrictSettings`)
+      throw new UsageError(`This setting only affects the file it's in, and thus cannot be set from the CLI`);
 
     const value: unknown = this.json
       ? JSON.parse(this.value)

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -422,6 +422,11 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.BOOLEAN,
     default: true,
   },
+  enableStrictSettings: {
+    description: `If true, unknown settings will cause Yarn to abort`,
+    type: SettingsType.BOOLEAN,
+    default: true,
+  },
   enableImmutableCache: {
     description: `If true, the cache is reputed immutable and actions that would modify it will throw`,
     type: SettingsType.BOOLEAN,
@@ -540,6 +545,7 @@ export interface ConfigurationValueMap {
 
   // Settings related to security
   enableScripts: boolean;
+  enableStrictSettings: boolean;
   enableImmutableCache: boolean;
   checksumBehavior: string;
 
@@ -909,12 +915,7 @@ export class Configuration {
     const environmentSettings = getEnvironmentSettings();
     delete environmentSettings.rcFilename;
 
-    const rcFiles: Array<{
-      path: PortablePath;
-      cwd: PortablePath;
-      data: any;
-      strict?: boolean
-    }> = await Configuration.findRcFiles(startingCwd);
+    const rcFiles = await Configuration.findRcFiles(startingCwd);
 
     const homeRcFile = await Configuration.findHomeRcFile();
     if (homeRcFile) {
@@ -1080,7 +1081,12 @@ export class Configuration {
 
   static async findRcFiles(startingCwd: PortablePath) {
     const rcFilename = getRcFilename();
-    const rcFiles = [];
+    const rcFiles: Array<{
+      path: PortablePath;
+      cwd: PortablePath;
+      data: any;
+      strict?: boolean
+    }> = [];
 
     let nextCwd = startingCwd;
     let currentCwd = null;
@@ -1255,7 +1261,9 @@ export class Configuration {
   }
 
   use(source: string, data: {[key: string]: unknown}, folder: PortablePath, {strict = true, overwrite = false}: {strict?: boolean, overwrite?: boolean} = {}) {
-    for (const key of Object.keys(data)) {
+    strict = strict && this.get(`enableStrictSettings`);
+
+    for (const key of [`enableStrictSettings`, ...Object.keys(data)]) {
       const value = data[key];
       if (typeof value === `undefined`)
         continue;
@@ -1291,6 +1299,11 @@ export class Configuration {
       } catch (error) {
         error.message += ` in ${formatUtils.pretty(this, source, formatUtils.Type.PATH)}`;
         throw error;
+      }
+
+      if (key === `enableStrictSettings` && source !== `<environment>`) {
+        strict = parsed as boolean;
+        continue;
       }
 
       if (definition.type === SettingsType.MAP) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's a bit annoying when multiple PRs affect the PnP hook, because each one need to be merged against master.

**How did you fix it?**

This diff doesn't entirely solve that, but it makes it easier to run the merge conflict resolution without having to checkout the PRs locally.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
