### PR TITLE
Splits variables when interpolated outside of quotes

### DIFF
--- a/.yarn/versions/3f3739b9.yml
+++ b/.yarn/versions/3f3739b9.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -454,9 +454,12 @@ async function evaluateVariable(segment: ArgumentSegment & {type: `variable`}, o
       if (segment.quoted) {
         push(raw);
       } else {
-        for (const part of split(raw)) {
-          pushAndClose(part);
-        }
+        const parts = split(raw);
+
+        for (let t = 0; t < parts.length - 1; ++t)
+          pushAndClose(parts[t]);
+
+        push(parts[parts.length - 1]);
       }
     } break;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Variables weren't properly split when interpolating them outside of double-quotes.

**How did you fix it?**

Now check whether the current segment is quoted or not, and split accordingly.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
