### PR TITLE
Generates report at startup

### DIFF
--- a/.yarn/versions/8879720f.yml
+++ b/.yarn/versions/8879720f.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -699,6 +699,12 @@ export class Project {
 
     const resolutionQueue: Array<Promise<unknown>> = [];
 
+    // Doing these calls early is important: it seems calling it after we've started the resolution incurs very high
+    // performance penalty on WSL, with the Gatsby benchmark jumping from ~28s to ~130s. It's possible this is due to
+    // the number of async tasks being listed in the report, although it's strange this doesn't occur on other systems.
+    const currentArchitecture = nodeUtils.getArchitectureSet();
+    const supportedArchitectures = this.configuration.getSupportedArchitectures();
+
     await opts.report.startProgressPromise(Report.progressViaTitle(), async progress => {
       const startPackageResolution = async (locator: Locator) => {
         const originalPkg = await miscUtils.prettifyAsyncErrors(async () => {
@@ -859,9 +865,6 @@ export class Project {
       allDescriptors.delete(descriptorHash);
       allResolutions.delete(descriptorHash);
     }
-
-    const currentArchitecture = nodeUtils.getArchitectureSet();
-    const supportedArchitectures = this.configuration.getSupportedArchitectures();
 
     const conditionalLocators = new Set<LocatorHash>();
     const disabledLocators = new Set<LocatorHash>();

--- a/packages/yarnpkg-core/sources/nodeUtils.ts
+++ b/packages/yarnpkg-core/sources/nodeUtils.ts
@@ -2,11 +2,6 @@ import Module         from 'module';
 
 import * as miscUtils from './miscUtils';
 
-// Doing the `getReport` at startup is important: it seems calling it while the program is running incurs very high
-// performance penalty on WSL, with the Gatsby benchmark jumping from ~28s to ~130s. It's possible this is due to
-// the number of async tasks being listed in the report, although it's strange this doesn't occur on other systems.
-const report: any = process.report?.getReport() ?? {};
-
 export function builtinModules(): Set<string> {
   // @ts-expect-error
   return new Set(Module.builtinModules || Object.keys(process.binding(`natives`)));
@@ -18,6 +13,7 @@ function getLibc() {
   if (process.platform === `win32`)
     return null;
 
+  const report: any = process.report?.getReport() ?? {};
   const sharedObjects: Array<string> = report.sharedObjects ?? [];
 
   // Matches the first group if libc, second group if musl

--- a/packages/yarnpkg-core/sources/nodeUtils.ts
+++ b/packages/yarnpkg-core/sources/nodeUtils.ts
@@ -2,6 +2,11 @@ import Module         from 'module';
 
 import * as miscUtils from './miscUtils';
 
+// Doing the `getReport` at startup is important: it seems calling it while the program is running incurs very high
+// performance penalty on WSL, with the Gatsby benchmark jumping from ~28s to ~130s. It's possible this is due to
+// the number of async tasks being listed in the report, although it's strange this doesn't occur on other systems.
+const report: any = process.report?.getReport() ?? {};
+
 export function builtinModules(): Set<string> {
   // @ts-expect-error
   return new Set(Module.builtinModules || Object.keys(process.binding(`natives`)));
@@ -13,7 +18,6 @@ function getLibc() {
   if (process.platform === `win32`)
     return null;
 
-  const report: any = process.report?.getReport() ?? {};
   const sharedObjects: Array<string> = report.sharedObjects ?? [];
 
   // Matches the first group if libc, second group if musl


### PR DESCRIPTION
**What's the problem this PR addresses?**

Cf the comment; seems like WSL doesn't play nice with `getReport`.

**How did you fix it?**

Runs the report at startup, when the resources to log are still few.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
