### PR TITLE
feat(nm): Adds fine-grained per-workspace control for workspace self-references creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 - `hardlinks-global` node modules mode is automatically downgraded to `hardlinks-local` when global cache and install folder are on a different devices and the install continues normally. Warning is produced to the user with mitigation steps provided in documentation.
 - The nm linker maximizes chances to end-up with only one top-level node_modules in the case of using workspaces
+- The `nmSelfReferences` setting has been added to the nm linker to control whether workspaces are allowed to require themselves - results in creation of self-referencing symlinks.
 
 ## 3.0.1
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -511,6 +511,34 @@ describe(`Node_Modules`, () => {
     )
   );
 
+  test(`should respect self references settings`,
+    makeTemporaryEnv(
+      {
+        workspaces: [`ws1`, `ws2`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmSelfReferences: false,
+      },
+      async ({path, run}) => {
+        await writeJson(npath.toPortablePath(`${path}/ws1/package.json`), {
+          name: `ws1`,
+          installConfig: {
+            selfReferences: true,
+          },
+        });
+        await writeJson(npath.toPortablePath(`${path}/ws2/package.json`), {
+          name: `ws2`,
+        });
+
+        await run(`install`);
+
+        expect(await xfs.existsPromise(`${path}/node_modules/ws1` as PortablePath)).toEqual(true);
+        expect(await xfs.existsPromise(`${path}/node_modules/ws2` as PortablePath)).toEqual(false);
+      },
+    )
+  );
+
   test(`should not hoist multiple packages past workspace hoist border`,
     // . -> workspace -> dep1 -> dep2
     // should be hoisted to:

--- a/packages/gatsby/static/configuration/manifest.json
+++ b/packages/gatsby/static/configuration/manifest.json
@@ -330,6 +330,11 @@
           "type": "string",
           "enum": ["workspaces", "dependencies", "none"],
           "default": "none"
+        },
+        "selfReferences": {
+          "description": "Defines whether workspaces are allowed to require themselves - results in creation of self-referencing symlinks, overriding for the current workspace the value initially set for [`nmSelfReferences`](/configuration/yarnrc#nmSelfReferences)",
+          "type": "boolean",
+          "default": true
         }
       },
       "_exampleKeys": ["hoistingLimits"],

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -363,6 +363,12 @@
       "enum": ["workspaces", "dependencies", "none"],
       "default": "none"
     },
+    "nmSelfReferences": {
+      "_package": "@yarnpkg/plugin-nm",
+      "description": "Defines whether workspaces are allowed to require themselves - results in creation of self-referencing symlinks. This setting can be overriden per-workspace through the [`installConfig.selfReferences` field](/configuration/manifest#installConfig.selfReferences).",
+      "type": "boolean",
+      "default": true
+    },
     "nmMode": {
       "_package": "@yarnpkg/plugin-nm",
       "description": "If set to `hardlinks-local` Yarn will utilize hardlinks to reduce disk space consumption inside `node_modules` directories in a current project. With `hardlinks-global` Yarn will use global content addressable storage to reduce `node_modules` size across all the projects using this option.",

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -236,6 +236,12 @@ class NodeModulesInstaller implements Installer {
       return [workspace.relativeCwd, hoistingLimits];
     }));
 
+    const selfReferencesByCwd = new Map(this.opts.project.workspaces.map(workspace => {
+      let selfReferences = this.opts.project.configuration.get(`nmSelfReferences`);
+      selfReferences = workspace.manifest.installConfig?.selfReferences ?? selfReferences;
+      return [workspace.relativeCwd, selfReferences];
+    }));
+
     const pnpApi: PnpApi = {
       VERSIONS: {
         std: 1,
@@ -291,7 +297,7 @@ class NodeModulesInstaller implements Installer {
       },
     };
 
-    const {tree, errors, preserveSymlinksRequired} = buildNodeModulesTree(pnpApi, {pnpifyFs: false, validateExternalSoftLinks: true, hoistingLimitsByCwd, project: this.opts.project});
+    const {tree, errors, preserveSymlinksRequired} = buildNodeModulesTree(pnpApi, {pnpifyFs: false, validateExternalSoftLinks: true, hoistingLimitsByCwd, project: this.opts.project, selfReferencesByCwd});
     if (!tree) {
       for (const {messageName, text} of errors)
         this.opts.report.reportError(messageName, text);

--- a/packages/plugin-nm/sources/index.ts
+++ b/packages/plugin-nm/sources/index.ts
@@ -10,6 +10,7 @@ declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     nmHoistingLimits: NodeModulesHoistingLimits;
     nmMode: NodeModulesMode;
+    nmSelfReferences: boolean;
   }
 }
 
@@ -40,6 +41,11 @@ const plugin: Plugin<Hooks> = {
         NodeModulesMode.HARDLINKS_GLOBAL,
       ],
       default: NodeModulesMode.CLASSIC,
+    },
+    nmSelfReferences: {
+      description: `If set to 'false' the workspace will not be allowed to require itself and correspoding self-referncing symlink will not be created`,
+      type: SettingsType.BOOLEAN,
+      default: true,
     },
   },
   linkers: [

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -37,6 +37,7 @@ export interface PublishConfig {
 
 export interface InstallConfig {
   hoistingLimits?: string;
+  selfReferences?: boolean;
 }
 
 export class Manifest {
@@ -553,6 +554,12 @@ export class Manifest {
             this.installConfig.hoistingLimits = data.installConfig.hoistingLimits;
           } else {
             errors.push(new Error(`Invalid hoisting limits definition`));
+          }
+        } else if (key == `selfReferences`) {
+          if (typeof data.installConfig.selfReferences == `boolean`) {
+            this.installConfig.selfReferences = data.installConfig.selfReferences;
+          } else {
+            errors.push(new Error(`Invalid selfReferences definition, must be a boolean value`));
           }
         } else {
           errors.push(new Error(`Unrecognized installConfig key: ${key}`));

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -53,6 +53,7 @@ export interface NodeModulesTreeOptions {
   pnpifyFs?: boolean;
   validateExternalSoftLinks?: boolean;
   hoistingLimitsByCwd?: Map<PortablePath, NodeModulesHoistingLimits>;
+  selfReferencesByCwd?: Map<PortablePath, Boolean>;
   project?: Project;
 }
 
@@ -305,7 +306,8 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
       }
     }
 
-    parent.dependencies.add(node);
+    if (pkg !== parentPkg || pkg.linkType !== LinkType.SOFT || !options.selfReferencesByCwd || options.selfReferencesByCwd.get(parentRelativeCwd))
+      parent.dependencies.add(node);
 
     if (!isSeen) {
       const siblingPortalDependencyMap = new Map<string, {target: DependencyTarget, portal: PhysicalPackageLocator}>();


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Sometimes self-referencing symlinks in workspaces are expected and wanted and sometimes they cause troubles. The reasons they are not expected - is pre-workspace era tools and frameworks usage, that don't know how to work with symlinks. The reasons they are expected are two-fold:
  1. Yarn 1.x workspaces semantics, when all workspaces were implicit dependencies of the root workspace. We continue to support these semantics over Yarn berry core in the nm linker, by creating and hoisting self-references. 
  2. New yarn berry core semantics, when all the workspaces are not implicitly dependencies of the root workspace, the relations must be defined explicitly, but at the same time, the workspaces are allowed to require themselves. 

Fixes #3256

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have added support for fine-grained per-workspace control of self-references creation to let the users control and allow them to use tools and frameworks that do not treat symlinks well (React Native).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
