### PR TITLE
fix: add npmAuditRegistry to yarnrc schema

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -389,6 +389,13 @@
       "type": "boolean",
       "default": false
     },
+    "npmAuditRegistry": {
+      "_package": "@yarnpkg/plugin-npm",
+      "description": "Defines the registry that must be used when auditing dependencies. Doesn't need to be defined, in which case the value of `npmRegistryServer` will be used.",
+      "type": "string",
+      "format": "uri",
+      "examples": ["https://npm.pkg.github.com"]
+    },
     "npmAuthIdent": {
       "_package": "@yarnpkg/plugin-npm",
       "description": "Defines the authentication credentials to use by default when accessing your registries (equivalent to `_auth` in the v1). This settings is strongly discouraged in favor of `npmAuthToken`.",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Didn't realise this schema existed when I submitted #3583. Only noticed when @paul-soporan commented on the PR to move the changeset configuration options.

**How did you fix it?**

Added the missing configuration option to the yarnrc schema.

I didn't mention the publish registry in the schema as for now that fallback behaviour is just included for backward compatibility, and will be removed in the next major version.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
