### PR TITLE
feat: make `{add,up}` respect modifiers when attaching local workspaces

### DIFF
--- a/.yarn/versions/033ce877.yml
+++ b/.yarn/versions/033ce877.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/add.test.ts.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/add.test.ts.snap
@@ -8,7 +8,7 @@ Object {
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Fetch step
 ➤ YN0013: │ no-deps@npm:2.0.0 can't be found in the cache and will be fetched from the remote registry
-➤ YN0019: │ no-deps-npm-1.0.0-cf533b267a-0c5dcef5d1.zip appears to be unused - removing
+➤ YN0019: │ no-deps-npm-1.0.0-cf533b267a-a33284e534.zip appears to be unused - removing
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/add.test.ts.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/add.test.ts.snap
@@ -8,7 +8,7 @@ Object {
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Fetch step
 ➤ YN0013: │ no-deps@npm:2.0.0 can't be found in the cache and will be fetched from the remote registry
-➤ YN0019: │ no-deps-npm-1.0.0-cf533b267a-a33284e534.zip appears to be unused - removing
+➤ YN0019: │ no-deps-npm-1.0.0-cf533b267a-0c5dcef5d1.zip appears to be unused - removing
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -1,4 +1,4 @@
-import {xfs} from '@yarnpkg/fslib';
+import {PortablePath, xfs} from '@yarnpkg/fslib';
 
 const {
   tests: {getPackageDirectoryPath},
@@ -13,7 +13,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps@1.0.0`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `1.0.0`,
           },
@@ -26,7 +26,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -35,11 +35,11 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should add a new regular dependency to the current project (implicit tilde)`,
+      `it should add a new regular dependency to the current project (explicit tilde)`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-T`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `~2.0.0`,
           },
@@ -48,11 +48,11 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should add a new regular dependency to the current project (implicit exact)`,
+      `it should add a new regular dependency to the current project (explicit exact)`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-E`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `2.0.0`,
           },
@@ -61,12 +61,12 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should add a new regular dependency to the current project (implicit caret)`,
+      `it should add a new regular dependency to the current project (explicit caret)`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
         await run(`add`, `no-deps`, `-C`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -80,7 +80,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `~2.0.0`,
           },
@@ -94,7 +94,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, ``);
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `2.0.0`,
           },
@@ -109,7 +109,7 @@ describe(`Commands`, () => {
 
         await run(`add`, packagePath);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: packagePath,
           },
@@ -122,7 +122,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-D`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -139,7 +139,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -156,7 +156,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -173,7 +173,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-D`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -190,7 +190,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -207,7 +207,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -220,7 +220,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-P`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           peerDependencies: {
             [`no-deps`]: `*`,
           },
@@ -264,7 +264,7 @@ describe(`Commands`, () => {
         await run(`add`, `no-deps`, `-D`);
         await run(`add`, `no-deps`, `-P`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -280,7 +280,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `inject-node-gyp`);
 
-        const content = await xfs.readFilePromise(`${path}/yarn.lock`, `utf8`);
+        const content = await xfs.readFilePromise(`${path}/yarn.lock` as PortablePath, `utf8`);
         const lock = parseSyml(content);
 
         await expect(lock).toMatchObject({
@@ -294,22 +294,180 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should suggest a workspace if it would match the request`,
+      `it should suggest a workspace if it would match the request (explicit path)`,
       makeTemporaryEnv({
         private: true,
         workspaces: [`packages/*`],
       }, async ({path, run, source}) => {
-        await xfs.mkdirpPromise(`${path}/packages/no-deps`);
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
 
-        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json`, {
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+        });
+
+        await run(`add`, `no-deps@workspace:packages/no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:packages/no-deps`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (explicit semver)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+
+        await run(`add`, `no-deps@workspace:1.0.0`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:1.0.0`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (implicit caret)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
           name: `no-deps`,
         });
 
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
-            [`no-deps`]: `workspace:packages/no-deps`,
+            [`no-deps`]: `workspace:^`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (explicit tilde)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+        });
+
+        await run(`add`, `no-deps`, `-T`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:~`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (explicit exact)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+        });
+
+        await run(`add`, `no-deps`, `-E`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:*`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (explicit caret)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+        });
+
+        await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
+        await run(`add`, `no-deps`, `-C`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:^`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (tilde via defaultSemverRangePrefix)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+        });
+
+        await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
+        await run(`add`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:~`,
+          },
+        });
+      })
+    );
+
+    test(
+      `it should suggest a workspace if it would match the request (exact via defaultSemverRangePrefix)`,
+      makeTemporaryEnv({
+        private: true,
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(`${path}/packages/no-deps` as PortablePath);
+
+        await xfs.writeJsonPromise(`${path}/packages/no-deps/package.json` as PortablePath, {
+          name: `no-deps`,
+        });
+
+        await run(`config`, `set`, `defaultSemverRangePrefix`, ``);
+        await run(`add`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `workspace:*`,
           },
         });
       })
@@ -322,7 +480,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json`)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -337,7 +495,7 @@ describe(`Commands`, () => {
     }, async ({path, run, source}) => {
       await run(`install`);
 
-      const preUpgradeCache = await xfs.readdirPromise(`${path}/.yarn/cache`);
+      const preUpgradeCache = await xfs.readdirPromise(`${path}/.yarn/cache` as PortablePath);
 
       expect(preUpgradeCache.find(entry => entry.includes(`no-deps-npm-1.0.0`))).toBeDefined();
 
@@ -345,7 +503,7 @@ describe(`Commands`, () => {
 
       await expect({code, stdout, stderr}).toMatchSnapshot();
 
-      const postUpgradeCache = await xfs.readdirPromise(`${path}/.yarn/cache`);
+      const postUpgradeCache = await xfs.readdirPromise(`${path}/.yarn/cache` as PortablePath);
 
       expect(postUpgradeCache.find(entry => entry.includes(`no-deps-npm-1.0.0`))).toBeUndefined();
       expect(postUpgradeCache.find(entry => entry.includes(`no-deps-npm-2.0.0`))).toBeDefined();


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn add` and `yarn up` didn't respect the modifier (either specified as `defaultSemverRangePrefix` or through `--caret`/`--tilde`/`--exact`) and always added workspaces with the `workspace:${relativeCwd}` range which isn't too useful as it gets replaced with the exact version at pack time.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made `suggestUtils.getSuggestedDescriptors` take the modifier into account when attaching local workspaces. This means that, by default, workspaces will be attached with the `workspace:^` range.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
