### PR TITLE
fix: use properties of actual stdout and skip progress calculations if progress bars are not enabled

### DIFF
--- a/.yarn/versions/9c1aea62.yml
+++ b/.yarn/versions/9c1aea62.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -243,7 +243,7 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
   enableProgressBars: {
     description: `If true, the CLI is allowed to show a progress bar for long-running events`,
     type: SettingsType.BOOLEAN,
-    default: !isCI && process.stdout.isTTY && process.stdout.columns > 22,
+    default: !isCI,
     defaultText: `<dynamic>`,
   },
   enableTimers: {

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -1,6 +1,7 @@
 import sliceAnsi                                                                    from '@arcanis/slice-ansi';
 import CI                                                                           from 'ci-info';
 import {Writable}                                                                   from 'stream';
+import {WriteStream}                                                                from 'tty';
 
 import {Configuration}                                                              from './Configuration';
 import {MessageName, stringifyMessageName}                                          from './MessageName';
@@ -11,6 +12,7 @@ import {Locator}                                                                
 
 export type StreamReportOptions = {
   configuration: Configuration;
+  enableProgressBars?: boolean;
   forgettableBufferSize?: number;
   forgettableNames?: Set<MessageName | null>;
   includeFooter?: boolean;
@@ -169,11 +171,12 @@ export class StreamReport extends Report {
     lastTitle?: string;
   }> = new Map();
 
+  private readonly enableProgressBars: boolean;
   private progressTime: number = 0;
   private progressFrame: number = 0;
   private progressTimeout: ReturnType<typeof setTimeout> | null = null;
-  private progressStyle: {date?: Array<number>, chars: Array<string>, size: number};
-  private progressMaxScaledSize: number;
+  private progressStyle: {date?: Array<number>, chars: Array<string>, size: number} | null = null;
+  private progressMaxScaledSize: number | null = null;
 
   private forgettableBufferSize: number;
   private forgettableNames: Set<MessageName | null>;
@@ -189,6 +192,7 @@ export class StreamReport extends Report {
     includeWarnings = includeLogs,
     forgettableBufferSize = BASE_FORGETTABLE_BUFFER_SIZE,
     forgettableNames = new Set(),
+    enableProgressBars = configuration.get(`enableProgressBars`) && !json && (stdout as WriteStream).isTTY && (stdout as WriteStream).columns > 22,
   }: StreamReportOptions) {
     super();
 
@@ -203,15 +207,19 @@ export class StreamReport extends Report {
     this.json = json;
     this.stdout = stdout;
 
-    const styleName = this.configuration.get(`progressBarStyle`) || defaultStyle;
-    if (!Object.prototype.hasOwnProperty.call(PROGRESS_STYLES, styleName))
-      throw new Error(`Assertion failed: Invalid progress bar style`);
+    this.enableProgressBars = enableProgressBars;
 
-    this.progressStyle = PROGRESS_STYLES[styleName];
-    const PAD_LEFT = `➤ YN0000: ┌ `.length;
+    if (this.enableProgressBars) {
+      const styleName = this.configuration.get(`progressBarStyle`) || defaultStyle;
+      if (!Object.prototype.hasOwnProperty.call(PROGRESS_STYLES, styleName))
+        throw new Error(`Assertion failed: Invalid progress bar style`);
 
-    const maxWidth = Math.max(0, Math.min(process.stdout.columns - PAD_LEFT, 80));
-    this.progressMaxScaledSize = Math.floor(this.progressStyle.size * maxWidth / 80);
+      this.progressStyle = PROGRESS_STYLES[styleName];
+      const PAD_LEFT = `➤ YN0000: ┌ `.length;
+
+      const maxWidth = Math.max(0, Math.min((stdout as WriteStream).columns - PAD_LEFT, 80));
+      this.progressMaxScaledSize = Math.floor(this.progressStyle.size * maxWidth / 80);
+    }
   }
 
   hasErrors() {
@@ -426,6 +434,9 @@ export class StreamReport extends Report {
   }
 
   reportProgress(progressIt: ProgressIterable) {
+    if (!this.enableProgressBars)
+      return {...Promise.resolve(), stop: () => {}};
+
     if (progressIt.hasProgress && progressIt.hasTitle)
       throw new Error(`Unimplemented: Progress bars can't have both progress and titles.`);
 
@@ -571,7 +582,7 @@ export class StreamReport extends Report {
   }
 
   private clearProgress({delta = 0, clear = false}: {delta?: number, clear?: boolean}) {
-    if (!this.configuration.get(`enableProgressBars`) || this.json)
+    if (!this.enableProgressBars)
       return;
 
     if (this.progress.size + delta > 0) {
@@ -583,7 +594,7 @@ export class StreamReport extends Report {
   }
 
   private writeProgress() {
-    if (!this.configuration.get(`enableProgressBars`) || this.json)
+    if (!this.enableProgressBars)
       return;
 
     if (this.progressTimeout !== null)
@@ -607,8 +618,8 @@ export class StreamReport extends Report {
       let progressBar = ``;
 
       if (typeof progress.lastScaledSize !== `undefined`) {
-        const ok = this.progressStyle.chars[0].repeat(progress.lastScaledSize);
-        const ko = this.progressStyle.chars[1].repeat(this.progressMaxScaledSize - progress.lastScaledSize);
+        const ok = this.progressStyle!.chars[0].repeat(progress.lastScaledSize);
+        const ko = this.progressStyle!.chars[1].repeat(this.progressMaxScaledSize! - progress.lastScaledSize);
         progressBar = ` ${ok}${ko}`;
       }
 
@@ -633,7 +644,7 @@ export class StreamReport extends Report {
     } else {
       for (const progress of this.progress.values()) {
         const refreshedScaledSize = typeof progress.definition.progress !== `undefined`
-          ? Math.trunc(this.progressMaxScaledSize * progress.definition.progress)
+          ? Math.trunc(this.progressMaxScaledSize! * progress.definition.progress)
           : undefined;
 
         const previousScaledSize = progress.lastScaledSize;
@@ -656,7 +667,7 @@ export class StreamReport extends Report {
   }
 
   private truncate(str: string, {truncate}: {truncate?: boolean} = {}) {
-    if (!this.configuration.get(`enableProgressBars`))
+    if (!this.enableProgressBars)
       truncate = false;
 
     if (typeof truncate === `undefined`)
@@ -665,7 +676,7 @@ export class StreamReport extends Report {
     // The -1 is to account for terminals that would wrap after
     // the last column rather before the first overwrite
     if (truncate)
-      str = sliceAnsi(str, 0, process.stdout.columns - 1);
+      str = sliceAnsi(str, 0, (this.stdout as WriteStream).columns - 1);
 
     return str;
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

- We used `process.stdout.{rows,columns}` in `yarn upgrade-interactive`
- We used `process.stdout.{rows,columns}` in `StreamReport`
- We computed `progressMaxScaledSize` even if progress bars weren't enabled
- We reported and refreshed progress even if progress bars weren't enabled

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- Switched it to `this.context.stdout`.
- Switched it to `this.stdout`.
- Made it only be computed if they are enabled.
- Added an `return {...Promise.resolve(), stop: () => {}};` early return to `reportProgress`

Recurrent install benchmark on the next.js repo with all examples included:

```sh
➜  next.js git:(canary) ✗ CI=1 YARN_IGNORE_PATH=1 hyperfine -w 1 "node ./master.cjs --mode skip-build" "node ./skip-progress.cjs --mode skip-build"
Benchmark 1: node ./master.cjs --mode skip-build
  Time (mean ± σ):      9.148 s ±  0.119 s    [User: 11.025 s, System: 0.802 s]
  Range (min … max):    8.957 s …  9.378 s    10 runs
 
Benchmark 2: node ./skip-progress.cjs --mode skip-build
  Time (mean ± σ):      9.052 s ±  0.093 s    [User: 10.860 s, System: 0.813 s]
  Range (min … max):    8.893 s …  9.175 s    10 runs
 
Summary
  'node ./skip-progress.cjs --mode skip-build' ran
    1.01 ± 0.02 times faster than 'node ./master.cjs --mode skip-build'
```

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
