### PR TITLE
fix: return exit code in `yarn version --immediate`

### DIFF
--- a/.yarn/versions/dd3c6000.yml
+++ b/.yarn/versions/dd3c6000.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -107,8 +107,9 @@ export default class VersionCommand extends BaseCommand {
     versionFile.releases.set(workspace, releaseStrategy as any);
     await versionFile.saveAll();
 
-    if (!deferred) {
-      await this.cli.run([`version`, `apply`]);
-    }
+    if (!deferred)
+      return await this.cli.run([`version`, `apply`]);
+
+    return 0;
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Running `yarn version --immediate` also runs `yarn version apply`, but the exit code doesn't get returned which causes it to exit with exit code `0` even when there are errors.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
