### PR TITLE
Set platform to node to fix builder issues

### DIFF
--- a/.yarn/versions/9fef648d.yml
+++ b/.yarn/versions/9fef648d.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -121,6 +121,7 @@ export default class BuildBundleCommand extends Command {
           define: {YARN_VERSION: JSON.stringify(version)},
           outfile: output,
           logLevel: `silent`,
+          format: `iife`,
           platform: `node`,
           plugins: [valLoader, pnpPlugin()],
           minify: !this.noMinify,

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -121,6 +121,7 @@ export default class BuildBundleCommand extends Command {
           define: {YARN_VERSION: JSON.stringify(version)},
           outfile: output,
           logLevel: `silent`,
+          platform: 'node',
           plugins: [valLoader, pnpPlugin()],
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -121,7 +121,7 @@ export default class BuildBundleCommand extends Command {
           define: {YARN_VERSION: JSON.stringify(version)},
           outfile: output,
           logLevel: `silent`,
-          platform: 'node',
+          platform: `node`,
           plugins: [valLoader, pnpPlugin()],
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -113,6 +113,7 @@ export default class BuildPluginCommand extends Command {
           bundle: true,
           outfile: output,
           logLevel: `silent`,
+          format: `iife`,
           platform: `node`,
           plugins: [dynamicLibResolver, pnpPlugin()],
           minify: !this.noMinify,

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -113,7 +113,7 @@ export default class BuildPluginCommand extends Command {
           bundle: true,
           outfile: output,
           logLevel: `silent`,
-          platform: 'node',
+          platform: `node`,
           plugins: [dynamicLibResolver, pnpPlugin()],
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -113,6 +113,7 @@ export default class BuildPluginCommand extends Command {
           bundle: true,
           outfile: output,
           logLevel: `silent`,
+          platform: 'node',
           plugins: [dynamicLibResolver, pnpPlugin()],
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fixes #3233

Prior to this change, the plugin builder would attempt to bundle all dependencies which would fail with node dependencies like util or path.

**How did you fix it?**

By setting `platform` to `node` it will not attempt to bundle Node dependencies.

See the [ESBuild platform docs](https://esbuild.github.io/api/#platform) for more details.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
