### PR TITLE
fix(npm): avoid breaking change in `makePublishBody`

### DIFF
--- a/.yarn/versions/ae288973.yml
+++ b/.yarn/versions/ae288973.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/packages/plugin-npm/sources/npmPublishUtils.ts
+++ b/packages/plugin-npm/sources/npmPublishUtils.ts
@@ -8,7 +8,7 @@ import {URL}                    from 'url';
 
 import {normalizeRegistry}      from './npmConfigUtils';
 
-export async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, tag, registry, gitHead}: {access: string | undefined, tag: string, registry: string, gitHead: string | undefined}) {
+export async function makePublishBody(workspace: Workspace, buffer: Buffer, {access, tag, registry, gitHead}: {access: string | undefined, tag: string, registry: string, gitHead?: string}) {
   const configuration = workspace.project.configuration;
 
   const ident = workspace.manifest.name!;


### PR DESCRIPTION
**What's the problem this PR addresses?**

A breaking change (typecheck wise) was introduced in https://github.com/yarnpkg/berry/pull/3148 forcing consumers to provide a `gitHead` property to `makePublishBody`

Fixes https://github.com/yarnpkg/berry/pull/3148/files#r727458750

**How did you fix it?**

Make the `gitHead` property optional

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.