### PR TITLE
fix(nm): Better portal hoisting by giving priority to portal dependencies first

### DIFF
--- a/.yarn/versions/a048c53b.yml
+++ b/.yarn/versions/a048c53b.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - The `node` field inside the `npm_config_user_agent` Yarn sets will now include a leading `v`.
 - Yarn is now able to recover from a corrupted install state.
 - Yarn is now able to migrate classic lockfiles containing unconventional tarball URLs
+- The nm linker hoists portals after hoisting their dependencies first
 
 ### Miscellaneous Features
 

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -304,7 +304,7 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
     if (!node) {
       let dependencyKind = HoisterDependencyKind.REGULAR;
       if (isExternalSoftLinkPackage)
-        dependencyKind = HoisterDependencyKind.PORTAL;
+        dependencyKind = HoisterDependencyKind.EXTERNAL_SOFT_LINK;
       else if (pkg.linkType === LinkType.SOFT && locator.name.endsWith(WORKSPACE_NAME_SUFFIX))
         dependencyKind = HoisterDependencyKind.WORKSPACE;
 

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -3,7 +3,7 @@ import {toFilename, npath, ppath}                                             fr
 import {NativePath, PortablePath, Filename}                                   from '@yarnpkg/fslib';
 import {PnpApi, PhysicalPackageLocator, PackageInformation, DependencyTarget} from '@yarnpkg/pnp';
 
-import {hoist, HoisterTree, HoisterResult}                                    from './hoist';
+import {hoist, HoisterTree, HoisterResult, HoisterDependencyKind}             from './hoist';
 
 // Babel doesn't support const enums, thats why we use non-const enum for LinkType in @yarnpkg/pnp
 // But because of this TypeScript requires @yarnpkg/pnp during runtime
@@ -284,7 +284,7 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
     reference: topLocator.reference,
     peerNames: topPkg.packagePeers,
     dependencies: new Set<HoisterTree>(),
-    isWorkspace: true,
+    dependencyKind: HoisterDependencyKind.WORKSPACE,
   };
 
   const nodes = new Map<string, HoisterTree>();
@@ -302,7 +302,13 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
     const isExternalSoftLinkPackage = isExternalSoftLink(pkg, locator, pnp, topPkgPortableLocation);
 
     if (!node) {
-      const isWorkspace = pkg.linkType === LinkType.SOFT && locator.name.endsWith(WORKSPACE_NAME_SUFFIX);
+      let dependencyKind = HoisterDependencyKind.REGULAR;
+      if (isExternalSoftLinkPackage)
+        dependencyKind = HoisterDependencyKind.PORTAL;
+      else if (pkg.linkType === LinkType.SOFT && locator.name.endsWith(WORKSPACE_NAME_SUFFIX))
+        dependencyKind = HoisterDependencyKind.WORKSPACE;
+
+
       node = {
         name,
         identName: locator.name,
@@ -310,8 +316,8 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
         dependencies: new Set(),
         // View peer dependencies as regular dependencies for workspaces
         // (meeting workspace peer dependency constraints is sometimes hard, sometimes impossible for the nm linker)
-        peerNames: isWorkspace ? new Set() : pkg.packagePeers,
-        isWorkspace,
+        peerNames: dependencyKind === HoisterDependencyKind.WORKSPACE ? new Set() : pkg.packagePeers,
+        dependencyKind,
       };
 
       nodes.set(nodeKey, node);

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -461,7 +461,7 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
   if (isHoistable) {
     isHoistable = node.dependencyKind !== HoisterDependencyKind.EXTERNAL_SOFT_LINK || node.dependencies.size === 0;
     if (outputReason && !isHoistable) {
-      reason = `- portal with unhoisted dependencies`;
+      reason = `- external soft link with unhoisted dependencies`;
     }
   }
 

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -46,11 +46,14 @@
  * until you run out of candidates for current tree root.
  */
 type PackageName = string;
-export type HoisterTree = {name: PackageName, identName: PackageName, reference: string, dependencies: Set<HoisterTree>, peerNames: Set<PackageName>, hoistPriority?: number, isWorkspace?: boolean};
+export enum HoisterDependencyKind {
+  REGULAR, WORKSPACE, PORTAL,
+}
+export type HoisterTree = {name: PackageName, identName: PackageName, reference: string, dependencies: Set<HoisterTree>, peerNames: Set<PackageName>, hoistPriority?: number, dependencyKind?: HoisterDependencyKind};
 export type HoisterResult = {name: PackageName, identName: PackageName, references: Set<string>, dependencies: Set<HoisterResult>};
 type Locator = string;
 type Ident = string;
-type HoisterWorkTree = {name: PackageName, references: Set<string>, ident: Ident, locator: Locator, dependencies: Map<PackageName, HoisterWorkTree>, originalDependencies: Map<PackageName, HoisterWorkTree>, hoistedDependencies: Map<PackageName, HoisterWorkTree>, peerNames: ReadonlySet<PackageName>, decoupled: boolean, reasons: Map<PackageName, string>, isHoistBorder: boolean, hoistedFrom: Map<PackageName, Array<string>>, hoistedTo: Map<PackageName, string>, hoistPriority: number, isWorkspace: boolean};
+type HoisterWorkTree = {name: PackageName, references: Set<string>, ident: Ident, locator: Locator, dependencies: Map<PackageName, HoisterWorkTree>, originalDependencies: Map<PackageName, HoisterWorkTree>, hoistedDependencies: Map<PackageName, HoisterWorkTree>, peerNames: ReadonlySet<PackageName>, decoupled: boolean, reasons: Map<PackageName, string>, isHoistBorder: boolean, hoistedFrom: Map<PackageName, Array<string>>, hoistedTo: Map<PackageName, string>, hoistPriority: number, dependencyKind: HoisterDependencyKind};
 
 /**
  * Mapping which packages depend on a given package alias + ident. It is used to determine hoisting weight,
@@ -237,7 +240,7 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
   if (node.decoupled)
     return node;
 
-  const {name, references, ident, locator, dependencies, originalDependencies, hoistedDependencies, peerNames, reasons, isHoistBorder, hoistPriority, isWorkspace, hoistedFrom, hoistedTo} = node;
+  const {name, references, ident, locator, dependencies, originalDependencies, hoistedDependencies, peerNames, reasons, isHoistBorder, hoistPriority, dependencyKind, hoistedFrom, hoistedTo} = node;
   // To perform node hoisting from parent node we must clone parent nodes up to the root node,
   // because some other package in the tree might depend on the parent package where hoisting
   // cannot be performed
@@ -254,7 +257,7 @@ const decoupleGraphNode = (parent: HoisterWorkTree, node: HoisterWorkTree): Hois
     decoupled: true,
     isHoistBorder,
     hoistPriority,
-    isWorkspace,
+    dependencyKind,
     hoistedFrom: new Map(hoistedFrom),
     hoistedTo: new Map(hoistedTo),
   };
@@ -449,9 +452,16 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
     reason = `- self-reference`;
 
   if (isHoistable) {
-    isHoistable = !node.isWorkspace;
+    isHoistable = node.dependencyKind !== HoisterDependencyKind.WORKSPACE;
     if (outputReason && !isHoistable) {
       reason = `- workspace`;
+    }
+  }
+
+  if (isHoistable) {
+    isHoistable = node.dependencyKind !== HoisterDependencyKind.PORTAL || node.dependencies.size === 0;
+    if (outputReason && !isHoistable) {
+      reason = `- portal with unhoisted dependencies`;
     }
   }
 
@@ -467,7 +477,7 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
     // It is difficult to find all common ancestors, but there is one easy to find common ancestor -
     // the root workspace, so, for now, we either hoist direct dependencies into the root workspace, or we keep them
     // unhoisted, thus we are safe from various pathological cases with `--preserve-symlinks`
-    isHoistable = !parentNode.isWorkspace || parentNode.hoistedFrom.has(node.name) || rootNodePathLocators.size === 1;
+    isHoistable = parentNode.dependencyKind !== HoisterDependencyKind.WORKSPACE || parentNode.hoistedFrom.has(node.name) || rootNodePathLocators.size === 1;
     if (outputReason && !isHoistable) {
       reason = parentNode.reasons.get(node.name)!;
     }
@@ -773,7 +783,7 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
     decoupled: true,
     isHoistBorder: true,
     hoistPriority: 0,
-    isWorkspace: true,
+    dependencyKind: HoisterDependencyKind.WORKSPACE,
     hoistedFrom: new Map(),
     hoistedTo: new Map(),
   };
@@ -784,7 +794,7 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
     let workNode = seenNodes.get(node);
     const isSeen = !!workNode;
     if (!workNode) {
-      const {name, identName, reference, peerNames, hoistPriority, isWorkspace} = node;
+      const {name, identName, reference, peerNames, hoistPriority, dependencyKind} = node;
       const dependenciesNmHoistingLimits = options.hoistingLimits.get(parentNode.locator);
       workNode = {
         name,
@@ -799,7 +809,7 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
         decoupled: true,
         isHoistBorder: dependenciesNmHoistingLimits ? dependenciesNmHoistingLimits.has(name) : false,
         hoistPriority: hoistPriority || 0,
-        isWorkspace: isWorkspace || false,
+        dependencyKind: dependencyKind || HoisterDependencyKind.REGULAR,
         hoistedFrom: new Map(),
         hoistedTo: new Map(),
       };

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -47,7 +47,7 @@
  */
 type PackageName = string;
 export enum HoisterDependencyKind {
-  REGULAR, WORKSPACE, PORTAL,
+  REGULAR, WORKSPACE, EXTERNAL_SOFT_LINK,
 }
 export type HoisterTree = {name: PackageName, identName: PackageName, reference: string, dependencies: Set<HoisterTree>, peerNames: Set<PackageName>, hoistPriority?: number, dependencyKind?: HoisterDependencyKind};
 export type HoisterResult = {name: PackageName, identName: PackageName, references: Set<string>, dependencies: Set<HoisterResult>};
@@ -459,7 +459,7 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
   }
 
   if (isHoistable) {
-    isHoistable = node.dependencyKind !== HoisterDependencyKind.PORTAL || node.dependencies.size === 0;
+    isHoistable = node.dependencyKind !== HoisterDependencyKind.EXTERNAL_SOFT_LINK || node.dependencies.size === 0;
     if (outputReason && !isHoistable) {
       reason = `- portal with unhoisted dependencies`;
     }

--- a/packages/yarnpkg-nm/tests/hoist.test.ts
+++ b/packages/yarnpkg-nm/tests/hoist.test.ts
@@ -1,4 +1,4 @@
-import {hoist, HoisterTree, HoisterResult} from '../sources/hoist';
+import {hoist, HoisterTree, HoisterResult, HoisterDependencyKind} from '../sources/hoist';
 
 const toTree = (obj: any, key: string = `.`, nodes = new Map()): HoisterTree => {
   let node = nodes.get(key);
@@ -10,7 +10,7 @@ const toTree = (obj: any, key: string = `.`, nodes = new Map()): HoisterTree => 
       reference: key.match(/@?[^@]+@?(.+)?/)![1] || ``,
       dependencies: new Set<HoisterTree>(),
       peerNames: new Set<string>((obj[key] || {}).peerNames || []),
-      isWorkspace: (obj[key] || {}).isWorkspace,
+      dependencyKind: (obj[key] || {}).dependencyKind,
     };
     nodes.set(key, node);
 
@@ -543,10 +543,10 @@ describe(`hoist`, () => {
     // otherwise accessing A via . -> W3 with --preserve-symlinks will result in A@Z,
     // but accessing it via W3(w) will result in A@Y
     const tree = {
-      '.': {dependencies: [`W1(w)`, `W3`, `A@Z`], isWorkspace: true},
-      'W1(w)': {dependencies: [`W2(w)`, `A@Y`], isWorkspace: true},
-      'W2(w)': {dependencies: [`W3(w)`], isWorkspace: true},
-      'W3(w)': {dependencies: [`A@X`], isWorkspace: true},
+      '.': {dependencies: [`W1(w)`, `W3`, `A@Z`], dependencyKind: HoisterDependencyKind.WORKSPACE},
+      'W1(w)': {dependencies: [`W2(w)`, `A@Y`], dependencyKind: HoisterDependencyKind.WORKSPACE},
+      'W2(w)': {dependencies: [`W3(w)`], dependencyKind: HoisterDependencyKind.WORKSPACE},
+      'W3(w)': {dependencies: [`A@X`], dependencyKind: HoisterDependencyKind.WORKSPACE},
     };
 
     expect(getTreeHeight(hoist(toTree(tree), {check: true}))).toEqual(5);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The nm hoister uses an eager approach to all the dependencies. Unfortunately, this doesn't play well for portals, since the portal dependencies might be hoistable to the direct parent, but if the portal symlink was hoisted to the root workspace or other indirect parent the dependencies might not be hoistable anymore. This situation leads to portal conflict diagnostic code to pass, but then assertion failure during an attempt to write non-hoisted portal dependencies to disk.

Fixes: #3873 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have introduced knowledge about portals to the hoister algorithm, when it sees the portal it makes sure all the dependencies of the portal to be hoisted first and only after that the portal itself can be hoisted (provided portal requirements still hold).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
