### PR TITLE
feat: automatic ZipFS memory management

### DIFF
--- a/packages/plugin-essentials/sources/commands/info.ts
+++ b/packages/plugin-essentials/sources/commands/info.ts
@@ -237,12 +237,7 @@ export default class InfoCommand extends BaseCommand {
 
         const fetchResult = await fetcher.fetch(pkg, fetcherOptions);
 
-        let manifest;
-        try {
-          manifest = await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs});
-        } finally {
-          fetchResult.releaseFs?.();
-        }
+        const manifest = await Manifest.find(fetchResult.prefixPath, {baseFs: fetchResult.packageFs});
 
         registerData(`Manifest`, {
           [`License`]: formatUtils.tuple(formatUtils.Type.NO_HINT, manifest.license),

--- a/packages/plugin-exec/sources/ExecFetcher.ts
+++ b/packages/plugin-exec/sources/ExecFetcher.ts
@@ -47,7 +47,7 @@ export class ExecFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator),
       loader: () => this.fetchFromDisk(locator, opts),
@@ -57,7 +57,6 @@ export class ExecFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       localPath: this.getLocalPath(locator, opts),
       checksum,

--- a/packages/plugin-exec/sources/ExecResolver.ts
+++ b/packages/plugin-exec/sources/ExecResolver.ts
@@ -1,7 +1,7 @@
 import {Resolver, ResolveOptions, MinimalResolveOptions}        from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest, DescriptorHash, Package} from '@yarnpkg/core';
 import {LinkType}                                               from '@yarnpkg/core';
-import {miscUtils, structUtils, hashUtils}                      from '@yarnpkg/core';
+import {structUtils, hashUtils}                                 from '@yarnpkg/core';
 
 import {PROTOCOL}                                               from './constants';
 import * as execUtils                                           from './execUtils';
@@ -70,9 +70,7 @@ export class ExecResolver implements Resolver {
 
     const packageFetch = await opts.fetchOptions.fetcher.fetch(locator, opts.fetchOptions);
 
-    const manifest = await miscUtils.releaseAfterUseAsync(async () => {
-      return await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
-    }, packageFetch.releaseFs);
+    const manifest = await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
 
     return {
       ...locator,

--- a/packages/plugin-exec/sources/execUtils.ts
+++ b/packages/plugin-exec/sources/execUtils.ts
@@ -53,10 +53,6 @@ export async function loadGeneratorFile(range: string, protocol: string, opts: F
     ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
     : parentFetch;
 
-  // Discard the parent fs unless we really need it to access the files
-  if (parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-    parentFetch.releaseFs();
-
   const generatorFs = effectiveParentFetch.packageFs;
   const generatorPath = ppath.join(effectiveParentFetch.prefixPath, path);
 

--- a/packages/plugin-file/sources/FileFetcher.ts
+++ b/packages/plugin-file/sources/FileFetcher.ts
@@ -29,7 +29,7 @@ export class FileFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the disk`),
       loader: () => this.fetchFromDisk(locator, opts),
@@ -39,7 +39,6 @@ export class FileFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       localPath: this.getLocalPath(locator, opts),
       checksum,

--- a/packages/plugin-file/sources/FileResolver.ts
+++ b/packages/plugin-file/sources/FileResolver.ts
@@ -1,4 +1,4 @@
-import {miscUtils, structUtils, hashUtils}               from '@yarnpkg/core';
+import {structUtils, hashUtils}                          from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
@@ -82,9 +82,7 @@ export class FileResolver implements Resolver {
 
     const packageFetch = await opts.fetchOptions.fetcher.fetch(locator, opts.fetchOptions);
 
-    const manifest = await miscUtils.releaseAfterUseAsync(async () => {
-      return await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
-    }, packageFetch.releaseFs);
+    const manifest = await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
 
     return {
       ...locator,

--- a/packages/plugin-file/sources/TarballFileFetcher.ts
+++ b/packages/plugin-file/sources/TarballFileFetcher.ts
@@ -1,6 +1,6 @@
 import {Fetcher, FetchOptions, FetchResult, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                                 from '@yarnpkg/core';
-import {miscUtils, structUtils, tgzUtils}                        from '@yarnpkg/core';
+import {structUtils, tgzUtils}                                   from '@yarnpkg/core';
 import {PortablePath, ppath, CwdFS}                              from '@yarnpkg/fslib';
 
 import {TARBALL_REGEXP, PROTOCOL}                                from './constants';
@@ -23,7 +23,7 @@ export class TarballFileFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the disk`),
       loader: () => this.fetchFromDisk(locator, opts),
@@ -33,7 +33,6 @@ export class TarballFileFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       checksum,
     };
@@ -54,20 +53,14 @@ export class TarballFileFetcher implements Fetcher {
       ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
       : parentFetch;
 
-    // Discard the parent fs unless we really need it to access the files
-    if (parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-      parentFetch.releaseFs();
-
     const sourceFs = effectiveParentFetch.packageFs;
     const sourcePath = ppath.join(effectiveParentFetch.prefixPath, path);
     const sourceBuffer = await sourceFs.readFilePromise(sourcePath);
 
-    return await miscUtils.releaseAfterUseAsync(async () => {
-      return await tgzUtils.convertToZip(sourceBuffer, {
-        compressionLevel: opts.project.configuration.get(`compressionLevel`),
-        prefixPath: structUtils.getIdentVendorPath(locator),
-        stripComponents: 1,
-      });
-    }, effectiveParentFetch.releaseFs);
+    return await tgzUtils.convertToZip(sourceBuffer, {
+      compressionLevel: opts.project.configuration.get(`compressionLevel`),
+      prefixPath: structUtils.getIdentVendorPath(locator),
+      stripComponents: 1,
+    });
   }
 }

--- a/packages/plugin-file/sources/TarballFileResolver.ts
+++ b/packages/plugin-file/sources/TarballFileResolver.ts
@@ -1,7 +1,7 @@
 import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
-import {miscUtils, structUtils}                          from '@yarnpkg/core';
+import {structUtils}                                     from '@yarnpkg/core';
 import {npath}                                           from '@yarnpkg/fslib';
 
 import {FILE_REGEXP, TARBALL_REGEXP, PROTOCOL}           from './constants';
@@ -66,9 +66,7 @@ export class TarballFileResolver implements Resolver {
 
     const packageFetch = await opts.fetchOptions.fetcher.fetch(locator, opts.fetchOptions);
 
-    const manifest = await miscUtils.releaseAfterUseAsync(async () => {
-      return await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
-    }, packageFetch.releaseFs);
+    const manifest = await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
 
     return {
       ...locator,

--- a/packages/plugin-file/sources/fileUtils.ts
+++ b/packages/plugin-file/sources/fileUtils.ts
@@ -52,21 +52,15 @@ export async function makeArchiveFromLocator(locator: Locator, {protocol, fetchO
     ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
     : parentFetch;
 
-  // Discard the parent fs unless we really need it to access the files
-  if (parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-    parentFetch.releaseFs();
-
   const sourceFs = effectiveParentFetch.packageFs;
   const sourcePath = ppath.join(effectiveParentFetch.prefixPath, path);
 
-  return await miscUtils.releaseAfterUseAsync(async () => {
-    return await tgzUtils.makeArchiveFromDirectory(sourcePath, {
-      baseFs: sourceFs,
-      prefixPath: structUtils.getIdentVendorPath(locator),
-      compressionLevel: fetchOptions.project.configuration.get(`compressionLevel`),
-      inMemory,
-    });
-  }, effectiveParentFetch.releaseFs);
+  return await tgzUtils.makeArchiveFromDirectory(sourcePath, {
+    baseFs: sourceFs,
+    prefixPath: structUtils.getIdentVendorPath(locator),
+    compressionLevel: fetchOptions.project.configuration.get(`compressionLevel`),
+    inMemory,
+  });
 }
 
 export async function makeBufferFromLocator(locator: Locator, {protocol, fetchOptions}: {protocol: string, fetchOptions: FetchOptions}) {

--- a/packages/plugin-git/sources/GitFetcher.ts
+++ b/packages/plugin-git/sources/GitFetcher.ts
@@ -27,7 +27,7 @@ export class GitFetcher implements Fetcher {
     if (result !== null)
       return result;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote repository`),
       loader: () => this.cloneFromRemote(normalizedLocator, nextOpts),
@@ -37,7 +37,6 @@ export class GitFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       checksum,
     };

--- a/packages/plugin-git/sources/GitResolver.ts
+++ b/packages/plugin-git/sources/GitResolver.ts
@@ -1,5 +1,5 @@
 import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
-import {miscUtils, structUtils}                          from '@yarnpkg/core';
+import {structUtils}                                     from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 
@@ -43,9 +43,7 @@ export class GitResolver implements Resolver {
 
     const packageFetch = await opts.fetchOptions.fetcher.fetch(locator, opts.fetchOptions);
 
-    const manifest = await miscUtils.releaseAfterUseAsync(async () => {
-      return await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
-    }, packageFetch.releaseFs);
+    const manifest = await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
 
     return {
       ...locator,

--- a/packages/plugin-github/sources/GithubFetcher.ts
+++ b/packages/plugin-github/sources/GithubFetcher.ts
@@ -21,7 +21,7 @@ export class GithubFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from GitHub`),
       loader: () => this.fetchFromNetwork(locator, opts),
@@ -31,7 +31,6 @@ export class GithubFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       checksum,
     };

--- a/packages/plugin-http/sources/TarballHttpFetcher.ts
+++ b/packages/plugin-http/sources/TarballHttpFetcher.ts
@@ -22,7 +22,7 @@ export class TarballHttpFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote server`),
       loader: () => this.fetchFromNetwork(locator, opts),
@@ -32,7 +32,6 @@ export class TarballHttpFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       checksum,
     };

--- a/packages/plugin-http/sources/TarballHttpResolver.ts
+++ b/packages/plugin-http/sources/TarballHttpResolver.ts
@@ -1,7 +1,7 @@
 import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
-import {miscUtils, structUtils}                          from '@yarnpkg/core';
+import {structUtils}                                     from '@yarnpkg/core';
 
 import {PROTOCOL_REGEXP, TARBALL_REGEXP}                 from './constants';
 
@@ -52,9 +52,7 @@ export class TarballHttpResolver implements Resolver {
 
     const packageFetch = await opts.fetchOptions.fetcher.fetch(locator, opts.fetchOptions);
 
-    const manifest = await miscUtils.releaseAfterUseAsync(async () => {
-      return await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
-    }, packageFetch.releaseFs);
+    const manifest = await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
 
     return {
       ...locator,

--- a/packages/plugin-link/sources/LinkFetcher.ts
+++ b/packages/plugin-link/sources/LinkFetcher.ts
@@ -40,10 +40,6 @@ export class LinkFetcher implements Fetcher {
       ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath), localPath: PortablePath.root}
       : parentFetch;
 
-    // Discard the parent fs unless we really need it to access the files
-    if (parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-      parentFetch.releaseFs();
-
     const sourceFs = effectiveParentFetch.packageFs;
     const sourcePath = ppath.resolve(
       effectiveParentFetch.localPath ?? effectiveParentFetch.packageFs.getRealPath(),
@@ -52,9 +48,9 @@ export class LinkFetcher implements Fetcher {
     );
 
     if (parentFetch.localPath) {
-      return {packageFs: new CwdFS(sourcePath, {baseFs: sourceFs}), releaseFs: effectiveParentFetch.releaseFs, prefixPath: PortablePath.dot, localPath: sourcePath};
+      return {packageFs: new CwdFS(sourcePath, {baseFs: sourceFs}), prefixPath: PortablePath.dot, localPath: sourcePath};
     } else {
-      return {packageFs: new JailFS(sourcePath, {baseFs: sourceFs}), releaseFs: effectiveParentFetch.releaseFs, prefixPath: PortablePath.dot};
+      return {packageFs: new JailFS(sourcePath, {baseFs: sourceFs}), prefixPath: PortablePath.dot};
     }
   }
 }

--- a/packages/plugin-link/sources/LinkResolver.ts
+++ b/packages/plugin-link/sources/LinkResolver.ts
@@ -1,7 +1,7 @@
 import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest, Package}          from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
-import {miscUtils, structUtils}                          from '@yarnpkg/core';
+import {structUtils}                                     from '@yarnpkg/core';
 import {npath}                                           from '@yarnpkg/fslib';
 
 import {LINK_PROTOCOL}                                   from './constants';
@@ -51,9 +51,7 @@ export class LinkResolver implements Resolver {
 
     const packageFetch = await opts.fetchOptions.fetcher.fetch(locator, opts.fetchOptions);
 
-    const manifest = await miscUtils.releaseAfterUseAsync(async () => {
-      return await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
-    }, packageFetch.releaseFs);
+    const manifest = await Manifest.find(packageFetch.prefixPath, {baseFs: packageFetch.packageFs});
 
     return {
       ...locator,

--- a/packages/plugin-link/sources/RawLinkFetcher.ts
+++ b/packages/plugin-link/sources/RawLinkFetcher.ts
@@ -40,10 +40,6 @@ export class RawLinkFetcher implements Fetcher {
       ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath), localPath: PortablePath.root}
       : parentFetch;
 
-    // Discard the parent fs unless we really need it to access the files
-    if (parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-      parentFetch.releaseFs();
-
     const sourceFs = effectiveParentFetch.packageFs;
     const sourcePath = ppath.resolve(
       effectiveParentFetch.localPath ?? effectiveParentFetch.packageFs.getRealPath(),
@@ -52,9 +48,9 @@ export class RawLinkFetcher implements Fetcher {
     );
 
     if (parentFetch.localPath) {
-      return {packageFs: new CwdFS(sourcePath, {baseFs: sourceFs}), releaseFs: effectiveParentFetch.releaseFs, prefixPath: PortablePath.dot, discardFromLookup: true, localPath: sourcePath};
+      return {packageFs: new CwdFS(sourcePath, {baseFs: sourceFs}), prefixPath: PortablePath.dot, discardFromLookup: true, localPath: sourcePath};
     } else {
-      return {packageFs: new JailFS(sourcePath, {baseFs: sourceFs}), releaseFs: effectiveParentFetch.releaseFs, prefixPath: PortablePath.dot, discardFromLookup: true};
+      return {packageFs: new JailFS(sourcePath, {baseFs: sourceFs}), prefixPath: PortablePath.dot, discardFromLookup: true};
     }
   }
 }

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -28,7 +28,7 @@ export class NpmHttpFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote server`),
       loader: () => this.fetchFromNetwork(locator, opts),
@@ -38,7 +38,6 @@ export class NpmHttpFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       checksum,
     };

--- a/packages/plugin-npm/sources/NpmSemverFetcher.ts
+++ b/packages/plugin-npm/sources/NpmSemverFetcher.ts
@@ -30,7 +30,7 @@ export class NpmSemverFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the remote registry`),
       loader: () => this.fetchFromNetwork(locator, opts),
@@ -40,7 +40,6 @@ export class NpmSemverFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       checksum,
     };

--- a/packages/plugin-patch/sources/PatchFetcher.ts
+++ b/packages/plugin-patch/sources/PatchFetcher.ts
@@ -1,6 +1,6 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions, ReportError, MessageName, Report} from '@yarnpkg/core';
 import {Locator}                                                                      from '@yarnpkg/core';
-import {miscUtils, structUtils}                                                       from '@yarnpkg/core';
+import {structUtils}                                                                  from '@yarnpkg/core';
 import {ppath, xfs, ZipFS, Filename, CwdFS, PortablePath}                             from '@yarnpkg/fslib';
 import {getLibzipPromise}                                                             from '@yarnpkg/libzip';
 
@@ -23,7 +23,7 @@ export class PatchFetcher implements Fetcher {
   async fetch(locator: Locator, opts: FetchOptions) {
     const expectedChecksum = opts.checksums.get(locator.locatorHash) || null;
 
-    const [packageFs, releaseFs, checksum] = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
+    const {packageFs, checksum} = await opts.cache.fetchPackageFromCache(locator, expectedChecksum, {
       onHit: () => opts.report.reportCacheHit(locator),
       onMiss: () => opts.report.reportCacheMiss(locator, `${structUtils.prettyLocator(opts.project.configuration, locator)} can't be found in the cache and will be fetched from the disk`),
       loader: () => this.patchPackage(locator, opts),
@@ -33,7 +33,6 @@ export class PatchFetcher implements Fetcher {
 
     return {
       packageFs,
-      releaseFs,
       prefixPath: structUtils.getIdentVendorPath(locator),
       localPath: this.getLocalPath(locator, opts),
       checksum,
@@ -59,9 +58,7 @@ export class PatchFetcher implements Fetcher {
       level: opts.project.configuration.get(`compressionLevel`),
     });
 
-    await miscUtils.releaseAfterUseAsync(async () => {
-      await initialCopy.copyPromise(prefixPath, sourceFetch.prefixPath, {baseFs: sourceFetch.packageFs, stableSort: true});
-    }, sourceFetch.releaseFs);
+    await initialCopy.copyPromise(prefixPath, sourceFetch.prefixPath, {baseFs: sourceFetch.packageFs, stableSort: true});
 
     initialCopy.saveAndClose();
 

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -124,10 +124,6 @@ export async function loadPatchFiles(parentLocator: Locator | null, patchPaths: 
     ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
     : parentFetch;
 
-  // Discard the parent fs unless we really need it to access the files
-  if (parentFetch && parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-    parentFetch.releaseFs();
-
   // First we obtain the specification for all the patches that we'll have to
   // apply to the original package.
   const patchFiles = await miscUtils.releaseAfterUseAsync(async () => {

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -158,7 +158,7 @@ export class Cache {
     }
   }
 
-  async fetchPackageFromCache(locator: Locator, expectedChecksum: string | null, {onHit, onMiss, loader, ...opts}: {onHit?: () => void, onMiss?: () => void, loader?: () => Promise<ZipFS> } & CacheOptions): Promise<[FakeFS<PortablePath>, () => void, string | null]> {
+  async fetchPackageFromCache(locator: Locator, expectedChecksum: string | null, {onHit, onMiss, loader, ...opts}: {onHit?: () => void, onMiss?: () => void, loader?: () => Promise<ZipFS> } & CacheOptions): Promise<{packageFs: FakeFS<PortablePath>, checksum: string | null}> {
     const mirrorPath = this.getLocatorMirrorPath(locator);
 
     const baseFs = new NodeFS();
@@ -355,8 +355,6 @@ export class Cache {
 
     this.markedFiles.add(cachePath);
 
-    let zipFs: ZipFS | undefined;
-
     const libzip = await getLibzipPromise();
 
     const zipFsBuilder = shouldMock
@@ -364,7 +362,7 @@ export class Cache {
       : () => new ZipFS(cachePath, {baseFs, libzip, readOnly: true});
 
     const lazyFs = new LazyFS<PortablePath>(() => miscUtils.prettifySyncErrors(() => {
-      return zipFs = zipFsBuilder();
+      return zipFsBuilder();
     }, message => {
       return `Failed to open the cache entry for ${structUtils.prettyLocator(this.configuration, locator)}: ${message}`;
     }), ppath);
@@ -373,16 +371,16 @@ export class Cache {
     // (there's no need to create the lazy baseFs instance to gather the already-known cachePath)
     const aliasFs = new AliasFS(cachePath, {baseFs: lazyFs, pathUtils: ppath});
 
-    const releaseFs = () => {
-      zipFs?.discardAndClose();
-    };
-
     // We hide the checksum if the package presence is conditional, because it becomes unreliable
     const exposedChecksum = !opts.unstablePackages?.has(locator.locatorHash)
       ? checksum
       : null;
 
-    return [aliasFs, releaseFs, exposedChecksum];
+    // TODO: remove the tuple fallback in the next major
+    return Object.assign({
+      packageFs: aliasFs,
+      checksum: exposedChecksum,
+    }, [aliasFs, () => {}, exposedChecksum]);
   }
 }
 

--- a/packages/yarnpkg-core/sources/Fetcher.ts
+++ b/packages/yarnpkg-core/sources/Fetcher.ts
@@ -25,12 +25,6 @@ export type FetchResult = {
   packageFs: FakeFS<PortablePath>;
 
   /**
-   * If set, this function will be called once the fetch result isn't needed
-   * anymore. Typically used to release the ZipFS memory.
-   */
-  releaseFs?: () => void;
-
-  /**
    * The path where the package can be found within the `packageFs`. This is
    * typically the `node_modules/<scope>/<name>` path.
    */

--- a/packages/yarnpkg-core/sources/Installer.ts
+++ b/packages/yarnpkg-core/sources/Installer.ts
@@ -52,24 +52,6 @@ export type FinalizeInstallData = {
   customData?: any;
 };
 
-export type InstallPackageExtraApi = {
-  /**
-   * The core reclaims the virtual filesystem by default when the
-   * `installPackage` function returns. This may be annoying when working on
-   * parallel installers, since `installPackage` are guaranteed to work
-   * sequentially (and thus no two packages could be installed at the same
-   * time, since one's fs would be closed as soon as the second would start).
-   *
-   * To avoid that, you can call the `holdFetchResult` function from this extra
-   * API to indicate to the core that it shouldn't reclaim the filesystem until
-   * the API passed in parameter as finished executing. Note that this may lead
-   * to higher memory consumption (since multiple packages may be kept in
-   * memory), so you'll need to implement an upper bound to the number of
-   * concurrent package installs.
-   */
-  holdFetchResult: (promise: Promise<void>) => void;
-};
-
 export interface Installer {
   /**
    * Return an arbitrary key.
@@ -105,9 +87,8 @@ export interface Installer {
    *
    * @param pkg The package being installed
    * @param fetchResult The fetched information about the package
-   * @param api An additional API one can use to interact with the core
    */
-  installPackage(pkg: Package, fetchResult: FetchResult, api: InstallPackageExtraApi): Promise<InstallStatus>;
+  installPackage(pkg: Package, fetchResult: FetchResult): Promise<InstallStatus>;
 
   /**
    * Link a package and its internal (same-linker) dependencies.

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -14,7 +14,7 @@ import zlib                                                             from 'zl
 import {Cache, CacheOptions}                                            from './Cache';
 import {Configuration, FormatType}                                      from './Configuration';
 import {Fetcher, FetchOptions}                                          from './Fetcher';
-import {Installer, BuildDirective, BuildType, InstallStatus}            from './Installer';
+import {Installer, BuildDirective, BuildType}                           from './Installer';
 import {LegacyMigrationResolver}                                        from './LegacyMigrationResolver';
 import {Linker, LinkOptions}                                            from './Linker';
 import {LockfileResolver}                                               from './LockfileResolver';
@@ -950,13 +950,10 @@ export class Project {
           return;
         }
 
-        if (fetchResult.checksum != null)
+        if (fetchResult.checksum != null) {
           this.storedChecksums.set(pkg.locatorHash, fetchResult.checksum);
-        else
+        } else {
           this.storedChecksums.delete(pkg.locatorHash);
-
-        if (fetchResult.releaseFs) {
-          fetchResult.releaseFs();
         }
       }).finally(() => {
         progress.tick();
@@ -1017,11 +1014,6 @@ export class Project {
       if (typeof fetchResult === `undefined`)
         throw new Error(`Assertion failed: The fetch result should have been registered`);
 
-      const holdPromises: Array<Promise<void>> = [];
-      const holdFetchResult = (promise: Promise<void>) => {
-        holdPromises.push(promise);
-      };
-
       const workspace = this.tryWorkspaceByLocator(pkg);
       if (workspace !== null) {
         const buildScripts: Array<BuildDirective> = [];
@@ -1031,22 +1023,12 @@ export class Project {
           if (scripts.has(scriptName))
             buildScripts.push([BuildType.SCRIPT, scriptName]);
 
-        try {
-          for (const [linker, installer] of installers) {
-            if (linker.supportsPackage(pkg, linkerOptions)) {
-              const result = await installer.installPackage(pkg, fetchResult, {holdFetchResult});
-              if (result.buildDirective !== null) {
-                throw new Error(`Assertion failed: Linkers can't return build directives for workspaces; this responsibility befalls to the Yarn core`);
-              }
+        for (const [linker, installer] of installers) {
+          if (linker.supportsPackage(pkg, linkerOptions)) {
+            const result = await installer.installPackage(pkg, fetchResult);
+            if (result.buildDirective !== null) {
+              throw new Error(`Assertion failed: Linkers can't return build directives for workspaces; this responsibility befalls to the Yarn core`);
             }
-          }
-        } finally {
-          if (holdPromises.length === 0) {
-            fetchResult.releaseFs?.();
-          } else {
-            pendingPromises.push(Promise.all(holdPromises).catch(() => {}).then(() => {
-              fetchResult.releaseFs?.();
-            }));
           }
         }
 
@@ -1069,18 +1051,7 @@ export class Project {
         if (!installer)
           throw new Error(`Assertion failed: The installer should have been registered`);
 
-        let installStatus: InstallStatus;
-        try {
-          installStatus = await installer.installPackage(pkg, fetchResult, {holdFetchResult});
-        } finally {
-          if (holdPromises.length === 0) {
-            fetchResult.releaseFs?.();
-          } else {
-            pendingPromises.push(Promise.all(holdPromises).then(() => {}).then(() => {
-              fetchResult.releaseFs?.();
-            }));
-          }
-        }
+        const installStatus = await installer.installPackage(pkg, fetchResult);
 
         packageLinkers.set(pkg.locatorHash, linker);
         packageLocations.set(pkg.locatorHash, installStatus.packageLocation);

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -17,7 +17,7 @@ export type {PluginConfiguration, SettingsDefinition, MapConfigurationValue, Pac
 export type {ConfigurationValueMap, ConfigurationDefinitionMap}                                           from './Configuration';
 export type {Fetcher, FetchOptions, FetchResult, MinimalFetchOptions}                                     from './Fetcher';
 export {BuildType}                                                                                        from './Installer';
-export type {Installer, BuildDirective, InstallStatus, InstallPackageExtraApi, FinalizeInstallStatus}     from './Installer';
+export type {Installer, BuildDirective, InstallStatus, FinalizeInstallStatus}     from './Installer';
 export {LightReport}                                                                                      from './LightReport';
 export type {Linker, LinkOptions, MinimalLinkOptions}                                                     from './Linker';
 export {Manifest}                                                                                         from './Manifest';


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`ZipFS` memory management was entirely manual - we always had to call one of `ZipFS.prototype.{save,discard}AndClose` to avoid memory leaks. This was very unfortunate because we had to design other parts of the architecture with this in mind. For example, the `fetchResult`s had a `releaseFs` function that would release the `ZipFS` memory and that had to be called immediately after using the fetch results. This meant that it was hard for us to reuse `fetchResult`s between different functions and the performance was taking a hit because of this (e.g. the link step had to decompress all archives again).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made ZipFS memory management entirely automatic using [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) to automatically free the memory allocated by libzip when the `ZipFS` instances are garbage-collected.

Now, unfortunately `FinalizationRegistry` only got introduced in Node 14.6.0 and we still have to support Node 12.x over Yarn 3.x's lifetime. Because of this, I don't see how this PR could be merged earlier than Yarn 4.x.

**Breaking Changes:**
- The usage of `FinalizationRegistry` that requires us to drop support for Node 12. If we find a way to avoid memory leaks we can gate it behind the presence of `FinalizationRegistry`.
- `api.holdFetchResult` inside `Installer['installPackage']` got removed since it doesn't make sense anymore. It got introduced in 3.1 so most likely nobody's using it, but it can be replaced with a no-op function if absolutely necessary.
- Removed `releaseFs` from `FetchResult`. It shouldn't affect people that returned it or called it since it was optional anyways. It's a type-only breaking change.
- Made `fetchPackageFromCache` return an object with the results rather than a tuple so that it isn't order dependent. Still kept the tuple via `Object.assign` magic so that it isn't a runtime breaking change since all third-party plugins that add fetchers that use the cache would have to be updated. Yet again, a type-only breaking change for now. I don't intend to remove the fallback until at least Yarn 5.x.
- The fact that `releaseFs` won't be called anymore, leading to memory leaks on Node 12. I don't see what we can do about this. I need to note the fact that these memory leaks wouldn't happen at runtime when using PnP since things would still go through the `ZipOpenFS` then which still cleans up the memory, so they would only happen during installs. I intend to benchmark the memory usage on very large repos and, depending on how significant this memory leak is, we might be able to even ignore it? :thinking: If that's the case we could land this in a minor with a few more tweaks.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
