### PR TITLE
chore(compat): update extensions list

### DIFF
--- a/.github/workflows/plugin-compat-workflow.yml
+++ b/.github/workflows/plugin-compat-workflow.yml
@@ -4,9 +4,11 @@ on:
     - master
     paths:
     - 'packages/plugin-compat/**'
+    - '!packages/plugin-compat/sources/extensions.ts'
   pull_request:
     paths:
     - 'packages/plugin-compat/**'
+    - '!packages/plugin-compat/sources/extensions.ts'
 
 name: 'plugin-compat'
 jobs:

--- a/.yarn/versions/fb7f48cc.yml
+++ b/.yarn/versions/fb7f48cc.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -552,4 +552,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'magic-string': `^0.25.7`,
     },
   }],
+  // https://github.com/elm-community/elm-webpack-loader/pull/202
+  [`elm-webpack-loader@*`, {
+    dependencies: {
+      temp: `^0.9.4`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -534,4 +534,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'json-parse-even-better-errors': `^2.3.1`,
     },
   }],
+  // https://github.com/npm/bin-links/pull/17
+  [`bin-links@*`, {
+    dependencies: {
+      'mkdirp-infer-owner': `^1.0.2`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -558,4 +558,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       temp: `^0.9.4`,
     },
   }],
+  // https://github.com/winstonjs/winston-transport/pull/58
+  [`winston-transport@<=4.4.0`, {
+    dependencies: {
+      logform: `^2.2.0`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -522,4 +522,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       redux: `^4.0.0`,
     },
   }],
+  // https://github.com/snowpackjs/snowpack/pull/3556
+  [`skypack@<=0.3.2`, {
+    dependencies: {
+      tar: `^6.1.0`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -546,4 +546,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       rollup: `^1.20.0 || ^2.0.0`,
     },
   }],
+  // https://github.com/snowpackjs/snowpack/pull/3673
+  [`snowpack@*`, {
+    dependencies: {
+      'magic-string': `^0.25.7`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -528,4 +528,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       tar: `^6.1.0`,
     },
   }],
+  // https://github.com/npm/metavuln-calculator/pull/8
+  [`@npmcli/metavuln-calculator@*`, {
+    dependencies: {
+      'json-parse-even-better-errors': `^2.3.1`,
+    },
+  }],
 ];

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -540,4 +540,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'mkdirp-infer-owner': `^1.0.2`,
     },
   }],
+  // https://github.com/snowpackjs/rollup-plugin-polyfill-node/pull/30
+  [`rollup-plugin-polyfill-node@*`, {
+    peerDependencies: {
+      rollup: `^1.20.0 || ^2.0.0`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Updates the extensions list to include
- https://github.com/snowpackjs/snowpack/pull/3556
- https://github.com/npm/metavuln-calculator/pull/8
- https://github.com/npm/bin-links/pull/17
- https://github.com/snowpackjs/rollup-plugin-polyfill-node/pull/30
- https://github.com/snowpackjs/snowpack/pull/3673
- https://github.com/elm-community/elm-webpack-loader/pull/202
- https://github.com/winstonjs/winston-transport/pull/58

Fixes the failing e2e test for `snowpack` which has been failing for over a month now

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.