### PR TITLE
docs(workspace-tools): add description for workspaces foreach --jobs unlimited

### DIFF
--- a/.yarn/versions/c6ca5622.yml
+++ b/.yarn/versions/c6ca5622.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-workspace-tools"

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -21,7 +21,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     details: `
       This command will run a given sub-command on current and all its descendant workspaces. Various flags can alter the exact behavior of the command:
 
-      - If \`-p,--parallel\` is set, the commands will be ran in parallel; they'll by default be limited to a number of parallel tasks roughly equal to half your core number, but that can be overridden via \`-j,--jobs\`.
+      - If \`-p,--parallel\` is set, the commands will be ran in parallel; they'll by default be limited to a number of parallel tasks roughly equal to half your core number, but that can be overridden via \`-j,--jobs\`, or disabled by setting \`-j unlimited\`.
 
       - If \`-p,--parallel\` and \`-i,--interlaced\` are both set, Yarn will print the lines from the output as it receives them. If \`-i,--interlaced\` wasn't set, it would instead buffer the output from each process and print the resulting buffers only after their source processes have exited.
 
@@ -80,7 +80,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
   });
 
   jobs = Option.String(`-j,--jobs`, {
-    description: `The maximum number of parallel tasks that the execution will be limited to`,
+    description: `The maximum number of parallel tasks that the execution will be limited to; or \`unlimited\``,
     validator: t.isOneOf([t.isEnum([`unlimited`]), t.applyCascade(t.isNumber(), [t.isInteger(), t.isAtLeast(1)])]),
   });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When looking for an option to run all jobs on a parallel task using `yarn workspaces foreach --jobs`, one is not presented with the option for `unlimited` parallel runs, the only way to figure it out is looking in the code.

**How did I Fix it**

Added documentation to the `--jobs` option of `workspaces foreach` showing the usage of the new option `unlimited`.

Documents #3440

**Images of the documentation**

<img width="869" alt="Screen Shot 2021-09-16 at 14 06 36" src="https://user-images.githubusercontent.com/2848323/133657215-affc3096-2623-4d72-bb5d-f04716e29f17.png">
<img width="856" alt="Screen Shot 2021-09-16 at 14 06 40" src="https://user-images.githubusercontent.com/2848323/133657228-e8f49a42-d88c-4631-b1c8-e4b9074b0880.png">
<img width="639" alt="Screen Shot 2021-09-16 at 14 08 05" src="https://user-images.githubusercontent.com/2848323/133657230-97f523b1-7355-4e00-95d5-22cad983f302.png">





**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
