### PR TITLE
ci: fix e2e tests timing out

### DIFF
--- a/.github/workflows/e2e-svelte-kit-workflow.yml
+++ b/.github/workflows/e2e-svelte-kit-workflow.yml
@@ -30,7 +30,7 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        yes | yarn create svelte@next my-app && cd my-app
-        yarn
+        yes | YARN_PNP_ENABLE_ESM_LOADER=true yarn create svelte@next my-app && cd my-app
+        YARN_PNP_ENABLE_ESM_LOADER=true yarn
         yarn build
 

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -23,6 +23,15 @@ export YARN_ENABLE_IMMUTABLE_INSTALLS=0
 # We want to make sure the projects work in a monorepo
 export YARN_PNP_FALLBACK_MODE=none
 
+# TODO: Remove when either of these issues are fixed
+# - https://github.com/nodejs/node/issues/39140
+# - https://github.com/nodejs/node/issues/37782
+# - https://github.com/facebook/jest/issues/12060
+# Due to a bug in `jest-worker` and/or Node.js adding a loader
+# causes our e2e tests to time out so require the tests that needs it
+# to explicitly enable it
+export YARN_PNP_ENABLE_ESM_LOADER=false
+
 # Otherwise git commit doesn't work, and some tools require it
 git config --global user.email "you@example.com"
 git config --global user.name "John Doe"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Due to a bug in `jest-worker` and/or Node.js adding a loader causes our e2e tests to time out

- https://github.com/nodejs/node/issues/39140
- https://github.com/nodejs/node/issues/37782
- https://github.com/facebook/jest/issues/12060

**How did you fix it?**

Disable the loader by default and require the tests that need it to explicitly enable it

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.