### PR TITLE
fix(constraints): use JSON.stringify in workspace_field

### DIFF
--- a/.yarn/versions/52de201d.yml
+++ b/.yarn/versions/52de201d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
@@ -96,6 +96,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (empty project / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (empty project / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (multiple workspaces / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -214,6 +232,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (multiple workspaces / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (multiple workspaces / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (one regular dependency / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -312,6 +348,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (one regular dependency / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (one regular dependency / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (two development dependencies / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -405,6 +459,24 @@ Object {
   "stderr": "",
   "stdout": "➤ YN0037: root-workspace-0b6124 must have a field dependencies[\\"a-new-dep\\"] set to \\"1.0.0\\", but doesn't
 ➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (two development dependencies / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (two development dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
 ",
 }
 `;
@@ -507,6 +579,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (two regular dependencies / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (two regular dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (two regular dependencies, two development dependencies / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -601,6 +691,140 @@ Object {
   "code": 1,
   "stderr": "",
   "stdout": "➤ YN0037: root-workspace-0b6124 must have a field dependencies[\\"a-new-dep\\"] set to \\"1.0.0\\", but doesn't
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (two regular dependencies, two development dependencies / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (two regular dependencies, two development dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / empty constraints) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_dependency (ambiguous)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0053: root-workspace-0b6124 must depend on no-deps via conflicting ranges 1.0.0 and 2.0.0 (in dependencies)
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_dependency (extraneous)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_dependency (extraneous2)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_dependency (incompatible)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0023: root-workspace-0b6124 must depend on no-deps (via 2.0.0), but doesn't (in dependencies)
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_dependency (missing)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0023: root-workspace-0b6124 must depend on one-fixed-dep (via 1.0.0), but doesn't (in peerDependencies)
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_field (ambiguous)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0053: root-workspace-0b6124 must have a field dependencies[\\"a-new-dep\\"] set to conflicting values \\"1.0.0\\" or \\"2.0.0\\"
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_field (extraneous)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_field (incompatible)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field dependencies[\\"no-deps\\"] set to \\"2.0.0\\", but doesn't
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / gen_enforced_field (missing)) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field dependencies[\\"a-new-dep\\"] set to \\"1.0.0\\", but doesn't
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field _files set to [\\"/a\\",\\"/b\\",\\"/c\\"], but doesn't
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field _repository set to {\\"type\\":\\"git\\",\\"url\\":\\"ssh://git@github.com/yarnpkg/berry.git\\",\\"directory\\":\\".\\"}, but doesn't
 ➤ YN0000: Failed with errors
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
@@ -114,6 +114,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (empty project / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (multiple workspaces / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -250,6 +259,17 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (multiple workspaces / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0037: workspace-a must have a field _name set to \\"workspace-a\\", but doesn't
+➤ YN0037: workspace-b must have a field _name set to \\"workspace-b\\", but doesn't
+➤ YN0000: Failed with errors
+",
+}
+`;
+
 exports[`Commands constraints test (one regular dependency / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -358,6 +378,15 @@ Object {
 `;
 
 exports[`Commands constraints test (one regular dependency / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (one regular dependency / workspace_field w/ string FieldValue) 1`] = `
 Object {
   "code": 0,
   "stderr": "",
@@ -481,6 +510,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (two development dependencies / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (two regular dependencies / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -589,6 +627,15 @@ Object {
 `;
 
 exports[`Commands constraints test (two regular dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints test (two regular dependencies / workspace_field w/ string FieldValue) 1`] = `
 Object {
   "code": 0,
   "stderr": "",
@@ -714,6 +761,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints test (two regular dependencies, two development dependencies / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints test (various field types / empty constraints) 1`] = `
 Object {
   "code": 0,
@@ -727,7 +783,7 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0053: root-workspace-0b6124 must depend on no-deps via conflicting ranges 1.0.0 and 2.0.0 (in dependencies)
+  "stdout": "➤ YN0053: foo must depend on no-deps via conflicting ranges 1.0.0 and 2.0.0 (in dependencies)
 ➤ YN0000: Failed with errors
 ",
 }
@@ -755,7 +811,7 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0023: root-workspace-0b6124 must depend on no-deps (via 2.0.0), but doesn't (in dependencies)
+  "stdout": "➤ YN0023: foo must depend on no-deps (via 2.0.0), but doesn't (in dependencies)
 ➤ YN0000: Failed with errors
 ",
 }
@@ -765,7 +821,7 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0023: root-workspace-0b6124 must depend on one-fixed-dep (via 1.0.0), but doesn't (in peerDependencies)
+  "stdout": "➤ YN0023: foo must depend on one-fixed-dep (via 1.0.0), but doesn't (in peerDependencies)
 ➤ YN0000: Failed with errors
 ",
 }
@@ -775,7 +831,7 @@ exports[`Commands constraints test (various field types / gen_enforced_field (am
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0053: root-workspace-0b6124 must have a field dependencies[\\"a-new-dep\\"] set to conflicting values \\"1.0.0\\" or \\"2.0.0\\"
+  "stdout": "➤ YN0053: foo must have a field dependencies[\\"a-new-dep\\"] set to conflicting values \\"1.0.0\\" or \\"2.0.0\\"
 ➤ YN0000: Failed with errors
 ",
 }
@@ -794,7 +850,7 @@ exports[`Commands constraints test (various field types / gen_enforced_field (in
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field dependencies[\\"no-deps\\"] set to \\"2.0.0\\", but doesn't
+  "stdout": "➤ YN0037: foo must have a field dependencies[\\"no-deps\\"] set to \\"2.0.0\\", but doesn't
 ➤ YN0000: Failed with errors
 ",
 }
@@ -804,7 +860,7 @@ exports[`Commands constraints test (various field types / gen_enforced_field (mi
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field dependencies[\\"a-new-dep\\"] set to \\"1.0.0\\", but doesn't
+  "stdout": "➤ YN0037: foo must have a field dependencies[\\"a-new-dep\\"] set to \\"1.0.0\\", but doesn't
 ➤ YN0000: Failed with errors
 ",
 }
@@ -814,7 +870,7 @@ exports[`Commands constraints test (various field types / workspace_field w/ arr
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field _files set to [\\"/a\\",\\"/b\\",\\"/c\\"], but doesn't
+  "stdout": "➤ YN0037: foo must have a field _files set to [\\"/a\\",\\"/b\\",\\"/c\\"], but doesn't
 ➤ YN0000: Failed with errors
 ",
 }
@@ -824,7 +880,17 @@ exports[`Commands constraints test (various field types / workspace_field w/ obj
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0037: root-workspace-0b6124 must have a field _repository set to {\\"type\\":\\"git\\",\\"url\\":\\"ssh://git@github.com/yarnpkg/berry.git\\",\\"directory\\":\\".\\"}, but doesn't
+  "stdout": "➤ YN0037: foo must have a field _repository set to {\\"type\\":\\"git\\",\\"url\\":\\"ssh://git@github.com/yarnpkg/berry.git\\",\\"directory\\":\\".\\"}, but doesn't
+➤ YN0000: Failed with errors
+",
+}
+`;
+
+exports[`Commands constraints test (various field types / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 1,
+  "stderr": "",
+  "stdout": "➤ YN0037: foo must have a field _name set to \\"foo\\", but doesn't
 ➤ YN0000: Failed with errors
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
@@ -13,7 +13,7 @@ const constraints = {
     `
     gen_enforced_dependency(WorkspaceCwd, 'no-deps', null, _) :-
       WorkspaceCwd \\= '.'.
-    gen_enforced_dependency(WorkspaceCwd, 'no-deps', '1.0.0', DependencyType) :- 
+    gen_enforced_dependency(WorkspaceCwd, 'no-deps', '1.0.0', DependencyType) :-
       workspace_has_dependency(WorkspaceCwd, 'no-deps', '1.0.0', DependencyType).
     `,
   [`gen_enforced_dependency (ambiguous)`]: `gen_enforced_dependency(WorkspaceCwd, 'no-deps', '1.0.0', dependencies). gen_enforced_dependency(WorkspaceCwd, 'no-deps', '2.0.0', dependencies).`,
@@ -21,6 +21,8 @@ const constraints = {
   [`gen_enforced_field (incompatible)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies["no-deps"]', '2.0.0').`,
   [`gen_enforced_field (extraneous)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies', null).`,
   [`gen_enforced_field (ambiguous)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies["a-new-dep"]', '1.0.0'). gen_enforced_field(WorkspaceCwd, 'dependencies["a-new-dep"]', '2.0.0').`,
+  [`workspace_field w/ object FieldValue`]: `gen_enforced_field(WorkspaceCwd, '_repository', FieldValue) :- workspace_field(WorkspaceCwd, 'repository', FieldValue).`,
+  [`workspace_field w/ array FieldValue`]: `gen_enforced_field(WorkspaceCwd, '_files', FieldValue) :- workspace_field(WorkspaceCwd, 'files', FieldValue).`,
 };
 
 describe(`Commands`, () => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
@@ -21,6 +21,7 @@ const constraints = {
   [`gen_enforced_field (incompatible)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies["no-deps"]', '2.0.0').`,
   [`gen_enforced_field (extraneous)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies', null).`,
   [`gen_enforced_field (ambiguous)`]: `gen_enforced_field(WorkspaceCwd, 'dependencies["a-new-dep"]', '1.0.0'). gen_enforced_field(WorkspaceCwd, 'dependencies["a-new-dep"]', '2.0.0').`,
+  [`workspace_field w/ string FieldValue`]: `gen_enforced_field(WorkspaceCwd, '_name', FieldValue) :- workspace_field(WorkspaceCwd, 'name', FieldValue).`,
   [`workspace_field w/ object FieldValue`]: `gen_enforced_field(WorkspaceCwd, '_repository', FieldValue) :- workspace_field(WorkspaceCwd, 'repository', FieldValue).`,
   [`workspace_field w/ array FieldValue`]: `gen_enforced_field(WorkspaceCwd, '_files', FieldValue) :- workspace_field(WorkspaceCwd, 'files', FieldValue).`,
 };

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
@@ -60,6 +60,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (empty project / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (empty project / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (multiple workspaces / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -148,6 +166,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (multiple workspaces / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (multiple workspaces / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (one regular dependency / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -207,6 +243,24 @@ Object {
 ➤ YN0000: DependencyType = devDependencies
 ➤ YN0000: DependencyType = peerDependencies
 ➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (one regular dependency / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (one regular dependency / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
 ",
 }
 `;
@@ -277,6 +331,24 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (two development dependencies / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (two development dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (two regular dependencies / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -339,6 +411,24 @@ Object {
 ➤ YN0000: DependencyType = devDependencies
 ➤ YN0000: DependencyType = peerDependencies
 ➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (two regular dependencies / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (two regular dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
 ",
 }
 `;
@@ -410,6 +500,104 @@ Object {
   "stdout": "➤ YN0000: DependencyType = dependencies
 ➤ YN0000: DependencyType = devDependencies
 ➤ YN0000: DependencyType = peerDependencies
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (two regular dependencies, two development dependencies / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (two regular dependencies, two development dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / combined predicates) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / custom predicate) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: DependencyType = devDependencies
+➤ YN0000: DependencyType = peerDependencies
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / filter w/ workspace_field_test/3) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / filter w/ workspace_field_test/4) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / single predicate with ignored variable) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: WorkspaceName = 'root-workspace-0b6124'
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / single predicate) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: DependencyType = dependencies
+➤ YN0000: DependencyType = devDependencies
+➤ YN0000: DependencyType = peerDependencies
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / workspace_field w/ array FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: FieldValue = '[\\"/a\\",\\"/b\\",\\"/c\\"]'
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: FieldValue = '{\\"type\\":\\"git\\",\\"url\\":\\"ssh://git@github.com/yarnpkg/berry.git\\",\\"directory\\":\\".\\"}'
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
@@ -78,6 +78,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (empty project / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (multiple workspaces / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -184,6 +193,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (multiple workspaces / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (one regular dependency / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -257,6 +275,15 @@ Object {
 `;
 
 exports[`Commands constraints query test (one regular dependency / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (one regular dependency / workspace_field w/ string FieldValue) 1`] = `
 Object {
   "code": 0,
   "stderr": "",
@@ -349,6 +376,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (two development dependencies / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (two regular dependencies / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -425,6 +461,15 @@ Object {
 `;
 
 exports[`Commands constraints query test (two regular dependencies / workspace_field w/ object FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (two regular dependencies / workspace_field w/ string FieldValue) 1`] = `
 Object {
   "code": 0,
   "stderr": "",
@@ -523,6 +568,15 @@ Object {
 }
 `;
 
+exports[`Commands constraints query test (two regular dependencies, two development dependencies / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands constraints query test (various field types / combined predicates) 1`] = `
 Object {
   "code": 0,
@@ -565,7 +619,7 @@ exports[`Commands constraints query test (various field types / single predicate
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: WorkspaceName = 'root-workspace-0b6124'
+  "stdout": "➤ YN0000: WorkspaceName = foo
 ➤ YN0000: Done
 ",
 }
@@ -598,6 +652,16 @@ Object {
   "code": 0,
   "stderr": "",
   "stdout": "➤ YN0000: FieldValue = '{\\"type\\":\\"git\\",\\"url\\":\\"ssh://git@github.com/yarnpkg/berry.git\\",\\"directory\\":\\".\\"}'
+➤ YN0000: Done
+",
+}
+`;
+
+exports[`Commands constraints query test (various field types / workspace_field w/ string FieldValue) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: FieldValue = '\\"foo\\"'
 ➤ YN0000: Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/source.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/source.test.js.snap
@@ -829,3 +829,126 @@ gen_enforced_field(_, _, _) :- false.
 ",
 }
 `;
+
+exports[`Commands constraints source test (various field types / empty constraints) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
+exports[`Commands constraints source test (various field types / empty constraints) 2`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "dependency_type(dependencies).
+dependency_type(devDependencies).
+dependency_type(peerDependencies).
+workspace('.').
+workspace_ident('.', 'root-workspace-0b6124').
+workspace_version('.', []).
+workspace(_) :- false.
+workspace_ident(_, _) :- false.
+workspace_version(_, _) :- false.
+workspace_has_dependency(_, _, _, _) :- false.
+
+
+gen_enforced_dependency(_, _, _, _) :- false.
+gen_enforced_field(_, _, _) :- false.
+",
+}
+`;
+
+exports[`Commands constraints source test (various field types / gen_enforced_dependency (extraneous)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "gen_enforced_dependency(WorkspaceCwd, 'no-deps', null, _).<no line return>
+",
+}
+`;
+
+exports[`Commands constraints source test (various field types / gen_enforced_dependency (extraneous)) 2`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "dependency_type(dependencies).
+dependency_type(devDependencies).
+dependency_type(peerDependencies).
+workspace('.').
+workspace_ident('.', 'root-workspace-0b6124').
+workspace_version('.', []).
+workspace(_) :- false.
+workspace_ident(_, _) :- false.
+workspace_version(_, _) :- false.
+workspace_has_dependency(_, _, _, _) :- false.
+
+gen_enforced_dependency(WorkspaceCwd, 'no-deps', null, _).
+gen_enforced_dependency(_, _, _, _) :- false.
+gen_enforced_field(_, _, _) :- false.
+",
+}
+`;
+
+exports[`Commands constraints source test (various field types / gen_enforced_dependency (incompatible)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "gen_enforced_dependency(WorkspaceCwd, 'no-deps', '2.0.0', dependencies).<no line return>
+",
+}
+`;
+
+exports[`Commands constraints source test (various field types / gen_enforced_dependency (incompatible)) 2`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "dependency_type(dependencies).
+dependency_type(devDependencies).
+dependency_type(peerDependencies).
+workspace('.').
+workspace_ident('.', 'root-workspace-0b6124').
+workspace_version('.', []).
+workspace(_) :- false.
+workspace_ident(_, _) :- false.
+workspace_version(_, _) :- false.
+workspace_has_dependency(_, _, _, _) :- false.
+
+gen_enforced_dependency(WorkspaceCwd, 'no-deps', '2.0.0', dependencies).
+gen_enforced_dependency(_, _, _, _) :- false.
+gen_enforced_field(_, _, _) :- false.
+",
+}
+`;
+
+exports[`Commands constraints source test (various field types / gen_enforced_dependency (missing)) 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "gen_enforced_dependency(WorkspaceCwd, 'one-fixed-dep', '1.0.0', peerDependencies).<no line return>
+",
+}
+`;
+
+exports[`Commands constraints source test (various field types / gen_enforced_dependency (missing)) 2`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "dependency_type(dependencies).
+dependency_type(devDependencies).
+dependency_type(peerDependencies).
+workspace('.').
+workspace_ident('.', 'root-workspace-0b6124').
+workspace_version('.', []).
+workspace(_) :- false.
+workspace_ident(_, _) :- false.
+workspace_version(_, _) :- false.
+workspace_has_dependency(_, _, _, _) :- false.
+
+gen_enforced_dependency(WorkspaceCwd, 'one-fixed-dep', '1.0.0', peerDependencies).
+gen_enforced_dependency(_, _, _, _) :- false.
+gen_enforced_field(_, _, _) :- false.
+",
+}
+`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/source.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/source.test.js.snap
@@ -846,7 +846,7 @@ Object {
 dependency_type(devDependencies).
 dependency_type(peerDependencies).
 workspace('.').
-workspace_ident('.', 'root-workspace-0b6124').
+workspace_ident('.', 'foo').
 workspace_version('.', []).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
@@ -877,7 +877,7 @@ Object {
 dependency_type(devDependencies).
 dependency_type(peerDependencies).
 workspace('.').
-workspace_ident('.', 'root-workspace-0b6124').
+workspace_ident('.', 'foo').
 workspace_version('.', []).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
@@ -908,7 +908,7 @@ Object {
 dependency_type(devDependencies).
 dependency_type(peerDependencies).
 workspace('.').
-workspace_ident('.', 'root-workspace-0b6124').
+workspace_ident('.', 'foo').
 workspace_version('.', []).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
@@ -939,7 +939,7 @@ Object {
 dependency_type(devDependencies).
 dependency_type(peerDependencies).
 workspace('.').
-workspace_ident('.', 'root-workspace-0b6124').
+workspace_ident('.', 'foo').
 workspace_version('.', []).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/environments.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/environments.js
@@ -81,6 +81,7 @@ exports.environments = {
   },
   [`various field types`]: async path => {
     await writeJson(`${path}/package.json`, {
+      name: `foo`,
       repository: {
         type: `git`,
         url: `ssh://git@github.com/yarnpkg/berry.git`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/environments.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/environments.js
@@ -79,4 +79,18 @@ exports.environments = {
       },
     });
   },
+  [`various field types`]: async path => {
+    await writeJson(`${path}/package.json`, {
+      repository: {
+        type: `git`,
+        url: `ssh://git@github.com/yarnpkg/berry.git`,
+        directory: `.`,
+      },
+      files: [
+        `/a`,
+        `/b`,
+        `/c`,
+      ],
+    });
+  },
 };

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -90,6 +90,20 @@ describe(`Commands`, () => {
       expect(fixedManifest.unparsedKey).toBe(`foo`);
     }));
 
+    test(`test apply fix to string fields`, makeTemporaryEnv(manifest, config, async ({path, run, source}) => {
+      environments[`various field types`](path);
+
+      await xfs.writeFilePromise(`${path}/constraints.pro`, `
+      gen_enforced_field(WorkspaceCwd, '_name', FieldValue) :- workspace_field(WorkspaceCwd, 'name', FieldValue).
+      `);
+
+      await run(`constraints`, `--fix`);
+
+      const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
+
+      expect(fixedManifest._name).toStrictEqual(`foo`);
+    }));
+
     test(`test apply fix to object fields`, makeTemporaryEnv(manifest, config, async ({path, run, source}) => {
       environments[`various field types`](path);
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -1,4 +1,6 @@
-import {xfs} from '@yarnpkg/fslib';
+import {xfs}          from '@yarnpkg/fslib';
+
+import {environments} from './environments';
 
 describe(`Commands`, () => {
   const config = {
@@ -86,6 +88,42 @@ describe(`Commands`, () => {
 
       expect(fixedManifest.scripts).toMatchObject({echo: `echo`});
       expect(fixedManifest.unparsedKey).toBe(`foo`);
+    }));
+
+    test(`test apply fix to object fields`, makeTemporaryEnv(manifest, config, async ({path, run, source}) => {
+      environments[`various field types`](path);
+
+      await xfs.writeFilePromise(`${path}/constraints.pro`, `
+      gen_enforced_field(WorkspaceCwd, '_repository', FieldValue) :- workspace_field(WorkspaceCwd, 'repository', FieldValue).
+      `);
+
+      await run(`constraints`, `--fix`);
+
+      const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
+
+      expect(fixedManifest._repository).toStrictEqual({
+        type: `git`,
+        url: `ssh://git@github.com/yarnpkg/berry.git`,
+        directory: `.`,
+      });
+    }));
+
+    test(`test apply fix to array fields`, makeTemporaryEnv(manifest, config, async ({path, run, source}) => {
+      environments[`various field types`](path);
+
+      await xfs.writeFilePromise(`${path}/constraints.pro`, `
+      gen_enforced_field(WorkspaceCwd, '_files', FieldValue) :- workspace_field(WorkspaceCwd, 'files', FieldValue).
+      `);
+
+      await run(`constraints`, `--fix`);
+
+      const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
+
+      expect(fixedManifest._files).toStrictEqual([
+        `/a`,
+        `/b`,
+        `/c`,
+      ]);
     }));
   });
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/query.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/query.test.js
@@ -11,6 +11,8 @@ const queries = {
   [`custom predicate`]: `custom_predicate(DependencyType).`,
   [`filter w/ workspace_field_test/3`]: `workspace(WorkspaceCwd), workspace_field_test(WorkspaceCwd, 'name', '$$ === "workspace-a"').`,
   [`filter w/ workspace_field_test/4`]: `workspace(WorkspaceCwd), workspace_field_test(WorkspaceCwd, 'name', '$$ === $0', ['workspace-b']).`,
+  [`workspace_field w/ object FieldValue`]: `workspace_field('.', 'repository', FieldValue).`,
+  [`workspace_field w/ array FieldValue`]: `workspace_field('.', 'files', FieldValue).`,
 };
 
 const constraintsFile = `

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/query.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/query.test.js
@@ -11,6 +11,7 @@ const queries = {
   [`custom predicate`]: `custom_predicate(DependencyType).`,
   [`filter w/ workspace_field_test/3`]: `workspace(WorkspaceCwd), workspace_field_test(WorkspaceCwd, 'name', '$$ === "workspace-a"').`,
   [`filter w/ workspace_field_test/4`]: `workspace(WorkspaceCwd), workspace_field_test(WorkspaceCwd, 'name', '$$ === $0', ['workspace-b']).`,
+  [`workspace_field w/ string FieldValue`]: `workspace_field('.', 'name', FieldValue).`,
   [`workspace_field w/ object FieldValue`]: `workspace_field('.', 'repository', FieldValue).`,
   [`workspace_field w/ array FieldValue`]: `workspace_field('.', 'files', FieldValue).`,
 };

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -86,7 +86,7 @@ const tauModule = new pl.type.Module(`constraints`, {
 
     prependGoals(thread, point, [new pl.type.Term(`=`, [
       fieldValue,
-      new pl.type.Term(String(value)),
+      new pl.type.Term(JSON.stringify(value)),
     ])]);
   },
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`workspace_field` uses `String(...)` instead of `JSON.stringify(...)`.

Fixes #3282.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use `JSON.stringify`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
