### PR TITLE
fix: move nodeLinker values to examples (instead of enum)

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -380,8 +380,8 @@
       "_package": "@yarnpkg/plugin-pnp",
       "description": "Defines what linker should be used for installing Node packages (useful to enable the node-modules plugin), one of: `pnp`, `pnpm` and `node-modules`.",
       "type": "string",
-      "enum": ["pnp", "pnpm", "node-modules"],
-      "default": "pnp"
+      "default": "pnp",
+      "examples": ["pnp", "pnpm", "node-modules"]
     },
     "npmAlwaysAuth": {
       "_package": "@yarnpkg/plugin-npm",


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

In the `.yarnrc.yml` schema, `nodeLinker` had its suggested values inside of the `enum` field. This was wrong because the `nodeLinker` can take any values, as plugins can register their own node linkers under the `nodeLinker` configuration option.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Moved it to `examples`. This way, editors will still show the examples as completions while not showing an error on `nodeLinker`s that we don't know about.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
