### PR TITLE
chore: render `environment` in a codeblock for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -43,8 +43,9 @@ body:
   - type: textarea
     attributes:
       label: Environment
+      render: shell
       description: |
-        **Tip:** you can run `yarn dlx -q envinfo --preset jest` and paste the result below:
+        Run `yarn dlx -q envinfo --preset jest` and paste the result into the form
       placeholder: |
         System:
           OS: macOS 11.4


### PR DESCRIPTION
**What's the problem this PR addresses?**

The textarea for the environment information doesn't preserve the indentation from the output of `yarn dlx -q envinfo --preset jest` which is annoying me ever so slightly.

**How did you fix it?**

Render it in a codeblock to preserve the indentation

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.