### PR TITLE
ci: add gulp e2e test

### DIFF
--- a/.github/workflows/e2e-gulp-workflow.yml
+++ b/.github/workflows/e2e-gulp-workflow.yml
@@ -38,5 +38,5 @@ jobs:
         yarn gulp
 
         # Test using the Gulp API and run public task via CLI.
-        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptFile = gulp.src('./gulpfile.js'); if (scriptFile) { console.log('Success: used gulp API import.'); } cb(); } exports.testGulpAPI = testGulpAPI;" | tee gulpfile.js
+        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptFile = gulp.src('./gulpfile.js'); if (scriptFile) { console.log('Success: used gulp API import.'); } cb(); }; exports.testGulpAPI = testGulpAPI;" | tee gulpfile.js
         yarn gulp testGulpAPI

--- a/.github/workflows/e2e-gulp-workflow.yml
+++ b/.github/workflows/e2e-gulp-workflow.yml
@@ -1,0 +1,42 @@
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/workflows/e2e-gulp-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Gulp'
+jobs:
+  chore:
+    name: 'Validating Gulp'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: 'Install Node'
+      uses: actions/setup-node@master
+      with:
+        node-version: 14.x
+
+    - name: 'Build the standard bundle'
+      run: |
+        node ./scripts/run-yarn.js build:cli
+
+    - name: 'Run Gulp E2E test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        yarn init -p
+        yarn add -D gulp
+
+        # Test running Gulp with a simple default task.
+        echo "const gulp = require('gulp'); const defaultTaskPrintCheck = (cb) => { console.log('Successfully ran gulp task'); cb(); }; exports.default = defaultTaskPrintCheck;" | tee gulp-test.js
+        yarn gulp
+
+        # Test using the Gulp API and run public task via CLI.
+        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptVinyl = gulp.src('./gulpfile.js'); if (scriptVinyl) { console.log('Successfully tested gulp API by finding script with src.'); } cb(); } exports.testGulpAPI = testGulpAPI;" | tee gulp-test.js
+        yarn gulp testGulpAPI

--- a/.github/workflows/e2e-gulp-workflow.yml
+++ b/.github/workflows/e2e-gulp-workflow.yml
@@ -34,9 +34,9 @@ jobs:
         yarn add -D gulp
 
         # Test running Gulp with a simple default task.
-        echo "const gulp = require('gulp'); const defaultTaskPrintCheck = (cb) => { console.log('Successfully ran gulp task'); cb(); }; exports.default = defaultTaskPrintCheck;" | tee gulp-test.js
+        echo "const gulp = require('gulp'); const defaultTaskPrintCheck = (cb) => { console.log('Success: ran gulp task'); cb(); }; exports.default = defaultTaskPrintCheck;" | tee gulp-test.js
         yarn gulp
 
         # Test using the Gulp API and run public task via CLI.
-        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptVinyl = gulp.src('./gulpfile.js'); if (scriptVinyl) { console.log('Successfully tested gulp API by finding script with src.'); } cb(); } exports.testGulpAPI = testGulpAPI;" | tee gulp-test.js
+        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptFile = gulp.src('./gulpfile.js'); if (scriptFile) { console.log('Success: used gulp API import.'); } cb(); } exports.testGulpAPI = testGulpAPI;" | tee gulp-test.js
         yarn gulp testGulpAPI

--- a/.github/workflows/e2e-gulp-workflow.yml
+++ b/.github/workflows/e2e-gulp-workflow.yml
@@ -34,9 +34,9 @@ jobs:
         yarn add -D gulp
 
         # Test running Gulp with a simple default task.
-        echo "const gulp = require('gulp'); const defaultTaskPrintCheck = (cb) => { console.log('Success: ran gulp task'); cb(); }; exports.default = defaultTaskPrintCheck;" | tee gulp-test.js
+        echo "const gulp = require('gulp'); const defaultTaskPrintCheck = (cb) => { console.log('Success: ran gulp task'); cb(); }; exports.default = defaultTaskPrintCheck;" | tee gulpfile.js
         yarn gulp
 
         # Test using the Gulp API and run public task via CLI.
-        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptFile = gulp.src('./gulpfile.js'); if (scriptFile) { console.log('Success: used gulp API import.'); } cb(); } exports.testGulpAPI = testGulpAPI;" | tee gulp-test.js
+        echo "const gulp = require('gulp'); const testGulpAPI = (cb) => { const scriptFile = gulp.src('./gulpfile.js'); if (scriptFile) { console.log('Success: used gulp API import.'); } cb(); } exports.testGulpAPI = testGulpAPI;" | tee gulpfile.js
         yarn gulp testGulpAPI

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ On top of our classic integration tests, we also run Yarn every day against the 
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Angular%20over%20PnPify/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-pnpify-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20CRA/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-cra-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Gatsby/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gatsby-workflow.yml)<br/>
+[![](https://github.com/yarnpkg/berry/workflows/E2E%20Gulp/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gulp-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Next/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-next-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Preact%20CLI/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-preact-cli-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Vue-CLI/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-vue-cli-workflow.yml)<br/>

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -128,6 +128,7 @@ Many common frontend tools now support Plug'n'Play natively!
 | Create-React-App | Starting from 2.0+ |
 | ESLint | Some compatibility issues w/ shared configs |
 | Gatsby | Supported with version ≥2.15.0, ≥3.7.0 |
+| Gulp | Supported with version 4.0+ | 
 | Husky | Starting from 4.0.0-1+ |
 | Jest | Starting from 24.1+ |
 | Next.js | Starting from 9.1.2+ |


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->

The Gulp package is still missing from the list of completed E2E tests required by #368.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I added an E2E test that installs gulp to a project as a dev dependency and tests with two short scripts.
One creates a simple default task that should run successfully when running "gulp", validating that the dependency installed and is able to run.

The next creates a public task that can be run with the "gulp <taskname>" CLI argument, and validates that we're able to import and use the gulp API by making use of the src() function to load the script file in.

I look forward to any suggestions for how to expand or improve E2E coverage for Gulp. Thanks for your time!

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
