### PR TITLE
fix: use parseOptionalBoolean on YARN_IGNORE_NODE

### DIFF
--- a/.yarn/versions/a1a4200d.yml
+++ b/.yarn/versions/a1a4200d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Various improvements have been made in the core to improve performance. Addition
 - Fixed a crash caused by a bad interaction between aliased packages and peer dependencies.
 - The ESBuild plugin will no longer allow access to Node.js builtins if the `platform` isn't set to Node.
 - SemVer ranges with build metadata can now be resolved.
+- The `YARN_IGNORE_NODE` environment variable will now be parsed using the same mechanism as env variable configuration settings (i.e. both `1`/`0` and `true`/`false` will be accepted)
 
 ### ZipFS Extension
 

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -60,6 +60,9 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     const version = process.versions.node;
     const range = `>=12 <14 || 14.2 - 14.9 || >14.10.0`;
 
+    // YARN_IGNORE_NODE is special because this code needs to execute as early as possible.
+    // It's not a regular core setting because Configuration.find may use functions not available
+    // on older Node versions.
     const ignoreNode = miscUtils.parseOptionalBoolean(process.env.YARN_IGNORE_NODE);
     if (!ignoreNode && !semverUtils.satisfiesWithPrereleases(version, range))
       throw new UsageError(`This tool requires a Node version compatible with ${range} (got ${version}). Upgrade Node, or set \`YARN_IGNORE_NODE=1\` in your environment.`);

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -1,11 +1,11 @@
-import {Configuration, CommandContext, PluginConfiguration, TelemetryManager, semverUtils} from '@yarnpkg/core';
-import {PortablePath, npath, xfs}                                                          from '@yarnpkg/fslib';
-import {execFileSync}                                                                      from 'child_process';
-import {isCI}                                                                              from 'ci-info';
-import {Cli, UsageError}                                                                   from 'clipanion';
-import {realpathSync}                                                                      from 'fs';
+import {Configuration, CommandContext, PluginConfiguration, TelemetryManager, semverUtils, miscUtils} from '@yarnpkg/core';
+import {PortablePath, npath, xfs}                                                                     from '@yarnpkg/fslib';
+import {execFileSync}                                                                                 from 'child_process';
+import {isCI}                                                                                         from 'ci-info';
+import {Cli, UsageError}                                                                              from 'clipanion';
+import {realpathSync}                                                                                 from 'fs';
 
-import {pluginCommands}                                                                    from './pluginCommands';
+import {pluginCommands}                                                                               from './pluginCommands';
 
 function runBinary(path: PortablePath) {
   const physicalPath = npath.fromPortablePath(path);
@@ -60,7 +60,8 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     const version = process.versions.node;
     const range = `>=12 <14 || 14.2 - 14.9 || >14.10.0`;
 
-    if (process.env.YARN_IGNORE_NODE !== `1` && !semverUtils.satisfiesWithPrereleases(version, range))
+    const ignoreNode = miscUtils.parseOptionalBoolean(process.env.YARN_IGNORE_NODE);
+    if (!ignoreNode && !semverUtils.satisfiesWithPrereleases(version, range))
       throw new UsageError(`This tool requires a Node version compatible with ${range} (got ${version}). Upgrade Node, or set \`YARN_IGNORE_NODE=1\` in your environment.`);
 
     // Since we only care about a few very specific settings (yarn-path and ignore-path) we tolerate extra configuration key.


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`YARN_IGNORE_NODE` was compared to `1` instead of being parsed like all env variable configuration settings.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

We now parse it using `miscUtils.parseOptionalBoolean` which correctly parses both `1`/`0` and `true`/`false`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
