### PR TITLE
fix(core): prevents findPackageLocation from being called from unactivated linkers

### DIFF
--- a/.yarn/versions/7d8190c0.yml
+++ b/.yarn/versions/7d8190c0.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -351,6 +351,22 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should throw a proper error if not find any locator`,
+      makeTemporaryEnv(
+        async ({path, run, source}) => {
+          await xfs.mkdirPromise(`${path}/non-workspace`);
+          await xfs.writeJsonPromise(`${path}/non-workspace/package.json`, {
+            name: `non-workspace`,
+          });
+
+          await expect(run(`install`, {cwd: `${path}/non-workspace`})).rejects.toMatchObject({
+            code: 1,
+            stdout: expect.stringMatching(/The nearest package directory \(.+\) doesn't seem to be part of the project declared in .+\./g),
+          });
+        },
+      ));
+
+    test(
       `it should fetch only required packages when using \`--mode=update-lockfile\``,
       makeTemporaryEnv({
         dependencies: {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -352,19 +352,18 @@ describe(`Commands`, () => {
 
     test(
       `it should throw a proper error if not find any locator`,
-      makeTemporaryEnv(
-        async ({path, run, source}) => {
-          await xfs.mkdirPromise(`${path}/non-workspace`);
-          await xfs.writeJsonPromise(`${path}/non-workspace/package.json`, {
-            name: `non-workspace`,
-          });
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await xfs.mkdirPromise(`${path}/non-workspace`);
+        await xfs.writeJsonPromise(`${path}/non-workspace/package.json`, {
+          name: `non-workspace`,
+        });
 
-          await expect(run(`install`, {cwd: `${path}/non-workspace`})).rejects.toMatchObject({
-            code: 1,
-            stdout: expect.stringMatching(/The nearest package directory \(.+\) doesn't seem to be part of the project declared in .+\./g),
-          });
-        },
-      ));
+        await expect(run(`install`, {cwd: `${path}/non-workspace`})).rejects.toMatchObject({
+          code: 1,
+          stdout: expect.stringMatching(/The nearest package directory \(.+\) doesn't seem to be part of the project declared in .+\./g),
+        });
+      }),
+    );
 
     test(
       `it should fetch only required packages when using \`--mode=update-lockfile\``,

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -40,7 +40,7 @@ export class NodeModulesLinker implements Linker {
 
   async findPackageLocation(locator: Locator, opts: LinkOptions) {
     if (!this.isEnabled(opts))
-      throw new Error(`Assertion failed: Expected the npm linker to be enabled`);
+      throw new Error(`Assertion failed: Expected the node-modules linker to be enabled`);
 
     const workspace = opts.project.tryWorkspaceByLocator(locator);
     if (workspace)

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -35,10 +35,13 @@ export class NodeModulesLinker implements Linker {
   private installStateCache: Map<string, Promise<InstallState | null>> = new Map();
 
   supportsPackage(pkg: Package, opts: MinimalLinkOptions) {
-    return opts.project.configuration.get(`nodeLinker`) === `node-modules`;
+    return this.isEnabled(opts);
   }
 
   async findPackageLocation(locator: Locator, opts: LinkOptions) {
+    if (!this.isEnabled(opts))
+      throw new Error(`Assertion failed: Expected the npm linker to be enabled`);
+
     const workspace = opts.project.tryWorkspaceByLocator(locator);
     if (workspace)
       return workspace.cwd;
@@ -62,6 +65,9 @@ export class NodeModulesLinker implements Linker {
   }
 
   async findPackageLocator(location: PortablePath, opts: LinkOptions) {
+    if (!this.isEnabled(opts))
+      return null;
+
     const installState = await miscUtils.getFactoryWithDefault(this.installStateCache, opts.project.cwd, async () => {
       return await findInstallState(opts.project, {unrollAliases: true});
     });
@@ -88,6 +94,10 @@ export class NodeModulesLinker implements Linker {
 
   makeInstaller(opts: LinkOptions) {
     return new NodeModulesInstaller(opts);
+  }
+
+  private isEnabled(opts: MinimalLinkOptions) {
+    return opts.project.configuration.get(`nodeLinker`) === `node-modules`;
   }
 }
 

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -11,11 +11,11 @@ export type PnpmCustomData = {
 
 export class PnpmLinker implements Linker {
   supportsPackage(pkg: Package, opts: MinimalLinkOptions) {
-    return opts.project.configuration.get(`nodeLinker`) === `pnpm`;
+    return this.isEnabled(opts);
   }
 
   async findPackageLocation(locator: Locator, opts: LinkOptions) {
-    if (opts.project.configuration.get(`nodeLinker`) !== `pnpm`)
+    if (!this.isEnabled(opts))
       throw new Error(`Assertion failed: Expected the pnpm linker to be enabled`);
 
     const customDataKey = getCustomDataKey();
@@ -31,7 +31,7 @@ export class PnpmLinker implements Linker {
   }
 
   async findPackageLocator(location: PortablePath, opts: LinkOptions): Promise<Locator | null> {
-    if (opts.project.configuration.get(`nodeLinker`) !== `pnpm`)
+    if (!this.isEnabled(opts))
       return null;
 
     const customDataKey = getCustomDataKey();
@@ -64,6 +64,10 @@ export class PnpmLinker implements Linker {
 
   makeInstaller(opts: LinkOptions) {
     return new PnpmInstaller(opts);
+  }
+
+  private isEnabled(opts: MinimalLinkOptions) {
+    return opts.project.configuration.get(`nodeLinker`) === `pnpm`;
   }
 }
 
@@ -235,18 +239,19 @@ class PnpmInstaller implements Installer {
 
           const storeEntryPath = ppath.join(storeLocation, storeEntry as Filename);
 
-          removals.push(xfs.readdirPromise(storeEntryPath).then(entries => {
-            return Promise.all(entries.map(async entry => {
-              const p = ppath.join(storeEntryPath, entry);
-              if (entry === Filename.nodeModules) {
-                const extraneous = await getNodeModulesListing(p);
-                extraneous.delete(identComponents.join(ppath.sep) as PortablePath);
-                return cleanNodeModules(p, extraneous);
-              } else {
-                return xfs.removePromise(p);
-              }
-            }));
-          })
+          removals.push(xfs.readdirPromise(storeEntryPath)
+            .then(entries => {
+              return Promise.all(entries.map(async entry => {
+                const p = ppath.join(storeEntryPath, entry);
+                if (entry === Filename.nodeModules) {
+                  const extraneous = await getNodeModulesListing(p);
+                  extraneous.delete(identComponents.join(ppath.sep) as PortablePath);
+                  return cleanNodeModules(p, extraneous);
+                } else {
+                  return xfs.removePromise(p);
+                }
+              }));
+            })
             .catch(error => {
               if (error.code !== `ENOENT`) {
                 throw error;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `findLocatorForLocation` method was attempting to get the locator from the linkers, then to query the package location (in order to get the root of the package). The problem was that it was doing this even on disabled linkers, causing crashes in the `findPackageLocation` calls since their install states were missing. As a result, the errors reported by running `yarn install` within a non-workspace directory were incorrect.

Closes #3777
Closes #3792 (Supersedes)

**How did you fix it?**

This diff ensures that the linkers never advertise anything as a package they own when they are disabled.

I think it should be a fairly safe change, but I'll keep an eye on the tests in case I forgot an edge case.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
