### PR TITLE
ci: enable ESM loader for Docusaurus

### DIFF
--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -24,12 +24,20 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
+
+        # TODO: Remove once https://github.com/yarnpkg/berry/blob/bd146ccddf95aae9c99c0c48d86b1d8997f1dccf/scripts/e2e-setup-ci.sh#L31-L38 is fixed
+        YARN_PNP_ENABLE_ESM_LOADER=true
+
         yarn dlx create-docusaurus@latest my-website classic && cd my-website
         yarn build
 
     - name: 'Running the TypeScript integration test'
       run: |
         source scripts/e2e-setup-ci.sh
+
+        # TODO: Remove once https://github.com/yarnpkg/berry/blob/bd146ccddf95aae9c99c0c48d86b1d8997f1dccf/scripts/e2e-setup-ci.sh#L31-L38 is fixed
+        YARN_PNP_ENABLE_ESM_LOADER=true
+
         yarn dlx create-docusaurus@latest my-website-ts classic --typescript && cd my-website-ts
         yarn build
       if: |


### PR DESCRIPTION
**What's the problem this PR addresses?**

The Docusaurus e2e test started failing at [2022-01-26T20:01:17Z](https://github.com/yarnpkg/berry/actions/runs/1752768894) because it tries to import ESM but the ESM loader isn't enabled.

**How did you fix it?**

Enable the ESM loader

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.