### PR TITLE
fix: use latest stable yarn version as the wrapper in the packageManager field if the yarn version isn't tagged

### DIFF
--- a/.yarn/versions/5e317228.yml
+++ b/.yarn/versions/5e317228.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -190,6 +190,8 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
     if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion))
       manifest.packageManager = `yarn@${bundleVersion}`;
+    else
+      manifest.packageManager = null;
 
     const data = {};
     manifest.exportTo(data);

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -188,11 +188,12 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
     const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();
 
-    if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion))
-      manifest.packageManager = `yarn@${bundleVersion}`;
-    else
-      // If the version isn't tagged, we use the latest stable version as the wrapper
-      manifest.packageManager = await resolveTag(configuration, `stable`);
+    manifest.packageManager = `yarn@${
+      bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion)
+        ? bundleVersion
+        // If the version isn't tagged, we use the latest stable version as the wrapper
+        : await resolveTag(configuration, `stable`)
+    }`;
 
     const data = {};
     manifest.exportTo(data);

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -191,7 +191,8 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
     if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion))
       manifest.packageManager = `yarn@${bundleVersion}`;
     else
-      manifest.packageManager = null;
+      // If the version isn't tagged, we use the latest stable version as the wrapper
+      manifest.packageManager = await resolveTag(configuration, `stable`);
 
     const data = {};
     manifest.exportTo(data);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn set version` sets the `packageManager` field of the top-level-manifest if the Yarn version is tagged (i.e. released on the registry), but it doesn't change it when the Yarn version isn't tagged (e.g. `yarn set version from sources` or `yarn set version <path-that-has-untagged-version>`). In these cases the version specified inside the `packageManager` field is the one used as the wrapper that calls the real Yarn binary that the project uses, and it's recommended to keep it up to date. Because of this I made `yarn set version` use the latest stable version as the wrapper.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it set it to the latest stable version.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
