### PR TITLE
chore(compat): add peer dependencies for `@docusaurus/responsive-loader`

### DIFF
--- a/.yarn/versions/92db221e.yml
+++ b/.yarn/versions/92db221e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -703,4 +703,11 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'webpack-cli': optionalPeerDep,
     },
   }],
+  // https://github.com/slorber/responsive-loader/pull/1/files
+  [`@docusaurus/responsive-loader@<1.5.0`, {
+    peerDependenciesMeta: {
+      sharp: optionalPeerDep,
+      jimp: optionalPeerDep,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

See https://github.com/slorber/responsive-loader/pull/1

**How did you fix it?**

Added sharp and jimp as peer dependencies, which is the intended functionality

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
