### PR TITLE
docs: remove outdated warnings about global cache

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -104,7 +104,7 @@
     },
     "enableGlobalCache": {
       "_package": "@yarnpkg/core",
-      "description": "If true, Yarn will disregard the `cacheFolder` settings and will store the cache files into a folder shared by all local projects sharing the same configuration. Note that enabling the global cache isn't advised on OSX: it opens the door to some subtle incompatibilities while not providing significant size improvements (this is because the OSX default filesystem supports Copy-on-Write, so each file in your cache is already a light pointer to a single global file).",
+      "description": "If true, Yarn will disregard the `cacheFolder` settings and will store the cache files into a folder shared by all local projects sharing the same configuration.",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
Removes outdated information which is no longer the case about the `enableGlobalCache` option.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

**How did you fix it?**
<!-- A detailed description of your implementation. -->
Deleted some docs.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
