### PR TITLE
fix(core): remove recursive dependency check

### DIFF
--- a/.yarn/versions/6c15d928.yml
+++ b/.yarn/versions/6c15d928.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/.yarn/versions/6c15d928.yml
+++ b/.yarn/versions/6c15d928.yml
@@ -1,2 +1,34 @@
 releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
+  "@yarnpkg/doctor": patch
+  "@yarnpkg/esbuild-plugin-pnp": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-compat": patch
+  "@yarnpkg/plugin-constraints": patch
+  "@yarnpkg/plugin-dlx": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-file": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+  "@yarnpkg/plugin-http": patch
+  "@yarnpkg/plugin-init": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-link": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-patch": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+  "@yarnpkg/plugin-stage": patch
+  "@yarnpkg/plugin-typescript": patch
+  "@yarnpkg/plugin-version": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+  "@yarnpkg/pnp": patch
+  "@yarnpkg/pnpify": patch
+  "@yarnpkg/sdks": patch
+  vscode-zipfs: patch

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1958,14 +1958,6 @@ function applyVirtualResolutionMutations({
         continue;
       }
 
-      // The stack overflow is checked against two level because a workspace
-      // may have a dev dependency on another workspace that lists the first
-      // one as a regular dependency. In this case the loop will break so we
-      // don't need to throw an exception.
-      const stackDepth = virtualStack.get(pkg.locatorHash);
-      if (typeof stackDepth === `number` && stackDepth >= 2)
-        reportStackOverflow();
-
       let virtualizedDescriptor: Descriptor;
       let virtualizedPackage: Package;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

In certain repositories, the exact nature of which has been hard to pin down, a check added to resolve https://github.com/yarnpkg/berry/issues/776 was causing a 'stack overflow' error on install.

Discussed in the follow issue, the proposal was to remove this check as it does not seem to cause 776 to reoccur.

https://github.com/yarnpkg/berry/issues/3434

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The check has simply been removed.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
