### PR TITLE
fix(nm): Avoids usage of localeCompare for the strings

### DIFF
--- a/.yarn/versions/e137d1fc.yml
+++ b/.yarn/versions/e137d1fc.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -133,7 +133,13 @@ export const buildLocatorMap = (nodeModulesTree: NodeModulesTree): NodeModulesLo
     val.locations = val.locations.sort((loc1: PortablePath, loc2: PortablePath) => {
       const len1 = loc1.split(ppath.delimiter).length;
       const len2 = loc2.split(ppath.delimiter).length;
-      return len1 !== len2 ? len2 - len1 : loc2.localeCompare(loc1);
+      if (loc2 === loc1) {
+        return 0;
+      } else if (len1 !== len2) {
+        return len2 - len1;
+      } else {
+        return loc2 > loc1 ? 1 : -1;
+      }
     });
   }
 

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -986,7 +986,13 @@ const dumpDepTree = (tree: HoisterWorkTree) => {
       return ``;
 
     nodeCount++;
-    const dependencies = Array.from(pkg.dependencies.values()).sort((n1, n2) => n1.name.localeCompare(n2.name));
+    const dependencies = Array.from(pkg.dependencies.values()).sort((n1, n2) => {
+      if (n1.name === n2.name) {
+        return 0;
+      } else {
+        return n1.name > n2.name ? 1 : -1;
+      }
+    });
 
     let str = ``;
     parents.add(pkg);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

As discussed here:
https://github.com/yarnpkg/berry/issues/3648#issuecomment-952351470
the `localeCompare` might produce non-deterministic results, depending on the system locale, the input and the specifics of the usage. The chance there are practical problems with `localeCompre` code in nm linker is low to non-existent, because it affects only writing to `node_modules/.yarn-state.yml` and the order of entries in this file doesn't effect anything except its contents. But it is still better to be on the safe side and avoid usage of `localeCompare` to not introduce practical problems unintentionally.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed `localeCompare` usage in favor of direct string comparison.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
