### PR TITLE
Adds Doppler to the search UI

### DIFF
--- a/packages/gatsby/src/components/hit/index.js
+++ b/packages/gatsby/src/components/hit/index.js
@@ -213,7 +213,7 @@ export const Links = ({name, homepage, repository}) => (
 );
 
 const HitItem = styled.div`
-  padding: 1.5rem 1rem 2rem;
+  padding: 1.5rem 0 2rem;
   border-bottom: 1px solid #eceeef;
   position: relative;
 `;

--- a/packages/gatsby/src/components/search/SearchResults.js
+++ b/packages/gatsby/src/components/search/SearchResults.js
@@ -20,6 +20,45 @@ const Hits = connectHits(({hits, onTagClick, onOwnerClick, searchState}) =>
   )),
 );
 
+const InfoBar = styled.div`
+  display: flex;
+
+  background: #2188b6;
+  color: rgba(255, 255, 255, 0.8);
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+
+  margin: 0 auto 0 auto;
+  padding: 0 15px 0 15px;
+  width: 1140px;
+  max-width: 100%;
+`;
+
+const StatsText = styled.div`
+  flex: none;
+  padding: 0.7rem 0;
+  margin-right: 1rem;
+`;
+
+const Sponsors = styled.a`
+  padding: 0.7rem 0;
+
+  flex: none;
+  margin-left: auto;
+
+  color: inherit;
+
+  span {
+    display: inline-block;
+
+    color: #85ecf7;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+`;
+
 const ResultsContainer = styled.div`
   margin: 0 auto 0 auto;
   padding: 0 15px 0 15px;
@@ -32,15 +71,11 @@ const SearchFooter = styled.div`
   margin-bottom: 50px;
 `;
 
-const StatsText = styled.div`
-  padding: 0 16px 0 16px;
-`;
-
 const RefinementContainer = styled.div`
   .ais-CurrentRefinements-list {
     list-style-type: none;
     padding: 0;
-    margin-top: 0.5em;
+    margin: 0;
     font-size: 0.8125rem;
   }
 
@@ -58,19 +93,18 @@ const RefinementContainer = styled.div`
   }
 `;
 
-const ResultsFound = ({pagination, onTagClick, onOwnerClick, searchState}) => (
+const ResultsFound = ({pagination, onTagClick, onOwnerClick, searchState}) => <>
+  <InfoBar>
+    <InfoContainer>
+      <StatsText>
+        <Stats translations={{stats: (num, time) => `found ${num.toLocaleString(`en`)} packages in ${time}ms`}}/>
+      </StatsText>
+      <Sponsors href={`https://www.doppler.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=yarn&utm_source=github`}>
+        Thanks to <span>Doppler</span>, the Universal Secrets Platform, for sponsoring Yarn!
+      </Sponsors>
+    </InfoContainer>
+  </InfoBar>
   <ResultsContainer>
-    <StatsText>
-      <RefinementContainer>
-        <CurrentRefinements />
-      </RefinementContainer>
-      <Stats
-        translations={{
-          stats: (num, time) =>
-            `found ${num.toLocaleString(`en`)} packages in ${time}ms`,
-        }}
-      />
-    </StatsText>
     <Hits onTagClick={onTagClick} onOwnerClick={onOwnerClick} searchState={searchState} />
     <Pagination pagination={pagination} />
     <SearchFooter>
@@ -82,7 +116,7 @@ const ResultsFound = ({pagination, onTagClick, onOwnerClick, searchState}) => (
       .
     </SearchFooter>
   </ResultsContainer>
-);
+</>;
 
 const NoPackagesFound = styled.div`
   padding: 0 15px;


### PR DESCRIPTION
**What's the problem this PR addresses?**

With Doppler sponsoring us [Gold tier](https://github.com/sponsors/yarnpkg), we can return the favour and thank them on our search result page. I tried to find a balance between non-intrusive and non-invisible, I think it works well (it doesn't take extra vertical space, but it's at the top of the search results):

![image](https://user-images.githubusercontent.com/1037931/148132706-d58286a7-5d43-4977-922d-6964dfff9fe3.png)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
