### PR TITLE
fix(core): match `logFilters.pattern` against any part of the log entry

### DIFF
--- a/.yarn/versions/ebb1bd16.yml
+++ b/.yarn/versions/ebb1bd16.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - CLI bundles built from sources output `commit` hash instead of `tree` hash as part of their version
 - `workspaces foreach run` now handles the fact that a script containing `:` only becomes global if it exists in one workspace.
 - The PnP compatibility patch for `resolve` will no longer resolve missing modules to a file with the same name located next to the issuer
+- `logFilters` using `pattern` matchers now match any part of the log entry
 
 ### Installs
 

--- a/packages/yarnpkg-core/sources/formatUtils.ts
+++ b/packages/yarnpkg-core/sources/formatUtils.ts
@@ -397,7 +397,7 @@ export function addLogFilterSupport(report: Report, {configuration}: {configurat
 
     const pattern = filter.get(`pattern`);
     if (typeof pattern !== `undefined`) {
-      logFiltersByPatternMatcher.push([micromatch.matcher(pattern), level]);
+      logFiltersByPatternMatcher.push([micromatch.matcher(pattern, {contains: true}), level]);
     }
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`logFilters.pattern` treats the log entries as if they were filepaths which makes matching entries containing slashes really verbose.

Fixes https://github.com/yarnpkg/berry/pull/3032#issuecomment-922272497 (cc @olee)

**How did you fix it?**

Enable `contains` to match any part of the log entry

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.