### PR TITLE
Adds support for `workspace:^` in peerDependencies

### DIFF
--- a/.yarn/versions/37f592a2.yml
+++ b/.yarn/versions/37f592a2.yml
@@ -1,0 +1,29 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-pack": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/constraints.pro
+++ b/constraints.pro
@@ -50,6 +50,12 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, 'workspace:*', 'devDepend
   % Only consider those that target something that could be a workspace
   workspace_ident(DependencyCwd, DependencyIdent).
 
+% This rule enforces that all workspaces must depend on other workspaces using `workspace:^` in peerDependencies
+gen_enforced_dependency(WorkspaceCwd, DependencyIdent, 'workspace:^', 'peerDependencies') :-
+  workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, 'peerDependencies'),
+  % Only consider those that target something that could be a workspace
+  workspace_ident(DependencyCwd, DependencyIdent).
+
 % This rule enforces that all packages must not depend on inquirer - we use enquirer instead
 gen_enforced_dependency(WorkspaceCwd, 'inquirer', null, DependencyType) :-
   workspace_has_dependency(WorkspaceCwd, 'inquirer', _, DependencyType).

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -360,6 +360,11 @@ describe(`Commands`, () => {
           devDependencies: {
             [dependency]: `workspace:^1.0.0`,
           },
+          peerDependencies: {
+            [dependency]: `workspace:*`,
+            [foo]: `workspace:^`,
+            [bar]: `workspace:~`,
+          },
         });
 
         await run(`install`);
@@ -375,6 +380,9 @@ describe(`Commands`, () => {
         expect(packedManifest.devDependencies[dependency]).toBe(`^1.0.0`);
         expect(packedManifest.dependencies[foo]).toBe(`^2.0.0`);
         expect(packedManifest.dependencies[bar]).toBe(`~3.0.0`);
+        expect(packedManifest.peerDependencies[dependency]).toBe(`1.0.0`);
+        expect(packedManifest.peerDependencies[foo]).toBe(`^2.0.0`);
+        expect(packedManifest.peerDependencies[bar]).toBe(`~3.0.0`);
 
         const originalManifest = await fsUtils.readJson(`${path}/dependant/package.json`);
 
@@ -382,6 +390,9 @@ describe(`Commands`, () => {
         expect(originalManifest.devDependencies[dependency]).toBe(`workspace:^1.0.0`);
         expect(originalManifest.dependencies[foo]).toBe(`workspace:^`);
         expect(originalManifest.dependencies[bar]).toBe(`workspace:~`);
+        expect(originalManifest.peerDependencies[dependency]).toBe(`workspace:*`);
+        expect(originalManifest.peerDependencies[foo]).toBe(`workspace:^`);
+        expect(originalManifest.peerDependencies[bar]).toBe(`workspace:~`);
       }),
     );
 

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -4,8 +4,8 @@
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3",
-    "@yarnpkg/plugin-patch": "^3.0.1-rc.1"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/plugin-patch": "workspace:^"
   },
   "devDependencies": {
     "@types/lodash-es": "4.17.4",

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -17,8 +17,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.136",

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -10,8 +10,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/cli": "workspace:*",

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -17,8 +17,8 @@
     "typanion": "^3.3.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/ci-info": "^2",

--- a/packages/plugin-exec/package.json
+++ b/packages/plugin-exec/package.json
@@ -9,7 +9,7 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/core": "workspace:*",

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -8,7 +8,7 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/core": "workspace:*"

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -11,7 +11,7 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/git-url-parse": "^9.0.0",

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -8,8 +8,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3",
-    "@yarnpkg/plugin-git": "^2.4.0"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/plugin-git": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/core": "workspace:*",

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -8,7 +8,7 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/core": "workspace:*"

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -10,8 +10,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.136",

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -15,9 +15,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3",
-    "@yarnpkg/plugin-essentials": "^3.1.0-rc.2"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/plugin-essentials": "workspace:^"
   },
   "devDependencies": {
     "@types/diff": "^4.0.2",

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -8,7 +8,7 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/core": "workspace:*"

--- a/packages/plugin-nm/package.json
+++ b/packages/plugin-nm/package.json
@@ -15,8 +15,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.1",

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -12,10 +12,10 @@
     "typanion": "^3.3.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3",
-    "@yarnpkg/plugin-npm": "^2.5.0",
-    "@yarnpkg/plugin-pack": "^3.1.0-rc.2"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/plugin-npm": "workspace:^",
+    "@yarnpkg/plugin-pack": "workspace:^"
   },
   "devDependencies": {
     "@npm/types": "^1.0.1",

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -11,8 +11,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3",
-    "@yarnpkg/plugin-pack": "^3.1.0-rc.2"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/plugin-pack": "workspace:^"
   },
   "devDependencies": {
     "@types/semver": "^7.1.0",

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -11,8 +11,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.1",

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -10,8 +10,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/cli": "workspace:*",

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -14,8 +14,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.1",

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -9,8 +9,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@yarnpkg/builder": "workspace:*",

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -10,9 +10,9 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3",
-    "@yarnpkg/plugin-essentials": "^3.1.0-rc.2"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/plugin-essentials": "workspace:^"
   },
   "devDependencies": {
     "@algolia/requester-common": "4.0.0-beta.14",

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -15,8 +15,8 @@
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.136",

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -12,8 +12,8 @@
     "typanion": "^3.3.0"
   },
   "peerDependencies": {
-    "@yarnpkg/cli": "^3.1.0-rc.2",
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/cli": "workspace:^",
+    "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.1",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -43,7 +43,7 @@
     "typescript": "^4.4.2"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "^3.1.0-rc.3"
+    "@yarnpkg/core": "workspace:^"
   },
   "scripts": {
     "postpack": "rm -rf lib",

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -2,11 +2,12 @@ import {FakeFS, Filename, NodeFS, PortablePath, ppath}    from '@yarnpkg/fslib';
 import {Resolution, parseResolution, stringifyResolution} from '@yarnpkg/parsers';
 import semver                                             from 'semver';
 
+import {WorkspaceResolver}                                from './WorkspaceResolver';
 import * as miscUtils                                     from './miscUtils';
 import * as semverUtils                                   from './semverUtils';
 import * as structUtils                                   from './structUtils';
-import {IdentHash}                                        from './types';
 import {Ident, Descriptor}                                from './types';
+import {IdentHash}                                        from './types';
 
 export type AllDependencies = 'dependencies' | 'devDependencies' | 'peerDependencies';
 export type HardDependencies = 'dependencies' | 'devDependencies';
@@ -363,7 +364,7 @@ export class Manifest {
           continue;
         }
 
-        if (typeof range !== `string` || !semverUtils.validRange(range)) {
+        if (typeof range !== `string` || (!semverUtils.validRange(range) && !range.startsWith(WorkspaceResolver.protocol))) {
           errors.push(new Error(`Invalid dependency range for '${name}'`));
           range = `*`;
         }

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -364,7 +364,7 @@ export class Manifest {
           continue;
         }
 
-        if (typeof range !== `string` || (!semverUtils.validRange(range) && !range.startsWith(WorkspaceResolver.protocol))) {
+        if (typeof range !== `string` || (!range.startsWith(WorkspaceResolver.protocol) && !semverUtils.validRange(range))) {
           errors.push(new Error(`Invalid dependency range for '${name}'`));
           range = `*`;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5294,7 +5294,7 @@ __metadata:
     typescript: ^4.4.2
     yup: ^0.32.9
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5638,8 +5638,8 @@ __metadata:
     resolve: ^1.17.0
     semver: ^7.1.2
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
-    "@yarnpkg/plugin-patch": ^3.0.1-rc.1
+    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/plugin-patch": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5659,8 +5659,8 @@ __metadata:
     tslib: ^1.13.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5675,8 +5675,8 @@ __metadata:
     clipanion: ^3.0.1
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5703,8 +5703,8 @@ __metadata:
     tslib: ^1.13.0
     typanion: ^3.3.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5718,7 +5718,7 @@ __metadata:
     tslib: ^1.13.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5730,7 +5730,7 @@ __metadata:
     "@yarnpkg/fslib": "workspace:^2.6.0-rc.2"
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5746,7 +5746,7 @@ __metadata:
     semver: ^7.1.2
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5759,8 +5759,8 @@ __metadata:
     "@yarnpkg/plugin-git": "workspace:*"
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
-    "@yarnpkg/plugin-git": ^2.4.0
+    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/plugin-git": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5772,7 +5772,7 @@ __metadata:
     "@yarnpkg/fslib": "workspace:^2.6.0-rc.2"
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5788,8 +5788,8 @@ __metadata:
     lodash: ^4.17.15
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5815,9 +5815,9 @@ __metadata:
     tslib: ^1.13.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
-    "@yarnpkg/plugin-essentials": ^3.1.0-rc.2
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/plugin-essentials": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5829,7 +5829,7 @@ __metadata:
     "@yarnpkg/fslib": "workspace:^2.6.0-rc.2"
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5852,8 +5852,8 @@ __metadata:
     micromatch: ^4.0.2
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5874,10 +5874,10 @@ __metadata:
     tslib: ^1.13.0
     typanion: ^3.3.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
-    "@yarnpkg/plugin-npm": ^2.5.0
-    "@yarnpkg/plugin-pack": ^3.1.0-rc.2
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/plugin-npm": "workspace:^"
+    "@yarnpkg/plugin-pack": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5895,8 +5895,8 @@ __metadata:
     ssri: ^6.0.1
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.1.0-rc.3
-    "@yarnpkg/plugin-pack": ^3.1.0-rc.2
+    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/plugin-pack": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5915,8 +5915,8 @@ __metadata:
     tar-stream: ^2.0.1
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5931,8 +5931,8 @@ __metadata:
     clipanion: ^3.0.1
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5952,8 +5952,8 @@ __metadata:
     semver: ^7.1.2
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5969,8 +5969,8 @@ __metadata:
     tslib: ^1.13.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -5990,9 +5990,9 @@ __metadata:
     tslib: ^1.13.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
-    "@yarnpkg/plugin-essentials": ^3.1.0-rc.2
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/plugin-essentials": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -6017,8 +6017,8 @@ __metadata:
     tslib: ^1.13.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -6038,8 +6038,8 @@ __metadata:
     typanion: ^3.3.0
     typescript: ^4.4.2
   peerDependencies:
-    "@yarnpkg/cli": ^3.1.0-rc.2
-    "@yarnpkg/core": ^3.1.0-rc.3
+    "@yarnpkg/cli": "workspace:^"
+    "@yarnpkg/core": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's currently impossible to use the pack-time workspace version management to let Yarn inject the right version number for inter-workspaces peer dependencies when publishing a package. As a result, merging release branches lead to painful merge conflicts.

**How did you fix it?**

The `peerDependencies` field now accepts the `workspace:` specifier (only with a semver range; relative workspace paths aren't supported unlike other dependency types). When found, Yarn will check that the inherited peer dependency is a workspace, and that it matches the specified range.

Additionally, the `workspace:^`, `workspace:~`, and `workspace:*` specifiers are now supported as well and will be replaced at publish time by respectively `^1.0.0`, `~1.0.0`, and `1.0.0` (assuming the target workspace is version `1.0.0`).

One option I initially considered was to just accept `^` and `~` as aliases for `*`. However I eventually decided against it since it would depart from the syntax used in dependencies/peer dependencies. Still, to be completely clear, this improvement doesn't change that **peer dependencies don't/cannot enforce the source of a peer dependency in any general term** (for example, you can't enforce that the peer dependency must be filled via a `file:` dependency). Workspaces are quite special to many aspects, and this is one of them - it doesn't change the general rule.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
