### PR TITLE
fix: catch error to find a locator

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -382,5 +382,22 @@ describe(`Commands`, () => {
         expect(cacheAfter.find(entry => entry.includes(`no-deps-npm-2.0.0`))).toBeDefined();
       }),
     );
+    test(`it should throw a proper error if not find any locator`,
+      makeTemporaryEnv(
+        {
+          workspaces: [`workspace`],
+        },
+        async ({path, run, source}) => {
+          await xfs.mkdirPromise(`${path}/non-workspace`);
+          await xfs.writeJsonPromise(`${path}/non-workspace/package.json`, {
+            name: `non-workspace`,
+          });
+
+          await expect(run(`install`, {cwd: `${path}/non-workspace`})).rejects.toMatchObject({
+            code: 1,
+            stdout: expect.stringMatching(/The nearest package directory \(.+\) doesn't seem to be part of the project declared in .+\./g),
+          });
+        },
+      ));
   });
 });

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -624,18 +624,20 @@ export class Project {
     const linkerOptions = {project: this, report};
 
     for (const linker of linkers) {
-      const locator = await linker.findPackageLocator(cwd, linkerOptions);
-      if (locator) {
-        // If strict mode, the specified cwd must be a package,
-        // not merely contained in a package.
-        if (strict) {
-          const location = await linker.findPackageLocation(locator, linkerOptions);
-          if (location.replace(TRAILING_SLASH_REGEXP, ``) !== cwd.replace(TRAILING_SLASH_REGEXP, ``)) {
-            continue;
+      try {
+        const locator = await linker.findPackageLocator(cwd, linkerOptions);
+        if (locator) {
+          // If strict mode, the specified cwd must be a package,
+          // not merely contained in a package.
+          if (strict) {
+            const location = await linker.findPackageLocation(locator, linkerOptions);
+            if (location.replace(TRAILING_SLASH_REGEXP, ``) !== cwd.replace(TRAILING_SLASH_REGEXP, ``)) {
+              continue;
+            }
           }
+          return locator;
         }
-        return locator;
-      }
+      } catch (_) {}
     }
 
     return null;

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -637,7 +637,7 @@ export class Project {
           }
           return locator;
         }
-      } catch (_) {}
+      } catch {}
     }
 
     return null;


### PR DESCRIPTION
**What's the problem this PR addresses?**

findPackageLocator or findPackageLocation may throw an Error to break the for-loop.

Closes #3777

**How did you fix it?**

catch the error to continue

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
