### PR TITLE
refactor!: Remove vscode-stylelint SDK

### DIFF
--- a/.yarn/versions/9c0db68d.yml
+++ b/.yarn/versions/9c0db68d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": major

--- a/.yarn/versions/9c0db68d.yml
+++ b/.yarn/versions/9c0db68d.yml
@@ -1,2 +1,2 @@
 releases:
-  "@yarnpkg/sdks": major
+  "@yarnpkg/sdks": minor

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -139,6 +139,7 @@ Many common frontend tools now support Plug'n'Play natively!
 | Storybook | Starting from 6.0+ |
 | TypeScript | Via [`plugin-compat`](https://github.com/yarnpkg/berry/tree/master/packages/plugin-compat) (enabled by default)
 | TypeScript-ESLint | Starting from 2.12+ |
+| VSCode-Stylelint | Starting from 1.1+ |
 | WebStorm | Starting from 2019.3+; See [Editor SDKs](https://yarnpkg.com/getting-started/editor-sdks) |
 | Webpack | Starting from 5+ ([plugin](https://github.com/arcanis/pnp-webpack-plugin) available for 4.x) |
 

--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -28,7 +28,6 @@ Generally speaking:
 | Builtin VSCode TypeScript Server | [typescript](https://yarnpkg.com/package/typescript) |
 | [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
 | [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
-| [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) | [stylelint](https://stylelint.io/) |
 | [flow-for-vscode*](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode) | [flow-bin](https://flow.org/) |
 
 > \* Flow is currently [incompatible with PnP](/features/pnp#incompatible).

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -179,7 +179,6 @@ export type SupportedSdk =
   | 'prettier'
   | 'typescript-language-server'
   | 'typescript'
-  | 'stylelint'
   | 'svelte-language-server'
   | 'flow-bin';
 

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -216,17 +216,6 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
   return wrapper;
 };
 
-export const generateStylelintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
-  const wrapper = new Wrapper(`stylelint` as PortablePath, {pnpApi, target});
-
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`bin/stylelint.js` as PortablePath);
-  await wrapper.writeFile(`lib/index.js` as PortablePath);
-
-  return wrapper;
-};
-
 export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`svelte-language-server` as PortablePath, {pnpApi, target});
 
@@ -252,7 +241,6 @@ export const BASE_SDKS: BaseSdks = [
   [`prettier`, generatePrettierBaseWrapper],
   [`typescript-language-server`, generateTypescriptLanguageServerBaseWrapper],
   [`typescript`, generateTypescriptBaseWrapper],
-  [`stylelint`, generateStylelintBaseWrapper],
   [`svelte-language-server`, generateSvelteLanguageServerBaseWrapper],
   [`flow-bin`, generateFlowBinBaseWrapper],
 ];

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -76,22 +76,6 @@ export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpA
   });
 };
 
-export const generateStylelintWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
-  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`stylelint.stylelintPath`]: npath.fromPortablePath(
-      wrapper.getProjectPathTo(
-        `lib/index.js` as PortablePath,
-      ),
-    ),
-  });
-
-  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
-    [`recommendations`]: [
-      `stylelint.vscode-stylelint`,
-    ],
-  });
-};
-
 export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`svelte.language-server.ls-path`]: npath.fromPortablePath(
@@ -130,7 +114,6 @@ export const VSCODE_SDKS: IntegrationSdks = [
   [`prettier`, generatePrettierWrapper],
   [`typescript-language-server`, null],
   [`typescript`, generateTypescriptWrapper],
-  [`stylelint`, generateStylelintWrapper],
   [`svelte-language-server`, generateSvelteLanguageServerWrapper],
   [`flow-bin`, generateFlowBinWrapper],
 ];


### PR DESCRIPTION
Resolves #3844

vscode-stylelint supports PnP natively since 1.1 so SDKs are no longer needed.

- SDK removed.
- Stylelint removed from SDK documentation.
- Added vscode-stylelint to the native support list in PnP docs.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
