### PR TITLE
fix(core): ignore corrupted install state

### DIFF
--- a/.yarn/versions/e0e4e264.yml
+++ b/.yarn/versions/e0e4e264.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - The ESM loader is now enabled regardless of the entrypoint module type, this fixes support for dynamic imports in commonjs modules when the entrypoint is also commonjs
 - `yarn workspaces foreach run` is now able to run binaries
 - The `node` field inside the `npm_config_user_agent` Yarn sets will now include a leading `v`.
+- Yarn is now able to recover from a corrupted install state.
 
 ### Miscellaneous Features
 

--- a/packages/yarnpkg-core/tests/Project.test.ts
+++ b/packages/yarnpkg-core/tests/Project.test.ts
@@ -283,4 +283,22 @@ describe(`Project`, () => {
       }
     });
   });
+
+  it(`should recover from a corrupted install state`, async() => {
+    await xfs.mktempPromise(async dir => {
+      await xfs.writeJsonPromise(ppath.join(dir, Filename.manifest), {name: `foo`});
+      await xfs.writeFilePromise(ppath.join(dir, Filename.lockfile), ``);
+
+      const configuration = getConfiguration(dir);
+      const {project} = await Project.find(configuration, dir);
+      const cache = await Cache.find(configuration);
+
+      await project.install({cache, report: new ThrowReport()});
+
+      const statePath = configuration.get(`installStatePath`);
+      await xfs.writeFilePromise(statePath, `invalid state`);
+
+      await expect(project.restoreInstallState()).resolves.toEqual(undefined);
+    });
+  });
 });

--- a/packages/yarnpkg-core/tests/Project.test.ts
+++ b/packages/yarnpkg-core/tests/Project.test.ts
@@ -298,7 +298,7 @@ describe(`Project`, () => {
       const statePath = configuration.get(`installStatePath`);
       await xfs.writeFilePromise(statePath, `invalid state`);
 
-      await expect(project.restoreInstallState()).resolves.toEqual(undefined);
+      await expect(project.restoreInstallState()).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

If for whatever reason the install state is corrupted then Yarn is unable to recover and the user has to manually delete the install state to continue.

**How did you fix it?**

Catch the error and carry on as if the install state doesn't exist.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.