### PR TITLE
fix: make release workflow work with versions that can't be described by strategies

### DIFF
--- a/.yarn/versions/95fb1770.yml
+++ b/.yarn/versions/95fb1770.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/.yarn/versions/95fb1770.yml
+++ b/.yarn/versions/95fb1770.yml
@@ -1,2 +1,6 @@
 releases:
+  "@yarnpkg/libui": patch
   "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
@@ -303,5 +303,45 @@ describe(`Commands`, () => {
         });
       }),
     );
+
+    test(
+      `it should successfully apply a version bump that can't be described by a strategy`,
+      makeTemporaryEnv({
+        version: `1.0.0`,
+      }, {
+        plugins: [
+          require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+        ],
+      }, async ({path, run, source}) => {
+        await expect(run(`version`, `3.4.5`)).resolves.toMatchObject({
+          code: 0,
+        });
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          version: `3.4.5`,
+        });
+      }),
+    );
+
+    test(
+      `it should successfully apply a version bump that can't be described by a strategy on top of the stored version`,
+      makeTemporaryEnv({
+        version: `1.0.0`,
+      }, {
+        plugins: [
+          require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+        ],
+      }, async ({path, run, source}) => {
+        await run(`version`, `major`, `--deferred`);
+
+        await expect(run(`version`, `3.4.5`)).resolves.toMatchObject({
+          code: 0,
+        });
+
+        await expect(readJson(`${path}/package.json`)).resolves.toMatchObject({
+          version: `3.4.5`,
+        });
+      }),
+    );
   });
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/apply.test.ts
@@ -156,6 +156,33 @@ describe(`Commands`, () => {
       )
     );
 
+    test(
+      `it should successfully apply a version bump that can't be described by a strategy (deferred)`,
+      makeTemporaryEnv(
+        {
+          version: `1.0.0`,
+        },
+        {
+          plugins: [
+            require.resolve(`@yarnpkg/monorepo/scripts/plugin-version.js`),
+          ],
+        },
+        async ({path, run}) => {
+          await run(`version`, `3.4.5`, `--deferred`);
+
+          await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
+            version: `1.0.0`,
+          });
+
+          await run(`version`, `apply`);
+
+          await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
+            version: `3.4.5`,
+          });
+        }
+      )
+    );
+
     const alternatives = [
       [`implicit`, `1.0.0`, true],
       [`implicit range`, `^1.0.0`, true],

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -17,6 +17,8 @@ export enum Decision {
   PRERELEASE = `prerelease`,
 }
 
+export type IncrementDecision = Exclude<Decision, Decision.UNDECIDED | Decision.DECLINE>;
+
 export type Releases = Map<Workspace, string>;
 
 export function validateReleaseDecision(decision: unknown): string {

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -17,10 +17,13 @@ export enum Decision {
   PRERELEASE = `prerelease`,
 }
 
-export type Releases =
-  Map<Workspace, Exclude<Decision, Decision.UNDECIDED>>;
+export type Releases = Map<Workspace, string>;
 
-export function validateReleaseDecision(decision: unknown) {
+export function validateReleaseDecision(decision: unknown): string {
+  const semverDecision = semver.valid(decision as string);
+  if (semverDecision)
+    return semverDecision;
+
   return miscUtils.validateEnum(omit(Decision, `UNDECIDED`), decision as string);
 }
 
@@ -289,7 +292,7 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
     releases: releaseStore,
 
     async saveAll() {
-      const releases: {[key: string]: Exclude<Decision, Decision.UNDECIDED | Decision.DECLINE>} = {};
+      const releases: {[key: string]: string} = {};
       const declined: Array<string> = [];
       const undecided: Array<string> = [];
 
@@ -304,7 +307,7 @@ export async function openVersionFile(project: Project, {allowEmpty = false}: {a
         if (decision === Decision.DECLINE) {
           declined.push(identStr);
         } else if (typeof decision !== `undefined`) {
-          releases[identStr] = decision;
+          releases[identStr] = validateReleaseDecision(decision);
         } else if (changedWorkspaces.has(workspace)) {
           undecided.push(identStr);
         }

--- a/packages/yarnpkg-libui/sources/hooks/useListInput.ts
+++ b/packages/yarnpkg-libui/sources/hooks/useListInput.ts
@@ -1,8 +1,9 @@
 import {useKeypress} from './useKeypress';
 
-export const useListInput = function <T>(value: T, values: Array<T>, {active, minus, plus, set, loop = true}: {active: boolean, minus: string, plus: string, set: (value: T) => void, loop?: boolean}) {
+export const useListInput = function <T>(value: unknown, values: Array<T>, {active, minus, plus, set, loop = true}: {active: boolean, minus: string, plus: string, set: (value: T) => void, loop?: boolean}) {
   useKeypress({active}, (ch, key) => {
-    const index = values.indexOf(value);
+    // It's fine if the value doesn't exist inside the list
+    const index = values.indexOf(value as T);
     switch (key.name) {
       case minus: {
         const nextValueIndex = index - 1;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

What the title says.

Example: Running `yarn version 3.4.5` didn't work if the current version was `1.0.0`.

Fixes #3322.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By allowing semver versions in release files again.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
