### PR TITLE
docs: remove outdated note about `production` installs

### DIFF
--- a/packages/gatsby/static/configuration/manifest.json
+++ b/packages/gatsby/static/configuration/manifest.json
@@ -127,7 +127,7 @@
       "_exampleKeys": ["fsevents"]
     },
     "devDependencies": {
-      "description": "Similar to the `dependencies` field, except that these dependencies are only installed on local installs and will never be installed by the consumers of your package. Note that because that would lead to different install trees depending on whether the install is made in \"production\" or \"development\" mode, Yarn doesn't offer a way to prevent the installation of dev dependencies at the moment.",
+      "description": "Similar to the `dependencies` field, except that these dependencies are only installed on local installs and will never be installed by the consumers of your package.",
       "type": "object",
       "patternProperties": {
         "^(?:@([^/]+?)/)?([^/]+?)$": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The docs about `devDependencies` contains a note about Yarn not providing a "production" install but that has been outdated since https://github.com/yarnpkg/berry/pull/1087 

**How did you fix it?**

Removed the note

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.