### PR TITLE
chore: replace substr with substring

### DIFF
--- a/.yarn/versions/1e78f225.yml
+++ b/.yarn/versions/1e78f225.yml
@@ -1,0 +1,38 @@
+releases:
+  "@yarnpkg/core": patch
+  "@yarnpkg/fslib": patch
+  "@yarnpkg/shell": patch
+  vscode-zipfs: patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/vscode-zipfs/sources/TerminalLinkProvider.ts
+++ b/packages/vscode-zipfs/sources/TerminalLinkProvider.ts
@@ -69,7 +69,7 @@ export function registerTerminalLinkProvider() {
       }
 
       await vscode.window.showTextDocument(
-        vscode.Uri.parse(`zip:${link.data.substr(0, matchIndex).replace(/^\/?/, `/`)}`),
+        vscode.Uri.parse(`zip:${link.data.substring(0, matchIndex).replace(/^\/?/, `/`)}`),
         {
           selection,
         },

--- a/packages/yarnpkg-core/sources/Report.ts
+++ b/packages/yarnpkg-core/sources/Report.ts
@@ -224,9 +224,9 @@ export abstract class Report {
         lineIndex = chunkStr.indexOf(`\n`);
 
         if (lineIndex !== -1) {
-          const line = buffer + chunkStr.substr(0, lineIndex);
+          const line = buffer + chunkStr.substring(0, lineIndex);
 
-          chunkStr = chunkStr.substr(lineIndex + 1);
+          chunkStr = chunkStr.substring(lineIndex + 1);
           buffer = ``;
 
           if (prefix !== null) {

--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -47,7 +47,7 @@ export class Workspace {
     // @ts-expect-error: It's ok to initialize it now, even if it's readonly (setup is called right after construction)
     this.relativeCwd = ppath.relative(this.project.cwd, this.cwd) || PortablePath.dot;
 
-    const ident = this.manifest.name ? this.manifest.name : structUtils.makeIdent(null, `${this.computeCandidateName()}-${hashUtils.makeHash<string>(this.relativeCwd).substr(0, 6)}`);
+    const ident = this.manifest.name ? this.manifest.name : structUtils.makeIdent(null, `${this.computeCandidateName()}-${hashUtils.makeHash<string>(this.relativeCwd).substring(0, 6)}`);
     const reference = this.manifest.version ? this.manifest.version : `0.0.0`;
 
     // @ts-expect-error: It's ok to initialize it now, even if it's readonly (setup is called right after construction)

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -669,8 +669,8 @@ export function prettyIdent(configuration: Configuration, ident: Ident): string 
 
 function prettyRangeNoColors(range: string): string {
   if (range.startsWith(VIRTUAL_PROTOCOL)) {
-    const nested = prettyRangeNoColors(range.substr(range.indexOf(`#`) + 1));
-    const abbrev = range.substr(VIRTUAL_PROTOCOL.length, VIRTUAL_ABBREVIATE);
+    const nested = prettyRangeNoColors(range.substring(range.indexOf(`#`) + 1));
+    const abbrev = range.substring(VIRTUAL_PROTOCOL.length, VIRTUAL_ABBREVIATE);
 
     // I'm not satisfied of how the virtual packages appear in the output
 

--- a/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
+++ b/packages/yarnpkg-fslib/sources/ZipOpenFS.ts
@@ -903,7 +903,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
     let filePath = `` as PortablePath;
 
     while (true) {
-      const pathPartWithArchive = p.substr(filePath.length);
+      const pathPartWithArchive = p.substring(filePath.length);
 
       let archivePart;
       if (!this.fileExtensions) {
@@ -940,7 +940,7 @@ export class ZipOpenFS extends BasePortableFakeFS {
 
       return {
         archivePath: filePath,
-        subPath: this.pathUtils.join(PortablePath.root, p.substr(filePath.length) as PortablePath),
+        subPath: this.pathUtils.join(PortablePath.root, p.substring(filePath.length) as PortablePath),
       };
     }
   }

--- a/packages/yarnpkg-shell/sources/pipe.ts
+++ b/packages/yarnpkg-shell/sources/pipe.ts
@@ -308,9 +308,9 @@ function createStreamReporter(reportFn: (text: string) => void, prefix: string |
       lineIndex = chunkStr.indexOf(`\n`);
 
       if (lineIndex !== -1) {
-        const line = buffer + chunkStr.substr(0, lineIndex);
+        const line = buffer + chunkStr.substring(0, lineIndex);
 
-        chunkStr = chunkStr.substr(lineIndex + 1);
+        chunkStr = chunkStr.substring(lineIndex + 1);
         buffer = ``;
 
         if (prefix !== null) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

As explained on MDN [String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated, and is replaced with [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring)

It shouldn't impact yarn when it comes to usability as it runs in Node.js environment, but the deprecating warning from TypeScript will go away.

**How did you fix it?**

Replaced usages of `substr` with `substring`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
