### PR TITLE
fix(website): fix carousel control dots z-index

### DIFF
--- a/packages/gatsby/src/components/search/SearchResults.js
+++ b/packages/gatsby/src/components/search/SearchResults.js
@@ -82,6 +82,8 @@ const SponsorCarousel = styled(Carousel)`
     flex: 1;
     margin: 0;
     line-height: 1em;
+
+    z-index: auto;
   }
 `;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Apparently the sponsor carousel control dots have their `z-index` set to `1` by default so that they display on top of the selected item, but in our case we display the dots next to the selected item and the `z-index` messes things up when the sponsors section is hidden behind the searchbar after scrolling.

![image](https://user-images.githubusercontent.com/32596136/152121548-d06587fd-300a-48b3-b0eb-29e917860508.png)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Set `z-index` to `auto`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
