### PR TITLE
fix(pnpify): escape require path

### DIFF
--- a/.yarn/versions/78cfe28d.yml
+++ b/.yarn/versions/78cfe28d.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 - The pnpm linker will now remove the `node_modules/.store` and `node_modules` folders if they are empty.
 
+### Bugfixes
+
+- `@yarnpkg/pnpify` now escapes paths correctly
+
 ### Miscellaneous Features
 
 - Reporting for Git errors has been improved.

--- a/packages/yarnpkg-pnpify/sources/commands/RunCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/RunCommand.ts
@@ -33,7 +33,7 @@ export default class RunCommand extends Command {
 
   async execute() {
     let {NODE_OPTIONS} = process.env;
-    NODE_OPTIONS = `${NODE_OPTIONS || ``} --require "${dynamicRequire.resolve(`@yarnpkg/pnpify`)}"`.trim();
+    NODE_OPTIONS = `${NODE_OPTIONS || ``} --require ${JSON.stringify(dynamicRequire.resolve(`@yarnpkg/pnpify`))}`.trim();
 
     const {code} = await execUtils.pipevp(this.commandName, this.args, {
       cwd: npath.toPortablePath(this.cwd),


### PR DESCRIPTION
**What's the problem this PR addresses?**

The require path added to `NODE_OPTIONS` by `@yarnpkg/pnpify` isn't escaped so it fails on Windows

Fixes https://github.com/yarnpkg/berry/issues/3680

**How did you fix it?**

Use `JSON.stringify` to escape and quote the path

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.