### PR TITLE
fix(pnpm): don't remove store before install finishes

### DIFF
--- a/.yarn/versions/ce68f7d0.yml
+++ b/.yarn/versions/ce68f7d0.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -272,13 +272,12 @@ class PnpmInstaller implements Installer {
           removals.push(xfs.removePromise(ppath.join(storeLocation, record)));
 
       await Promise.all(removals);
-
-      await removeIfEmpty(storeLocation);
     }
 
     // Wait for the package installs to catch up
     await this.asyncActions.wait(),
 
+    await removeIfEmpty(storeLocation);
     await removeIfEmpty(getNodeModulesLocation(this.opts.project));
 
     return {


### PR DESCRIPTION
**What's the problem this PR addresses?**

There is potential for a race condition in the pnpm linker where it might try to remove the store while packages are about to be written to disk.

**How did you fix it?**

Check if the store is empty after the install is complete

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.