### PR TITLE
docs: add try catch around the use of `sessionStorage` in `useScroll`

### DIFF
--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -4,11 +4,17 @@ const useScroll = () => {
   const ref = useRef();
 
   const readBrowserStorage = id => {
-    return sessionStorage.getItem(`berry:navigation:${id}`);
+    try {
+      return sessionStorage.getItem(`berry:navigation:${id}`);
+    } catch {
+      return 0;
+    }
   };
 
   const setBrowserStorage = (id, pos) => {
-    sessionStorage.setItem(`berry:navigation:${id}`, pos.toString());
+    try {
+      sessionStorage.setItem(`berry:navigation:${id}`, pos.toString());
+    } catch {}
   };
 
   useLayoutEffect(() => {

--- a/packages/gatsby/src/utils/useScroll.js
+++ b/packages/gatsby/src/utils/useScroll.js
@@ -7,7 +7,7 @@ const useScroll = () => {
     try {
       return sessionStorage.getItem(`berry:navigation:${id}`);
     } catch {
-      return 0;
+      return undefined;
     }
   };
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
It's my first time contributing to this repository so I thought I'd give it a try to a `good first issue`.  Please tell me if anything is wrong with this
Resolves #3759

...

**How did you fix it?**
From what I've tested, the `sessionStorage` is existing when cookies are disabled but using it throws an error. Adding a try/catch prevents the site from crashing.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
