### PR TITLE
fix: get rid of breaking change in plugin-constraints

### DIFF
--- a/.yarn/versions/4f33a65e.yml
+++ b/.yarn/versions/4f33a65e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
@@ -661,7 +661,7 @@ exports[`Commands constraints query test (various field types / workspace_field 
 Object {
   "code": 0,
   "stderr": "",
-  "stdout": "➤ YN0000: FieldValue = '\\"foo\\"'
+  "stdout": "➤ YN0000: FieldValue = foo
 ➤ YN0000: Done
 ",
 }

--- a/packages/plugin-constraints/sources/tauModule.ts
+++ b/packages/plugin-constraints/sources/tauModule.ts
@@ -86,7 +86,10 @@ const tauModule = new pl.type.Module(`constraints`, {
 
     prependGoals(thread, point, [new pl.type.Term(`=`, [
       fieldValue,
-      new pl.type.Term(JSON.stringify(value)),
+      // TODO: Investigate whether we should JSON.stringify primitive values too.
+      // For now we don't because it would be a breaking change.
+      // https://github.com/yarnpkg/berry/issues/3584
+      new pl.type.Term(typeof value === `object` ? JSON.stringify(value) : value),
     ])]);
   },
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

#3284 introduced a breaking change in `plugin-constraints`.

Fixes #3584.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it only use `JSON.stringify` if the value is an object. This way it doesn't undo the fix for the original issue while getting rid of the breaking change.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
