### PR TITLE
fix(core): handle `workspaces` set to `null`

### DIFF
--- a/.yarn/versions/1e028524.yml
+++ b/.yarn/versions/1e028524.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -410,7 +410,7 @@ export class Manifest {
       }
     }
 
-    if (typeof data.workspaces === `object` && data.workspaces.nohoist)
+    if (typeof data.workspaces === `object` && data.workspaces !== null && data.workspaces.nohoist)
       errors.push(new Error(`'nohoist' is deprecated, please use 'installConfig.hoistingLimits' instead`));
 
     const workspaces = Array.isArray(data.workspaces)

--- a/packages/yarnpkg-core/tests/Manifest.test.ts
+++ b/packages/yarnpkg-core/tests/Manifest.test.ts
@@ -6,6 +6,10 @@ describe(`Manifest`, () => {
     expect(manifest.name!.name).toEqual(`foo`);
   });
 
+  it(`should handle 'workspaces' set to null`, () => {
+    expect(() => Manifest.fromText(`{"workspaces":null}`)).not.toThrow();
+  });
+
   describe(`exportTo`, () => {
     it(`should add a scripts field if a script was newly added`, () => {
       const manifest = Manifest.fromText(`{}`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Yarn crashes if the `workspaces` field is set to `null`.

Fixes https://github.com/yarnpkg/berry/issues/3947

**How did you fix it?**

Check that `workspaces` isn't `null` before trying to access its properties

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.