### PR TITLE
fix(builder): Outputs commit-hash instead of tree-hash as part of the CLI version.

### DIFF
--- a/.yarn/versions/b8f1abb1.yml
+++ b/.yarn/versions/b8f1abb1.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnp"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - Direct portal dependencies for `node_modules` install are given priority during hoisting now, to prevent cases when indirect regular dependencies take place in the install tree first and block the way for direct portal dependencies.
 - Usage of `pnpify` inside directories containing spaces is now possible.
 - Hoisting algorithm speedup, impacts recurrent `node_modules` installs time.
+- CLI bundles built from sources output `commit` hash instead of `tree` hash as part of their version
 
 ### Installs
 

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -22,7 +22,7 @@ const pkgJsonVersion = (basedir: string): string => {
 
 const suggestHash = async (basedir: string) => {
   try {
-    const unique = await execFile(`git`, [`show`, `-s`, `--pretty=format:%ad.%t`, `--date=short`], {cwd: basedir});
+    const unique = await execFile(`git`, [`show`, `-s`, `--pretty=format:%ad.%h`, `--date=short`], {cwd: basedir});
     return `git.${unique.stdout.trim().replace(/-/g, ``).replace(`.`, `.hash-`)}`;
   } catch {
     return null;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Yarn CLI bundles built from sources output tree-hash as part of the version. I don't know if this was intended, it is very difficult to find sources that were used to build the bundle from tree hash. It is much more natural to use commit hash. You can see immediately everywhere over GitHub each commit hash.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have changed `builder` to use commit hash instead of tree hash as part of the version of CLI.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
