### PR TITLE
fix(esbuild): remove invalid `publishConfig.bin`

### DIFF
--- a/.yarn/versions/6b81de03.yml
+++ b/.yarn/versions/6b81de03.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch

--- a/.yarn/versions/6b81de03.yml
+++ b/.yarn/versions/6b81de03.yml
@@ -1,5 +1,14 @@
 releases:
+  "@yarnpkg/builder": patch
   "@yarnpkg/esbuild-plugin-pnp": patch
 
 declined:
-  - "@yarnpkg/builder"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/pnp"

--- a/.yarn/versions/6b81de03.yml
+++ b/.yarn/versions/6b81de03.yml
@@ -1,2 +1,5 @@
 releases:
   "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"

--- a/packages/esbuild-plugin-pnp/package.json
+++ b/packages/esbuild-plugin-pnp/package.json
@@ -20,7 +20,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "bin": "./lib/cli.js",
     "typings": "./lib/index.d.ts"
   },
   "files": [


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

publishConfig.bin is pointing to a file that does not exist, which causes an error while installing the package as a dependency with pnpm.

```
ENOENT: no such file or directory, chmod '.../node_modules/.pnpm/@yarnpkg+esbuild-plugin-pnp@2.0.0-rc.1_esbuild@0.13.2/node_modules/@yarnpkg/esbuild-plugin-pnp/lib/cli.js'
```

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed the publishConfig.bin field

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
