### PR TITLE
perf(fslib): skip unnecessary `realpath` calls in `xfs.mktemp*`

### DIFF
--- a/.yarn/versions/3b5fd138.yml
+++ b/.yarn/versions/3b5fd138.yml
@@ -1,0 +1,38 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/fslib": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/json-proxy"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/xfs.ts
+++ b/packages/yarnpkg-fslib/sources/xfs.ts
@@ -32,8 +32,8 @@ export type XFS = NodeFS & {
 const tmpdirs = new Set<PortablePath>();
 
 let tmpEnv: {
-  tmpdir: PortablePath,
-  realTmpdir: PortablePath,
+  tmpdir: PortablePath;
+  realTmpdir: PortablePath;
 } | null = null;
 
 function initTmpEnv() {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/fslib`s `xfs.mktemp*` performs unnecessary `realpath` calls on directories we know can't be symlinks.

Ref https://github.com/yarnpkg/berry/issues/4057

**How did you fix it?**

Call `realpath` on the tmpdir once and avoid calling it on the created folder.

**Benchmark results**

On the gatsby benchmark this removes 3839 statx calls when fetching packages

```sh
YARN_IGNORE_PATH=1 hyperfine -w 1 --prepare="rm -rf ./.yarn-global"\
  "node ./master.cjs --mode skip-build"\
  "node ./skip-realpath.cjs --mode skip-build"
Benchmark 1: node ./master.cjs --mode skip-build
  Time (mean ± σ):      8.058 s ±  0.109 s    [User: 51.520 s, System: 3.590 s]
  Range (min … max):    7.893 s …  8.234 s    10 runs

Benchmark 2: node ./skip-realpath.cjs --mode skip-build
  Time (mean ± σ):      7.957 s ±  0.081 s    [User: 51.740 s, System: 3.676 s]
  Range (min … max):    7.801 s …  8.027 s    10 runs

Summary
  'node ./skip-realpath.cjs --mode skip-build' ran
    1.01 ± 0.02 times faster than 'node ./master.cjs --mode skip-build'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.