### PR TITLE
fix(shell): make cd ENOENT error recoverable

### DIFF
--- a/.yarn/versions/99492e8d.yml
+++ b/.yarn/versions/99492e8d.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -1953,4 +1953,60 @@ describe(`Shell`, () => {
       });
     });
   });
+
+  describe(`Builtins`, () => {
+    describe(`cd`, () => {
+      it(`should throw recoverable errors when the target is not a directory`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await xfs.writeFilePromise(`${tmpDir}/file` as PortablePath, ``);
+
+          await expect(bufferResult(
+            `cd file && echo OK || echo KO`,
+            [],
+            {cwd: tmpDir},
+          )).resolves.toMatchObject({
+            exitCode: 0,
+            stdout: `KO\n`,
+            stderr: `cd: not a directory: file\n`,
+          });
+        });
+      });
+
+      it(`should throw recoverable errors when the target does not exist`, async () => {
+        await xfs.mktempPromise(async tmpDir => {
+          await expect(bufferResult(
+            `cd doesnt-exist && echo OK || echo KO`,
+            [],
+            {cwd: tmpDir},
+          )).resolves.toMatchObject({
+            exitCode: 0,
+            stdout: `KO\n`,
+            stderr: `cd: no such file or directory: doesnt-exist\n`,
+          });
+        });
+      });
+    });
+
+    describe(`sleep`, () => {
+      it(`should throw recoverable errors when the operand is missing`, async () => {
+        await expect(bufferResult(
+          `sleep && echo OK || echo KO`,
+        )).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `KO\n`,
+          stderr: `sleep: missing operand\n`,
+        });
+      });
+
+      it(`should throw recoverable errors when the operand is an invalid time interval`, async () => {
+        await expect(bufferResult(
+          `sleep invalid && echo OK || echo KO`,
+        )).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: `KO\n`,
+          stderr: `sleep: invalid time interval 'invalid'\n`,
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- The shell's cd ENOENT error wasn't a recoverable error.
- We still used `stderr.write` & `return 1` in some places instead of using the `ShellError` abstraction

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- Made the error recoverable
- Made it use `ShellError` everywhere

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
