### PR TITLE
fix(vscode-zipfs): add `onStartupFinished` to `activationEvents`

### DIFF
--- a/.yarn/versions/e1764054.yml
+++ b/.yarn/versions/e1764054.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: patch

--- a/packages/vscode-zipfs/package.json
+++ b/packages/vscode-zipfs/package.json
@@ -20,7 +20,8 @@
     "onLanguage:zip",
     "onFileSystem:zip",
     "onCommand:zipfs.mountZipFile",
-    "onCommand:zipfs.mountZipEditor"
+    "onCommand:zipfs.mountZipEditor",
+    "onStartupFinished"
   ],
   "main": "./build/index.js",
   "sideEffects": false,

--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -16,6 +16,7 @@ function mount(uri: vscode.Uri) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+  // Until a more specific activation event exists this requires onStartupFinished
   context.subscriptions.push(registerTerminalLinkProvider());
 
   context.subscriptions.push(vscode.workspace.registerFileSystemProvider(`zip`, new ZipFSProvider(), {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The extension isn't activated automatically when using `enableGlobalCache: true` since the workspace doesn't contain any `.zip` files. This means the `TerminalLinkProvider` can't do its job until after the extension is activated by the user performing a `Go to Definition` or otherwise manually interacting with it.

**How did you fix it?**

Added `onStartupFinished` to `activationEvents`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.