### PR TITLE
Explain limitation to neovim native LSP go-to-definition support

### DIFF
--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -80,6 +80,8 @@ With the `.yarn/sdks` in place TypeScript support should work out of the box wit
 
 ##### Supporting go-to-definition et al.
 
+> **Note:** Due to a bug in [Neovim's URI handling](https://github.com/neovim/neovim/pull/14959) go-to-definition is only supported in neovim-nightly or v0.6 (when available).
+
 As well as the [vim-rzip](https://github.com/lbrayner/vim-rzip) plugin you'll also need the following snippet to handle Yarn PnP's URIs emitted from [theia-ide/typescript-language-server](https://github.com/theia-ide/typescript-language-server). See [lbrayner/vim-rzip#15](https://github.com/lbrayner/vim-rzip/issues/15) for further details.
 
 ```vim

--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -80,7 +80,7 @@ With the `.yarn/sdks` in place TypeScript support should work out of the box wit
 
 ##### Supporting go-to-definition et al.
 
-> **Note:** Due to a bug in [Neovim's URI handling](https://github.com/neovim/neovim/pull/14959) go-to-definition is only supported in neovim-nightly or v0.6 (when available).
+> **Note:** Due to a bug in [Neovim's URI handling](https://github.com/neovim/neovim/pull/14959) go-to-definition is only supported in neovim-nightly.
 
 As well as the [vim-rzip](https://github.com/lbrayner/vim-rzip) plugin you'll also need the following snippet to handle Yarn PnP's URIs emitted from [theia-ide/typescript-language-server](https://github.com/theia-ide/typescript-language-server). See [lbrayner/vim-rzip#15](https://github.com/lbrayner/vim-rzip/issues/15) for further details.
 


### PR DESCRIPTION

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Neovim's native LSP doesn't support go-to-definition like behaviour unless using the nightly builds. This adds a note to the docs to explain this. Bit of a continuation of #3192.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated the docs copying note format from other note.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
