### PR TITLE
fix: don't unplug required locators that have conditions

### DIFF
--- a/.yarn/versions/27505549.yml
+++ b/.yarn/versions/27505549.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -414,7 +414,7 @@ export class PnpInstaller implements Installer {
     if (FORCED_UNPLUG_PACKAGES.has(pkg.identHash))
       return true;
 
-    if (pkg.conditions != null)
+    if (this.opts.project.conditionalLocators.has(pkg.locatorHash))
       return true;
 
     if (customPackageData.manifest.preferUnplugged !== null)


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This has been bothering me ever since the conditional dependencies PR was merged and I want to debate it one last time before finally making a decision so that I can tick it off my TODO list. :smile: 

(A conditional locator is a locator that has `conditions` *and is `optional` too*)

I believe that we should only unplug conditional locators rather than unplugging all locators that have conditions. Reasons:

- Consistency, there's no other place in the codebase where we special-case *all* packages that have `conditions`
- It doesn't make sense semantically to unplug all locators that have conditions, as some of them can still work even inside zip archives. There's also the fact that "lists `conditions`" isn't synonymous with "has native files", a package could simply be written in JS and only do things on one specific platform.

I don't see this one-line change as adding more complexity and I believe that we should try aiming for as much consistency and correctness as possible.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By only unplugging locators that are conditional, not required locators that happen to have conditions.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
