### PR TITLE
Add support for esbuild watch mode by default

### DIFF
--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -73,7 +73,7 @@ async function defaultOnResolve(args: OnResolveArgs, {resolvedPath, error}: OnRe
   }
 
   if (resolvedPath !== null) {
-    return {namespace: `pnp`, path: resolvedPath};
+    return {namespace: `pnp`, path: resolvedPath, watchFiles: [resolvedPath]};
   } else {
     return {external: true, ...mergeWith};
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->

By default, [esbuild](https://github.com/evanw/esbuild) only runs [watch mode](https://esbuild.github.io/api/#watch) when namespace is set to `file`.

Currently, @yarnpkg/esbuild-plugin-pnp implemented namespace as `pnp`, which leads esbuild to not run watch mode on files that pnp plugin resolved. but esbuild can run watch on files that pnp plugin loaded, if `watchFiles` or `watchDir` are specified in resolved files.

> watchFiles and watchDirs
> 
> These properties let you return additional file system paths for esbuild's watch mode to scan. By default esbuild will only  scan the path provided to onLoad plugins, and only if the namespace is file. If your plugin needs to react to additional changes in the file system, it needs to use one of these properties. 
>
> A rebuild will be triggered if any file in the watchFiles array has been changed since the last build. Change detection is somewhat complicated and may check the file contents and/or the file's metadata.

documentation from https://esbuild.github.io/plugins/#resolve-results.

This patch adds `watchFiles` property to `OnResolveResult`.

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I fixed it by adding `watchFiles` property to `OnResolveResult`.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
