### PR TITLE
docs: add notes about external packages

### DIFF
--- a/.yarn/versions/5f57d7bd.yml
+++ b/.yarn/versions/5f57d7bd.yml
@@ -1,0 +1,14 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/pnpify": patch
+  "@yarnpkg/sdks": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/packages/gatsby/gatsby-config.js
+++ b/packages/gatsby/gatsby-config.js
@@ -112,19 +112,19 @@ module.exports = {
       options: {
         binaries: [
           {
-            namespace: null,
+            package: null,
             binary: `${__dirname}/../../scripts/run-yarn.js`,
           },
           {
-            namespace: `pnpify`,
+            package: `@yarnpkg/pnpify`,
             binary: `${__dirname}/../../scripts/run-pnpify.js`,
           },
           {
-            namespace: `sdks`,
+            package: `@yarnpkg/sdks`,
             binary: `${__dirname}/../../scripts/run-sdks.js`,
           },
           {
-            namespace: `builder`,
+            package: `@yarnpkg/builder`,
             binary: `${__dirname}/../../scripts/run-builder.js`,
           },
         ],

--- a/packages/gatsby/gatsby-plugin-clipanion-cli/gatsby-node.js
+++ b/packages/gatsby/gatsby-plugin-clipanion-cli/gatsby-node.js
@@ -3,9 +3,13 @@ const {execFileSync}  = require(`child_process`);
 exports.sourceNodes = ({actions, createNodeId, createContentDigest}, opts) => {
   const {createNode} = actions;
 
-  for (const {binary, namespace} of opts.binaries) {
-    const namespaceLeadingSlash = namespace ? `/${namespace}` : ``;
-    const namespaceTrailingSlash = namespace ? `${namespace}/` : ``;
+  for (const {binary, package} of opts.binaries) {
+    const packageParts = package?.match(/^(?:@([^/]+?)\/)?([^/]+)$/);
+
+    const [, scope, name] = packageParts ?? [];
+
+    const namespaceLeadingSlash = name ? `/${name}` : ``;
+    const namespaceTrailingSlash = name ? `${name}/` : ``;
 
     const output = execFileSync(`node`, [binary, `--clipanion=definitions`]);
 
@@ -39,7 +43,17 @@ exports.sourceNodes = ({actions, createNodeId, createContentDigest}, opts) => {
         sections.push([
           `> **Plugin**\n`,
           `>\n`,
-          `> To use this command, first install the \`${pluginName}\` plugin: \`yarn plugin import ${pluginName}\`\n`,
+          `> To use this command, first install the [\`${pluginName}\`](https://github.com/yarnpkg/berry/blob/HEAD/packages/plugin-${pluginName}/README.md) plugin: \`yarn plugin import ${pluginName}\`\n`,
+        ].join(``));
+      }
+
+      if (package) {
+        sections.push([
+          `> **External Package**\n`,
+          `>\n`,
+          `> To use this command, you need to use the [\`${package}\`](https://github.com/yarnpkg/berry/blob/HEAD/packages/${scope}-${name}/README.md) package either:\n`,
+          `> - By installing it locally using [\`yarn add\`](/cli/add) and running it using [\`yarn run\`](/cli/run)\n`,
+          `> - By downloading and running it in a temporary environment using [\`yarn dlx\`](/cli/dlx)\n`,
         ].join(``));
       }
 

--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -48,6 +48,11 @@ const Content = styled.div`
     background-color: #fff3e2;
   }
 
+  blockquote > ul {
+    margin: 0;
+    padding: 0.5em 2em;
+  }
+
   blockquote > p {
     margin: 0;
   }

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -17,8 +17,8 @@ A CLI tool designed for creating, building, and managing complex plugins.
 
 ## Commands
 
-- [`build bundle`](https://yarnpkg.com/builder/cli/build/bundle) - Build the local bundle.
+- [`builder build bundle`](https://yarnpkg.com/builder/cli/build/bundle) - Build the local bundle.
 
-- [`build plugin`](https://yarnpkg.com/builder/cli/build/plugin) - Build a local plugin.
+- [`builder build plugin`](https://yarnpkg.com/builder/cli/build/plugin) - Build a local plugin.
 
-- [`new plugin`](https://yarnpkg.com/builder/cli/new/plugin) - Create a new plugin.
+- [`builder new plugin`](https://yarnpkg.com/builder/cli/new/plugin) - Create a new plugin.

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -39,6 +39,8 @@ export default class BuildBundleCommand extends Command {
     description: `build the local bundle`,
     details: `
       This command builds the local bundle - the Yarn binary file that is installed in projects.
+
+      For more details about the build process, please consult the \`@yarnpkg/builder\` README: https://github.com/yarnpkg/berry/blob/HEAD/packages/yarnpkg-builder/README.md.
     `,
     examples: [[
       `Build the local bundle`,

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -34,6 +34,8 @@ export default class BuildPluginCommand extends Command {
     description: `build a local plugin`,
     details: `
       This command builds a local plugin.
+
+      For more details about the build process, please consult the \`@yarnpkg/builder\` README: https://github.com/yarnpkg/berry/blob/HEAD/packages/yarnpkg-builder/README.md.
     `,
     examples: [[
       `Build a local plugin`,

--- a/packages/yarnpkg-builder/sources/commands/new/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/new/plugin.ts
@@ -13,6 +13,8 @@ export default class NewPluginCommand extends Command {
     description: `generate the template for a new plugin`,
     details: `
       This command generates a new plugin based on the template.
+
+      For more details about the build process, please consult the \`@yarnpkg/builder\` README: https://github.com/yarnpkg/berry/blob/HEAD/packages/yarnpkg-builder/README.md.
     `,
     examples: [[
       `Create a new plugin`,

--- a/packages/yarnpkg-pnpify/README.md
+++ b/packages/yarnpkg-pnpify/README.md
@@ -1,0 +1,13 @@
+# @yarnpkg/pnpify
+
+A CLI tool designed for running commands with a virtual node_modules folder.
+
+[**Documentation**](https://yarnpkg.com/advanced/pnpify)
+
+## Installation
+
+`yarn add -D @yarnpkg/pnpify`
+
+## Commands
+
+- [`pnpify run`](https://yarnpkg.com/pnpify/cli/run) - Run a command with a virtual node_modules folder.

--- a/packages/yarnpkg-pnpify/sources/commands/RunCommand.ts
+++ b/packages/yarnpkg-pnpify/sources/commands/RunCommand.ts
@@ -17,6 +17,8 @@ export default class RunCommand extends Command {
       When a non-PnP-compliant project tries to access the \`node_modules\` directories (for example through \`readdir\` or \`readFile\`), PnPify intercepts those calls and converts them into calls to the PnP API. Then, based on the result, it simulates the existence of a virtual \`node_modules\` folder that the underlying tool will then consume - still unaware that the files are extracted from a virtual filesystem.
 
       The \`run\` keyword can be omitted if the executed command doesn't conflict with built-in commands.
+
+      For more details on PnPify, please consult the dedicated page from our website: https://yarnpkg.com/advanced/pnpify.
     `,
     examples: [[
       `Run Angular using PnPify`,

--- a/packages/yarnpkg-sdks/README.md
+++ b/packages/yarnpkg-sdks/README.md
@@ -1,0 +1,11 @@
+# @yarnpkg/sdks
+
+A CLI tool designed for generating and updating [Editor SDKs](https://yarnpkg.com/getting-started/editor-sdks) and settings.
+
+## Installation
+
+`yarn add -D @yarnpkg/sdks`
+
+## Commands
+
+- [`sdks`](https://yarnpkg.com/sdks/cli/default) - Generate editor SDKs and settings.

--- a/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
@@ -32,6 +32,8 @@ export default class SdkCommand extends Command {
       The supported integrations at this time are: ${[...SUPPORTED_INTEGRATIONS.keys()].map(integration => `\`${integration}\``).join(`, `)}.
 
       **Note:** This command always updates the already-installed SDKs and editor settings, no matter which arguments are passed.
+
+      For more details on Editor SDKs, please consult the dedicated page from our website: https://yarnpkg.com/sdks/cli/default.
     `,
     examples: [[
       `Generate the base SDKs`,

--- a/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
@@ -33,7 +33,7 @@ export default class SdkCommand extends Command {
 
       **Note:** This command always updates the already-installed SDKs and editor settings, no matter which arguments are passed.
 
-      For more details on Editor SDKs, please consult the dedicated page from our website: https://yarnpkg.com/sdks/cli/default.
+      For more details on Editor SDKs, please consult the dedicated page from our website: https://yarnpkg.com/getting-started/editor-sdks.
     `,
     examples: [[
       `Generate the base SDKs`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- `@yarnpkg/sdks` and `@yarnpkg/pnpify` didn't have READMEs.
- The command details of our external packages didn't have a `for more details` footer linking back to the main page in the docs.
- The pages of commands added by plugins didn't link to the README of the plugin.
- The pages of commands added by external packages didn't mention the fact that they need to be installed separately.

Fixes https://github.com/yarnpkg/berry/issues/3809.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- Added READMEs.
- Added one.
- Linked the name of the plugin to its README.
- Added a section about it, linked the external package name to its README, and mentioned how it can be installed.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
