### PR TITLE
fix(sdks): update neovim zipfile paths in TypeScript SDK

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -85,7 +85,7 @@ const moduleWrapper = tsserver => {
           // everything else is up to neovim
           case `neovim`: {
             str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = `zipfile:${str}`;
+            str = `zipfile://${str}`;
           } break;
 
           default: {
@@ -100,8 +100,7 @@ const moduleWrapper = tsserver => {
 
   function fromEditorPath(str) {
     switch (hostInfo) {
-      case `coc-nvim`:
-      case `neovim`: {
+      case `coc-nvim`: {
         str = str.replace(/\.zip::/, `.zip/`);
         // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
         // So in order to convert it back, we use .* to match all the thing
@@ -109,6 +108,12 @@ const moduleWrapper = tsserver => {
         return process.platform === `win32`
           ? str.replace(/^.*zipfile:\//, ``)
           : str.replace(/^.*zipfile:/, ``);
+      } break;
+
+      case `neovim`: {
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+        return str.replace(/^zipfile:\/\//, ``);
       } break;
 
       case `vscode`:

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -85,7 +85,7 @@ const moduleWrapper = tsserver => {
           // everything else is up to neovim
           case `neovim`: {
             str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = `zipfile:${str}`;
+            str = `zipfile://${str}`;
           } break;
 
           default: {
@@ -100,8 +100,7 @@ const moduleWrapper = tsserver => {
 
   function fromEditorPath(str) {
     switch (hostInfo) {
-      case `coc-nvim`:
-      case `neovim`: {
+      case `coc-nvim`: {
         str = str.replace(/\.zip::/, `.zip/`);
         // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
         // So in order to convert it back, we use .* to match all the thing
@@ -109,6 +108,12 @@ const moduleWrapper = tsserver => {
         return process.platform === `win32`
           ? str.replace(/^.*zipfile:\//, ``)
           : str.replace(/^.*zipfile:/, ``);
+      } break;
+
+      case `neovim`: {
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+        return str.replace(/^zipfile:\/\//, ``);
       } break;
 
       case `vscode`:

--- a/.yarn/versions/8643ebe9.yml
+++ b/.yarn/versions/8643ebe9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -112,7 +112,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               // everything else is up to neovim
               case \`neovim\`: {
                 str = normalize(resolved).replace(/\\.zip\\//, \`.zip::\`);
-                str = \`zipfile:\${str}\`;
+                str = \`zipfile://\${str}\`;
               } break;
 
               default: {
@@ -127,8 +127,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
       function fromEditorPath(str) {
         switch (hostInfo) {
-          case \`coc-nvim\`:
-          case \`neovim\`: {
+          case \`coc-nvim\`: {
             str = str.replace(/\\.zip::/, \`.zip/\`);
             // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
             // So in order to convert it back, we use .* to match all the thing
@@ -136,6 +135,12 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
             return process.platform === \`win32\`
               ? str.replace(/^.*zipfile:\\//, \`\`)
               : str.replace(/^.*zipfile:/, \`\`);
+          } break;
+
+          case \`neovim\`: {
+            str = str.replace(/\\.zip::/, \`.zip/\`);
+            // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+            return str.replace(/^zipfile:\\/\\//, \`\`);
           } break;
 
           case \`vscode\`:


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

It appears that as of zip.vim v32 the [URL format has changed](https://github.com/neovim/neovim/blob/c0efe49e78eca3a17a5934cc283199122d081467/runtime/doc/pi_zip.txt#L105-L107). This version is included in Vim as of [v8.2.3606](https://github.com/vim/vim/commit/519cc559b08b800edc429688aece7ad6a00d41eb) and Neovim as of [v0.6.0](https://github.com/neovim/neovim/commit/c0efe49e78eca3a17a5934cc283199122d081467), I believe.

I don't have a working setup from before this change, but believe the format was `/path/foo.zip:/path/foo.zip::bar.js`, while now, browsing a zipfile in Neovim opens paths like `zipfile:///path/foo.zip::bar.js`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- In `toEditorPath`, I changed the Neovim case to create `zipfile:///path...` URLs.
- In `fromEditorPath`, I added a new Neovim case (previously shared with coc-nvim) to reverse the new format.

I'm unsure about backwards compatibility. I guess we would again have to send a patch to Neovim to indicate the zip.vim version in `hostInfo` or something, but that leaves at least the released Neovim versions 0.6.0 and 0.6.1 in the dark, and just seems like a big hassle. So... yeah.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.