### PR TITLE
perf(core): skip unnecessary exists checks

### DIFF
--- a/.yarn/versions/c608964d.yml
+++ b/.yarn/versions/c608964d.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -96,10 +96,14 @@ export class Manifest {
   static async tryFind(path: PortablePath, {baseFs = new NodeFS()}: {baseFs?: FakeFS<PortablePath>} = {}) {
     const manifestPath = ppath.join(path, `package.json` as Filename);
 
-    if (!await baseFs.existsPromise(manifestPath))
-      return null;
+    try {
+      return await Manifest.fromFile(manifestPath, {baseFs});
+    } catch (err) {
+      if (err.code === `ENOENT`)
+        return null;
 
-    return await Manifest.fromFile(manifestPath, {baseFs});
+      throw err;
+    }
   }
 
   static async find(path: PortablePath, {baseFs}: {baseFs?: FakeFS<PortablePath>} = {}) {

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -41,9 +41,7 @@ export class Workspace {
 
   async setup() {
     // @ts-expect-error: It's ok to initialize it now
-    this.manifest = xfs.existsSync(ppath.join(this.cwd, Manifest.fileName))
-      ? await Manifest.find(this.cwd)
-      : new Manifest();
+    this.manifest = await Manifest.tryFind(this.cwd) ?? new Manifest();
 
     // We use ppath.relative to guarantee that the default hash will be consistent even if the project is installed on different OS / path
     // @ts-expect-error: It's ok to initialize it now, even if it's readonly (setup is called right after construction)


### PR DESCRIPTION
**What's the problem this PR addresses?**

When setting up `Workspace` and `Manifest` instances Yarn does an unnecessary "file exists" check.

**How did you fix it?**

Remove them.

**Benchmark results**

```sh
# Berry repo (Ran in WSL but stored on the Windows side (/mnt/c/))

YARN_IGNORE_PATH=1 hyperfine -w 1\
                    "node ./master.cjs exec pwd"\
                    "node ./skip-exists-sync.cjs exec pwd"\
                    "node ./skip-exists-sync-and-promise.cjs exec pwd"
Benchmark 1: node ./master.cjs exec pwd
  Time (mean ± σ):     945.1 ms ±  10.3 ms    [User: 786.6 ms, System: 112.4 ms]
  Range (min … max):   932.9 ms … 968.9 ms    10 runs

Benchmark 2: node ./skip-exists-sync.cjs exec pwd
  Time (mean ± σ):     897.0 ms ±   5.8 ms    [User: 781.2 ms, System: 106.7 ms]
  Range (min … max):   888.0 ms … 906.4 ms    10 runs

Benchmark 3: node ./skip-exists-sync-and-promise.cjs exec pwd
  Time (mean ± σ):     846.3 ms ±   6.7 ms    [User: 770.4 ms, System: 103.8 ms]
  Range (min … max):   831.7 ms … 854.7 ms    10 runs

Summary
  'node ./skip-exists-sync-and-promise.cjs exec pwd' ran
    1.06 ± 0.01 times faster than 'node ./skip-exists-sync.cjs exec pwd'
    1.12 ± 0.01 times faster than 'node ./master.cjs exec pwd'

# Next.js repo with all examples included (WSL)

YARN_IGNORE_PATH=1 hyperfine -w 1\
                    "node ./master.cjs exec pwd"\
                    "node ./skip-exists-sync.cjs exec pwd"\
                    "node ./skip-exists-sync-and-promise.cjs exec pwd"
Benchmark 1: node ./master.cjs exec pwd
  Time (mean ± σ):      1.417 s ±  0.048 s    [User: 1.627 s, System: 0.232 s]
  Range (min … max):    1.386 s …  1.548 s    10 runs

Benchmark 2: node ./skip-exists-sync.cjs exec pwd
  Time (mean ± σ):      1.395 s ±  0.010 s    [User: 1.604 s, System: 0.229 s]
  Range (min … max):    1.372 s …  1.407 s    10 runs

Benchmark 3: node ./skip-exists-sync-and-promise.cjs exec pwd
  Time (mean ± σ):      1.382 s ±  0.007 s    [User: 1.588 s, System: 0.221 s]
  Range (min … max):    1.372 s …  1.392 s    10 runs

Summary
  'node ./skip-exists-sync-and-promise.cjs exec pwd' ran
    1.01 ± 0.01 times faster than 'node ./skip-exists-sync.cjs exec pwd'
    1.03 ± 0.03 times faster than 'node ./master.cjs exec pwd'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.