### PR TITLE
Parallelizes package unplugging

### DIFF
--- a/.yarn/versions/d5a60103.yml
+++ b/.yarn/versions/d5a60103.yml
@@ -1,8 +1,8 @@
 releases:
   "@yarnpkg/cli": patch
-  "@yarnpkg/core": patch
-  "@yarnpkg/plugin-pnp": patch
-  "@yarnpkg/plugin-pnpm": patch
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-pnp": minor
+  "@yarnpkg/plugin-pnpm": minor
 
 declined:
   - "@yarnpkg/plugin-compat"

--- a/.yarn/versions/d5a60103.yml
+++ b/.yarn/versions/d5a60103.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -1,8 +1,7 @@
-import {Descriptor, FetchResult, formatUtils, Installer, InstallPackageExtraApi, Linker, LinkOptions, LinkType, Locator, LocatorHash, Manifest, MessageName, MinimalLinkOptions, Package, Project, structUtils} from '@yarnpkg/core';
-import {Dirent, Filename, PortablePath, ppath, xfs}                                                                                                                                                             from '@yarnpkg/fslib';
-import {jsInstallUtils}                                                                                                                                                                                         from '@yarnpkg/plugin-pnp';
-import {UsageError}                                                                                                                                                                                             from 'clipanion';
-import pLimit                                                                                                                                                                                                   from 'p-limit';
+import {Descriptor, FetchResult, formatUtils, Installer, InstallPackageExtraApi, Linker, LinkOptions, LinkType, Locator, LocatorHash, Manifest, MessageName, MinimalLinkOptions, Package, Project, miscUtils, structUtils} from '@yarnpkg/core';
+import {Dirent, Filename, PortablePath, ppath, xfs}                                                                                                                                                                        from '@yarnpkg/fslib';
+import {jsInstallUtils}                                                                                                                                                                                                    from '@yarnpkg/plugin-pnp';
+import {UsageError}                                                                                                                                                                                                        from 'clipanion';
 
 export type PnpmCustomData = {
   pathByLocator: Map<LocatorHash, PortablePath>;
@@ -72,7 +71,7 @@ export class PnpmLinker implements Linker {
 }
 
 class PnpmInstaller implements Installer {
-  private asyncActions = new AsyncActions();
+  private readonly asyncActions = new miscUtils.AsyncActions(10);
 
   constructor(private opts: LinkOptions) {
     // Nothing to do
@@ -389,59 +388,5 @@ async function removeIfEmpty(dir: PortablePath) {
     if (error.code !== `ENOENT` && error.code !== `ENOTEMPTY`) {
       throw error;
     }
-  }
-}
-
-type Deferred = {
-  promise: Promise<void>;
-  resolve: () => void;
-  reject: (err: Error) => void;
-};
-
-function makeDeferred(): Deferred {
-  let resolve: () => void;
-  let reject: (err: Error) => void;
-
-  const promise = new Promise<void>((resolveFn, rejectFn) => {
-    resolve = resolveFn;
-    reject = rejectFn;
-  });
-
-  return {promise, resolve: resolve!, reject: reject!};
-}
-
-class AsyncActions {
-  deferred = new Map<string, Deferred>();
-  promises = new Map<string, Promise<void>>();
-  limit = pLimit(10);
-
-  set(key: string, factory: () => Promise<void>) {
-    let deferred = this.deferred.get(key);
-    if (typeof deferred === `undefined`)
-      this.deferred.set(key, deferred = makeDeferred());
-
-    const promise = this.limit(() => factory());
-    this.promises.set(key, promise);
-
-    promise.then(() => {
-      if (this.promises.get(key) === promise) {
-        deferred!.resolve();
-      }
-    }, err => {
-      if (this.promises.get(key) === promise) {
-        deferred!.reject(err);
-      }
-    });
-
-    return deferred.promise;
-  }
-
-  reduce(key: string, factory: (action: Promise<void>) => Promise<void>) {
-    const promise = this.promises.get(key) ?? Promise.resolve();
-    this.set(key, () => factory(promise));
-  }
-
-  async wait() {
-    await Promise.all(this.promises.values());
   }
 }

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -251,7 +251,7 @@ export class AsyncActions {
   private limit: Limit;
 
   constructor(limit: number) {
-    this.limit = pLimit(10);
+    this.limit = pLimit(limit);
   }
 
   set(key: string, factory: () => Promise<void>) {

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -1,6 +1,7 @@
 import {PortablePath, npath, xfs} from '@yarnpkg/fslib';
 import {UsageError}               from 'clipanion';
 import micromatch                 from 'micromatch';
+import pLimit, {Limit}            from 'p-limit';
 import semver                     from 'semver';
 import {Readable, Transform}      from 'stream';
 
@@ -222,6 +223,65 @@ export class BufferStream extends Transform {
 
   _flush(cb: any) {
     cb(null, Buffer.concat(this.chunks));
+  }
+}
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
+};
+
+function makeDeferred(): Deferred {
+  let resolve: () => void;
+  let reject: (err: Error) => void;
+
+  const promise = new Promise<void>((resolveFn, rejectFn) => {
+    resolve = resolveFn;
+    reject = rejectFn;
+  });
+
+  return {promise, resolve: resolve!, reject: reject!};
+}
+
+export class AsyncActions {
+  private deferred = new Map<string, Deferred>();
+  private promises = new Map<string, Promise<void>>();
+
+  private limit: Limit;
+
+  constructor(limit: number) {
+    this.limit = pLimit(10);
+  }
+
+  set(key: string, factory: () => Promise<void>) {
+    let deferred = this.deferred.get(key);
+    if (typeof deferred === `undefined`)
+      this.deferred.set(key, deferred = makeDeferred());
+
+    const promise = this.limit(() => factory());
+    this.promises.set(key, promise);
+
+    promise.then(() => {
+      if (this.promises.get(key) === promise) {
+        deferred!.resolve();
+      }
+    }, err => {
+      if (this.promises.get(key) === promise) {
+        deferred!.reject(err);
+      }
+    });
+
+    return deferred.promise;
+  }
+
+  reduce(key: string, factory: (action: Promise<void>) => Promise<void>) {
+    const promise = this.promises.get(key) ?? Promise.resolve();
+    this.set(key, () => factory(promise));
+  }
+
+  async wait() {
+    await Promise.all(this.promises.values());
   }
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Packages are currently unplugged one by one. Now that we have a proper API to start processing such things in the background while we use the CPU for other things, we should use it.

**How did you fix it?**

Wrap unplugs into `api.holdFetchResult`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
