### PR TITLE
perf(core): limit concurrent network requests

### DIFF
--- a/.yarn/versions/59e996f0.yml
+++ b/.yarn/versions/59e996f0.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -324,9 +324,9 @@
     },
     "networkConcurrency": {
       "_package": "@yarnpkg/core",
-      "description": "Defines how many requests are allowed to run at the same time. By default Yarn doesn't put limits on it, but it may sometimes be required when working behind proxies that don't handle large amounts of requests very well.",
+      "description": "Defines how many requests are allowed to run at the same time. Yarn defaults to 50 concurrent requests but it may be required to limit it even more when working behind proxies that can't handle large amounts of concurrent requests.",
       "type": "number",
-      "default": "Infinity",
+      "default": 50,
       "examples": [8]
     },
     "networkSettings": {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -325,7 +325,7 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
   networkConcurrency: {
     description: `Maximal number of concurrent requests`,
     type: SettingsType.NUMBER,
-    default: Infinity,
+    default: 50,
   },
   networkSettings: {
     description: `Network settings per hostname (glob patterns are supported)`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The resolution step is a bit slow but at some point (the last benchmark) it gets unbearably slow where it's sitting at 0% CPU usage for a couple of minutes before some requests finish.

**How did you fix it?**

Limit the amount of concurrent requests to 50 since there wasn't much difference between 32 and 64

**Results**

1887 packages - tested on the Gatsby benchmark

```
YARN_IGNORE_PATH=1 hyperfine -w 1 --prepare="rm -rf yarn.lock" \
    "YARN_NETWORK_CONCURRENCY=8 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=16 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile" \
    "node ./master.cjs --mode update-lockfile"
Benchmark #1: YARN_NETWORK_CONCURRENCY=8 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     17.490 s ±  2.079 s    [User: 12.709 s, System: 2.241 s]
  Range (min … max):   15.360 s … 21.448 s    10 runs

Benchmark #2: YARN_NETWORK_CONCURRENCY=16 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     18.313 s ±  4.800 s    [User: 12.828 s, System: 2.219 s]
  Range (min … max):   14.196 s … 26.686 s    10 runs

Benchmark #3: YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     16.193 s ±  0.901 s    [User: 12.397 s, System: 2.260 s]
  Range (min … max):   14.802 s … 17.322 s    10 runs

Benchmark #4: YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     15.739 s ±  1.535 s    [User: 12.789 s, System: 2.174 s]
  Range (min … max):   13.803 s … 19.250 s    10 runs

Benchmark #5: node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     15.928 s ±  1.393 s    [User: 12.316 s, System: 2.156 s]
  Range (min … max):   14.277 s … 18.538 s    10 runs

Summary
  'YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile' ran
    1.01 ± 0.13 times faster than 'node ./master.cjs --mode update-lockfile'
    1.03 ± 0.12 times faster than 'YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile'
    1.11 ± 0.17 times faster than 'YARN_NETWORK_CONCURRENCY=8 node ./master.cjs --mode update-lockfile'
    1.16 ± 0.33 times faster than 'YARN_NETWORK_CONCURRENCY=16 node ./master.cjs --mode update-lockfile'
```

4044 packages - tested on https://github.com/storybookjs/storybook/tree/7b13e0c03a5230d6eab682b0e657ea29542f6861

```
YARN_IGNORE_PATH=1 hyperfine -w 1 --prepare="rm -rf yarn.lock" \
    "YARN_NETWORK_CONCURRENCY=8 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=16 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile" \
    "node ./master.cjs --mode update-lockfile"
Benchmark #1: YARN_NETWORK_CONCURRENCY=8 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     79.484 s ± 65.857 s    [User: 28.526 s, System: 5.508 s]
  Range (min … max):   33.531 s … 205.080 s    10 runs

Benchmark #2: YARN_NETWORK_CONCURRENCY=16 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     40.860 s ±  7.650 s    [User: 28.571 s, System: 5.253 s]
  Range (min … max):   27.398 s … 48.382 s    10 runs

Benchmark #3: YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     29.371 s ±  2.733 s    [User: 28.642 s, System: 5.055 s]
  Range (min … max):   26.688 s … 33.925 s    10 runs

Benchmark #4: YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     26.656 s ±  0.872 s    [User: 28.735 s, System: 5.087 s]
  Range (min … max):   25.533 s … 27.915 s    10 runs

Benchmark #5: node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     43.824 s ± 18.730 s    [User: 31.086 s, System: 5.441 s]
  Range (min … max):   28.895 s … 90.497 s    10 runs

Summary
  'YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile' ran
    1.10 ± 0.11 times faster than 'YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile'
    1.53 ± 0.29 times faster than 'YARN_NETWORK_CONCURRENCY=16 node ./master.cjs --mode update-lockfile'
    1.64 ± 0.70 times faster than 'node ./master.cjs --mode update-lockfile'
    2.98 ± 2.47 times faster than 'YARN_NETWORK_CONCURRENCY=8 node ./master.cjs --mode update-lockfile'
```

6449 packages - tested on https://github.com/vercel/next.js/tree/16a737d9b55923c1ef7f89b99b3ef39e0d8e8488 with `examples/*` added to the workspaces

```
time YARN_IGNORE_PATH=1 hyperfine -w 1 --prepare="rm -rf yarn.lock" \
    "YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile" \
    "YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile" \
    "node ./master.cjs --mode update-lockfile"
Benchmark #1: YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     88.199 s ±  8.429 s    [User: 74.489 s, System: 12.731 s]
  Range (min … max):   78.145 s … 100.118 s    10 runs

Benchmark #2: YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     81.842 s ±  5.990 s    [User: 75.444 s, System: 12.208 s]
  Range (min … max):   76.992 s … 97.858 s    10 runs

Benchmark #3: node ./master.cjs --mode update-lockfile
  Time (mean ± σ):     430.526 s ± 353.898 s    [User: 82.239 s, System: 13.262 s]
  Range (min … max):   152.111 s … 1201.643 s    10 runs

Summary
  'YARN_NETWORK_CONCURRENCY=64 node ./master.cjs --mode update-lockfile' ran
    1.08 ± 0.13 times faster than 'YARN_NETWORK_CONCURRENCY=32 node ./master.cjs --mode update-lockfile'
    5.26 ± 4.34 times faster than 'node ./master.cjs --mode update-lockfile'

________________________________________________________
Executed in  109.26 mins    fish           external
   usr time   42.60 mins  173.00 micros   42.60 mins
   sys time    7.07 mins  142.00 micros    7.07 mins
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.