### PR TITLE
Editor SDK support for resolving portaled dependencies

### DIFF
--- a/.yarn/versions/88da1151.yml
+++ b/.yarn/versions/88da1151.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -45,6 +45,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       const pnpApi = require(\`pnpapi\`);
 
       const isVirtual = str => str.match(/\\/(\\$\\$virtual|__virtual__)\\//);
+      const isPortal = str => str.startsWith("portal:/");
       const normalize = str => str.replace(/\\\\/g, \`/\`).replace(/^\\/?/, \`/\`);
 
       const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
@@ -71,7 +72,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
           if (resolved) {
             const locator = pnpApi.findPackageLocator(resolved);
-            if (locator && dependencyTreeRoots.has(\`\${locator.name}@\${locator.reference}\`)) {
+            if (locator && (dependencyTreeRoots.has(\`\${locator.name}@\${locator.reference}\`) || isPortal(locator.reference))) {
               str = resolved;
             }
           }


### PR DESCRIPTION
**What's the problem this PR addresses?**
This PR fixes a bug where navigating to a dependency fails in the editor SDK when using portals and PnP.
Resolves #4090

**How did you fix it?**
I don't properly understand the code I'm changing here so please be kind! This is a local fix I applied which fixes the issue for me.

I've just changed the code path that is used for workspace linked packages to also work for portal packages.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
