### PR TITLE
fix(pack): Handle workspace protocol for optional dependencies

### DIFF
--- a/.yarn/versions/b7986013.yml
+++ b/.yarn/versions/b7986013.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -327,10 +327,11 @@ describe(`Commands`, () => {
     test(
       `it should replace the workspace: protocol correctly`,
       makeTemporaryEnv({
-        workspaces: [`./dependency`, `./dependant`, `./foo`, `./bar`],
+        workspaces: [`./dependency`, `./dependant`, `./optional`, `./foo`, `./bar`],
       }, async({path, run, source}) => {
         const dependency = `@test/dependency`;
         const dependant = `@test/dependant`;
+        const optional = `@test/optional`;
         const foo = `@test/foo`;
         const bar = `@test/bar`;
 
@@ -349,6 +350,11 @@ describe(`Commands`, () => {
           version: `3.0.0`,
         });
 
+        await fsUtils.writeJson(`${path}/optional/package.json`, {
+          name: optional,
+          version: `4.0.0`,
+        });
+
         await fsUtils.writeJson(`${path}/dependant/package.json`, {
           name: dependant,
           version: `1.0.0`,
@@ -364,6 +370,9 @@ describe(`Commands`, () => {
             [dependency]: `workspace:*`,
             [foo]: `workspace:^`,
             [bar]: `workspace:~`,
+          },
+          optionalDependencies: {
+            [optional]: `workspace:*`,
           },
         });
 
@@ -383,6 +392,7 @@ describe(`Commands`, () => {
         expect(packedManifest.peerDependencies[dependency]).toBe(`1.0.0`);
         expect(packedManifest.peerDependencies[foo]).toBe(`^2.0.0`);
         expect(packedManifest.peerDependencies[bar]).toBe(`~3.0.0`);
+        expect(packedManifest.optionalDependencies[optional]).toBe(`4.0.0`);
 
         const originalManifest = await fsUtils.readJson(`${path}/dependant/package.json`);
 
@@ -393,6 +403,7 @@ describe(`Commands`, () => {
         expect(originalManifest.peerDependencies[dependency]).toBe(`workspace:*`);
         expect(originalManifest.peerDependencies[foo]).toBe(`workspace:^`);
         expect(originalManifest.peerDependencies[bar]).toBe(`workspace:~`);
+        expect(originalManifest.optionalDependencies[optional]).toBe(`workspace:*`);
       }),
     );
 

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -70,7 +70,12 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
           // for workspace:version we simply strip the protocol
           versionToWrite = range.selector;
 
-        rawManifest[dependencyType][structUtils.stringifyIdent(descriptor)] = versionToWrite;
+        // Ensure optional dependencies are handled as well
+        const identDescriptor = structUtils.makeDescriptor(descriptor, `unknown`);
+        const finalDependencyType = dependencyType === `dependencies` && workspace.manifest.ensureDependencyMeta(identDescriptor).optional
+          ? `optionalDependencies`
+          : dependencyType;
+        rawManifest[finalDependencyType][structUtils.stringifyIdent(descriptor)] = versionToWrite;
       }
     }
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently if you are using a workspace protocol for an optional dependency, it will be not be updated to the actual version when getting packed. This PR fixes that issue by writing the injected workspace dependency version into the optional dependency as well.

Resolves #4080 

...

**How did you fix it?**
This has been fixed by checking the metadata of each dependency  to determine whether or not it is optional, and will write the new version to `optionalDependencies` if it is.  This is necessary as optional dependencies are stored with normal dependencies, as they are the same just with the `optional` bool.

However, because optional dependencies get stored with an ident created via `structUtils.makeDescriptor(realDescriptor, 'unknown');` I have had to do the same when packing so that it can safely find the correct dependency without crashing due to an invalid semver range. This is the only part I was really unsure about, so if there is a better way to do this I would love to hear it!

...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
