### PR TITLE
fix(shell): validate cwd passed as option

### DIFF
--- a/.yarn/versions/76610b44.yml
+++ b/.yarn/versions/76610b44.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -1012,6 +1012,9 @@ export async function execute(command: string, args: Array<string> = [], {
   variables = {},
   glob = globUtils,
 }: Partial<UserOptions> = {}) {
+  if (!baseFs.existsSync(cwd))
+    throw new Error(`Cannot execute command in non-existent directory: "${npath.fromPortablePath(cwd)}"`);
+
   const normalizedEnv: {[key: string]: string} = {};
   for (const [key, value] of Object.entries(env))
     if (typeof value !== `undefined`)

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -1,8 +1,8 @@
-import {xfs, ppath, Filename, PortablePath} from '@yarnpkg/fslib';
-import {execute, UserOptions}               from '@yarnpkg/shell';
-import {PassThrough}                        from 'stream';
-import stripAnsi                            from 'strip-ansi';
-import {promisify}                          from 'util';
+import {xfs, ppath, Filename, PortablePath, npath} from '@yarnpkg/fslib';
+import {execute, UserOptions}                      from '@yarnpkg/shell';
+import {PassThrough}                               from 'stream';
+import stripAnsi                                   from 'strip-ansi';
+import {promisify}                                 from 'util';
 
 const setTimeoutPromise = promisify(setTimeout);
 
@@ -86,6 +86,18 @@ const bufferResult = async (command: string, args: Array<string> = [], options: 
 };
 
 describe(`Shell`, () => {
+  describe(`Option validation`, () => {
+    it(`should throw an unrecoverable error if executed inside a cwd that doesn't exist`, async () => {
+      await xfs.mktempPromise(async tmpDir => {
+        await expect(bufferResult(
+          ``,
+          [],
+          {cwd: `${tmpDir}/doesnt-exist` as PortablePath},
+        )).rejects.toThrow(`Cannot execute command in non-existent directory: "${npath.fromPortablePath(tmpDir)}/doesnt-exist"`);
+      });
+    });
+  });
+
   describe(`Simple shell features`, () => {
     it(`should support an empty string`, async () => {
       await expect(bufferResult(


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell doesn't validate the `cwd` parameter, meaning that if a non-existent cwd is passed, builtins like `cd ~` and `pwd` will continue to work while commands such as `corepack -v` will break with a cryptic `command not found: corepack`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it throw if the `cwd` doesn't exist.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
