### PR TITLE
docs: update SDKs guide to use working .dir-locals.el

### DIFF
--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -137,28 +137,8 @@ yarn dlx @yarnpkg/sdks base
 
 ```lisp
 ((typescript-mode
-  . (
-     ;; Enable typescript-language-server and eslint LSP clients.
-     (lsp-enabled-clients . (ts-ls eslint))
-     (eval . (lexical-let ((project-directory (car (dir-locals-find-file default-directory))))
-               (set (make-local-variable 'flycheck-javascript-eslint-executable)
-                    (concat project-directory ".yarn/sdks/eslint/bin/eslint.js"))
-
-               (eval-after-load 'lsp-clients
-                 '(progn
-                    (plist-put lsp-deps-providers
-                               :local (list :path (lambda (path) (concat project-directory ".yarn/sdks/" path))))))
-
-               (lsp-dependency 'typescript-language-server
-                               '(:local "typescript-language-server/lib/cli.js"))
-               (lsp-dependency 'typescript
-                               '(:local "typescript/bin/tsserver"))
-
-               ;; Re-(start) LSP to pick up the dependency changes above. Or use
-               ;; `hack-local-variables-hook` as proposed in lsp-mode's FAQ:
-               ;; https://emacs-lsp.github.io/lsp-mode/page/faq/
-               ;; (lsp)
-               )))))
+  . ((eval . (let ((project-directory (car (dir-locals-find-file default-directory))))
+                (setq lsp-clients-typescript-server-args `("--tsserver-path" ,(concat project-directory ".yarn/sdks/typescript/bin/tsserver") "--stdio")))))))
 ```
 
 3. Do note, that you can rename `:local` as you'd like in case you have SDKs stored elsewhere (other than `.yarn/sdks/...`) in other projects.


### PR DESCRIPTION
**What's the problem this PR addresses?**
Resolves #2816 

In the issue @martinjlowm and @SirensOfTitan weren't sure if this was a great solution, but does work on emacs 27.2 while the one on the docs does not work. I think we should at least update the docs to have something that works out of the box so this isnt a roadblock for others, and then when someone with more elisp knowledge comes around they can make it better.

...

**How did you fix it?**
N/A

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
