### PR TITLE
feat(vscode-zipfs): unmount

### DIFF
--- a/.yarn/versions/70f09833.yml
+++ b/.yarn/versions/70f09833.yml
@@ -1,0 +1,2 @@
+releases:
+  vscode-zipfs: minor

--- a/packages/vscode-zipfs/package.json
+++ b/packages/vscode-zipfs/package.json
@@ -41,7 +41,12 @@
     "commands": [
       {
         "command": "zipfs.mountZipFile",
-        "title": "Mount as Zip",
+        "title": "Mount Zip",
+        "category": "Zip"
+      },
+      {
+        "command": "zipfs.unmountZipFile",
+        "title": "Unmount Zip",
         "category": "Zip"
       },
       {
@@ -53,8 +58,13 @@
     "menus": {
       "explorer/context": [
         {
-          "when": "resourceLangId == zip",
+          "when": "resourceLangId == zip && !explorerResourceIsRoot",
           "command": "zipfs.mountZipFile",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == zip && explorerResourceIsRoot",
+          "command": "zipfs.unmountZipFile",
           "group": "navigation"
         }
       ],
@@ -62,6 +72,10 @@
         {
           "when": "false",
           "command": "zipfs.mountZipFile"
+        },
+        {
+          "when": "false",
+          "command": "zipfs.unmountZipFile"
         },
         {
           "when": "editorLangId == zip",

--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -15,6 +15,29 @@ function mount(uri: vscode.Uri) {
   }
 }
 
+function unmount(uri: vscode.Uri): void {
+  const zipUri = vscode.Uri.parse(`zip:${uri.fsPath}`);
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(zipUri);
+  if (!workspaceFolder) {
+    vscode.window.showErrorMessage(`Cannot unmount ${zipUri.fsPath}: not mounted`);
+    return;
+  }
+
+  if (!vscode.workspace.workspaceFolders)
+    throw new Error(`Assertion failed: workspaceFolders is undefined`);
+
+  // When calling `updateWorkspaceFolders`, vscode still keeps the "workspace mode" even if a single folder remains which is quite annoying.
+  // Because of this, we execute `vscode.openFolder` to open the workspace folder.
+  if (vscode.workspace.workspaceFolders.length === 2) {
+    const otherFolder = vscode.workspace.workspaceFolders.find(folder => folder.index !== workspaceFolder.index)!;
+
+    vscode.commands.executeCommand(`vscode.openFolder`, otherFolder.uri, {forceNewWindow: false});
+  } else {
+    vscode.workspace.updateWorkspaceFolders(workspaceFolder.index, 1);
+  }
+}
+
 export function activate(context: vscode.ExtensionContext) {
   // Until a more specific activation event exists this requires onStartupFinished
   context.subscriptions.push(registerTerminalLinkProvider());
@@ -25,6 +48,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(vscode.commands.registerCommand(`zipfs.mountZipFile`, (uri: vscode.Uri) => {
     mount(uri);
+  }));
+
+  context.subscriptions.push(vscode.commands.registerCommand(`zipfs.unmountZipFile`, (uri: vscode.Uri) => {
+    unmount(uri);
   }));
 
   context.subscriptions.push(vscode.commands.registerCommand(`zipfs.mountZipEditor`, () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`vscode-zipfs` didn't offer a way to unmount a zip file from the context menu.

Fixes https://github.com/yarnpkg/berry/issues/3730.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added an `unmountZipFile` command that is only shown when the zip file is mounted. It either removes the zip file from the current workspace if there are multiple remaining folders in that workspace or it gets rid of the workspace and returns back to "single-folder mode" otherwise.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
