### PR TITLE
feat: improve upgrade-interactive paging

### DIFF
--- a/.yarn/versions/ba257392.yml
+++ b/.yarn/versions/ba257392.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-interactive-tools": patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 ### Commands
 
 - A new `yarn explain` command has been added. It can be used to explain an error code or list all available error codes.
+- `yarn upgrade-interactive` now has improved paging:
+  - The suggestions that fit in the viewport will be fetched in the foreground and will load one-by-one.
+  - The suggestions that don't will be fetched in the background and will be loaded in batches to increase responsiveness and reduce input lag.
+  - Most notably, you won't have to wait for all of the suggestions to be fetched (which took a very long time before on large monorepos) before you can start navigating through the list.
 
 ### Installs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 - A new `yarn explain` command has been added. It can be used to explain an error code or list all available error codes.
 - `yarn upgrade-interactive` now has improved paging:
+  - Yarn will display as many suggestions as can fit in the viewport (rather than a fixed-size list).
   - The suggestions that fit in the viewport will be fetched in the foreground and will load one-by-one.
   - The suggestions that don't will be fetched in the background and will be loaded in batches to increase responsiveness and reduce input lag.
   - Most notably, you won't have to wait for all of the suggestions to be fetched (which took a very long time before on large monorepos) before you can start navigating through the list.

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -13,7 +13,13 @@ import React, {useEffect, useRef, useState}                                     
 import semver                                                                                                                           from 'semver';
 
 const SIMPLE_SEMVER = /^((?:[\^~]|>=?)?)([0-9]+)(\.[0-9]+)(\.[0-9]+)((?:-\S+)?)$/;
-const DEFAULT_WINDOW_SIZE = 10;
+
+// eslint-disable-next-line @typescript-eslint/comma-dangle -- the trailing comma is required because of parsing ambiguities
+const partition = <T,>(array: Array<T>, size: number): Array<Array<T>> => {
+  return array.length > 0
+    ? [array.slice(0, size)].concat(partition(array.slice(size), size))
+    : [];
+};
 
 type UpgradeSuggestion = {value: string | null, label: string};
 type UpgradeSuggestions = Array<UpgradeSuggestion>;
@@ -47,6 +53,15 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     await project.restoreInstallState({
       restoreResolutions: false,
     });
+
+    // 7 = 1-line command written by the user
+    //   + 2-line prompt
+    //   + 1 newline
+    //   + 1-line header
+    //   + 1 newline
+    //     [...package list]
+    //   + 1 empty line
+    const VIEWPORT_SIZE = process.stdout.rows - 7;
 
     const colorizeRawDiff = (from: string, to: string) => {
       const diff = diffWords(from, to);
@@ -206,49 +221,92 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
             </Text>
             <Pad active={active} length={padLength}/>
           </Box>
-          {suggestions !== null
-            ? <ItemOptions active={active} options={suggestions} value={action} skewer={true} onChange={setAction} sizes={[17, 17, 17]} />
-            : <Box marginLeft={2}><Text color={`gray`}>Fetching suggestions...</Text></Box>
-          }
+          <ItemOptions active={active} options={suggestions} value={action} skewer={true} onChange={setAction} sizes={[17, 17, 17]} />
         </Box>
       </>;
     };
 
-    const UpgradeEntries = ({dependencies}: { dependencies: Array<Descriptor> }) => {
-      const [suggestions, setSuggestions] = useState<Array<readonly [Descriptor, UpgradeSuggestions]> | null>(null);
+    const UpgradeEntries = ({dependencies}: {dependencies: Array<Descriptor>}) => {
+      const [suggestions, setSuggestions] = useState<Array<{descriptor: Descriptor, suggestions: UpgradeSuggestions} | null>>(dependencies.map(() => null));
       const mountedRef = useRef<boolean>(true);
+
+      const getSuggestionsForDescriptor = async (descriptor: Descriptor) => {
+        const suggestions = await fetchSuggestions(descriptor);
+        if (suggestions.filter(suggestion => suggestion.label !== ``).length <= 1)
+          return null;
+
+        return {descriptor, suggestions};
+      };
 
       useEffect(() => {
         return () => {
           mountedRef.current = false;
         };
-      });
-
-      useEffect(() => {
-        Promise.all(dependencies.map(descriptor => fetchSuggestions(descriptor)))
-          .then(allSuggestions => {
-            const mappedToSuggestions = dependencies.map((descriptor, i) => {
-              const suggestionsForDescriptor = allSuggestions[i];
-              return [descriptor, suggestionsForDescriptor] as const;
-            }).filter(([_, suggestions]) => {
-              return suggestions.filter(suggestion => suggestion.label !== ``).length > 1;
-            });
-
-            if (mountedRef.current) {
-              setSuggestions(mappedToSuggestions);
-            }
-          });
       }, []);
 
-      // Still fetching
-      if (!suggestions)
-        return <Text>Fetching suggestions...</Text>;
+      useEffect(() => {
+        // Updating the invisible suggestions as they resolve causes continuous lag spikes while scrolling through the list of visible suggestions.
+        // Because of that, we update the invisible suggestions in batches of VIEWPORT_SIZE.
+
+        const foregroundDependencyCount = Math.trunc(VIEWPORT_SIZE * 1.75);
+
+        const foregroundDependencies = dependencies.slice(0, foregroundDependencyCount);
+        const backgroundDependencies = dependencies.slice(foregroundDependencyCount);
+
+        const backgroundDependencyGroups = partition(backgroundDependencies, VIEWPORT_SIZE);
+
+        const foregroundLock = foregroundDependencies
+          .map(getSuggestionsForDescriptor)
+          .reduce(async (lock, currentSuggestionPromise) => {
+            await lock;
+
+            const currentSuggestion = await currentSuggestionPromise;
+            if (currentSuggestion === null)
+              return;
+
+            if (!mountedRef.current)
+              return;
+
+            setSuggestions(suggestions => {
+              const firstEmptySlot = suggestions.findIndex(suggestion => suggestion === null);
+
+              const newSuggestions = [...suggestions];
+              newSuggestions[firstEmptySlot] = currentSuggestion;
+
+              return newSuggestions;
+            });
+          }, Promise.resolve());
+
+        backgroundDependencyGroups.reduce((lock, group) =>
+          Promise.all(group.map(descriptor => Promise.resolve().then(() => getSuggestionsForDescriptor(descriptor))))
+            .then(async newSuggestions => {
+              await lock;
+              if (mountedRef.current) {
+                setSuggestions(suggestions => {
+                  const firstEmptySlot = suggestions.findIndex(suggestion => suggestion === null);
+                  return suggestions
+                    .slice(0, firstEmptySlot)
+                    .concat(newSuggestions.filter(suggestion => suggestion !== null))
+                    .concat(suggestions.slice(firstEmptySlot + 1));
+                });
+              }
+            }), foregroundLock,
+        ).then(() => {
+          // Cleanup all empty slots
+          if (mountedRef.current) {
+            setSuggestions(suggestions => suggestions.filter(suggestion => suggestion !== null));
+          }
+        });
+      }, []);
 
       if (!suggestions.length)
         return <Text>No upgrades found</Text>;
 
-      return <ScrollableItems radius={DEFAULT_WINDOW_SIZE} children={suggestions.map(([descriptor, upgrades]) => {
-        return <UpgradeEntry key={descriptor.descriptorHash} active={false} descriptor={descriptor} suggestions={upgrades} />;
+      return <ScrollableItems radius={VIEWPORT_SIZE >> 1} children={suggestions.map((suggestion, index) => {
+        // We use the same keys so that we don't lose the selection when a suggestion finishes loading
+        return suggestion !== null
+          ? <UpgradeEntry key={index} active={false} descriptor={suggestion.descriptor} suggestions={suggestion.suggestions} />
+          : <Text key={index}>Loading...</Text>;
       })} />;
     };
 

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -280,14 +280,16 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         backgroundDependencyGroups.reduce((lock, group) =>
           Promise.all(group.map(descriptor => Promise.resolve().then(() => getSuggestionsForDescriptor(descriptor))))
             .then(async newSuggestions => {
+              newSuggestions = newSuggestions.filter(suggestion => suggestion !== null);
+
               await lock;
               if (mountedRef.current) {
                 setSuggestions(suggestions => {
                   const firstEmptySlot = suggestions.findIndex(suggestion => suggestion === null);
                   return suggestions
                     .slice(0, firstEmptySlot)
-                    .concat(newSuggestions.filter(suggestion => suggestion !== null))
-                    .concat(suggestions.slice(firstEmptySlot + 1));
+                    .concat(newSuggestions)
+                    .concat(suggestions.slice(firstEmptySlot + newSuggestions.length));
                 });
               }
             }), foregroundLock,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- `upgrade-interactive` didn't display as many suggestions as can fit in the viewport.
- Available upgrades were only displayed after all of the suggestions had been fetched, which took forever on large monorepos.

Fixes https://github.com/yarnpkg/berry/issues/3918.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- Made it display as many suggestions as can fit in the viewport.
- Made it fetch suggestions that fit in the viewport in the foreground and load them one-by-one (but they still wait on the previous one because otherwise they'd be jumping up and down as more suggestions are resolved).
- Made it fetch suggestions that don't fit in the viewport in the background in batches of one viewport at a time so that they don't affect responsiveness (fetching them one-by-one causes massive lag spikes while scrolling through the list of suggestions that fit in the viewport; displaying them only after all of them have been fetched isn't a good solution because they don't load fast enough as the user scrolls)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
