### PR TITLE
feat(plugin-npm): print error message specific to OTP being invalid

### DIFF
--- a/.yarn/versions/dc0140a5.yml
+++ b/.yarn/versions/dc0140a5.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-npm": minor
+  "@yarnpkg/plugin-npm-cli": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/dc0140a5.yml
+++ b/.yarn/versions/dc0140a5.yml
@@ -1,7 +1,7 @@
 releases:
-  "@yarnpkg/cli": minor
-  "@yarnpkg/plugin-npm": minor
-  "@yarnpkg/plugin-npm-cli": minor
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
 
 declined:
   - "@yarnpkg/plugin-compat"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/login.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/login.test.js
@@ -103,7 +103,7 @@ describe(`Commands`, () => {
               TEST_NPM_2FA_TOKEN: `incorrect OTP`,
             },
           }),
-        ).rejects.toThrowError(/Invalid authentication \(attempted as otp-user\)/);
+        ).rejects.toThrowError(/Invalid OTP token/);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -53,7 +53,7 @@ describe(`publish`, () =>   {
         env: {
           YARN_NPM_AUTH_TOKEN: validLogins.otpUser.npmAuthToken,
         },
-      })).rejects.toThrow();
+      })).rejects.toThrowError(/Invalid OTP token/);
     }));
 
   test(`should accept an otp and skip prompting for it`, makeTemporaryEnv({

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -34,6 +34,9 @@ export type Options = httpUtils.Options & RegistryOptions & {
  * a prohibited action, such as publishing a package with a similar name to an existing package.
  */
 export async function handleInvalidAuthenticationError(error: any, {attemptedAs, registry, headers, configuration}: {attemptedAs?: string, registry: string, headers: {[key: string]: string} | undefined, configuration: Configuration}) {
+  if (isOtpError(error))
+    throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid OTP token`);
+
   if (error.originalError?.name === `HTTPError` && error.originalError?.response.statusCode === 401) {
     throw new ReportError(MessageName.AUTHENTICATION_INVALID, `Invalid authentication (${typeof attemptedAs !== `string` ? `as ${await whoami(registry, headers, {configuration})}` : `attempted as ${attemptedAs}`})`);
   }


### PR DESCRIPTION
Sort of a followup to https://github.com/yarnpkg/berry/pull/3769