### PR TITLE
fix(essentials): make `--mode=update-lockfile` disable immutable installs

### DIFF
--- a/.yarn/versions/3bda1f12.yml
+++ b/.yarn/versions/3bda1f12.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -417,15 +417,15 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run}) => {
         await expect(run(`install`, `--mode=update-lockfile`, `--immutable`)).rejects.toMatchObject({
           code: 1,
-          stdout: expect.stringMatching(/`--immutable` and `--immutable-cache` cannot be used with `--mode=update-lockfile`/g),
+          stdout: expect.stringMatching(/--immutable and --immutable-cache cannot be used with --mode=update-lockfile/g),
         });
         await expect(run(`install`, `--mode=update-lockfile`, `--immutable-cache`)).rejects.toMatchObject({
           code: 1,
-          stdout: expect.stringMatching(/`--immutable` and `--immutable-cache` cannot be used with `--mode=update-lockfile`/g),
+          stdout: expect.stringMatching(/--immutable and --immutable-cache cannot be used with --mode=update-lockfile/g),
         });
         await expect(run(`install`, `--mode=update-lockfile`, `--immutable`, `--immutable-cache`)).rejects.toMatchObject({
           code: 1,
-          stdout: expect.stringMatching(/`--immutable` and `--immutable-cache` cannot be used with `--mode=update-lockfile`/g),
+          stdout: expect.stringMatching(/--immutable and --immutable-cache cannot be used with --mode=update-lockfile/g),
         });
       }),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -413,7 +413,7 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should throw when \`--immutable\` or \`--immutable-cache\` specified with \`--mode=update-lockfile\``,
+      `it should throw when \`--immutable\` or \`--immutable-cache\` is specified with \`--mode=update-lockfile\``,
       makeTemporaryEnv({}, async ({path, run}) => {
         await expect(run(`install`, `--mode=update-lockfile`, `--immutable`)).rejects.toMatchObject({
           code: 1,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -397,5 +397,37 @@ describe(`Commands`, () => {
         expect(cacheAfter.find(entry => entry.includes(`no-deps-npm-2.0.0`))).toBeDefined();
       }),
     );
+
+    test(
+      `it should disable immutable installs when using \`--mode=update-lockfile\``,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run}) => {
+        await xfs.writeFilePromise(`${path}/${Filename.rc}`, `enableImmutableInstalls: true`);
+
+        const {stdout} = await run(`install`, `--mode=update-lockfile`);
+        expect(stdout).not.toMatch(/YN0028/g);
+      }),
+    );
+
+    test(
+      `it should throw when \`--immutable\` or \`--immutable-cache\` specified with \`--mode=update-lockfile\``,
+      makeTemporaryEnv({}, async ({path, run}) => {
+        await expect(run(`install`, `--mode=update-lockfile`, `--immutable`)).rejects.toMatchObject({
+          code: 1,
+          stdout: expect.stringMatching(/`--immutable` and `--immutable-cache` cannot be used with `--mode=update-lockfile`/g),
+        });
+        await expect(run(`install`, `--mode=update-lockfile`, `--immutable-cache`)).rejects.toMatchObject({
+          code: 1,
+          stdout: expect.stringMatching(/`--immutable` and `--immutable-cache` cannot be used with `--mode=update-lockfile`/g),
+        });
+        await expect(run(`install`, `--mode=update-lockfile`, `--immutable`, `--immutable-cache`)).rejects.toMatchObject({
+          code: 1,
+          stdout: expect.stringMatching(/`--immutable` and `--immutable-cache` cannot be used with `--mode=update-lockfile`/g),
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -218,7 +218,8 @@ export default class YarnCommand extends BaseCommand {
       }
     }
 
-    const immutable = this.immutable ?? configuration.get(`enableImmutableInstalls`);
+    const updateMode = this.mode === InstallMode.UpdateLockfile;
+    const immutable = (this.immutable ?? configuration.get(`enableImmutableInstalls`)) && !updateMode;
 
     if (configuration.projectCwd !== null) {
       const fixReport = await StreamReport.start({
@@ -291,7 +292,7 @@ export default class YarnCommand extends BaseCommand {
     }
 
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration, {immutable: this.immutableCache, check: this.checkCache});
+    const cache = await Cache.find(configuration, {immutable: this.immutableCache && !updateMode, check: this.checkCache});
 
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -223,6 +223,7 @@ export default class YarnCommand extends BaseCommand {
       throw new UsageError(`${formatUtils.pretty(configuration, `--immutable`, formatUtils.Type.CODE)} and ${formatUtils.pretty(configuration, `--immutable-cache`, formatUtils.Type.CODE)} cannot be used with ${formatUtils.pretty(configuration, `--mode=update-lockfile`, formatUtils.Type.CODE)}`);
 
     const immutable = (this.immutable ?? configuration.get(`enableImmutableInstalls`)) && !updateMode;
+    const immutableCache = this.immutableCache && !updateMode;
 
     if (configuration.projectCwd !== null) {
       const fixReport = await StreamReport.start({
@@ -295,7 +296,7 @@ export default class YarnCommand extends BaseCommand {
     }
 
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration, {immutable: this.immutableCache && !updateMode, check: this.checkCache});
+    const cache = await Cache.find(configuration, {immutable: immutableCache, check: this.checkCache});
 
     if (!workspace)
       throw new WorkspaceRequiredError(project.cwd, this.context.cwd);

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -220,7 +220,7 @@ export default class YarnCommand extends BaseCommand {
 
     const updateMode = this.mode === InstallMode.UpdateLockfile;
     if (updateMode && (this.immutable || this.immutableCache))
-      throw new UsageError(`${formatUtils.pretty(configuration, '--immutable', formatUtils.Type.CODE)} and ${formatUtils.pretty(configuration, '--immutable-cache', formatUtils.Type.CODE)} cannot be used with ${formatUtils.pretty(configuration, '--mode=update-lockfile', formatUtils.Type.CODE)}`);
+      throw new UsageError(`${formatUtils.pretty(configuration, `--immutable`, formatUtils.Type.CODE)} and ${formatUtils.pretty(configuration, `--immutable-cache`, formatUtils.Type.CODE)} cannot be used with ${formatUtils.pretty(configuration, `--mode=update-lockfile`, formatUtils.Type.CODE)}`);
 
     const immutable = (this.immutable ?? configuration.get(`enableImmutableInstalls`)) && !updateMode;
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -219,9 +219,8 @@ export default class YarnCommand extends BaseCommand {
     }
 
     const updateMode = this.mode === InstallMode.UpdateLockfile;
-    if (updateMode && (this.immutable || this.immutableCache)) {
+    if (updateMode && (this.immutable || this.immutableCache))
       throw new UsageError(`\`--immutable\` and \`--immutable-cache\` cannot be used with \`--mode=update-lockfile\``);
-    }
 
     const immutable = (this.immutable ?? configuration.get(`enableImmutableInstalls`)) && !updateMode;
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -3,7 +3,7 @@ import {Configuration, Cache, MessageName, Project, ReportError, StreamReport, f
 import {xfs, ppath, Filename}                                                                            from '@yarnpkg/fslib';
 import {parseSyml, stringifySyml}                                                                        from '@yarnpkg/parsers';
 import CI                                                                                                from 'ci-info';
-import {Command, Option, Usage}                                                                          from 'clipanion';
+import {Command, Option, Usage, UsageError}                                                              from 'clipanion';
 import * as t                                                                                            from 'typanion';
 
 // eslint-disable-next-line arca/no-default-export
@@ -219,6 +219,10 @@ export default class YarnCommand extends BaseCommand {
     }
 
     const updateMode = this.mode === InstallMode.UpdateLockfile;
+    if (updateMode && (this.immutable || this.immutableCache)) {
+      throw new UsageError(`\`--immutable\` and \`--immutable-cache\` cannot be used with \`--mode=update-lockfile\``);
+    }
+
     const immutable = (this.immutable ?? configuration.get(`enableImmutableInstalls`)) && !updateMode;
 
     if (configuration.projectCwd !== null) {

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -220,7 +220,7 @@ export default class YarnCommand extends BaseCommand {
 
     const updateMode = this.mode === InstallMode.UpdateLockfile;
     if (updateMode && (this.immutable || this.immutableCache))
-      throw new UsageError(`\`--immutable\` and \`--immutable-cache\` cannot be used with \`--mode=update-lockfile\``);
+      throw new UsageError(`${formatUtils.pretty(configuration, '--immutable', formatUtils.Type.CODE)} and ${formatUtils.pretty(configuration, '--immutable-cache', formatUtils.Type.CODE)} cannot be used with ${formatUtils.pretty(configuration, '--mode=update-lockfile', formatUtils.Type.CODE)}`);
 
     const immutable = (this.immutable ?? configuration.get(`enableImmutableInstalls`)) && !updateMode;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Resolves #3606

**How did you fix it?**

`--mode=update-lockfile` means that the user has explicitly expected "dependency update mode".

This should take precedence over immutable mode, which is automatically set in the CI environment.

This change disables all immutable flag behaviors in the update mode.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
