### PR TITLE
fix: add pnpm to yarnrc schema in nodeLinker

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -378,9 +378,9 @@
     },
     "nodeLinker": {
       "_package": "@yarnpkg/plugin-pnp",
-      "description": "Defines what linker should be used for installing Node packages (useful to enable the node-modules plugin), one of: `pnp`, `node-modules`.",
+      "description": "Defines what linker should be used for installing Node packages (useful to enable the node-modules plugin), one of: `pnp`, `pnpm` and `node-modules`.",
       "type": "string",
-      "enum": ["pnp", "node-modules"],
+      "enum": ["pnp", "pnpm", "node-modules"],
       "default": "pnp"
     },
     "npmAlwaysAuth": {


### PR DESCRIPTION
**What's the problem this PR addresses?**
Some tools (namely VSCode YAML extension) use the published yarnrc schema to validate it, and it doesn't recognize `pnpm` linker yet.

...

**How did you fix it?**
Updates the yarnrc schema to list `pnpm` as a valid `nodeLinker` option since it's now supported by #3338.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.
  - I'm guessing this wouldn't be the case for docs. Happy to be corrected though.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
