### PR TITLE
feat(workspace-tools): support `--jobs 1` and `--jobs unlimited`

### DIFF
--- a/.yarn/versions/0cad2473.yml
+++ b/.yarn/versions/0cad2473.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": minor

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -215,3 +215,17 @@ Object {
 ",
 }
 `;
+
+exports[`Commands workspace foreach should start all the processes at once when --jobs is unlimited 1`] = `
+Object {
+  "code": 0,
+  "first7Lines": "➤ YN0000: [workspace-a]: Process started
+➤ YN0000: [workspace-b]: Process started
+➤ YN0000: [workspace-c]: Process started
+➤ YN0000: [workspace-d]: Process started
+➤ YN0000: [workspace-e]: Process started
+➤ YN0000: [workspace-f]: Process started
+➤ YN0000: [workspace-g]: Process started",
+  "stderr": "",
+}
+`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -350,7 +350,7 @@ describe(`Commands`, () => {
     );
 
     test(
-      `should throw an error when using --jobs with a value lower than 2`,
+      `should throw an error when using --jobs with a value lower than 1`,
       makeTemporaryEnv(
         {
           private: true,
@@ -360,9 +360,30 @@ describe(`Commands`, () => {
           await setupWorkspaces(path);
 
           await run(`install`);
-          await expect(run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `1`, `run`, `print`)).rejects.toThrowError(/expected to be at least 2 \(got 1\)/);
+          await expect(run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `0`, `run`, `print`)).rejects.toThrowError(/to be at least 1 \(got 0\)/);
+        }
+      )
+    );
+
+    test(
+      `should start all the processes at once when --jobs is unlimited`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
         },
-      ),
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `unlimited`, `--verbose`, `run`, `print`);
+
+          // We don't care what order they start in, just that they all started at the beginning.
+          const first7Lines = stdout.split(`\n`).slice(0, 7).sort().join(`\n`);
+
+          await expect({code, first7Lines, stderr}).toMatchSnapshot();
+        }
+      )
     );
 
     test(`can run on public workspaces only`, makeTemporaryEnv(

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -361,8 +361,8 @@ describe(`Commands`, () => {
 
           await run(`install`);
           await expect(run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `0`, `run`, `print`)).rejects.toThrowError(/to be at least 1 \(got 0\)/);
-        }
-      )
+        },
+      ),
     );
 
     test(
@@ -382,8 +382,8 @@ describe(`Commands`, () => {
           const first7Lines = stdout.split(`\n`).slice(0, 7).sort().join(`\n`);
 
           await expect({code, first7Lines, stderr}).toMatchSnapshot();
-        }
-      )
+        },
+      ),
     );
 
     test(`can run on public workspaces only`, makeTemporaryEnv(


### PR DESCRIPTION
**What's the problem this PR addresses?**

Permits users to specify `--jobs 1` and `--jobs unlimited` to `workspaces foreach` command.

`--jobs 1` takes precedence over `--parallel` and `--interlace`, disabling both. See the linked ticket below for justification.

`--jobs unlimited` kicks off every task simultaneously. It's intended to be used with watch tasks in combination with `--interlace`.

Resolves #3433.

**How did you fix it?**

- Change the argument validation to permit two new option values.
- Rearrange the way that concurrency/parallel/interlace arguments are initialized such that a calculated concurrency of 1 can override the parallel/interlace behavior to avoid extra work.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
