### PR TITLE
docs: fix example in plugin tutorial

### DIFF
--- a/packages/gatsby/content/advanced/plugin-tutorial.mdx
+++ b/packages/gatsby/content/advanced/plugin-tutorial.mdx
@@ -96,7 +96,7 @@ module.exports = {
       static paths = [[`addition`]];
 
       // Show descriptive usage for a --help argument passed to this command
-      static usage = Command.Usage({
+      static usage = BaseCommand.Usage({
         description: `hello world!`,
         details: `
           This command will print a nice message.

--- a/packages/gatsby/content/advanced/plugin-tutorial.mdx
+++ b/packages/gatsby/content/advanced/plugin-tutorial.mdx
@@ -89,14 +89,14 @@ module.exports = {
   name: `plugin-addition`,
   factory: require => {
     const {BaseCommand} = require(`@yarnpkg/cli`);
-    const {Option} = require(`clipanion`);
+    const {Command, Option} = require(`clipanion`);
     const t = require(`typanion`);
 
     class AdditionCommand extends BaseCommand {
       static paths = [[`addition`]];
 
       // Show descriptive usage for a --help argument passed to this command
-      static usage = BaseCommand.Usage({
+      static usage = Command.Usage({
         description: `hello world!`,
         details: `
           This command will print a nice message.


### PR DESCRIPTION
The `plugin-addition` example in [documentation](https://yarnpkg.com/advanced/plugin-tutorial#adding-commands) does not work without this change.
