### PR TITLE
fix(core): fix deduping of aliased virtual packages

### DIFF
--- a/.yarn/versions/7f7ad3c0.yml
+++ b/.yarn/versions/7f7ad3c0.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/dragon.test.js
@@ -597,6 +597,89 @@ describe(`Dragon tests`, () => {
             })()
         `)).resolves.toEqual(shouldHaveAccessToTheSameInstance);
         },
-      ));
+      ),
+    );
   }
+
+  test(
+    `it should pass the dragon test 12`,
+    makeTemporaryEnv(
+      {
+        workspaces: [
+          `pkg-a`,
+          `pkg-b`,
+        ],
+      },
+      async ({path, run, source}) => {
+        // This dragon test represents the following scenario:
+        //
+        // .
+        // ├── pkg-a/
+        // │   └── pkg-b
+        // └── pkg-b/
+        //     ├── pkg-c@1.0.0/
+        //     │   └── (peer) doesn't matter
+        //     └── pkg-d (alias to pkg-c@1.0.0)
+        //
+        // When this situation arises, because pkg-b is a dependency of pkg-a,
+        // it'll be traversed a first time as a dependency and will generate a
+        // virtual package for itself plus pkg-c and pkg-d. Something to note
+        // is that Yarn will not dedupe them into one virtual, because they
+        // have different idents and we don't support deduping across different
+        // idents (2021-12-01).
+        //
+        // Then a second pass is made, this time when Yarn iterates over pkg-b
+        // on its own (because it's a workspace, so it has its own perspective).
+        // During this new pass, Yarn sees that pkg-c already exists with the
+        // exact same set of dependencies (because it reified it at the time of
+        // the pkg-a pass). It'll then dedupe it rather than create a new virtual.
+        //
+        // But that's not it! pkg-d is then traversed as well, since it's also
+        // part of pkg-b's dependencies. However, while it's in the same case as
+        // pkg-c before it (it should be deduped because we already reified
+        // pkg-d during the pkg-a pass), a bug may trigger and Yarn will omit
+        // deduping it *while still referencing the package that got deduped
+        // away by pkg-c*.
+        //
+        // Indeed, since pkg-d is an alias of pkg-c, it also references the
+        // same virtual package (ie resolution). The problem is that this
+        // virtual package got deleted when traversing pkg-c. While in theory
+        // this isn't much of a problem (since we delete it from a set it's
+        // not a problem if we delete it twice), we have a heuristic supposed
+        // to determine whether the deduping is stable: we check whether the
+        // virtual package is deleted and, if it is, then we assume that a
+        // package doesn't need to be deduped.
+        //
+        // Since in the case of pkg-d the virtual package got already deleted
+        // by pkg-c, Yarn never went to apply the dedupe pass on pkg-d, causing
+        // it to still reference the deleted package, and thus crash down the
+        // road.
+        //
+        // I admit it's a little complex; feel free to read the commit changes,
+        // it's very small and may give you a better understanding.
+
+        await xfs.mkdirPromise(`${path}/pkg-a`);
+        await xfs.writeJsonPromise(`${path}/pkg-a/package.json`, {
+          name: `pkg-a`,
+          dependencies: {
+            [`pkg-b`]: `workspace:*`,
+          },
+        });
+
+        await xfs.mkdirPromise(`${path}/pkg-b`);
+        await xfs.writeJsonPromise(`${path}/pkg-b/package.json`, {
+          name: `pkg-b`,
+          dependencies: {
+            [`peer-deps`]: `1.0.0`,
+            [`fake-peer-deps`]: `npm:peer-deps@1.0.0`,
+          },
+          peerDependencies: {
+            [`whatever`]: `*`,
+          },
+        });
+
+        await run(`install`);
+      },
+    ),
+  );
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

I explained the issue in detail in the dragon test comment, feel free to take a look there.

**How did you fix it?**

I changed the heuristic so that instead of checking whether the virtual package got deleted, we now check whether the dependency got updated. It may be a very little bit slower, but better matches the intent of the code (to check whether the dependency needs to be deduped).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
