### PR TITLE
chore(dlx): add example of the `-p` flag

### DIFF
--- a/.yarn/versions/60c95789.yml
+++ b/.yarn/versions/60c95789.yml
@@ -1,0 +1,22 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-dlx": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -19,10 +19,16 @@ export default class DlxCommand extends BaseCommand {
 
       Using \`yarn dlx\` as a replacement of \`yarn add\` isn't recommended, as it makes your project non-deterministic (Yarn doesn't keep track of the packages installed through \`dlx\` - neither their name, nor their version).
     `,
-    examples: [[
-      `Use create-react-app to create a new React app`,
-      `yarn dlx create-react-app ./my-app`,
-    ]],
+    examples: [
+      [
+        `Use create-react-app to create a new React app`,
+        `yarn dlx create-react-app ./my-app`,
+      ],
+      [
+        `Install multiple packages for a single command`,
+        `yarn dlx -p typescript -p ts-node ts-node --transpile-only -e "console.log('hello!');"`,
+      ]
+    ],
   });
 
   packages = Option.Array(`-p,--package`, {

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -19,16 +19,13 @@ export default class DlxCommand extends BaseCommand {
 
       Using \`yarn dlx\` as a replacement of \`yarn add\` isn't recommended, as it makes your project non-deterministic (Yarn doesn't keep track of the packages installed through \`dlx\` - neither their name, nor their version).
     `,
-    examples: [
-      [
-        `Use create-react-app to create a new React app`,
-        `yarn dlx create-react-app ./my-app`,
-      ],
-      [
-        `Install multiple packages for a single command`,
-        `yarn dlx -p typescript -p ts-node ts-node --transpile-only -e "console.log('hello!');"`,
-      ]
-    ],
+    examples: [[
+      `Use create-react-app to create a new React app`,
+      `yarn dlx create-react-app ./my-app`,
+    ], [
+      `Install multiple packages for a single command`,
+      `yarn dlx -p typescript -p ts-node ts-node --transpile-only -e "console.log('hello!')"`,
+    ]],
   });
 
   packages = Option.Array(`-p,--package`, {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Adds documentation to the `yarn dlx` command. I had to read through the source to understand how to install multiple packages.

**How did you fix it?**

By adding an example to the documentation.

...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.