### PR TITLE
docs: add scroll-padding-top to avoid hiding anchor link targets

### DIFF
--- a/packages/gatsby/src/components/layout.css
+++ b/packages/gatsby/src/components/layout.css
@@ -11,6 +11,9 @@ body {
 
   font-family: "Open Sans", sans-serif;
   line-height: 1.5;
+  
+  /* match banner + topbar height to avoid hiding anchor link targets below topbar */
+  scroll-padding-top: 100px;
 }
 
 code {


### PR DESCRIPTION
**What's the problem this PR addresses?**
I can't see the target of anchor links, for example after searching and clicking the results. It's hidden below the topbar.

<img width="1079" alt="Screenshot 2021-12-30 at 14 53 34" src="https://user-images.githubusercontent.com/58563/147758305-dab24c93-d81f-4685-a2b5-6a37f6768e29.png">


<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
This sets `scroll-padding-top` to the height of the banner and topbar
<img width="1076" alt="Screenshot 2021-12-30 at 14 53 08" src="https://user-images.githubusercontent.com/58563/147758445-54740a33-8a35-4b3b-b1b8-b903ff1cbea7.png">



...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
