### PR TITLE
Fix "Hybrid PnP + node_modules mono-repo" recipe

### DIFF
--- a/packages/gatsby/content/getting-started/recipes.md
+++ b/packages/gatsby/content/getting-started/recipes.md
@@ -55,4 +55,4 @@ nodeLinker: node-modules
 pnpIgnorePatterns:
   - ./nm-packages/**
 ```
-- You can now run `cd nm-package/myproj && yarn install` and the project will be isolated from your pnp root.
+- You can now run `yarn` and the project will be isolated from your PnP root.

--- a/packages/gatsby/content/getting-started/recipes.md
+++ b/packages/gatsby/content/getting-started/recipes.md
@@ -55,4 +55,5 @@ nodeLinker: node-modules
 pnpIgnorePatterns:
   - ./nm-packages/**
 ```
-- You can now run `yarn` and the project will be isolated from your PnP root.
+- Run `yarn` to apply `pnpIgnorePatterns` in the repo root.
+- Run `cd nm-packages/myproj && yarn` to install the now isolated project.


### PR DESCRIPTION
Small fix in the ["Hybrid PnP + node_modules mono-repo"](https://yarnpkg.com/getting-started/recipes/#hybrid-pnp--node_modules-mono-repo) recipe: `yarn` (install) has to be called in the monorepo root, not inside the nm subproject.