### PR TITLE
chore: exclude `{bin,bundles}` from tsserver index

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "useUnknownInCatchVariables": false
   },
   "exclude": [
-    "packages/*/lib",
+    "packages/*/{lib,bin,bundles}",
     "packages/yarnpkg-doctor/fixtures",
     "packages/gatsby",
     "packages/yarnpkg-libzip/artifacts"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Using `Go to Symbol in Workspace` in VSCode (`CTRL + T`) takes longer than necessary and shows irrelevant results because it indexes the built bundles too.

![image](https://user-images.githubusercontent.com/32596136/147295181-e3544eff-4286-4d37-b4f6-aafd095bf8c5.png)


**How did you fix it?**
<!-- A detailed description of your implementation. -->

Excluded them in the `tsconfig.json`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
