### PR TITLE
ci: fix the `create-react-app` e2e test

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -25,14 +25,23 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
         yarn dlx create-react-app my-cra && cd my-cra
-        yarn add -D eslint-config-react-app
+
+        # TODO: Remove when create-react-app fixes their ESLint setup
+        yarn add -D eslint-config-react-app eslint
+
         yarn build
 
     - name: 'Running the TypeScript integration test'
       run: |
         source scripts/e2e-setup-ci.sh
         yarn dlx create-react-app my-cra-ts --template typescript && cd my-cra-ts
-        yarn add -D eslint-config-react-app
+
+        # TODO: Remove when create-react-app fixes their ESLint setup
+        yarn add -D eslint-config-react-app eslint
+
+        # TODO: Remove when https://github.com/facebook/create-react-app/pull/11751 is released
+        yarn add -D @types/testing-library__jest-dom
+
         yarn build
       if: |
         always()

--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -27,9 +27,6 @@ jobs:
         source scripts/e2e-setup-ci.sh
         yarn dlx create-react-app my-cra && cd my-cra
 
-        # TODO: Remove when https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896 is fixed
-        yarn set resolution mini-css-extract-plugin@npm:^2.4.5 2.4.5
-
         # TODO: Remove when create-react-app fixes their ESLint setup
         yarn add -D eslint-config-react-app eslint
 

--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -26,7 +26,13 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
         yarn dlx create-react-app my-cra && cd my-cra
-        yarn add -D eslint-config-react-app
+
+        # TODO: Remove when https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896 is fixed
+        yarn set resolution mini-css-extract-plugin@npm:^2.4.5 2.4.5
+
+        # TODO: Remove when create-react-app fixes their ESLint setup
+        yarn add -D eslint-config-react-app eslint
+
         yarn dlx -p @storybook/cli@next sb init --yes
         yarn build-storybook
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `create-react-app` e2e test has been failing for a while and https://github.com/facebook/create-react-app/pull/11751 hasn't been released yet.

I looked into the Storybook test as well but there are too many issues to deal with for now, I opened https://github.com/storybookjs/storybook/pull/17249 as a first step.

**How did you fix it?**

Add required workarounds to make it pass.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.