### PR TITLE
docs: link to `@rushstack/eslint-patch` in the PnP doc

### DIFF
--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -126,7 +126,7 @@ Many common frontend tools now support Plug'n'Play natively!
 | --- | --- |
 | Babel | Starting from `resolve` 1.9 |
 | Create-React-App | Starting from 2.0+ |
-| ESLint | Some compatibility issues w/ shared configs |
+| ESLint | Some compatibility issues w/ shared configs (fixable using [@rushstack/eslint-patch](https://yarnpkg.com/package/@rushstack/eslint-patch)) |
 | Gatsby | Supported with version ≥2.15.0, ≥3.7.0 |
 | Gulp | Supported with version 4.0+ | 
 | Husky | Starting from 4.0.0-1+ |


### PR DESCRIPTION
Using this package (3.5K stars), I was able to painlessly resolve the issues regarding having plugins as dependencies in a shareable config, while keeping PnP enabled. It could be worth mentioning that in the docs until eslint/eslint#3458 is merged.

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

N/A

**How did you fix it?**
<!-- A detailed description of your implementation. -->

N/A

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
