### PR TITLE
Renames pnpEnableExperimentalEsm into pnpEnableEsmLoader

### DIFF
--- a/.yarn/versions/84ac6b01.yml
+++ b/.yarn/versions/84ac6b01.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,7 +3,7 @@ changesetIgnorePatterns:
 
 enableGlobalCache: false
 
-pnpEnableExperimentalEsm: false
+pnpEnableEsmLoader: false
 
 immutablePatterns:
   - .pnp.*

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
@@ -273,7 +273,7 @@ describe(`Plug'n'Play - ESM`, () => {
     makeTemporaryEnv(
       { },
       {
-        pnpEnableExperimentalEsm: true,
+        pnpEnableEsmLoader: true,
       },
       async ({path, run, source}) => {
         await xfs.writeFilePromise(ppath.join(path, `index` as Filename), `console.log(typeof require === 'undefined')`);
@@ -371,7 +371,7 @@ describe(`Plug'n'Play - ESM`, () => {
         },
       },
       {
-        pnpEnableExperimentalEsm: true,
+        pnpEnableEsmLoader: true,
       },
       async ({path, run, source}) => {
         await xfs.writeFilePromise(ppath.join(path, `index.js` as Filename), `import('no-deps').then(() => console.log(42))`);

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -556,7 +556,7 @@
       "format": "uri-reference",
       "default": "./.pnp.data.json"
     },
-    "pnpEnableExperimentalEsm": {
+    "pnpEnableEsmLoader": {
       "_package": "@yarnpkg/plugin-pnp",
       "description": "If true, Yarn will generate an experimental ESM loader (`.pnp.loader.mjs`). Yarn tries to automatically detect whether ESM support is required.",
       "type": "boolean",

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -294,8 +294,8 @@ export class PnpInstaller implements Installer {
   }
 
   private isEsmEnabled() {
-    if (this.opts.project.configuration.sources.has(`pnpEnableExperimentalEsm`))
-      return this.opts.project.configuration.get(`pnpEnableExperimentalEsm`);
+    if (this.opts.project.configuration.sources.has(`pnpEnableEsmLoader`))
+      return this.opts.project.configuration.get(`pnpEnableEsmLoader`);
 
     if (this.isESMLoaderRequired)
       return true;

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -64,7 +64,7 @@ declare module '@yarnpkg/core' {
     pnpMode: string;
     pnpShebang: string;
     pnpIgnorePatterns: Array<string>;
-    pnpEnableExperimentalEsm: boolean
+    pnpEnableEsmLoader: boolean
     pnpEnableInlining: boolean;
     pnpFallbackMode: string;
     pnpUnpluggedFolder: PortablePath;
@@ -99,7 +99,7 @@ const plugin: Plugin<CoreHooks & StageHooks> = {
       default: [],
       isArray: true,
     },
-    pnpEnableExperimentalEsm: {
+    pnpEnableEsmLoader: {
       description: `If true, Yarn will generate an ESM loader (\`.pnp.loader.mjs\`). If this is not explicitly set Yarn tries to automatically detect whether ESM support is required.`,
       type: SettingsType.BOOLEAN,
       default: false,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Using `experimental` in the name isn't necessary since the setting is enabled by default (so only a segment of those who use it will see the warning), and would require either a compatibility check or users to edit their configuration once we graduate the feature. Note that It'll still be experimental, as explained in the documentation.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
