### PR TITLE
chore: install after updating release artifacts

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -48290,7 +48290,7 @@ class ZipFS extends BasePortableFakeFS {
     return this.readSync(fd, buffer, offset, length, position);
   }
 
-  readSync(fd, buffer, offset = 0, length = 0, position = -1) {
+  readSync(fd, buffer, offset = 0, length = buffer.byteLength, position = -1) {
     const entry = this.fds.get(fd);
     if (typeof entry === `undefined`) throw EBADF(`read`);
     let realPosition;

--- a/scripts/release/01-release-tags.sh
+++ b/scripts/release/01-release-tags.sh
@@ -69,6 +69,9 @@ yarn workspaces foreach \
 cp "$REPO_DIR"/packages/yarnpkg-cli/bin/yarn.js \
    "$REPO_DIR"/packages/berry-cli/bin/berry.js
 
+# In case the PnP hook got updated run an install to update the `.pnp.cjs` file
+YARN_ENABLE_IMMUTABLE_INSTALLS=0 yarn
+
 git add "$REPO_DIR"
 git commit -m "$COMMIT_MESSAGE"
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Depending on the order PRs are merged changes to `hook.js` and `.pnp.cjs` can end up getting reverted, the `hook.js` file is regenerated during release but `.pnp.cjs` isn't which causes the immutable install to fail when the release commit is tested.

**How did you fix it?**

Run an install after updating the release artifacts to make sure the `.pnp.cjs` file is up to date

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.