### PR TITLE
Add package-yaml and update yarn.build description

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -61,7 +61,9 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**plugin-installs**](https://gitlab.com/Larry1123/yarn-contrib/-/blob/master/packages/plugin-production-install/README.md) by [**Larry1123**](https://gitlab.com/Larry1123) - create minimal yarn installs after removing development dependencies, unrelated workspaces, `@types` packages, etc
 
-- [**yarn.build**](https://yarn.build/) by [**Owen Kelly**](https://github.com/ojkelly/yarn.build) - run builds and tests in parallel according to your workspace dependencies if they have changed, and bundle them up into deployable apps for Docker, AWS Lambda, or any other server.
+- [**yarn.build**](https://yarn.build/) by [**Owen Kelly**](https://github.com/ojkelly/yarn.build) - monorepo tooling that leverages Yarn's dependency graph to run `build` and `test` on whats changed in parallel as fast as possible. It also includes a command to `bundle` them up into deployable apps for Docker, AWS Lambda, or any other server. Each command is also available as an individual plugin.
+
+- [**package-yaml**](https://github.com/ojkelly/yarn.build#plugin-package-yaml) by [**yarn.build**](https://github.com/ojkelly/yarn.build) - per package opt-in to transparently using `package.yml` instead of `package.json`
 
 - [**licenses**](https://github.com/tophat/yarn-plugin-licenses) by [**Noah Negin-Ulster**](https://noahnu.com/) - audit direct and indirect dependency licenses to ensure compliance
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
This updates the description of yarn.build's plugin to cover a bunch of recent changes. Also includes an additional plugin from yarn.build.

I recently split the commands from yarn.build into individually installable plugins, so you can now just grab the ones you want if you don't want the full suite.

Added the `package.yaml` plugin, which I've been using for months in a polyglot repo. Particularly useful for building golang packages, as well as being able to add comments.

...

**How did you fix it?**
Updated the readme.
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
