### PR TITLE
Note that Zero-Installs depends on Plug'n'Play

### DIFF
--- a/packages/gatsby/content/features/zero-installs.md
+++ b/packages/gatsby/content/features/zero-installs.md
@@ -27,13 +27,15 @@ In order to make a project zero-install, you must be able to use it as soon as y
 
 - First, ensure that your project is using [Plug'n'Play](/features/plugnplay) to resolve dependencies via the cache folder and **not** from `node_modules`.
 
+  - While in theory you could check-in your `node_modules` folder rather than the cache, in practice the `node_modules` contains a gigantic amount of files that frequently change location and mess with Git's optimizations. By contrast, the Yarn cache contains exactly one file per package, that only change when the packages themselves change.
+
 - The cache folder is by default stored within your project folder (in `.yarn/cache`). Just make sure you add it to your repository (see also, [Offline Cache](/features/offline-cache)).
 
   - Again, this whole workflow is optional. If at some point you decide that in the end you prefer to keep using a global cache, just toggle on `enableGlobalCache` in the [yarnrc settings](/configuration/yarnrc#enableGlobalCache) and it'll be back to normal.
 
 - When running `yarn install`, Yarn will generate a `.pnp.cjs` file. Add it to your repository as well - it contains the dependency tree that Node will use to load your packages.
 
-- Depending on whether your dependencies have install scripts or not (we advise you to avoid it if you can and prefer wasm-powered alternatives) you may also want to add the `.yarn/unplugged` entries.
+- Depending on whether your dependencies have install scripts or not (we advise you to avoid it if you can, and prefer wasm-powered alternatives) you may also want to add the `.yarn/unplugged` entries.
 
 And that's it! Push your changes to your repository, checkout a new one somewhere, and check whether running `yarn start` (or whatever other script you'd normally use) works.
 

--- a/packages/gatsby/content/features/zero-installs.md
+++ b/packages/gatsby/content/features/zero-installs.md
@@ -25,6 +25,8 @@ Note that these challenges are not unique to Yarn — you may remember a time wh
 
 In order to make a project zero-install, you must be able to use it as soon as you clone it. This is very easy starting from Yarn 2!
 
+- First, ensure that your project is using [Plug'n'Play](/features/plugnplay) to resolve dependencies via the cache folder and **not** from `node_modules`.
+
 - The cache folder is by default stored within your project folder (in `.yarn/cache`). Just make sure you add it to your repository (see also, [Offline Cache](/features/offline-cache)).
 
   - Again, this whole workflow is optional. If at some point you decide that in the end you prefer to keep using a global cache, just toggle on `enableGlobalCache` in the [yarnrc settings](/configuration/yarnrc#enableGlobalCache) and it'll be back to normal.


### PR DESCRIPTION
**What's the problem this PR addresses?**

This PR adds a note to the docs that Zero-Installs depends on a project using Plug'n'Play. I ran into this following the [guide][migration-steps] to migrate from Yarn classic to Yarn 2. One step links out to a help item on [how to update the `.gitignore`][gitignore-faq], which mentions the Zero-Installs feature as an option. I followed the link to the feature page to understand more about it, but only when attempting to adopt the feature did it become clear that I would first have to use Plug'n'Play. I am blocked on adopting it as my project uses Flow.

**How did you fix it?**

The bullet points on the Zero-Installs page provides the sequence to enable the feature. I've added an extra step at the beginning to call out that projects using `node_modules` will have to first enable the Plug'n'Play feature to resolve dependencies from the cache.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

[migration-steps]: https://yarnpkg.com/getting-started/migration#step-by-step
[gitignore-faq]: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored