### PR TITLE
ci: add `create-vue` e2e test

### DIFF
--- a/.github/workflows/e2e-create-vue-workflow.yml
+++ b/.github/workflows/e2e-create-vue-workflow.yml
@@ -1,0 +1,53 @@
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/actions/prepare/action.yml
+    - .github/workflows/e2e-create-vue-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Create-Vue'
+jobs:
+  chore:
+    name: 'Validating Create-Vue'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: ./.github/actions/prepare
+
+    - name: 'Running the integration test (Vue 3)'
+      run: |
+        source scripts/e2e-setup-ci.sh
+
+        yarn dlx create-vue@3 vue-project --default --typescript --eslint-with-prettier
+        cd vue-project
+        yarn
+
+        # TODO: Remove when the template is updated to use vue-tsc@>=0.30.3
+        # https://github.com/johnsoncodehk/volar/pull/851
+        yarn up vue-tsc
+
+        yarn build
+        yarn lint
+
+    - name: 'Running the integration test (Vue 2)'
+      run: |
+        source scripts/e2e-setup-ci.sh
+
+        yarn dlx create-vue@2 vue-project --default --typescript
+        cd vue-project
+        yarn
+
+        # TODO: Remove when the template is updated to use vue-tsc@>=0.30.3
+        # https://github.com/johnsoncodehk/volar/pull/851
+        yarn up vue-tsc
+
+        yarn build
+      if: |
+        always()

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ On top of our classic integration tests, we also run Yarn every day against the 
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20NM%20Angular/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-nm-angular-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20PnP%20Angular/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-pnp-angular-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20CRA/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-cra-workflow.yml)<br/>
+[![](https://github.com/yarnpkg/berry/workflows/E2E%20Create-Vue/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-create-vue-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Gatsby/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gatsby-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Gulp/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-gulp-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/workflows/E2E%20Next/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-next-workflow.yml)<br/>


### PR DESCRIPTION
**What's the problem this PR addresses?**

The new Vue documentation documents using `create-vue` to bootstrap projects[^1] so we should have an e2e test covering it

[^1]: https://github.com/vuejs/docs/blob/5947c91478c518cdeb34c41ef518b2d6e2323918/src/guide/quick-start.md#local

Depends on
- https://github.com/yarnpkg/berry/pull/4020
- https://github.com/johnsoncodehk/volar/pull/851

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.