### PR TITLE
fix: convert `PortablePath`s to `NativePath`s before printing

### DIFF
--- a/.yarn/versions/597bb1d9.yml
+++ b/.yarn/versions/597bb1d9.yml
@@ -1,0 +1,32 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -1,5 +1,5 @@
 import {execUtils, scriptUtils, structUtils, tgzUtils}         from '@yarnpkg/core';
-import {Locator}                                               from '@yarnpkg/core';
+import {Locator, formatUtils}                                  from '@yarnpkg/core';
 import {Fetcher, FetchOptions, MinimalFetchOptions}            from '@yarnpkg/core';
 import {Filename, PortablePath, npath, ppath, xfs, NativePath} from '@yarnpkg/fslib';
 
@@ -154,7 +154,7 @@ export class ExecFetcher implements Fetcher {
         const {code} = await execUtils.pipevp(process.execPath, [`--require`, npath.fromPortablePath(runtimeFile), npath.fromPortablePath(generatorPath), structUtils.stringifyIdent(locator)], {cwd, env, stdin, stdout, stderr});
         if (code !== 0) {
           xfs.detachTemp(logDir);
-          throw new Error(`Package generation failed (exit code ${code}, logs can be found here: ${logFile})`);
+          throw new Error(`Package generation failed (exit code ${code}, logs can be found here: ${formatUtils.pretty(opts.project.configuration, logFile, formatUtils.Type.PATH)})`);
         }
       });
     });

--- a/packages/plugin-npm-cli/sources/commands/npm/info.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/info.ts
@@ -5,7 +5,6 @@ import {StreamReport, MessageName, semverUtils}          from '@yarnpkg/core';
 import {Filename, npath, ppath}                          from '@yarnpkg/fslib';
 import {npmHttpUtils}                                    from '@yarnpkg/plugin-npm';
 import {Command, Option, Usage, UsageError}              from 'clipanion';
-import path                                              from 'path';
 import semver                                            from 'semver';
 import {inspect}                                         from 'util';
 

--- a/packages/plugin-npm-cli/sources/commands/npm/info.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/info.ts
@@ -2,6 +2,7 @@ import * as npm                                          from '@npm/types';
 import {BaseCommand}                                     from '@yarnpkg/cli';
 import {Project, Configuration, structUtils, Descriptor} from '@yarnpkg/core';
 import {StreamReport, MessageName, semverUtils}          from '@yarnpkg/core';
+import {Filename, npath, ppath}                          from '@yarnpkg/fslib';
 import {npmHttpUtils}                                    from '@yarnpkg/plugin-npm';
 import {Command, Option, Usage, UsageError}              from 'clipanion';
 import path                                              from 'path';
@@ -105,7 +106,7 @@ export default class InfoCommand extends BaseCommand {
         if (identStr === `.`) {
           const workspace = project.topLevelWorkspace;
           if (!workspace.manifest.name)
-            throw new UsageError(`Missing 'name' field in ${path.join(workspace.cwd, `package.json`)}`);
+            throw new UsageError(`Missing 'name' field in ${npath.fromPortablePath(ppath.join(workspace.cwd, Filename.manifest))}`);
 
           descriptor = structUtils.makeDescriptor(workspace.manifest.name, `unknown`);
         } else {

--- a/packages/plugin-npm-cli/sources/commands/npm/tag/list.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/tag/list.ts
@@ -1,6 +1,6 @@
 import {BaseCommand, WorkspaceRequiredError}                                           from '@yarnpkg/cli';
 import {Configuration, Project, Ident, structUtils, formatUtils, treeUtils, miscUtils} from '@yarnpkg/core';
-import {ppath, Filename}                                                               from '@yarnpkg/fslib';
+import {ppath, Filename, npath}                                                        from '@yarnpkg/fslib';
 import {npmHttpUtils}                                                                  from '@yarnpkg/plugin-npm';
 import {Command, UsageError, Usage, Option}                                            from 'clipanion';
 
@@ -42,7 +42,7 @@ export default class NpmTagListCommand extends BaseCommand {
         throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
       if (!workspace.manifest.name)
-        throw new UsageError(`Missing 'name' field in ${ppath.join(workspace.cwd, Filename.manifest)}`);
+        throw new UsageError(`Missing 'name' field in ${npath.fromPortablePath(ppath.join(workspace.cwd, Filename.manifest))}`);
 
       ident = workspace.manifest.name;
     }

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -79,13 +79,13 @@ export default class PackCommand extends BaseCommand {
       json: this.json,
     }, async report => {
       await packUtils.prepareForPack(workspace, {report}, async () => {
-        report.reportJson({base: workspace.cwd});
+        report.reportJson({base: npath.fromPortablePath(workspace.cwd)});
 
         const files = await packUtils.genPackList(workspace);
 
         for (const file of files) {
-          report.reportInfo(null, file);
-          report.reportJson({location: file});
+          report.reportInfo(null, npath.fromPortablePath(file));
+          report.reportJson({location: npath.fromPortablePath(file)});
         }
 
         if (!this.dryRun) {
@@ -102,7 +102,7 @@ export default class PackCommand extends BaseCommand {
 
       if (!this.dryRun) {
         report.reportInfo(MessageName.UNNAMED, `Package archive generated in ${formatUtils.pretty(configuration, target, formatUtils.Type.PATH)}`);
-        report.reportJson({output: target});
+        report.reportJson({output: npath.fromPortablePath(target)});
       }
     });
 

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -484,7 +484,7 @@ export function applyReleases(project: Project, newVersions: Map<Workspace, stri
       : null;
 
     report.reportInfo(MessageName.UNNAMED, `${structUtils.prettyLocator(project.configuration, workspace.anchoredLocator)}: Bumped to ${newVersion}`);
-    report.reportJson({cwd: workspace.cwd, ident: identString, oldVersion, newVersion});
+    report.reportJson({cwd: npath.fromPortablePath(workspace.cwd), ident: identString, oldVersion, newVersion});
 
     const dependents = allDependents.get(workspace);
     if (typeof dependents === `undefined`)

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -296,7 +296,7 @@ export async function prepareExternalProject(cwd: PortablePath, outputPath: Port
           return;
 
         xfs.detachTemp(logDir);
-        throw new ReportError(MessageName.PACKAGE_PREPARATION_FAILED, `Packing the package failed (exit code ${code}, logs can be found here: ${logFile})`);
+        throw new ReportError(MessageName.PACKAGE_PREPARATION_FAILED, `Packing the package failed (exit code ${code}, logs can be found here: ${formatUtils.pretty(configuration, logFile, formatUtils.Type.PATH)})`);
       });
     });
   });
@@ -476,7 +476,7 @@ export async function executeWorkspaceLifecycleScript(workspace: Workspace, life
   await xfs.mktempPromise(async logDir => {
     const logFile = ppath.join(logDir, `${lifecycleScriptName}.log` as PortablePath);
 
-    const header = `# This file contains the result of Yarn calling the "${lifecycleScriptName}" lifecycle script inside a workspace ("${workspace.cwd}")\n`;
+    const header = `# This file contains the result of Yarn calling the "${lifecycleScriptName}" lifecycle script inside a workspace ("${npath.fromPortablePath(workspace.cwd)}")\n`;
 
     const {stdout, stderr} = configuration.getSubprocessStreams(logFile, {
       report,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some `PortablePath`s are printed without getting converted to `NativePath`s

**How did you fix it?**

Convert to `NativePath` before printing

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.