### PR TITLE
fix(essentials): accept `--network-timeout` as a legacy flag

### DIFF
--- a/.yarn/versions/301df8df.yml
+++ b/.yarn/versions/301df8df.yml
@@ -1,7 +1,23 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-interactive-tools": patch
 
 declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
   - "@yarnpkg/plugin-typescript"
-  - "@yarnpkg/cli"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/301df8df.yml
+++ b/.yarn/versions/301df8df.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -87,6 +87,7 @@ export default class YarnCommand extends BaseCommand {
   production = Option.Boolean(`--production`, {hidden: true});
   registry = Option.String(`--registry`, {hidden: true});
   silent = Option.Boolean(`--silent`, {hidden: true});
+  networkTimeout = Option.String(`--network-timeout`, {hidden: true});
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Cloud services, like CI/CD etc. which supports Yarn v1 and call the install command with e.g. `yarn install --non-interactive --prefer-offline --network-timeout 600000` we still can have Yarn v3 inside git, and it would then do the job.

By having `--network-timeout` included in the legacy list of CLI flags, we would avoid aborting the install routine.

**How did you fix it?**

Add `--network-timeout` (networkTimeout) to the list of legacy flags inside the `/commands/install.ts` file.

Like the `--silent` flag, we do noting about it. But the question is, should we mention that this option can be set inside a config file (if it is equivalent)?

**Checklist**

- [x] I have read the Contributing Guide.
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.