### PR TITLE
test(workspace-tools): fix a broken test

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -13,9 +13,15 @@ Object {
 
 exports[`Commands workspace foreach should execute 'node' command 1`] = `
 Object {
-  "code": "ENOENT",
+  "code": 0,
+  "orderedStdout": Array [
+    "➤ YN0000: workspace-c",
+    "➤ YN0000: workspace-d",
+    "➤ YN0000: workspace-e",
+    "➤ YN0000: workspace-f",
+    "➤ YN0000: workspace-g",
+  ],
   "stderr": "",
-  "stdout": "",
 }
 `;
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -102,11 +102,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `run`, `print`, {cwd: `${path}/packages/workspace-c`});
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `run`, `print`, {cwd: `${path}/packages/workspace-c`})).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -120,7 +117,6 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `node`, `-p`, `require("./package.json").name`, {cwd: `${path}/packages/workspace-c`});
 
@@ -142,7 +138,6 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--interlaced`, `--jobs`, `2`, `run`, `start`);
 
@@ -176,7 +171,6 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `--jobs`, `2`, `run`, `print`);
 
@@ -206,11 +200,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `run`, `print`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -224,11 +215,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `--include`, `workspace-a`, `--include`, `workspace-b`, `run`, `print`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--include`, `workspace-a`, `--include`, `workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -242,11 +230,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `workspace-b`, `run`, `print`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -263,11 +248,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`print`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -282,7 +264,6 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
           await expect(run(`workspaces`, `foreach`, `--jobs`, `2`, `run`, `print`)).rejects.toThrowError(/parallel must be set/);
         },
@@ -298,7 +279,6 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
           await expect(run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `0`, `run`, `print`)).rejects.toThrowError(/to be at least 1 \(got 0\)/);
         },
@@ -314,7 +294,6 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `unlimited`, `--verbose`, `run`, `print`);
 
@@ -361,9 +340,8 @@ describe(`Commands`, () => {
         });
 
         await run(`install`);
-        const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--no-private`, `run`, `print`);
 
-        await expect({code, stdout, stderr}).toMatchSnapshot();
+        await expect(run(`workspaces`, `foreach`, `--no-private`, `run`, `print`)).resolves.toMatchSnapshot();
       },
     ));
 
@@ -402,11 +380,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `test:colon`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--topological`, `run`, `test:colon`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -424,11 +399,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`test:foo`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`test:foo`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -445,11 +417,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `g:echo`);
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--topological`, `run`, `g:echo`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -463,11 +432,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--recursive`, `--topological`, `run`, `print`, {cwd: `${path}/packages/workspace-b`});
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--recursive`, `--topological`, `run`, `print`, {cwd: `${path}/packages/workspace-b`})).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -481,11 +447,8 @@ describe(`Commands`, () => {
         },
         async ({path, run}) => {
           await setupWorkspaces(path);
-
           await run(`install`);
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--recursive`, `--topological`, `--from`, `{workspace-a,workspace-b,workspace-g}`, `run`, `print`, {cwd: path});
-
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--recursive`, `--topological`, `--from`, `{workspace-a,workspace-b,workspace-g}`, `run`, `print`, {cwd: path})).resolves.toMatchSnapshot();
         },
       ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -103,6 +103,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `run`, `print`, {cwd: `${path}/packages/workspace-c`})).resolves.toMatchSnapshot();
         },
       ),
@@ -118,12 +119,15 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `node`, `-p`, `require("./package.json").name`, {cwd: `${path}/packages/workspace-c`});
 
           const orderedStdout = stdout.trim().split(`\n`);
           expect(orderedStdout.pop()).toContain(`Done`);
+
           // The exact order is unstable, so just make sure all the workspaces we expect to be there, are.
           orderedStdout.sort();
+
           await expect({code, orderedStdout, stderr}).toMatchSnapshot();
         },
       ),
@@ -139,6 +143,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--interlaced`, `--jobs`, `2`, `run`, `start`);
 
           const lines = stdout.trim().split(`\n`);
@@ -156,7 +161,6 @@ describe(`Commands`, () => {
             if (firstLine !== lines[i])
               isInterlaced = true;
 
-
           expect(isInterlaced).toBe(true);
         },
       ),
@@ -172,6 +176,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `--jobs`, `2`, `run`, `print`);
 
           const extractWorkspaces = output => {
@@ -201,6 +206,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--verbose`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
@@ -216,6 +222,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--verbose`, `--include`, `workspace-a`, `--include`, `workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
@@ -231,6 +238,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
@@ -249,6 +257,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`print`)).resolves.toMatchSnapshot();
         },
       ),
@@ -265,6 +274,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--jobs`, `2`, `run`, `print`)).rejects.toThrowError(/parallel must be set/);
         },
       ),
@@ -280,6 +290,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `0`, `run`, `print`)).rejects.toThrowError(/to be at least 1 \(got 0\)/);
         },
       ),
@@ -295,6 +306,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--jobs`, `unlimited`, `--verbose`, `run`, `print`);
 
           // We don't care what order they start in, just that they all started at the beginning.
@@ -381,6 +393,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--topological`, `run`, `test:colon`)).resolves.toMatchSnapshot();
         },
       ),
@@ -400,6 +413,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`test:foo`)).resolves.toMatchSnapshot();
         },
       ),
@@ -418,6 +432,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--topological`, `run`, `g:echo`)).resolves.toMatchSnapshot();
         },
       ),
@@ -433,6 +448,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--recursive`, `--topological`, `run`, `print`, {cwd: `${path}/packages/workspace-b`})).resolves.toMatchSnapshot();
         },
       ),
@@ -448,6 +464,7 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
           await run(`install`);
+
           await expect(run(`workspaces`, `foreach`, `--recursive`, `--topological`, `--from`, `{workspace-a,workspace-b,workspace-g}`, `run`, `print`, {cwd: path})).resolves.toMatchSnapshot();
         },
       ),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -135,12 +135,16 @@ describe(`Commands`, () => {
 
           try {
             await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `node`, `-p`, `require("./package.json").name`, {cwd: `${path}/packages/workspace-d`}));
+            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `node`, `-p`, `require("./package.json").name`, {cwd: `${path}/packages/workspace-c`}));
           } catch (error) {
             ({code, stdout, stderr} = error);
           }
 
-          await expect({code, stdout, stderr}).toMatchSnapshot();
+          const orderedStdout = stdout.trim().split(`\n`);
+          expect(orderedStdout.pop()).toContain(`Done`);
+          // The exact order is unstable, so just make sure all the workspaces we expect to be there, are.
+          orderedStdout.sort();
+          await expect({code, orderedStdout, stderr}).toMatchSnapshot();
         },
       ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -103,16 +103,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `run`, `print`, {cwd: `${path}/packages/workspace-c`}));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `run`, `print`, {cwd: `${path}/packages/workspace-c`});
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -129,16 +121,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `node`, `-p`, `require("./package.json").name`, {cwd: `${path}/packages/workspace-c`}));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `node`, `-p`, `require("./package.json").name`, {cwd: `${path}/packages/workspace-c`});
 
           const orderedStdout = stdout.trim().split(`\n`);
           expect(orderedStdout.pop()).toContain(`Done`);
@@ -159,16 +143,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--interlaced`, `--jobs`, `2`, `run`, `start`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--interlaced`, `--jobs`, `2`, `run`, `start`);
 
           const lines = stdout.trim().split(`\n`);
           const firstLine = lines[0];
@@ -201,16 +177,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `--jobs`, `2`, `run`, `print`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--parallel`, `--topological`, `--jobs`, `2`, `run`, `print`);
 
           const extractWorkspaces = output => {
             const relevantOutput = output.split(`\n`).filter(output => output.includes(`Test Workspace`));
@@ -239,16 +207,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `run`, `print`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `run`, `print`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -265,16 +225,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `--include`, `workspace-a`, `--include`, `workspace-b`, `run`, `print`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `--include`, `workspace-a`, `--include`, `workspace-b`, `run`, `print`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -291,16 +243,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `workspace-b`, `run`, `print`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `workspace-b`, `run`, `print`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -320,16 +264,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`print`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`print`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -403,16 +339,8 @@ describe(`Commands`, () => {
           },
         });
 
-        let code;
-        let stdout;
-        let stderr;
-
-        try {
-          await run(`install`);
-          ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--no-private`, `run`, `print`));
-        } catch (error) {
-          ({code, stdout, stderr} = error);
-        }
+        await run(`install`);
+        const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--no-private`, `run`, `print`);
 
         await expect({code, stdout, stderr}).toMatchSnapshot();
       },
@@ -428,10 +356,10 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
+          let code = 0;
           try {
             await run(`install`);
-            ({code} = await run(`workspaces`, `foreach`, `run`, `testExit`));
+            await run(`workspaces`, `foreach`, `run`, `testExit`);
           } catch (error) {
             ({code} = error);
           }
@@ -454,16 +382,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `test:colon`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `test:colon`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -484,16 +404,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`test:foo`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`test:foo`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -513,16 +425,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `g:echo`));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--topological`, `run`, `g:echo`);
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -539,16 +443,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--recursive`, `--topological`, `run`, `print`, {cwd: `${path}/packages/workspace-b`}));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--recursive`, `--topological`, `run`, `print`, {cwd: `${path}/packages/workspace-b`});
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },
@@ -565,16 +461,8 @@ describe(`Commands`, () => {
         async ({path, run}) => {
           await setupWorkspaces(path);
 
-          let code;
-          let stdout;
-          let stderr;
-
-          try {
-            await run(`install`);
-            ({code, stdout, stderr} = await run(`workspaces`, `foreach`, `--recursive`, `--topological`, `--from`, `{workspace-a,workspace-b,workspace-g}`, `run`, `print`, {cwd: path}));
-          } catch (error) {
-            ({code, stdout, stderr} = error);
-          }
+          await run(`install`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--recursive`, `--topological`, `--from`, `{workspace-a,workspace-b,workspace-g}`, `run`, `print`, {cwd: path});
 
           await expect({code, stdout, stderr}).toMatchSnapshot();
         },


### PR DESCRIPTION
**What's the problem this PR addresses?**

I found this broken test while writing https://github.com/yarnpkg/berry/pull/3440 but pulled the change out to its own PR. It looks like this test wanted to run a bunch of commands, but instead it got `ENOENT` because there was no such workspace folder.

**How did you fix it?**

Made a guess about what fixtures the test was intending to use, then updated the snapshots to match.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
