### PR TITLE
fix(website): make header take up less space on mobile

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -33,6 +33,9 @@ const NewsContainer = styled.div`
 
     white-space: pre-wrap;
     text-align: center;
+
+    line-height: 1.5em;
+    padding: 0.5em 1em;
   }
 
   background: #2188b6;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The header takes up too much space on mobile.

Before:

![Screen Shot 2022-02-02 at 17 11 36](https://user-images.githubusercontent.com/32596136/152181244-3c7a08b1-c527-4f2f-b5bc-8d05d78eb373.png)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

After:

![Screen Shot 2022-02-02 at 17 12 22](https://user-images.githubusercontent.com/32596136/152181346-2ba0b0a5-d41f-44be-8320-e8c4f8a87b24.png)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
