### PR TITLE
Remove number from titles in getting started docs

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -1,7 +1,7 @@
 ---
 category: getting-started
 path: /getting-started/install
-title: "2 - Installation"
+title: "Installation"
 description: Yarn's in-depth installation guide.
 ---
 

--- a/packages/gatsby/content/getting-started/intro.md
+++ b/packages/gatsby/content/getting-started/intro.md
@@ -1,7 +1,7 @@
 ---
 category: getting-started
 path: /getting-started
-title: "1 - Introduction"
+title: "Introduction"
 description: An introduction to Yarn, a package manager for your code.
 ---
 

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -1,7 +1,7 @@
 ---
 category: getting-started
 path: /getting-started/usage
-title: "3 - Usage"
+title: "Usage"
 description: A short overview of Yarn's most used commands.
 ---
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Only the first three pages in "getting started" docs has number in their title, which is inconsistent with other pages. Plus, the order is very obvious, most people probably don't need such a thing.

![image](https://user-images.githubusercontent.com/44045911/143734124-17c66e85-53dc-4914-a91e-497c2037389f.png)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Remove the number from the titles.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
