### PR TITLE
fix: pass context streams to renderForm

### DIFF
--- a/.yarn/versions/2c6f436a.yml
+++ b/.yarn/versions/2c6f436a.yml
@@ -1,0 +1,4 @@
+releases:
+  "@yarnpkg/libui": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-version": patch

--- a/packages/plugin-interactive-tools/sources/commands/search.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/search.tsx
@@ -248,7 +248,11 @@ export default class SearchCommand extends BaseCommand {
       );
     };
 
-    const installRequests = await renderForm(SearchApp, {});
+    const installRequests = await renderForm(SearchApp, {}, {
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+    });
     if (typeof installRequests === `undefined`)
       return 1;
 

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -334,7 +334,11 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
       </Box>;
     };
 
-    const updateRequests = await renderForm(GlobalListApp, {});
+    const updateRequests = await renderForm(GlobalListApp, {}, {
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+    });
     if (typeof updateRequests === `undefined`)
       return 1;
 

--- a/packages/plugin-version/sources/commands/version/check.tsx
+++ b/packages/plugin-version/sources/commands/version/check.tsx
@@ -325,7 +325,11 @@ export default class VersionCheckCommand extends BaseCommand {
       );
     };
 
-    const decisions = await renderForm<versionUtils.Releases>(App, {versionFile});
+    const decisions = await renderForm<versionUtils.Releases>(App, {versionFile}, {
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+    });
     if (typeof decisions === `undefined`)
       return 1;
 

--- a/packages/yarnpkg-libui/sources/misc/renderForm.tsx
+++ b/packages/yarnpkg-libui/sources/misc/renderForm.tsx
@@ -1,14 +1,22 @@
-import {useApp, render} from 'ink';
-import React            from 'react';
+import {useApp, render}     from 'ink';
+import React                from 'react';
+import {Readable, Writable} from 'stream';
 
-import {Application}    from '../components/Application';
-import {useKeypress}    from '../hooks/useKeypress';
+import {Application}        from '../components/Application';
+import {useKeypress}        from '../hooks/useKeypress';
 
 type InferProps<T> = T extends React.ComponentType<infer P> ? P : never;
 
 export type SubmitInjectedComponent<T, C = React.ComponentType> = React.ComponentType<InferProps<C> & { useSubmit: (value: T) => void }>;
 
-export async function renderForm<T, C = React.ComponentType>(UserComponent: SubmitInjectedComponent<T, C>, props: InferProps<C>) {
+// TODO: make the streams required in the next major so that people don't forget to pass them
+export type RenderFormOptions = {
+  stdin?: Readable;
+  stdout?: Writable;
+  stderr?: Writable;
+};
+
+export async function renderForm<T, C = React.ComponentType>(UserComponent: SubmitInjectedComponent<T, C>, props: InferProps<C>, {stdin, stdout, stderr}: RenderFormOptions = {}) {
   let returnedValue: T | undefined;
 
   const useSubmit = (value: T) => {
@@ -30,6 +38,11 @@ export async function renderForm<T, C = React.ComponentType>(UserComponent: Subm
     <Application>
       <UserComponent {...props} useSubmit={useSubmit}/>
     </Application>,
+    {
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream,
+      stderr: stderr as NodeJS.WriteStream,
+    },
   );
 
   await waitUntilExit();


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`renderForm` was using the `process` streams instead of the context streams.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use the context streams.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
