### PR TITLE
perf(core): skip checksum for cache entries when it isn't required

### DIFF
--- a/.yarn/versions/69964e29.yml
+++ b/.yarn/versions/69964e29.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -185,6 +185,11 @@ export class Cache {
     };
 
     const validateFile = async (path: PortablePath, refetchPath: PortablePath | null = null) => {
+      // We hide the checksum if the package presence is conditional, because it becomes unreliable
+      // so there is no point in computing it unless we're checking the cache
+      if (refetchPath === null && opts.unstablePackages?.has(locator.locatorHash))
+        return null;
+
       const actualChecksum = (!opts.skipIntegrityCheck || !expectedChecksum)
         ? `${this.cacheKey}/${await hashUtils.checksumFile(path)}`
         : expectedChecksum;


### PR DESCRIPTION
**What's the problem this PR addresses?**

We're computing the checksum for conditional cache entries only to throw it away.

**How did you fix it?**

Skip computing the checksum for conditional cache entries unless we're doing a cache check.

**Benchmark results**

```sh
# Next.js benchmark using next@12

YARN_IGNORE_PATH=1 hyperfine -w 1\
                    "node ./master.cjs --mode skip-build"\
                    "node ./skip-checksum.cjs --mode skip-build"
Benchmark 1: node ./master.cjs --mode skip-build
  Time (mean ± σ):     638.5 ms ±  13.2 ms    [User: 904.9 ms, System: 116.1 ms]
  Range (min … max):   623.2 ms … 663.7 ms    10 runs

Benchmark 2: node ./skip-checksum.cjs --mode skip-build
  Time (mean ± σ):     537.7 ms ±  10.8 ms    [User: 800.9 ms, System: 89.5 ms]
  Range (min … max):   524.9 ms … 560.5 ms    10 runs

Summary
  'node ./skip-checksum.cjs --mode skip-build' ran
    1.19 ± 0.03 times faster than 'node ./master.cjs --mode skip-build'

# Gatsby benchmark

YARN_IGNORE_PATH=1 hyperfine -w 1\
                    "node ./master.cjs --mode skip-build"\
                    "node ./skip-checksum.cjs --mode skip-build"
Benchmark 1: node ./master.cjs --mode skip-build
  Time (mean ± σ):      1.527 s ±  0.030 s    [User: 2.200 s, System: 0.374 s]
  Range (min … max):    1.486 s …  1.567 s    10 runs

Benchmark 2: node ./skip-checksum.cjs --mode skip-build
  Time (mean ± σ):      1.511 s ±  0.024 s    [User: 2.169 s, System: 0.389 s]
  Range (min … max):    1.491 s …  1.564 s    10 runs

Summary
  'node ./skip-checksum.cjs --mode skip-build' ran
    1.01 ± 0.03 times faster than 'node ./master.cjs --mode skip-build'

# Next.js repo with all examples included

YARN_IGNORE_PATH=1 hyperfine -w 1\
                    "node ./master.cjs --mode skip-build"\
                    "node ./skip-checksum.cjs --mode skip-build"
Benchmark 1: node ./master.cjs --mode skip-build
  Time (mean ± σ):      8.790 s ±  0.142 s    [User: 10.634 s, System: 1.949 s]
  Range (min … max):    8.663 s …  9.167 s    10 runs

Benchmark 2: node ./skip-checksum.cjs --mode skip-build
  Time (mean ± σ):      8.351 s ±  0.061 s    [User: 10.117 s, System: 1.880 s]
  Range (min … max):    8.271 s …  8.437 s    10 runs

Summary
  'node ./skip-checksum.cjs --mode skip-build' ran
    1.05 ± 0.02 times faster than 'node ./master.cjs --mode skip-build'

```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.