### PR TITLE
correct gitignore placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ package.tgz
 /vscode-case-study
 
 .idea
+
+# deepcode
+.dccache

--- a/packages/gatsby/content/getting-started/questions-and-answers.md
+++ b/packages/gatsby/content/getting-started/questions-and-answers.md
@@ -42,25 +42,25 @@ Most projects will only face those four problems, which can all be fixed in a go
 If you're using Zero-Installs:
 
 ```gitignore
-.yarn/*
 !.yarn/cache
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+.yarn/*
 ```
 
 If you're not using Zero-Installs:
 
 ```gitignore
-.pnp.*
-.yarn/*
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+.yarn/*
+.pnp.*
 ```
 
 If you're interested to know more about each of these files:


### PR DESCRIPTION
**What's the problem this PR addresses?**
Wrong `.gitignore` placement. It causes me trouble, I mostly accidentally push cache to the repo.

...

**How did you fix it?**
I just put the parent directory below.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
