### PR TITLE
feat: show warning when `dependenciesMeta.{built,unplugged}` is declared in non-top-level workspace

### DIFF
--- a/.yarn/versions/42313c0a.yml
+++ b/.yarn/versions/42313c0a.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryMonorepoEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryMonorepoEnv.ts
@@ -16,7 +16,10 @@ export const mtme = (
       const workspacePath = ppath.join(path, workspace as PortablePath);
       await fsUtils.mkdirp(workspacePath);
 
-      await fsUtils.writeJson(ppath.join(workspacePath, Filename.manifest), await deepResolve(manifest));
+      await fsUtils.writeJson(ppath.join(workspacePath, Filename.manifest), await deepResolve({
+        name: ppath.basename(workspace as PortablePath),
+        ...manifest,
+      }));
     }
   };
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/workspace.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/workspace.test.ts
@@ -57,7 +57,7 @@ describe(`Workspaces tests`, () => {
   );
 
   test(
-    `it should not implicitely make workspaces require-able`,
+    `it should not implicitly make workspaces require-able`,
     makeTemporaryEnv(
       {
         private: true,
@@ -84,7 +84,7 @@ describe(`Workspaces tests`, () => {
   );
 
   test(
-    `it should allow workspaces to require each others`,
+    `it should allow workspaces to require each other`,
     makeTemporaryEnv(
       {
         private: true,
@@ -280,5 +280,49 @@ describe(`Workspaces tests`, () => {
         ].join(``));
       },
     ),
+  );
+
+  test(
+    `it should show warnings when top-level manifest fields are declared inside workspace manifests`,
+    makeTemporaryMonorepoEnv({
+      workspaces: [
+        `packages/*`,
+      ],
+    }, {
+      [`packages/foo`]: {
+        resolutions: {
+          [`x`]: `1.0.0`,
+        },
+      },
+      [`packages/bar`]: {
+        dependenciesMeta: {
+          [`x`]: {
+            built: false,
+          },
+        },
+      },
+      [`packages/baz`]: {
+        dependenciesMeta: {
+          [`x`]: {
+            unplugged: true,
+          },
+        },
+      },
+      [`packages/qux`]: {
+        dependenciesMeta: {
+          [`x`]: {
+            optional: true,
+          },
+        },
+      },
+    }, async ({path, run, source}) => {
+      const {stdout} = await run(`install`);
+
+      expect(stdout).toContain(`foo: Field only allowed in top-level workspace manifest, will be ignored: resolutions`);
+      expect(stdout).toContain(`bar: Field only allowed in top-level workspace manifest, will be ignored: dependenciesMeta ➤ x ➤ built`);
+      expect(stdout).toContain(`baz: Field only allowed in top-level workspace manifest, will be ignored: dependenciesMeta ➤ x ➤ unplugged`);
+
+      expect(stdout).not.toContain(`qux: Field only allowed in top-level workspace manifest, will be ignored: dependenciesMeta ➤ x ➤ optional`);
+    }),
   );
 });

--- a/packages/yarnpkg-core/sources/CorePlugin.ts
+++ b/packages/yarnpkg-core/sources/CorePlugin.ts
@@ -55,8 +55,11 @@ export const CorePlugin: Plugin = {
       // Validate manifest
       const {manifest} = workspace;
 
-      if (manifest.resolutions.length && workspace.cwd !== workspace.project.cwd)
-        manifest.errors.push(new Error(`Resolutions field will be ignored`));
+      if (workspace.cwd !== workspace.project.cwd) {
+        for (const field of manifest.topLevelWorkspaceFields) {
+          manifest.errors.push(new Error(`Field only allowed in top-level workspace manifest, will be ignored: ${field}`));
+        }
+      }
 
       for (const manifestError of manifest.errors) {
         report.reportWarning(MessageName.INVALID_MANIFEST, manifestError.message);

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -84,9 +84,14 @@ export class Manifest {
   public raw: {[key: string]: any} = {};
 
   /**
-   * errors found in the raw manifest while loading
+   * Errors found in the raw manifest while loading.
    */
   public errors: Array<Error> = [];
+
+  /**
+   * Errors about these fields will be pushed to `this.errors` during the validation step if they are not declared inside the top-level workspace manifest.
+   */
+  public topLevelWorkspaceFields: Set<string> = new Set();
 
   static readonly fileName = `package.json` as Filename;
 
@@ -186,6 +191,7 @@ export class Manifest {
 
     this.raw = data;
     const errors: Array<Error> = [];
+    const topLevelWorkspaceFields: Set<string> = new Set();
 
     this.name = null;
     if (typeof data.name === `string`) {
@@ -427,6 +433,8 @@ export class Manifest {
           errors.push(new Error(`Invalid built meta field for '${pattern}'`));
           continue;
         }
+        if (typeof built !== `undefined`)
+          topLevelWorkspaceFields.add(`dependenciesMeta ➤ ${pattern} ➤ built`);
 
         const optional = tryParseOptionalBoolean(meta.optional, {yamlCompatibilityMode});
         if (optional === null) {
@@ -439,6 +447,8 @@ export class Manifest {
           errors.push(new Error(`Invalid unplugged meta field for '${pattern}'`));
           continue;
         }
+        if (typeof unplugged !== `undefined`)
+          topLevelWorkspaceFields.add(`dependenciesMeta ➤ ${pattern} ➤ unplugged`);
 
         Object.assign(dependencyMeta, {built, optional, unplugged});
       }
@@ -467,6 +477,8 @@ export class Manifest {
 
     this.resolutions = [];
     if (typeof data.resolutions === `object` && data.resolutions !== null) {
+      topLevelWorkspaceFields.add(`resolutions`);
+
       for (const [pattern, reference] of Object.entries(data.resolutions)) {
         if (typeof reference !== `string`) {
           errors.push(new Error(`Invalid resolution entry for '${pattern}'`));
@@ -624,6 +636,7 @@ export class Manifest {
       this.preferUnplugged = null;
 
     this.errors = errors;
+    this.topLevelWorkspaceFields = topLevelWorkspaceFields;
   }
 
   getForScope(type: string) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Just like the `resolutions` field, `dependenciesMeta.{built,unplugged}` can only be declared inside the top-level workspace manifest, but we don't currently show a warning if it is declared inside a workspace manifest.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it show a warning in that case.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
