### PR TITLE
docs: update migration guide to reflect the changes in Yarn 3

### DIFF
--- a/packages/gatsby/content/getting-started/migration.md
+++ b/packages/gatsby/content/getting-started/migration.md
@@ -110,11 +110,9 @@ All of this and more is documented in the following sections. In general, we adv
 
 ## General Advices
 
-### Upgrade to Node 10.19 or newer
+### Upgrade to Node.js 12.x or newer
 
-Node 8 reached its official End of Life in December 2019 and won't receive any further update. Yarn consequently doesn't support it anymore.
-
-Note that Node 10 itself will reach its own End of Life on May 2021, so support for it will likely be removed from Yarn 3. As a result we recommend upgrading to Node 12 or 14 whenever you can.
+Node.js 10.x reached its official End of Life in April 2021 and won't receive any further update. Yarn consequently doesn't support it anymore.
 
 ### Fix dependencies with `packageExtensions`
 


### PR DESCRIPTION
Yarn no longer supports Node.js 10.x (https://github.com/yarnpkg/berry/pull/2373), which has reached End-of-Life on 2021-04-30.

Refs: https://github.com/nodejs/Release#end-of-life-releases

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
