### PR TITLE
Fix Newsline Highlight

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -308,7 +308,7 @@ export const Header = ({children}) => {
       <NewsContainer>
         <NewsOverlay href={`https://classic.yarnpkg.com`}/>
         <NewsInner>
-          <NewsLine><Highlight>Important:</Highlight> This documentation covers Yarn 2.</NewsLine> <NewsLine>For 1.x docs, see classic.yarnpkg.com.</NewsLine>
+          <NewsLine><Highlight>Important:</Highlight> This documentation covers Yarn 2 and onwards.</NewsLine> <NewsLine>For 1.x docs, see classic.yarnpkg.com.</NewsLine>
         </NewsInner>
       </NewsContainer>
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
There is no documentation for yarn 3

**How did you fix it?**
Say that https://yarnpkg.com/ also covers v2 and onwards in the news header

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x I will check that all automated PR checks pass before the PR gets reviewed.
