### PR TITLE
Fixes search DT/TS disambiguation

### DIFF
--- a/packages/gatsby/src/components/hit/index.js
+++ b/packages/gatsby/src/components/hit/index.js
@@ -247,21 +247,25 @@ const HitVersion = styled.span`
   vertical-align: middle;
 `;
 
-const IconTypeScript = styled.img`
-  margin-left: 0.2em;
-  width: 0.8em;
-  height: 0.8em;
-  vertical-align: baseline;
+const HitTypeScript = styled.span`
+  font-size: 0.75rem;
+  border: solid 1px transparent;
+  color: #ffffff;
+  padding: 2px 4px;
+  border-radius: 4px;
+  margin-right: 8px;
+  letter-spacing: 0.2px;
+  background: #0380d9;
 `;
 
 export const TypeScript = ({name, ts}) => {
   if (ts === false)
     return null;
 
-  const iconTypescript = <IconTypeScript
-    src={IcoTypeScript}
+  const iconTypescript = <HitTypeScript
     alt={`TypeScript support: ${ts}`}
     title={`TypeScript support: ${ts}`}
+    children={ts === `definitely-typed` ? `DT` : `TS`}
   />;
 
   if (ts !== `definitely-typed`)
@@ -312,8 +316,8 @@ export const Hit = ({hit, onTagClick, onOwnerClick, searchState}) => (
     />
     <License type={hit.license} />
     <Deprecated deprecated={hit.deprecated} />
-    <HitVersion>{hit.version}</HitVersion>
     <TypeScript name={hit.name} ts={hit.types.ts} />
+    <HitVersion>{hit.version}</HitVersion>
     <HitDescription>
       {hit.deprecated ? (
         hit.deprecated

--- a/packages/gatsby/src/components/hit/index.js
+++ b/packages/gatsby/src/components/hit/index.js
@@ -14,7 +14,6 @@ import IcoHotT2       from '../../images/search/ico-hot-t2.svg';
 import IcoHotT3       from '../../images/search/ico-hot-t3.svg';
 import IcoHotT4       from '../../images/search/ico-hot-t4.svg';
 import IcoNpm         from '../../images/search/ico-npm.svg';
-import IcoTypeScript  from '../../images/search/ico-typescript.svg';
 
 import {
   getDownloadBucket,


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's always annoyed me that the search page shows whether a package has TS types or not, but not whether they come from @definitelytyped or not (which is important, since it means they may have to be installed separately). You had to put your mouse over the widget to see the alt text.

**How did you fix it?**

Replaced the hint with a version that shows either DT or TS in the widget, depending on the status.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
