### PR TITLE
fix(core): normalize scoped bin entries

### DIFF
--- a/.yarn/versions/203ecb3c.yml
+++ b/.yarn/versions/203ecb3c.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-1.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-1.0.0/bin.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log(require(`./package.json`).version);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@scoped/has-bin-entry",
+	"version": "1.0.0",
+	"bin": {
+		"@scoped/has-bin-entry": "./bin.js"
+	}
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
@@ -137,5 +137,23 @@ describe(`Commands`, () => {
         },
       ),
     );
+
+    test(`it should normalize scoped bin entries`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            "@scoped/has-bin-entry": `1.0.0`,
+          },
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          await expect(run(`run`, `has-bin-entry`)).resolves.toMatchObject({
+            code: 0,
+            stdout: `1.0.0\n`,
+          });
+        },
+      ),
+    );
   });
 });

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -296,7 +296,22 @@ export class Manifest {
           continue;
         }
 
-        this.bin.set(key, normalizeSlashes(value));
+        // Some registries incorrectly normalize the `bin` field of
+        // scoped packages to be invalid filenames.
+        // E.g. from
+        // {
+        //   "name": "@yarnpkg/doctor",
+        //   "bin": "index.js"
+        // }
+        // to
+        // {
+        //   "name": "@yarnpkg/doctor",
+        //   "bin": {
+        //     "@yarnpkg/doctor": "index.js"
+        //   }
+        // }
+        const binaryIdent = structUtils.parseIdent(key);
+        this.bin.set(binaryIdent.name, normalizeSlashes(value));
       }
     }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some registries incorrectly normalize the `bin` field of scoped packages to be invalid.
E.g. from

```json
{
	"name": "@yarnpkg/doctor",
	"bin": "index.js"
}
```

to

```json
{
	"name": "@yarnpkg/doctor",
	"bin": {
		"@yarnpkg/doctor": "index.js"
	}
}
```

Fixes https://github.com/yarnpkg/berry/issues/3793

**How did you fix it?**

Since binaries are valid idents parse them as such and only use the name, ignoring the scope

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.