### PR TITLE
feat: add the ability to auth in using certificate and private key

### DIFF
--- a/.yarn/versions/ed770662.yml
+++ b/.yarn/versions/ed770662.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": minor

--- a/.yarn/versions/ed770662.yml
+++ b/.yarn/versions/ed770662.yml
@@ -1,2 +1,33 @@
 releases:
+  "@yarnpkg/builder": minor
+  "@yarnpkg/cli": minor
   "@yarnpkg/core": minor
+  "@yarnpkg/doctor": minor
+  "@yarnpkg/esbuild-plugin-pnp": minor
+  "@yarnpkg/nm": minor
+  "@yarnpkg/plugin-compat": minor
+  "@yarnpkg/plugin-constraints": minor
+  "@yarnpkg/plugin-dlx": minor
+  "@yarnpkg/plugin-essentials": minor
+  "@yarnpkg/plugin-exec": minor
+  "@yarnpkg/plugin-file": minor
+  "@yarnpkg/plugin-git": minor
+  "@yarnpkg/plugin-github": minor
+  "@yarnpkg/plugin-http": minor
+  "@yarnpkg/plugin-init": minor
+  "@yarnpkg/plugin-interactive-tools": minor
+  "@yarnpkg/plugin-link": minor
+  "@yarnpkg/plugin-nm": minor
+  "@yarnpkg/plugin-npm": minor
+  "@yarnpkg/plugin-npm-cli": minor
+  "@yarnpkg/plugin-pack": minor
+  "@yarnpkg/plugin-patch": minor
+  "@yarnpkg/plugin-pnp": minor
+  "@yarnpkg/plugin-pnpm": minor
+  "@yarnpkg/plugin-stage": minor
+  "@yarnpkg/plugin-typescript": minor
+  "@yarnpkg/plugin-version": minor
+  "@yarnpkg/plugin-workspace-tools": minor
+  "@yarnpkg/pnp": minor
+  "@yarnpkg/pnpify": minor
+  "@yarnpkg/sdks": minor

--- a/.yarn/versions/ed770662.yml
+++ b/.yarn/versions/ed770662.yml
@@ -1,33 +1,33 @@
 releases:
-  "@yarnpkg/builder": minor
   "@yarnpkg/cli": minor
   "@yarnpkg/core": minor
-  "@yarnpkg/doctor": minor
-  "@yarnpkg/esbuild-plugin-pnp": minor
-  "@yarnpkg/nm": minor
-  "@yarnpkg/plugin-compat": minor
-  "@yarnpkg/plugin-constraints": minor
-  "@yarnpkg/plugin-dlx": minor
-  "@yarnpkg/plugin-essentials": minor
-  "@yarnpkg/plugin-exec": minor
-  "@yarnpkg/plugin-file": minor
-  "@yarnpkg/plugin-git": minor
-  "@yarnpkg/plugin-github": minor
-  "@yarnpkg/plugin-http": minor
-  "@yarnpkg/plugin-init": minor
-  "@yarnpkg/plugin-interactive-tools": minor
-  "@yarnpkg/plugin-link": minor
-  "@yarnpkg/plugin-nm": minor
-  "@yarnpkg/plugin-npm": minor
-  "@yarnpkg/plugin-npm-cli": minor
-  "@yarnpkg/plugin-pack": minor
-  "@yarnpkg/plugin-patch": minor
-  "@yarnpkg/plugin-pnp": minor
-  "@yarnpkg/plugin-pnpm": minor
-  "@yarnpkg/plugin-stage": minor
-  "@yarnpkg/plugin-typescript": minor
-  "@yarnpkg/plugin-version": minor
-  "@yarnpkg/plugin-workspace-tools": minor
-  "@yarnpkg/pnp": minor
-  "@yarnpkg/pnpify": minor
-  "@yarnpkg/sdks": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -33,6 +33,14 @@
       "format": "uri-reference",
       "examples": ["./exampleCA.pem"]
     },
+    "cert": {
+      "_package": "@yarnpkg/core",
+      "description": "Value of the certificate chain in PEM format.",
+      "type": "string",
+      "examples": [
+        "qwe2qeqwtretereqwdasdqweq"
+      ]
+    },
     "changesetBaseRefs": {
       "_package": "@yarnpkg/plugin-git",
       "description": "The base git refs that the current HEAD is compared against in the version plugin. This overrides the default behavior of comparing against master, origin/master, upstream/master, main, origin/main, and upstream/main. Supports git branches, tags, and commits.",
@@ -261,6 +269,12 @@
       "format": "uri-reference",
       "default": "./.yarn/install-state.gz"
     },
+    "key": {
+      "_package": "@yarnpkg/core",
+      "description": "Value of the private key in PEM format.",
+      "type": "string",
+      "examples": ["qwe2qeqwtretereqwdasdqweq"]
+    },
     "logFilters": {
       "description": "Defines overrides for log levels for message names or message text. Through this setting you can hide specific messages or give them a more important visibility.",
       "type": "array",
@@ -341,6 +355,9 @@
             "caFilePath": {
               "$ref": "#/properties/caFilePath"
             },
+            "cert": {
+              "$ref": "#/properties/cert"
+            },
             "enableNetwork": {
               "$ref": "#/properties/enableNetwork"
             },
@@ -349,9 +366,12 @@
             },
             "httpsProxy": {
               "$ref": "#/properties/httpsProxy"
+            },
+            "key": {
+              "$ref": "#/properties/key"
             }
           },
-          "_exampleKeys": ["caFilePath", "enableNetwork", "httpProxy", "httpsProxy"]
+          "_exampleKeys": ["caFilePath", "cert", "enableNetwork", "httpProxy", "httpsProxy", "key"]
         }
       },
       "_exampleKeys": ["*.example.com"]

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -33,13 +33,12 @@
       "format": "uri-reference",
       "examples": ["./exampleCA.pem"]
     },
-    "cert": {
+    "httpsCertFilePath": {
       "_package": "@yarnpkg/core",
-      "description": "Value of the certificate chain in PEM format.",
+      "description": "Path to file containing certificate chain in PEM format.",
       "type": "string",
-      "examples": [
-        "qwe2qeqwtretereqwdasdqweq"
-      ]
+      "format": "uri-reference",
+      "examples": ["./exampleCert.pem"]
     },
     "changesetBaseRefs": {
       "_package": "@yarnpkg/plugin-git",
@@ -269,11 +268,12 @@
       "format": "uri-reference",
       "default": "./.yarn/install-state.gz"
     },
-    "key": {
+    "httpsKeyFilePath": {
       "_package": "@yarnpkg/core",
-      "description": "Value of the private key in PEM format.",
+      "description": "Path to file containing private key in PEM format.",
       "type": "string",
-      "examples": ["qwe2qeqwtretereqwdasdqweq"]
+      "format": "uri-reference",
+      "examples": ["./exampleKey.pem"]
     },
     "logFilters": {
       "description": "Defines overrides for log levels for message names or message text. Through this setting you can hide specific messages or give them a more important visibility.",
@@ -355,8 +355,8 @@
             "caFilePath": {
               "$ref": "#/properties/caFilePath"
             },
-            "cert": {
-              "$ref": "#/properties/cert"
+            "httpsCertFilePath": {
+              "$ref": "#/properties/httpsCertFilePath"
             },
             "enableNetwork": {
               "$ref": "#/properties/enableNetwork"
@@ -367,11 +367,11 @@
             "httpsProxy": {
               "$ref": "#/properties/httpsProxy"
             },
-            "key": {
-              "$ref": "#/properties/key"
+            "httpsKeyFilePath": {
+              "$ref": "#/properties/httpsKeyFilePath"
             }
           },
-          "_exampleKeys": ["caFilePath", "cert", "enableNetwork", "httpProxy", "httpsProxy", "key"]
+          "_exampleKeys": ["caFilePath", "httpsCertFilePath", "enableNetwork", "httpProxy", "httpsProxy", "httpsKeyFilePath"]
         }
       },
       "_exampleKeys": ["*.example.com"]

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -379,12 +379,32 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
           type: SettingsType.STRING,
           default: null,
         },
+        key: {
+          description: `Value of the private key in PEM format`,
+          type: SettingsType.STRING,
+          default: null,
+        },
+        cert: {
+          description: `Value of the certificate chain in PEM format`,
+          type: SettingsType.STRING,
+          default: null,
+        },
       },
     },
   },
   caFilePath: {
     description: `A path to a file containing one or multiple Certificate Authority signing certificates`,
     type: SettingsType.ABSOLUTE_PATH,
+    default: null,
+  },
+  key: {
+    description: `Value of the private key in PEM format`,
+    type: SettingsType.STRING,
+    default: null,
+  },
+  cert: {
+    description: `Value of the certificate chain in PEM format`,
+    type: SettingsType.STRING,
     default: null,
   },
   enableStrictSsl: {
@@ -558,8 +578,12 @@ export interface ConfigurationValueMap {
     enableNetwork: boolean | null;
     httpProxy: string | null;
     httpsProxy: string | null;
+    key: string | null;
+    cert: string | null;
   }>>;
   caFilePath: PortablePath | null;
+  key: string | null;
+  cert: string | null;
   enableStrictSsl: boolean;
 
   logFilters: Array<miscUtils.ToMapValue<{code?: string, text?: string, pattern?: string, level?: formatUtils.LogLevel | null}>>;

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -379,14 +379,14 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
           type: SettingsType.STRING,
           default: null,
         },
-        key: {
-          description: `Value of the private key in PEM format`,
-          type: SettingsType.STRING,
+        httpsKeyFilePath: {
+          description: `Path to file containing private key in PEM format`,
+          type: SettingsType.ABSOLUTE_PATH,
           default: null,
         },
-        cert: {
-          description: `Value of the certificate chain in PEM format`,
-          type: SettingsType.STRING,
+        httpsCertFilePath: {
+          description: `Path to file containing certificate chain in PEM format`,
+          type: SettingsType.ABSOLUTE_PATH,
           default: null,
         },
       },
@@ -397,14 +397,14 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.ABSOLUTE_PATH,
     default: null,
   },
-  key: {
-    description: `Value of the private key in PEM format`,
-    type: SettingsType.STRING,
+  httpsKeyFilePath: {
+    description: `Path to file containing private key in PEM format`,
+    type: SettingsType.ABSOLUTE_PATH,
     default: null,
   },
-  cert: {
-    description: `Value of the certificate chain in PEM format`,
-    type: SettingsType.STRING,
+  httpsCertFilePath: {
+    description: `Path to file containing certificate chain in PEM format`,
+    type: SettingsType.ABSOLUTE_PATH,
     default: null,
   },
   enableStrictSsl: {
@@ -578,12 +578,12 @@ export interface ConfigurationValueMap {
     enableNetwork: boolean | null;
     httpProxy: string | null;
     httpsProxy: string | null;
-    key: string | null;
-    cert: string | null;
+    httpsKeyFilePath: PortablePath | null;
+    httpsCertFilePath: PortablePath | null;
   }>>;
   caFilePath: PortablePath | null;
-  key: string | null;
-  cert: string | null;
+  httpsKeyFilePath: PortablePath | null;
+  httpsCertFilePath: PortablePath | null;
   enableStrictSsl: boolean;
 
   logFilters: Array<miscUtils.ToMapValue<{code?: string, text?: string, pattern?: string, level?: formatUtils.LogLevel | null}>>;

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -124,6 +124,8 @@ export function getNetworkSettings(target: string | URL, opts: { configuration: 
     caFilePath: undefined,
     httpProxy: undefined,
     httpsProxy: undefined,
+    key: undefined,
+    cert: undefined,
   };
 
   const mergableKeys = Object.keys(mergedNetworkSettings) as Array<keyof NetworkSettingsType>;
@@ -254,6 +256,8 @@ async function requestImpl(target: string | URL, body: Body, {configuration, hea
   const retry = configuration.get(`httpRetry`);
   const rejectUnauthorized = configuration.get(`enableStrictSsl`);
   const caFilePath = networkConfig.caFilePath;
+  const certificate = networkConfig.cert ?? undefined;
+  const key = networkConfig.key ?? undefined;
 
   const {default: got} = await import(`got`);
 
@@ -269,6 +273,8 @@ async function requestImpl(target: string | URL, body: Body, {configuration, hea
     https: {
       rejectUnauthorized,
       certificateAuthority,
+      certificate,
+      key,
     },
     ...gotOptions,
   });

--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -16,7 +16,7 @@ import * as miscUtils                                        from './miscUtils';
 export {RequestError} from 'got';
 
 const cache = new Map<string, Promise<Buffer> | Buffer>();
-const certCache = new Map<PortablePath, Promise<Buffer> | Buffer>();
+const fileCache = new Map<PortablePath, Promise<Buffer> | Buffer>();
 
 const globalHttpAgent = new HttpAgent({keepAlive: true});
 const globalHttpsAgent = new HttpsAgent({keepAlive: true});
@@ -31,11 +31,11 @@ function parseProxy(specifier: string) {
   return {proxy};
 }
 
-async function getCachedCertificate(caFilePath: PortablePath) {
-  return miscUtils.getFactoryWithDefault(certCache, caFilePath, () => {
-    return xfs.readFilePromise(caFilePath).then(cert => {
-      certCache.set(caFilePath, cert);
-      return cert;
+async function getCachedFile(filePath: PortablePath) {
+  return miscUtils.getFactoryWithDefault(fileCache, filePath, () => {
+    return xfs.readFilePromise(filePath).then(file => {
+      fileCache.set(filePath, file);
+      return file;
     });
   });
 }
@@ -124,8 +124,8 @@ export function getNetworkSettings(target: string | URL, opts: { configuration: 
     caFilePath: undefined,
     httpProxy: undefined,
     httpsProxy: undefined,
-    key: undefined,
-    cert: undefined,
+    httpsKeyFilePath: undefined,
+    httpsCertFilePath: undefined,
   };
 
   const mergableKeys = Object.keys(mergedNetworkSettings) as Array<keyof NetworkSettingsType>;
@@ -256,13 +256,19 @@ async function requestImpl(target: string | URL, body: Body, {configuration, hea
   const retry = configuration.get(`httpRetry`);
   const rejectUnauthorized = configuration.get(`enableStrictSsl`);
   const caFilePath = networkConfig.caFilePath;
-  const certificate = networkConfig.cert ?? undefined;
-  const key = networkConfig.key ?? undefined;
+  const httpsCertFilePath = networkConfig.httpsCertFilePath;
+  const httpsKeyFilePath = networkConfig.httpsKeyFilePath;
 
   const {default: got} = await import(`got`);
 
   const certificateAuthority = caFilePath
-    ? await getCachedCertificate(caFilePath)
+    ? await getCachedFile(caFilePath)
+    : undefined;
+  const certificate = httpsCertFilePath
+    ? await getCachedFile(httpsCertFilePath)
+    : undefined;
+  const key = httpsKeyFilePath
+    ? await getCachedFile(httpsKeyFilePath)
     : undefined;
 
   const gotClient = got.extend({


### PR DESCRIPTION
**What's the problem this PR addresses?**
Current .yarnrc.yml configuration does not support authorization in registry via certificate and private key.

...

**How did you fix it?**
Added the ability to specify values ​​for the certificate and private key. 
Added setting of certificate and key in configuration "got" package

...

**Checklist**

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [x] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
