### PR TITLE
feat(plugin-version): add main to changesetBaseRefs default

### DIFF
--- a/.yarn/versions/b934d2e4.yml
+++ b/.yarn/versions/b934d2e4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -24,7 +24,7 @@ const plugin: Plugin = {
       type: SettingsType.STRING,
       isArray: true,
       isNullable: false,
-      default: [`master`, `origin/master`, `upstream/master`],
+      default: [`master`, `origin/master`, `upstream/master`, `main`, `origin/main`, `upstream/main`],
     },
     changesetIgnorePatterns: {
       description: `Array of glob patterns; files matching them will be ignored when fetching the changed files`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
- The default branch name for new repositories created on GitHub is now [`main`](https://github.com/github/renaming). plugin-version changesetBaseRefs default is set up only `master`. 

**How did you fix it?**
- add `main` to changesetBaseRefs default


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
