### PR TITLE
ci: enable PnP ESM loader in all e2e tests

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,7 +3,7 @@ runs:
   steps:
     - uses: actions/setup-node@master
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     #region Build the standard bundle
     - uses: actions/cache@v2

--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -24,20 +24,12 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-
-        # TODO: Remove once https://github.com/yarnpkg/berry/blob/bd146ccddf95aae9c99c0c48d86b1d8997f1dccf/scripts/e2e-setup-ci.sh#L31-L38 is fixed
-        YARN_PNP_ENABLE_ESM_LOADER=true
-
         yarn dlx create-docusaurus@latest my-website classic && cd my-website
         yarn build
 
     - name: 'Running the TypeScript integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-
-        # TODO: Remove once https://github.com/yarnpkg/berry/blob/bd146ccddf95aae9c99c0c48d86b1d8997f1dccf/scripts/e2e-setup-ci.sh#L31-L38 is fixed
-        YARN_PNP_ENABLE_ESM_LOADER=true
-
         yarn dlx create-docusaurus@latest my-website-ts classic --typescript && cd my-website-ts
         yarn build
       if: |

--- a/.github/workflows/e2e-pnp-angular-workflow.yml
+++ b/.github/workflows/e2e-pnp-angular-workflow.yml
@@ -25,9 +25,6 @@ jobs:
       run: |
         source scripts/e2e-setup-ci.sh
 
-        # TODO: Remove once https://github.com/yarnpkg/berry/blob/bd146ccddf95aae9c99c0c48d86b1d8997f1dccf/scripts/e2e-setup-ci.sh#L31-L38 is fixed
-        YARN_PNP_ENABLE_ESM_LOADER=true
-
         # TODO: Angular should be fixed to detect the correct package manager to install with
         # but for now we need to specify it
         yarn dlx -p @angular/cli@next ng new berry-angular --interactive=false --package-manager yarn

--- a/.github/workflows/e2e-svelte-kit-workflow.yml
+++ b/.github/workflows/e2e-svelte-kit-workflow.yml
@@ -24,10 +24,6 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-
-        # TODO: Remove once https://github.com/yarnpkg/berry/blob/bd146ccddf95aae9c99c0c48d86b1d8997f1dccf/scripts/e2e-setup-ci.sh#L31-L38 is fixed
-        YARN_PNP_ENABLE_ESM_LOADER=true
-
         yes | yarn create svelte@next my-app && cd my-app
         yarn
         yarn build

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -28,15 +28,6 @@ export YARN_ENABLE_IMMUTABLE_INSTALLS=0
 # We want to make sure the projects work in a monorepo
 export YARN_PNP_FALLBACK_MODE=none
 
-# TODO: Remove when either of these issues are fixed
-# - https://github.com/nodejs/node/issues/39140
-# - https://github.com/nodejs/node/issues/37782
-# - https://github.com/facebook/jest/issues/12060
-# Due to a bug in `jest-worker` and/or Node.js adding a loader
-# causes our e2e tests to time out so require the tests that needs it
-# to explicitly enable it
-export YARN_PNP_ENABLE_ESM_LOADER=false
-
 # Otherwise git commit doesn't work, and some tools require it
 git config --global user.email "you@example.com"
 git config --global user.name "John Doe"


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/nodejs/node/pull/41221 has shipped in Node.js v16.14 so we can now enable the PnP ESM loader for all e2e tests.

**How did you fix it?**

Updated the CI to use Node.js v16 and removed the disabling of the PnP ESM loader.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.