### PR TITLE
fix(yarnpkg-sdks): handle fromEditorPath for vim/neovim

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "6.8.0-sdk",
+  "version": "7.32.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -93,6 +93,7 @@ const moduleWrapper = tsserver => {
   function fromEditorPath(str) {
     switch (hostInfo) {
       case `coc-nvim`:
+      case `neovim`: {
         str = str.replace(/\.zip::/, `.zip/`);
         // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
         // So in order to convert it back, we use .* to match all the thing
@@ -100,15 +101,14 @@ const moduleWrapper = tsserver => {
         return process.platform === `win32`
           ? str.replace(/^.*zipfile:\//, ``)
           : str.replace(/^.*zipfile:/, ``);
-      case `neovim`:
-        str = str.replace(/\.zip::/, `.zip/`);
-        return process.platform === `win32`
-          ? str.replace(/^\^?zipfile:\//, ``)
-          : str.replace(/^\^?zipfile:/, ``);
-      default:
+      } break;
+
+      case `vscode`:
+      default: {
         return process.platform === `win32`
           ? str.replace(/^\^?zip:\//, ``)
           : str.replace(/^\^?zip:/, ``);
+      } break;
     }
   }
 

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -91,9 +91,25 @@ const moduleWrapper = tsserver => {
   }
 
   function fromEditorPath(str) {
-    return process.platform === `win32`
-      ? str.replace(/^\^?zip:\//, ``)
-      : str.replace(/^\^?zip:/, ``);
+    switch (hostInfo) {
+      case `coc-nvim`:
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
+        // So in order to convert it back, we use .* to match all the thing
+        // before `zipfile:`
+        return process.platform === `win32`
+          ? str.replace(/^.*zipfile:\//, ``)
+          : str.replace(/^.*zipfile:/, ``);
+      case `neovim`:
+        str = str.replace(/\.zip::/, `.zip/`);
+        return process.platform === `win32`
+          ? str.replace(/^\^?zipfile:\//, ``)
+          : str.replace(/^\^?zipfile:/, ``);
+      default:
+        return process.platform === `win32`
+          ? str.replace(/^\^?zip:\//, ``)
+          : str.replace(/^\^?zip:/, ``);
+    }
   }
 
   // Force enable 'allowLocalPluginLoads'

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -93,6 +93,7 @@ const moduleWrapper = tsserver => {
   function fromEditorPath(str) {
     switch (hostInfo) {
       case `coc-nvim`:
+      case `neovim`: {
         str = str.replace(/\.zip::/, `.zip/`);
         // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
         // So in order to convert it back, we use .* to match all the thing
@@ -100,15 +101,14 @@ const moduleWrapper = tsserver => {
         return process.platform === `win32`
           ? str.replace(/^.*zipfile:\//, ``)
           : str.replace(/^.*zipfile:/, ``);
-      case `neovim`:
-        str = str.replace(/\.zip::/, `.zip/`);
-        return process.platform === `win32`
-          ? str.replace(/^\^?zipfile:\//, ``)
-          : str.replace(/^\^?zipfile:/, ``);
-      default:
+      } break;
+
+      case `vscode`:
+      default: {
         return process.platform === `win32`
           ? str.replace(/^\^?zip:\//, ``)
           : str.replace(/^\^?zip:/, ``);
+      } break;
     }
   }
 

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -91,9 +91,25 @@ const moduleWrapper = tsserver => {
   }
 
   function fromEditorPath(str) {
-    return process.platform === `win32`
-      ? str.replace(/^\^?zip:\//, ``)
-      : str.replace(/^\^?zip:/, ``);
+    switch (hostInfo) {
+      case `coc-nvim`:
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
+        // So in order to convert it back, we use .* to match all the thing
+        // before `zipfile:`
+        return process.platform === `win32`
+          ? str.replace(/^.*zipfile:\//, ``)
+          : str.replace(/^.*zipfile:/, ``);
+      case `neovim`:
+        str = str.replace(/\.zip::/, `.zip/`);
+        return process.platform === `win32`
+          ? str.replace(/^\^?zipfile:\//, ``)
+          : str.replace(/^\^?zipfile:/, ``);
+      default:
+        return process.platform === `win32`
+          ? str.replace(/^\^?zip:\//, ``)
+          : str.replace(/^\^?zip:/, ``);
+    }
   }
 
   // Force enable 'allowLocalPluginLoads'

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "4.4.1-rc-sdk",
+  "version": "4.4.2-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/.yarn/versions/045085fb.yml
+++ b/.yarn/versions/045085fb.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -120,6 +120,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       function fromEditorPath(str) {
         switch (hostInfo) {
           case \`coc-nvim\`:
+          case \`neovim\`: {
             str = str.replace(/\\.zip::/, \`.zip/\`);
             // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
             // So in order to convert it back, we use .* to match all the thing
@@ -127,15 +128,14 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
             return process.platform === \`win32\`
               ? str.replace(/^.*zipfile:\\//, \`\`)
               : str.replace(/^.*zipfile:/, \`\`);
-          case \`neovim\`:
-            str = str.replace(/\\.zip::/, \`.zip/\`);
-            return process.platform === \`win32\`
-              ? str.replace(/^\\^?zipfile:\\//, \`\`)
-              : str.replace(/^\\^?zipfile:/, \`\`);
-          default:
+          } break;
+
+          case \`vscode\`:
+          default: {
             return process.platform === \`win32\`
               ? str.replace(/^\\^?zip:\\//, \`\`)
               : str.replace(/^\\^?zip:/, \`\`);
+          } break;
         }
       }
 

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -118,9 +118,25 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       }
 
       function fromEditorPath(str) {
-        return process.platform === \`win32\`
-          ? str.replace(/^\\^?zip:\\//, \`\`)
-          : str.replace(/^\\^?zip:/, \`\`);
+        switch (hostInfo) {
+          case \`coc-nvim\`:
+            str = str.replace(/\\.zip::/, \`.zip/\`);
+            // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
+            // So in order to convert it back, we use .* to match all the thing
+            // before \`zipfile:\`
+            return process.platform === \`win32\`
+              ? str.replace(/^.*zipfile:\\//, \`\`)
+              : str.replace(/^.*zipfile:/, \`\`);
+          case \`neovim\`:
+            str = str.replace(/\\.zip::/, \`.zip/\`);
+            return process.platform === \`win32\`
+              ? str.replace(/^\\^?zipfile:\\//, \`\`)
+              : str.replace(/^\\^?zipfile:/, \`\`);
+          default:
+            return process.platform === \`win32\`
+              ? str.replace(/^\\^?zip:\\//, \`\`)
+              : str.replace(/^\\^?zip:/, \`\`);
+        }
       }
 
       // Force enable 'allowLocalPluginLoads'


### PR DESCRIPTION
**What's the problem this PR addresses?**
I notice that auto imports are broken with yarn PNP for vim/neovim

...

**How did you fix it?**

Because `toEditorPath` is specialized for `vscode`, `coc-nvim`, and `neovim`, `fromEditorPath` should also have specialized handling for each host.

After this PR, I ran `yarn node scripts/run-sdks.js` and confirmed that auto import works for coc-nvim
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
