### PR TITLE
ci: add Docusaurus e2e test

### DIFF
--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -1,0 +1,36 @@
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/actions/prepare/action.yml
+    - .github/workflows/e2e-docusaurus-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Docusaurus'
+jobs:
+  chore:
+    name: 'Validating Docusaurus'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: ./.github/actions/prepare
+
+    - name: 'Running the integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        yarn dlx create-docusaurus@latest my-website classic && cd my-website
+        yarn build
+
+    - name: 'Running the TypeScript integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+        yarn dlx create-docusaurus@latest my-website-ts classic --typescript && cd my-website-ts
+        yarn build
+      if: |
+        always()

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ On top of our classic integration tests, we also run Yarn every day against the 
 </td><td valign="top">
 
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20ESBuild/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-esbuild-workflow.yml)<br/>
+[![](https://github.com/yarnpkg/berry/workflows/E2E%20Docusaurus/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-docusaurus-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20ESLint/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-eslint-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20FSEvents/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-fsevents-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Husky/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-husky-workflow.yml)<br/>

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -126,6 +126,7 @@ Many common frontend tools now support Plug'n'Play natively!
 | --- | --- |
 | Babel | Starting from `resolve` 1.9 |
 | Create-React-App | Starting from 2.0+ |
+| Docusaurus | Starting from 2.0.0-beta.14 |
 | ESLint | Some compatibility issues w/ shared configs (fixable using [@rushstack/eslint-patch](https://yarnpkg.com/package/@rushstack/eslint-patch)) |
 | Gatsby | Supported with version ≥2.15.0, ≥3.7.0 |
 | Gulp | Supported with version 4.0+ | 


### PR DESCRIPTION
**What's the problem this PR addresses?**

We don't have an e2e test for Docusaurus

Depends on 
- https://github.com/facebook/docusaurus/pull/6047
- https://github.com/facebook/docusaurus/pull/6097
- https://github.com/yarnpkg/berry/pull/3862

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.