### PR TITLE
fix(workspace-tools): make `workspaces foreach run` check for binaries

### DIFF
--- a/.yarn/versions/867de77f.yml
+++ b/.yarn/versions/867de77f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 - The pnpm linker will now remove the `node_modules/.store` and `node_modules` folders if they are empty.
 
+### Bugfixes
+
+- `yarn workspaces foreach run` is now able to run binaries
+
 ### Miscellaneous Features
 
 - Reporting for Git errors has been improved.

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -540,6 +540,30 @@ describe(`Commands`, () => {
         await expect(run(`workspaces`, `foreach`, `--since`, `--recursive`, `run`, `print`)).resolves.toMatchSnapshot();
       }),
     );
+
+    test(
+      `it should run on workspaces with matching binaries`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            'has-bin-entries': `1.0.0`,
+          },
+        },
+        {
+          plugins: [
+            require.resolve(`@yarnpkg/monorepo/scripts/plugin-workspace-tools.js`),
+          ],
+        },
+        async ({run}) => {
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `run`, `has-bin-entries`, `binary-executed`)).resolves.toMatchObject({
+            code: 0,
+            stdout: expect.stringContaining(`binary-executed`),
+          });
+        },
+      ),
+    );
   });
 });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn workspaces foreach run` doesn't support running binaries, only scripts.

Fixes https://github.com/yarnpkg/berry/issues/3095

**How did you fix it?**

Made it check if the workspace has a binary that matches the `scriptName`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.