### PR TITLE
fix(esbuild): disable Node.js builtins when `platform` isn't `node`

### DIFF
--- a/.yarn/versions/68aa817a.yml
+++ b/.yarn/versions/68aa817a.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - Yarn is now able to migrate classic lockfiles containing unconventional tarball URLs
 - The nm linker hoists portals after hoisting their dependencies first
 - The PnP filesystem now handles `read` and `readSync` using options
+- The ESBuild plugin will no longer allow access to Node.js builtins if the `platform` isn't set to Node.
 
 ### Miscellaneous Features
 

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -104,6 +104,8 @@ export function pnpPlugin({
 
       const externals = parseExternals(build.initialOptions.external ?? []);
 
+      const isPlatformNode = (build.initialOptions.platform ?? `browser`) === `node`;
+
       build.onResolve({filter}, args => {
         if (isExternal(args.path, externals))
           return {external: true};
@@ -122,7 +124,7 @@ export function pnpPlugin({
         let error;
         try {
           path = pnpApi.resolveRequest(args.path, effectiveImporter, {
-            considerBuiltins: true,
+            considerBuiltins: isPlatformNode,
             extensions,
           });
         } catch (e) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/esbuild-plugin-pnp` incorrectly resolves Node.js builtins when the `platform` isn't set to `node`.

Fixes https://github.com/yarnpkg/berry/issues/3365

**How did you fix it?**

Only enable `considerBuiltins` if `platform` is set to `node`.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.