### PR TITLE
fix(init): sync `.gitignore` with docs

### DIFF
--- a/.yarn/versions/b8e463fe.yml
+++ b/.yarn/versions/b8e463fe.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-init": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -174,16 +174,17 @@ export default class InitCommand extends BaseCommand {
         await xfs.writeFilePromise(lockfilePath, ``);
 
       const gitignoreLines = [
-        `/.yarn/*`,
-        `!/.yarn/patches`,
-        `!/.yarn/plugins`,
-        `!/.yarn/releases`,
-        `!/.yarn/sdks`,
+        `.yarn/*`,
+        `!.yarn/patches`,
+        `!.yarn/plugins`,
+        `!.yarn/releases`,
+        `!.yarn/sdks`,
+        `!.yarn/version`,        
         ``,
         `# Swap the comments on the following lines if you don't wish to use zero-installs`,
         `# Documentation here: https://yarnpkg.com/features/zero-installs`,
-        `!/.yarn/cache`,
-        `#/.pnp.*`,
+        `!.yarn/cache`,
+        `#.pnp.*`,
       ];
 
       const gitignoreBody = gitignoreLines.map(line => {

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -179,7 +179,7 @@ export default class InitCommand extends BaseCommand {
         `!.yarn/plugins`,
         `!.yarn/releases`,
         `!.yarn/sdks`,
-        `!.yarn/version`,        
+        `!.yarn/version`,
         ``,
         `# Swap the comments on the following lines if you don't wish to use zero-installs`,
         `# Documentation here: https://yarnpkg.com/features/zero-installs`,

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -179,7 +179,7 @@ export default class InitCommand extends BaseCommand {
         `!.yarn/plugins`,
         `!.yarn/releases`,
         `!.yarn/sdks`,
-        `!.yarn/version`,
+        `!.yarn/versions`,
         ``,
         `# Swap the comments on the following lines if you don't wish to use zero-installs`,
         `# Documentation here: https://yarnpkg.com/features/zero-installs`,


### PR DESCRIPTION
**What's the problem this PR addresses?**
The current status of the docs and the generated result of `yarn init -2` missmatch:
![image](https://user-images.githubusercontent.com/2266487/151700656-b3ce7c92-701e-419a-aed5-c2e955e88d58.png)

After asking on the `Yarn Discord server` It was suggested to sync `yarn init` as the docs would the right version of it

**How did you fix it?**

* Asked before on discord
* was suggested to PR it here
* Remove the leading `/` on missmatch
* Add by default `!.yarn/versions` 

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective. 
  edited through github portal/mobile, could not run it yet ^^
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
