### PR TITLE
docs: use BaseCommand in plugin tutorial

### DIFF
--- a/packages/gatsby/content/advanced/plugin-tutorial.md
+++ b/packages/gatsby/content/advanced/plugin-tutorial.md
@@ -63,9 +63,9 @@ Plugins can also register their own commands. To do this, we just have to write 
 module.exports = {
   name: `plugin-hello-world`,
   factory: require => {
-    const {Command} = require(`clipanion`);
+    const {BaseCommand} = require(`@yarnpkg/cli`);
 
-    class HelloWorldCommand extends Command {
+    class HelloWorldCommand extends BaseCommand {
       static paths = [[`hello`]];
 
       async execute() {
@@ -88,10 +88,11 @@ Now, try to run `yarn hello`. You'll see your message appear! Note that you can 
 module.exports = {
   name: `plugin-addition`,
   factory: require => {
-    const {Command, Option} = require(`clipanion`);
+    const {BaseCommand} = require(`@yarnpkg/cli`);
+    const {Option} = require(`clipanion`);
     const t = require(`typanion`);
 
-    class AdditionCommand extends Command {
+    class AdditionCommand extends BaseCommand {
       static paths = [[`addition`]];
 
       // Show descriptive usage for a --help argument passed to this command


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The plugin tutorial used commands that extended `Command` instead of `BaseCommand`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Changed it to use `BaseCommand`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
