### PR TITLE
fix(workspace-tools): handle global scripts correctly

### DIFF
--- a/.yarn/versions/2bc95c23.yml
+++ b/.yarn/versions/2bc95c23.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - Usage of `pnpify` inside directories containing spaces is now possible.
 - Hoisting algorithm speedup, impacts recurrent `node_modules` installs time.
 - CLI bundles built from sources output `commit` hash instead of `tree` hash as part of their version
+- `workspaces foreach run` now handles the fact that a script containing `:` only becomes global if it exists in one workspace.
 
 ### Installs
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -19,6 +19,17 @@ Object {
 }
 `;
 
+exports[`Commands workspace foreach should handle global scripts getting downgraded to a normal script 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: root workspace
+➤ YN0000: Test Workspace G
+➤ YN0000: Done
+",
+}
+`;
+
 exports[`Commands workspace foreach should include dependencies if using --recursive 1`] = `
 Object {
   "code": 0,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -85,6 +85,7 @@ async function setupWorkspaces(path) {
     version: `1.0.0`,
     scripts: {
       print: `echo Test Workspace G`,
+      'g:echo': `echo Test Workspace G`,
     },
     dependencies: {},
   });
@@ -486,6 +487,35 @@ describe(`Commands`, () => {
           try {
             await run(`install`);
             ({code, stdout, stderr} = await run(`test:foo`));
+          } catch (error) {
+            ({code, stdout, stderr} = error);
+          }
+
+          await expect({code, stdout, stderr}).toMatchSnapshot();
+        }
+      )
+    );
+
+    test(
+      `should handle global scripts getting downgraded to a normal script`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+          scripts: {
+            [`g:echo`]: `echo root workspace`,
+          },
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+
+          let code;
+          let stdout;
+          let stderr;
+
+          try {
+            await run(`install`);
+            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `g:echo`));
           } catch (error) {
             ({code, stdout, stderr} = error);
           }

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -137,8 +137,21 @@ export default class WorkspacesForeachCommand extends BaseCommand {
 
     const workspaces: Array<Workspace> = [];
 
+    // A script containing `:` becomes global if it exists in only one workspace.
+    let isGlobalScript = false;
+    if (scriptName?.includes(`:`)) {
+      for (const workspace of project.workspaces) {
+        if (workspace.manifest.scripts.has(scriptName)) {
+          isGlobalScript = !isGlobalScript;
+          if (isGlobalScript === false) {
+            break;
+          }
+        }
+      }
+    }
+
     for (const workspace of candidates) {
-      if (scriptName && !workspace.manifest.scripts.has(scriptName) && !scriptName.includes(`:`))
+      if (scriptName && !workspace.manifest.scripts.has(scriptName) && !isGlobalScript)
         continue;
 
       // Prevents infinite loop in the case of configuring a script as such:


### PR DESCRIPTION
**What's the problem this PR addresses?**

Scripts containing `:` become global but only if they exist in a single workspace, `workspaces foreach run` does not take this into account.

Fixes https://github.com/yarnpkg/berry/issues/3048

**How did you fix it?**

Loop over the workspaces and see if we encounter the script more than once

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.