### PR TITLE
docs: allow specifying order via front matter

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -1,8 +1,9 @@
 ---
 category: getting-started
 path: /getting-started/install
-title: "2 - Installation"
+title: Installation
 description: Yarn's in-depth installation guide.
+order: 2
 ---
 
 ## Install Corepack

--- a/packages/gatsby/content/getting-started/intro.md
+++ b/packages/gatsby/content/getting-started/intro.md
@@ -1,8 +1,9 @@
 ---
 category: getting-started
 path: /getting-started
-title: "1 - Introduction"
+title: Introduction
 description: An introduction to Yarn, a package manager for your code.
+order: 1
 ---
 
 Yarn is a package manager for your code. It allows you to use and share code with other developers from around the world. Yarn does this quickly, securely, and reliably so you don't ever have to worry.

--- a/packages/gatsby/content/getting-started/usage.md
+++ b/packages/gatsby/content/getting-started/usage.md
@@ -1,8 +1,9 @@
 ---
 category: getting-started
 path: /getting-started/usage
-title: "3 - Usage"
+title: Usage
 description: A short overview of Yarn's most used commands.
+order: 3
 ---
 
 Now that you have Yarn [installed](/getting-started/install), you can start using it! Here are some of the most common commands you'll need.

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -35,9 +35,9 @@ export default function Template({data}) {
     const item = {
       to: path,
       name: title,
-    }
+    };
 
-    if (typeof order === 'number') {
+    if (typeof order === `number`) {
       orderedItems[order - 1] = item;
     } else {
       items.push(item);

--- a/packages/gatsby/src/templates/article.js
+++ b/packages/gatsby/src/templates/article.js
@@ -23,16 +23,30 @@ function getGitPageUrl(postAbsolutePath) {
 }
 
 // eslint-disable-next-line arca/no-default-export
-export default function Template({data, pageContext: {category}}) {
+export default function Template({data}) {
   const {allMarkdownRemark, markdownRemark} = data;
   const {frontmatter, html, fileAbsolutePath} = markdownRemark;
 
+  const orderedItems = [];
+  const items = [];
+
+  for (const {node} of allMarkdownRemark.edges) {
+    const {path, title, order} = node.frontmatter;
+    const item = {
+      to: path,
+      name: title,
+    }
+
+    if (typeof order === 'number') {
+      orderedItems[order - 1] = item;
+    } else {
+      items.push(item);
+    }
+  }
+
   return <>
     <Global styles={GlobalStyleOverrides} />
-    <LayoutContentNav items={allMarkdownRemark.edges.map(({node}) => ({
-      to: node.frontmatter.path,
-      name: node.frontmatter.title,
-    }))}>
+    <LayoutContentNav items={orderedItems.concat(items)}>
       <SEO
         title={frontmatter.title}
         description={frontmatter.description}
@@ -56,6 +70,7 @@ export const pageQuery = graphql`
           frontmatter {
             path
             title
+            order
           }
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Supersede #3806

This PR introduces the ability to specifying the order of documentation article in the side navigation via `order` front matter.

![image](https://user-images.githubusercontent.com/44045911/143909352-a5f8aa6f-31ed-421c-a80b-ddd7c29c0027.png)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
