### PR TITLE
docs: fix typo, improve readability, and unify formatting

### DIFF
--- a/packages/gatsby/static/configuration/manifest.json
+++ b/packages/gatsby/static/configuration/manifest.json
@@ -227,7 +227,7 @@
       "_exampleKeys": ["react-dom"]
     },
     "resolutions": {
-      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolutions` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
+      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\n\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolutions` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
       "type": "object",
       "patternProperties": {
         "^relay-compiler$": {

--- a/packages/gatsby/static/configuration/manifest.json
+++ b/packages/gatsby/static/configuration/manifest.json
@@ -227,7 +227,7 @@
       "_exampleKeys": ["react-dom"]
     },
     "resolutions": {
-      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\n\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolutions` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
+      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\n\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote: The `resolutions` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
       "type": "object",
       "patternProperties": {
         "^relay-compiler$": {

--- a/packages/gatsby/static/configuration/manifest.json
+++ b/packages/gatsby/static/configuration/manifest.json
@@ -227,7 +227,7 @@
       "_exampleKeys": ["react-dom"]
     },
     "resolutions": {
-      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolution` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
+      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolutions` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
       "type": "object",
       "patternProperties": {
         "^relay-compiler$": {

--- a/packages/gatsby/static/configuration/manifest.json
+++ b/packages/gatsby/static/configuration/manifest.json
@@ -227,7 +227,7 @@
       "_exampleKeys": ["react-dom"]
     },
     "resolutions": {
-      "description": "This field allows you to instruct Yarn to use a specific resolution instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolution` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
+      "description": "This field allows you to instruct Yarn to use a specific resolution (specific package version) instead of anything the resolver would normally pick. This is useful to enforce all your packages to use a single version of a dependency, or backport a fix. The syntax for the resolution key accepts one level of specificity, so all the following examples are correct.\nNote: When a path is relative, like it can be with the `file:` and `portal:` protocols, it is resolved relative to the path of the project.\n\nNote that the `resolution` field can only be set at the root of the project, and will generate a warning if used in any other workspace.",
       "type": "object",
       "patternProperties": {
         "^relay-compiler$": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The [description  for the `resolutions` field](https://yarnpkg.com/configuration/manifest#resolutions) in the Yarn's documentation contains a typo and could be more understandable. Changes in this PR fix the aforementioned typo and improve the readability of the field's description.

...

**How did you fix it?**

- I have added the missing "s" letter in the "resolution**s**" word.
- I have added the missing line break (`\n`) that someone forgot to put there.
- I have unified the formatting for the document to be more coherent.

...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
