### PR TITLE
docs: add `gcp-auth` to third-party plugin list

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -71,6 +71,8 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**az-cli-auth**](https://github.com/FishandRichardsonPC/yarn-plugin-az-cli-auth) by [**Fish & Richardson P.C**](https://fr.com) - Uses the az cli to generate auth tokens when using azure devops repos
 
+- [**gcp-auth**](https://github.com/AndyClausen/yarn-plugin-gcp-auth) by [**Andreas Clausen**](https://github.com/AndyClausen) - Uses gcloud to generate access tokens when using Google Artifact Regitry repos
+
 - [**outdated**](https://github.com/mskelton/yarn-plugin-outdated) by [**Mark Skelton**](https://github.com/mskelton) - lists outdated dependencies similar to the Yarn 1.x `outdated` command
 
 - [**engines**](https://github.com/devoto13/yarn-plugin-engines) by [**Yaroslav Admin**](https://github.com/devoto13) - enforces a Node version range specified in the `package.json`'s `engines.node` field

--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -71,7 +71,7 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**az-cli-auth**](https://github.com/FishandRichardsonPC/yarn-plugin-az-cli-auth) by [**Fish & Richardson P.C**](https://fr.com) - Uses the az cli to generate auth tokens when using azure devops repos
 
-- [**gcp-auth**](https://github.com/AndyClausen/yarn-plugin-gcp-auth) by [**Andreas Clausen**](https://github.com/AndyClausen) - Uses gcloud to generate access tokens when using Google Artifact Regitry repos
+- [**gcp-auth**](https://github.com/AndyClausen/yarn-plugin-gcp-auth) by [**Andreas Clausen**](https://github.com/AndyClausen) - Uses gcloud to generate access tokens when using Google Artifact Registry repos
 
 - [**outdated**](https://github.com/mskelton/yarn-plugin-outdated) by [**Mark Skelton**](https://github.com/mskelton) - lists outdated dependencies similar to the Yarn 1.x `outdated` command
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This will add a [third-party plugin](https://github.com/AndyClausen/yarn-plugin-gcp-auth)  to the plugin list. The plugin will add a GCP access token to the NPM authentication header to any requests going to Google Artifact Registry repos - much like the existing [az-cli-auth](https://github.com/FishandRichardsonPC/yarn-plugin-az-cli-auth).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
