### PR TITLE
fix(sdks): support `tsserver` inter-process communication

### DIFF
--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "4.4.2-sdk",
+  "version": "4.5.2-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/.yarn/versions/dd3df2e2.yml
+++ b/.yarn/versions/dd3df2e2.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -170,8 +170,9 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       let hostInfo = \`unknown\`;
 
       Object.assign(Session.prototype, {
-        onMessage(/** @type {string} */ message) {
-          const parsedMessage = JSON.parse(message)
+        onMessage(/** @type {string | object} */ message) {
+          const isStringMessage = typeof message === 'string';
+          const parsedMessage = isStringMessage ? JSON.parse(message) : message;
 
           if (
             parsedMessage != null &&
@@ -185,9 +186,14 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
             }
           }
 
-          return originalOnMessage.call(this, JSON.stringify(parsedMessage, (key, value) => {
-            return typeof value === \`string\` ? fromEditorPath(value) : value;
-          }));
+          const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {
+            return typeof value === 'string' ? fromEditorPath(value) : value;
+          });
+
+          return originalOnMessage.call(
+            this,
+            isStringMessage ? processedMessageJSON : JSON.parse(processedMessageJSON)
+          );
         },
 
         send(/** @type {any} */ msg) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

[TypeScript 4.6](https://github.com/microsoft/TypeScript/issues/46858) and [VSCode 1.64](https://github.com/microsoft/vscode/issues/139607) will start using inter-process communication which the SDK doesn't handle and crashes.

- https://github.com/microsoft/vscode/pull/135341
- https://github.com/microsoft/TypeScript/pull/46418

**How did you fix it?**

Update the SDK to handle `object` messages

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.