### PR TITLE
fix(nm): Properly hoist nested workspaces

### DIFF
--- a/.yarn/versions/64d8f84b.yml
+++ b/.yarn/versions/64d8f84b.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - Hoisting algorithm speedup, impacts recurrent `node_modules` installs time.
 - CLI bundles built from sources output `commit` hash instead of `tree` hash as part of their version
 - `workspaces foreach run` now handles the fact that a script containing `:` only becomes global if it exists in one workspace.
+- Nested workspaces are properly hoisted by `node-modules` linker.
+- Self-referencing symlinks are not created for anonymous workspaces by `node-modules` linker, since they cannot be used anyway from the code.
 
 ### Installs
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1339,13 +1339,14 @@ describe(`Node_Modules`, () => {
 
 
   test(
-    `it should fallback to dependencies if the parent doesn't provide the peer dependency`,
+    `should fallback to dependencies if the parent doesn't provide the peer dependency`,
     makeTemporaryEnv(
       {},
       {
         nodeLinker: `node-modules`,
       },
       async ({path, run, source}) => {
+        console.log(path);
         const appPath = ppath.join(path, `lib-1` as Filename);
         const libPath = ppath.join(path, `lib-2` as Filename);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Fixes issue: #3429, by taking into account physical location on the filesystem of nested workspaces and not only their place in the dependency graph.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The place of nested workspaces on the file system is tracked now. The hoisting rule has been added to disallow hoisting workspace over the parent workspace in the dependency graph, while still allowing hoisting workspace dependencies freely.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
