### PR TITLE
fix(plugin-pnpm): various improvements

### DIFF
--- a/.yarn/versions/61c4a98a.yml
+++ b/.yarn/versions/61c4a98a.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-pnpm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 ### Installs
 
-- The pnpm linker will now remove the `node_modules/.store` and `node_modules` folders if they are empty.
+- The pnpm linker has received various improvements:
+  - It will now remove the `node_modules/.store` and `node_modules` folders if they are empty.
+  - It now supports running binaries of soft links.
+  - It will now create self-references for packages that don't depend on other versions of themselves.
+  - It will now remove scope folders (e.g. `node_modules/@yarnpkg`) if they are empty or after removing a scoped dependency.
 
 ### Miscellaneous Features
 

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-dep-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-dep-1.0.0/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    // $FlowFixMe The whole point of this file is to be dynamic
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-dep-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-dep-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "self-require-dep",
+  "version": "1.0.0",
+  "dependencies": {
+    "various-requires": "1.0.0"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-dep-1.0.0/self.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-dep-1.0.0/self.js
@@ -1,0 +1,1 @@
+module.exports = require('various-requires/self');

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-trap-1.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-trap-1.0.0/bin.js
@@ -1,0 +1,1 @@
+console.log(42);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-trap-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/self-require-trap-1.0.0/package.json
@@ -3,5 +3,6 @@
     "version": "1.0.0",
     "dependencies": {
         "self-require-trap": "2.0.0"
-    }
+    },
+    "bin": "./bin"
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
@@ -531,6 +531,23 @@ describe(`Basic tests`, () => {
           },
         ),
       );
+
+      test(
+        `it should not add the implicit self dependency if an explicit one already exists`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`self-require-trap`]: `1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await expect(source(`require('self-require-trap/self') !== require('self-require-trap')`)).resolves.toEqual(
+              true,
+            );
+          },
+        ),
+      );
     });
   }
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
@@ -49,6 +49,24 @@ describe(`Basic tests`, () => {
       );
 
       test(
+        `it should correctly install a single scoped dependency that contains no sub-dependencies`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`@types/no-deps`]: `1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await expect(source(`require('@types/no-deps')`)).resolves.toMatchObject({
+              name: `@types/no-deps`,
+              version: `1.0.0`,
+            });
+          },
+        ),
+      );
+
+      test(
         `it should correctly install a dependency that itself contains a fixed dependency`,
         makeTemporaryEnv(
           {
@@ -479,7 +497,7 @@ describe(`Basic tests`, () => {
       );
 
       test(
-        `it should allow accessing a package via too many slashes`,
+        `it should support self-requires in direct dependencies`,
         makeTemporaryEnv(
           {
             dependencies: {[`various-requires`]: `1.0.0`},
@@ -488,7 +506,25 @@ describe(`Basic tests`, () => {
           async ({path, run, source}) => {
             await run(`install`);
 
-            await expect(source(`require('various-requires//self')`)).resolves.toMatchObject({
+            await expect(source(`require('various-requires/self')`)).resolves.toMatchObject({
+              name: `various-requires`,
+              version: `1.0.0`,
+            });
+          },
+        ),
+      );
+
+      test(
+        `it should support self-requires in transitive dependencies`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`self-require-dep`]: `1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await expect(source(`require('self-require-dep/self')`)).resolves.toMatchObject({
               name: `various-requires`,
               version: `1.0.0`,
             });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/basic.test.js
@@ -67,6 +67,24 @@ describe(`Basic tests`, () => {
       );
 
       test(
+        `it should correctly install a single aliased dependency that contains no sub-dependencies`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`aliased`]: `npm:no-deps@1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await expect(source(`require('aliased')`)).resolves.toMatchObject({
+              name: `no-deps`,
+              version: `1.0.0`,
+            });
+          },
+        ),
+      );
+
+      test(
         `it should correctly install a dependency that itself contains a fixed dependency`,
         makeTemporaryEnv(
           {
@@ -540,11 +558,71 @@ describe(`Basic tests`, () => {
           },
           config,
           async ({path, run, source}) => {
+            // We run 2 installs because while refactoring the pnpm linker, running a second install highlighted a symlink issue
+            for (let i = 0; i < 2; i++) {
+              await run(`install`);
+
+              await expect(source(`require('self-require-trap')`)).resolves.toMatchObject({
+                name: `self-require-trap`,
+                version: `1.0.0`,
+              });
+
+              await expect(source(`require('self-require-trap/self')`)).resolves.toMatchObject({
+                name: `self-require-trap`,
+                version: `2.0.0`,
+              });
+            }
+          },
+        ),
+      );
+
+      test(
+        `it should not add the implicit self dependency if an explicit one already exists (aliases)`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`aliased`]: `npm:self-require-trap@1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            // We run 2 installs because while refactoring the pnpm linker, running a second install highlighted a symlink issue
+            for (let i = 0; i < 2; i++) {
+              await run(`install`);
+
+              await expect(source(`require('aliased')`)).resolves.toMatchObject({
+                name: `self-require-trap`,
+                version: `1.0.0`,
+              });
+
+              await expect(source(`require('aliased/self')`)).resolves.toMatchObject({
+                name: `self-require-trap`,
+                version: `2.0.0`,
+              });
+            }
+          },
+        ),
+      );
+
+      test(
+        `it should correctly install a soft-link`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`soft-link`]: `portal:./soft-link`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await xfs.mkdirPromise(`${path}/soft-link`);
+            await xfs.writeJsonPromise(`${path}/soft-link/package.json`, {
+              name: `soft-link`,
+              version: `1.0.0`,
+            });
+            await xfs.writeFilePromise(`${path}/soft-link/index.js`, `module.exports = require('./package.json');\n`);
+
             await run(`install`);
 
-            await expect(source(`require('self-require-trap/self') !== require('self-require-trap')`)).resolves.toEqual(
-              true,
-            );
+            await expect(source(`require('soft-link')`)).resolves.toMatchObject({
+              name: `soft-link`,
+              version: `1.0.0`,
+            });
           },
         ),
       );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
@@ -132,22 +132,20 @@ describe(`Install Artifact Cleanup`, () => {
 
       // Sanity check
       await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
-
-      // We only symlink the package itself, not its dependencies
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/one-fixed-dep/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(false);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/one-fixed-dep/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(true);
 
       const entries = await lsStore(path);
       const oneFixedDepEntry = entries.find(entry => entry.startsWith(`one-fixed-dep`));
       expect(oneFixedDepEntry).toBeDefined();
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
 
-      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/foo` as PortablePath);
-      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/foo/bar` as PortablePath, ``);
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/foo` as PortablePath);
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/foo/bar` as PortablePath, ``);
 
       await run(`install`);
 
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/foo` as PortablePath)).resolves.toStrictEqual(false);
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/foo` as PortablePath)).resolves.toStrictEqual(false);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
     }));
 
     it(`should remove extraneous nested entries that look like scopes`, makeTemporaryEnv({}, {
@@ -157,24 +155,22 @@ describe(`Install Artifact Cleanup`, () => {
 
       // Sanity check
       await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
-
-      // We only symlink the package itself, not its dependencies
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/one-fixed-dep/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(false);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/one-fixed-dep/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(true);
 
       const entries = await lsStore(path);
       const oneFixedDepEntry = entries.find(entry => entry.startsWith(`one-fixed-dep`));
       expect(oneFixedDepEntry).toBeDefined();
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
 
-      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/@foo` as PortablePath);
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/@foo` as PortablePath);
 
       await run(`install`);
 
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/@foo` as PortablePath)).resolves.toStrictEqual(false);
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/@foo` as PortablePath)).resolves.toStrictEqual(false);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
     }));
 
-    it(`should remove extraneous nested entries (no self-references)`, makeTemporaryEnv({}, {
+    it(`should remove extraneous nested entries (self-require-trap)`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,
     }, async ({path, run, source}) => {
       await run(`add`, `self-require-trap@1.0.0`);
@@ -199,24 +195,22 @@ describe(`Install Artifact Cleanup`, () => {
 
       // Sanity check
       await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
-
-      // We only symlink the package itself, not its dependencies
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/one-fixed-dep/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(false);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/one-fixed-dep/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(true);
 
       const entries = await lsStore(path);
       const oneFixedDepEntry = entries.find(entry => entry.startsWith(`one-fixed-dep`));
       expect(oneFixedDepEntry).toBeDefined();
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
 
-      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps/foo` as PortablePath);
-      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps/foo/bar` as PortablePath, ``);
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps/foo` as PortablePath);
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps/foo/bar` as PortablePath, ``);
 
       await run(`install`);
 
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps/foo/bar` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/one-fixed-dep/node_modules/no-deps/foo/bar` as PortablePath)).resolves.toStrictEqual(true);
     }));
 
-    it(`should not remove extraneous files in valid nested entries (no self-references for the root entry)`, makeTemporaryEnv({}, {
+    it(`should not remove extraneous files in valid nested entries (self-require-trap)`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,
     }, async ({path, run, source}) => {
       await run(`add`, `self-require-trap@1.0.0`);
@@ -267,7 +261,7 @@ describe(`Install Artifact Cleanup`, () => {
       await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}` as PortablePath)).resolves.toStrictEqual(false);
     }));
 
-    it(`should remove extraneous files in .store entries when self-references are created`, makeTemporaryEnv({}, {
+    it(`should remove extraneous files in .store entries`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,
     }, async ({path, run, source}) => {
       await run(`add`, `no-deps@1.0.0`);
@@ -289,7 +283,7 @@ describe(`Install Artifact Cleanup`, () => {
       await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/foo` as PortablePath)).resolves.toStrictEqual(false);
     }));
 
-    it(`should not remove extraneous files in .store entries when self-references are not created`, makeTemporaryEnv({}, {
+    it(`should remove extraneous files in .store entries (self-require-trap)`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,
     }, async ({path, run, source}) => {
       await run(`add`, `self-require-trap@1.0.0`);
@@ -301,14 +295,165 @@ describe(`Install Artifact Cleanup`, () => {
       const entries = await lsStore(path);
       const selfRequireTrapEntry = entries.find(entry => entry.startsWith(`self-require-trap-npm-1.0.0`));
       expect(selfRequireTrapEntry).toBeDefined();
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/self-require-trap/node_modules/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
 
       await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/foo` as PortablePath);
       await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/foo/bar` as PortablePath, ``);
 
       await run(`install`);
 
-      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/foo/bar` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous files in the prefix path of .store entries`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `no-deps@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const noDepsEntry = entries.find(entry => entry.startsWith(`no-deps`));
+      expect(noDepsEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/foo` as PortablePath);
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/foo/bar` as PortablePath, ``);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous files in the prefix path of .store entries (self-require-trap)`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `self-require-trap@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const selfRequireTrapEntry = entries.find(entry => entry.startsWith(`self-require-trap-npm-1.0.0`));
+      expect(selfRequireTrapEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/self-require-trap/node_modules/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/foo` as PortablePath);
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/foo/bar` as PortablePath, ``);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous files that look like scopes in the prefix path of .store entries`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `no-deps@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const noDepsEntry = entries.find(entry => entry.startsWith(`no-deps`));
+      expect(noDepsEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/@foo` as PortablePath);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/@foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous files that look like scopes in the prefix path of .store entries (self-require-trap)`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `self-require-trap@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const selfRequireTrapEntry = entries.find(entry => entry.startsWith(`self-require-trap-npm-1.0.0`));
+      expect(selfRequireTrapEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/self-require-trap/node_modules/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/@foo` as PortablePath);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/@foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous scoped files in the prefix path of .store entries`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `no-deps@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const noDepsEntry = entries.find(entry => entry.startsWith(`no-deps`));
+      expect(noDepsEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/@foo` as PortablePath);
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/@foo/bar` as PortablePath, ``);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${noDepsEntry}/node_modules/@foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous scoped files in the prefix path of .store entries (self-require-trap)`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `self-require-trap@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const selfRequireTrapEntry = entries.find(entry => entry.startsWith(`self-require-trap-npm-1.0.0`));
+      expect(selfRequireTrapEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/self-require-trap/node_modules/self-require-trap` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.mkdirPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/@foo` as PortablePath);
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/@foo/bar` as PortablePath, ``);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${selfRequireTrapEntry}/node_modules/@foo` as PortablePath)).resolves.toStrictEqual(false);
+    }));
+
+    it(`should remove extraneous files in scope folders in the prefix path of .store entries`, makeTemporaryEnv({}, {
+      nodeLinker: `pnpm`,
+    }, async ({path, run, source}) => {
+      await run(`add`, `@types/no-deps@1.0.0`);
+
+      // Sanity check
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath)).resolves.toStrictEqual(true);
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/@types/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      const entries = await lsStore(path);
+      const typesNoDepsEntry = entries.find(entry => entry.startsWith(`@types-no-deps`));
+      expect(typesNoDepsEntry).toBeDefined();
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${typesNoDepsEntry}/node_modules/@types/no-deps` as PortablePath)).resolves.toStrictEqual(true);
+
+      await xfs.writeFilePromise(`${path}/${Filename.nodeModules}/.store/${typesNoDepsEntry}/node_modules/@types/foo` as PortablePath, ``);
+
+      await run(`install`);
+
+      await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${typesNoDepsEntry}/node_modules/@types/foo` as PortablePath)).resolves.toStrictEqual(false);
     }));
 
     it(`should remove the node_modules folder after switching to the pnp linker`, makeTemporaryEnv({}, {}, async ({path, run, source}) => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
@@ -216,7 +216,7 @@ describe(`Install Artifact Cleanup`, () => {
       await expect(xfs.existsPromise(`${path}/${Filename.nodeModules}/.store/${oneFixedDepEntry}/node_modules/no-deps/foo/bar` as PortablePath)).resolves.toStrictEqual(true);
     }));
 
-    it(`should not remove extraneous files in valid nested entries (no self-references)`, makeTemporaryEnv({}, {
+    it(`should not remove extraneous files in valid nested entries (no self-references for the root entry)`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,
     }, async ({path, run, source}) => {
       await run(`add`, `self-require-trap@1.0.0`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -360,22 +360,6 @@ describe(`Plug'n'Play`, () => {
   );
 
   test(
-    `it should not add the implicit self dependency if an explicit one already exists`,
-    makeTemporaryEnv(
-      {
-        dependencies: {[`self-require-trap`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
-
-        await expect(source(`require('self-require-trap/self') !== require('self-require-trap')`)).resolves.toEqual(
-          true,
-        );
-      },
-    ),
-  );
-
-  test(
     `it should run scripts using a Node version that auto-injects the hook`,
     makeTemporaryEnv(
       {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -555,6 +555,71 @@ describe(`Scripts tests`, () => {
           ]);
         }),
       );
+
+      test(
+        `it should run the bin of self-require-trap`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`self-require-trap`]: `1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await expect(run(`run`, `self-require-trap`)).resolves.toMatchObject({
+              code: 0,
+              stdout: `42\n`,
+              stderr: ``,
+            });
+          },
+        ),
+      );
+
+      test(
+        `it should run the bin of self-require-trap (aliased)`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`aliased`]: `npm:self-require-trap@1.0.0`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await run(`install`);
+
+            await expect(run(`run`, `self-require-trap`)).resolves.toMatchObject({
+              code: 0,
+              stdout: `42\n`,
+              stderr: ``,
+            });
+          },
+        ),
+      );
+
+      test(
+        `it should run the bin of a soft-link`,
+        makeTemporaryEnv(
+          {
+            dependencies: {[`soft-link`]: `portal:./soft-link`},
+          },
+          config,
+          async ({path, run, source}) => {
+            await xfs.mkdirPromise(`${path}/soft-link`);
+            await xfs.writeJsonPromise(`${path}/soft-link/package.json`, {
+              name: `soft-link`,
+              version: `1.0.0`,
+              bin: `./bin`,
+            });
+            await xfs.writeFilePromise(`${path}/soft-link/bin.js`, `console.log(42);\n`);
+
+            await run(`install`);
+
+            await expect(run(`run`, `soft-link`)).resolves.toMatchObject({
+              code: 0,
+              stdout: `42\n`,
+              stderr: ``,
+            });
+          },
+        ),
+      );
     });
   }
 });

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -137,6 +137,13 @@ class PnpmInstaller implements Installer {
 
     const storeLocation = getStoreLocation(this.opts.project);
 
+    const assertNodeModules = (path: string) => {
+      if (!path.endsWith(`${Filename.nodeModules}/`))
+        throw new Error(`Assertion failed: Expected path to end in "${Filename.nodeModules}/"`);
+
+      return path as PortablePath;
+    };
+
     this.asyncActions.reduce(locator.locatorHash, async action => {
       // Wait that the package is properly installed before starting to copy things into it
       await action;
@@ -148,7 +155,7 @@ class PnpmInstaller implements Installer {
       const locatorName = structUtils.stringifyIdent(locator) as PortablePath;
 
       const nmPath = ppath.contains(storeLocation, pkgPath)
-        ? pkgPath.slice(0, -locatorName.length) as PortablePath
+        ? assertNodeModules(pkgPath.slice(0, -locatorName.length))
         : ppath.join(pkgPath, Filename.nodeModules);
 
       // Retrieve what's currently inside the package's true nm folder. We


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- The `PnpmLinker` didn't install transitive dependencies in such a way that they can require themselves
- The `PnpmLinker` didn't support running binaries of soft links
- The `PnpmLinker` didn't remove the scope folder (e.g. `node_modules/@yarnpkg`) after removing a scoped dependency
- The `PnpmLinker` didn't remove folders that looked like scopes

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- ~~Made it copy the package sources to `node_modules/.store/<hash>/node_modules/<ident>` and use that as the symlink source so that self-references work. There is a special edge-case though: when a package depends on a different version of itself. Both pnp and nm get that right (though pnpm doesn't), so I made it skip generating self-references in that case (i.e. made it keep copying the sources to `node_modules/.store/<hash>` so that the dependency can be put inside `node_modules/.store/<hash>/node_modules/<ident>`.~~ The sources will now be copied to `node_modules/.store/<hash>/node_modules/<ident>` and dependencies will be symlinked to `node_modules/.store/<hash>/node_modules/<ident>/node_modules`.
- Made it persist `packageLocations` (now renamed to `pathByLocator`) inside the install state and made `findPackageLocation` query that
- Made it remove those
- Made it remove those

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
