### PR TITLE
Fixes Prolog errors

### DIFF
--- a/.yarn/versions/0be2150d.yml
+++ b/.yarn/versions/0be2150d.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-constraints": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
@@ -691,7 +691,7 @@ exports[`Commands constraints query test with an unknown predicate 1`] = `
 Object {
   "code": 1,
   "stderr": "",
-  "stdout": "➤ YN0044: Existence error: procedure hello_word/1 not found
+  "stdout": "➤ YN0044: Existence error: procedure hello_word/1 not found (in top_level/0)
 ➤ YN0000: Failed with errors
 ",
 }

--- a/packages/gatsby/content/advanced/error-codes.md
+++ b/packages/gatsby/content/advanced/error-codes.md
@@ -342,3 +342,19 @@ to start the application in order for portal dependency to find its subdependenc
 ## YN0074 - `NM_HARDLINKS_MODE_DOWNGRADED`
 
 `nmMode` has been downgraded to `hardlinks-local` due to global cache and install folder being on different devices. Consider changing `globalFolder` setting and place the global cache on the same device as your project, if you want `hardlinks-global` to take effect.
+
+## YN0075 - `PROLOG_INSTANTIATION_ERROR`
+
+This error appears when a Prolog predicate is called with an invalid signature. Specifically, it means that some of the predicate parameters are non-instantiated (ie have no defined value), when the predicate would expect some. This doesn't mean that you need to hardcode a value, just that you need to assign one before calling the predicate. In the case of the `WorkspaceCwd` parameter from most of the Yarn predicates, it means that instead of calling:
+
+```
+workspace_field(WorkspaceCwd, 'name', _).
+```
+
+You would also use the `workspace/1` predicate to let Prolog "fill" the `WorkspaceCwd` parameter prior to using it in `workspace_field/3`:
+
+```
+workspace(WorkspaceCwd), workspace_field(WorkspaceCwd, 'name', _).
+```
+
+For more information about the parameters that must be instantiated when calling the predicate reported by the error message, consult the [dedicated page](/features/constraints#query-predicate) from our documentation.

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -35,7 +35,7 @@ const tauModule = new pl.type.Module(`constraints`, {
     const [descriptorIdent, descriptorRange, workspaceCwd] = atom.args;
 
     if (!isAtom(descriptorIdent) || !isAtom(descriptorRange)) {
-      thread.throwError(pl.error.instantiation(atom.indicator));
+      thread.throw_error(pl.error.instantiation(atom.indicator));
       return;
     }
 
@@ -65,7 +65,7 @@ const tauModule = new pl.type.Module(`constraints`, {
     const [workspaceCwd, fieldName, fieldValue] = atom.args;
 
     if (!isAtom(workspaceCwd) || !isAtom(fieldName)) {
-      thread.throwError(pl.error.instantiation(atom.indicator));
+      thread.throw_error(pl.error.instantiation(atom.indicator));
       return;
     }
 
@@ -109,7 +109,7 @@ const tauModule = new pl.type.Module(`constraints`, {
     const [workspaceCwd, fieldName, checkCode, checkArgv] = atom.args;
 
     if (!isAtom(workspaceCwd) || !isAtom(fieldName) || !isAtom(checkCode) || !isInstantiatedList(checkArgv)) {
-      thread.throwError(pl.error.instantiation(atom.indicator));
+      thread.throw_error(pl.error.instantiation(atom.indicator));
       return;
     }
 

--- a/packages/plugin-constraints/sources/tauProlog.d.ts
+++ b/packages/plugin-constraints/sources/tauProlog.d.ts
@@ -205,7 +205,7 @@ declare module 'tau-prolog' {
 
         public prepend(states: State[]): void;
 
-        public throwError(error: Term<1, 'error'>): void;
+        public throw_error(error: Term<1, 'error'>): void;
 
         public success(state: State, parent?: State): void;
       }

--- a/packages/plugin-nm/package.json
+++ b/packages/plugin-nm/package.json
@@ -8,7 +8,7 @@
     "@yarnpkg/nm": "workspace:^3.0.0-rc.1",
     "@yarnpkg/parsers": "workspace:^2.4.0",
     "@yarnpkg/plugin-pnp": "workspace:^3.0.1",
-    "@yarnpkg/pnp": "workspace:^3.0.1-rc.1",
+    "@yarnpkg/pnp": "workspace:^3.0.1",
     "@zkochan/cmd-shim": "^5.1.0",
     "clipanion": "^3.0.1",
     "micromatch": "^4.0.2",

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -77,6 +77,7 @@ export enum MessageName {
   NM_PRESERVE_SYMLINKS_REQUIRED = 72,
   UPDATE_LOCKFILE_ONLY_SKIP_LINK = 73,
   NM_HARDLINKS_MODE_DOWNGRADED = 74,
+  PROLOG_INSTANTIATION_ERROR = 75,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5836,7 +5836,7 @@ __metadata:
     "@yarnpkg/parsers": "workspace:^2.4.0"
     "@yarnpkg/plugin-pnp": "workspace:^3.0.1"
     "@yarnpkg/plugin-stage": "workspace:*"
-    "@yarnpkg/pnp": "workspace:^3.0.1-rc.1"
+    "@yarnpkg/pnp": "workspace:^3.0.1"
     "@zkochan/cmd-shim": ^5.1.0
     clipanion: ^3.0.1
     micromatch: ^4.0.2
@@ -6033,7 +6033,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/pnp@workspace:*, @yarnpkg/pnp@workspace:^3.0.1, @yarnpkg/pnp@workspace:^3.0.1-rc.1, @yarnpkg/pnp@workspace:packages/yarnpkg-pnp":
+"@yarnpkg/pnp@workspace:*, @yarnpkg/pnp@workspace:^3.0.1, @yarnpkg/pnp@workspace:packages/yarnpkg-pnp":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/pnp@workspace:packages/yarnpkg-pnp"
   dependencies:


### PR DESCRIPTION
**What's the problem this PR addresses?**

The Prolog errors were kinda broken.

**How did you fix it?**

- Fixes our types to rename `throwError` into `throw_error`.
- Fixes instantiation error reporting.
- Adds documentation explaining the error.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
