### PR TITLE
docs: fix the broken plugnplay link

### DIFF
--- a/packages/gatsby/content/features/zero-installs.md
+++ b/packages/gatsby/content/features/zero-installs.md
@@ -25,7 +25,7 @@ Note that these challenges are not unique to Yarn — you may remember a time wh
 
 In order to make a project zero-install, you must be able to use it as soon as you clone it. This is very easy starting from Yarn 2!
 
-- First, ensure that your project is using [Plug'n'Play](/features/plugnplay) to resolve dependencies via the cache folder and **not** from `node_modules`.
+- First, ensure that your project is using [Plug'n'Play](/features/pnp) to resolve dependencies via the cache folder and **not** from `node_modules`.
 
   - While in theory you could check-in your `node_modules` folder rather than the cache, in practice the `node_modules` contains a gigantic amount of files that frequently change location and mess with Git's optimizations. By contrast, the Yarn cache contains exactly one file per package, that only change when the packages themselves change.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
The plug n' play link in [zero installs](http://localhost:8000/features/zero-installs) is broken. The link toward plug n' play document seems to be changed before. 

**How did you fix it?**
I changed the broken link from `/features/plugnplay` to `/features/pnp`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
