### PR TITLE
fix(website): wrap keys and values on configuration pages

### DIFF
--- a/packages/gatsby/src/components/syntax.tsx
+++ b/packages/gatsby/src/components/syntax.tsx
@@ -3,6 +3,8 @@ import styled, {StyledComponent}              from '@emotion/styled';
 import {FaLink}                               from 'react-icons/fa';
 import React, {PropsWithChildren, useContext} from 'react';
 
+import {ifMobile}                             from './responsive';
+
 export type Theme = {
   name: string;
 
@@ -82,6 +84,7 @@ export const Main = styled.div`
 
   font-family: "Open Sans", sans-serif;
   white-space: normal;
+  overflow-wrap: break-word;
 
   & + * {
     margin-top: 0 !important;
@@ -131,6 +134,10 @@ const DescriptionAnchor = styled.div<ThemeProps>`
 const DescriptionContainer = styled.div`
   padding: 1em;
 
+  ${ifMobile} {
+    padding: 1em 0;
+  }
+
   &:first-of-type {
     margin-top: 0;
   }
@@ -138,12 +145,16 @@ const DescriptionContainer = styled.div`
   & + div {
     margin-top: -0.5em;
   }
+
+  span {
+    white-space: normal;
+    overflow-wrap: break-word;
+  }
 `;
 
 const AnchorContainer = styled.a`
-  margin-left: -15px;
-
-  padding: 15px;
+  margin-left: -0.5em;
+  padding: 0.5em;
 
   color: inherit;
   text-decoration: none;
@@ -154,6 +165,7 @@ const Description = styled.div`
 
   font-family: "Open Sans", sans-serif;
   white-space: normal;
+  overflow-wrap: break-word;
 `;
 
 const NestedSectionHeaderContext = React.createContext(1);
@@ -182,9 +194,9 @@ const Describe = ({theme, name, description, anchor, children}: PropsWithChildre
   <DescriptionAnchor id={`${anchor}`} theme={theme}>
     <NestedSectionHeader name={name}>
       <DescriptionContainer theme={theme}>
-        {<Description theme={theme}>
+        <Description theme={theme}>
           {description}
-        </Description>}
+        </Description>
         {children}
       </DescriptionContainer>
     </NestedSectionHeader>
@@ -192,7 +204,7 @@ const Describe = ({theme, name, description, anchor, children}: PropsWithChildre
 </> : children as JSX.Element;
 
 const Anchor = () => <>
-  <span style={{fontSize: `0.7em`}}>
+  <span style={{fontSize: `0.7em`, whiteSpace: `nowrap`}}>
     <FaLink/>
   </span>
 </>;
@@ -283,7 +295,7 @@ export type ScalarPropertyProps = DescribeProps & ScalarProps;
 
 export const ScalarProperty = ({theme, name, anchor = name, placeholder, description}: ScalarPropertyProps) => <>
   <Describe theme={theme} name={name} description={description} anchor={description ? anchor : null}>
-    <div>
+    <div style={{marginRight: `-2vw`}}>
       <Key theme={theme} name={name} anchorTarget={description ? anchor : null} /><span style={{color: getColorForScalar(theme, placeholder) ?? undefined}}>{theme.formatValue(placeholder)}</span>{theme.dictionaries.suffix}
     </div>
   </Describe>


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When keys and values on the configuration pages didn't fit on a single line, they overflowed out of the viewport.

![image](https://user-images.githubusercontent.com/32596136/152032095-e1e7e94b-48cc-4400-b5fe-c0b33c79a45e.png)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made them wrap to the next lines.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
