### PR TITLE
fix(plugin-nm): update data key version

### DIFF
--- a/.yarn/versions/ddc6b36f.yml
+++ b/.yarn/versions/ddc6b36f.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -122,7 +122,7 @@ class NodeModulesInstaller implements Installer {
   getCustomDataKey() {
     return JSON.stringify({
       name: `NodeModulesInstaller`,
-      version: 1,
+      version: 2,
     });
   }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

In https://github.com/yarnpkg/berry/pull/3575/files#diff-b6f2618cc58bd274cb6c2114799ab4f80cd5971a299ea847dd8c031c5c411134L370-L371 the custom data for the linkers changed but the custom data key wasn't updated.

Fixes https://github.com/yarnpkg/berry/issues/3877

**How did you fix it?**

Update the version in the data key.

I updated the key for the `PnpLinker` in https://github.com/yarnpkg/berry/pull/2161 and @paul-soporan updated the key for the `PnpmLinker` in https://github.com/yarnpkg/berry/pull/3681 so they're already fixed.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.