### PR TITLE
fix: pnpm linker not support run yarn command in postinstall script

### DIFF
--- a/.yarn/versions/377b0117.yml
+++ b/.yarn/versions/377b0117.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-pnpm": patch

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -34,7 +34,16 @@ export class PnpmLinker implements Linker {
       return null;
 
     const customDataKey = getCustomDataKey();
-    const customData = opts.project.installersCustomData.get(customDataKey) as any;
+    let customData = opts.project.installersCustomData.get(customDataKey) as any;
+    if (!customData) {
+      await opts.project.restoreInstallState({
+        restoreInstallersCustomData: true,
+        restoreResolutions: false,
+        restoreBuildState: false,
+      });
+      customData = opts.project.installersCustomData.get(customDataKey) as any;
+    }
+
     if (!customData)
       throw new UsageError(`The project in ${formatUtils.pretty(opts.project.configuration, `${opts.project.cwd}/package.json`, formatUtils.Type.PATH)} doesn't seem to have been installed - running an install there might help`);
 
@@ -42,7 +51,8 @@ export class PnpmLinker implements Linker {
     if (nmRootLocation) {
       const nmLocator = customData.locatorByPath.get(nmRootLocation[1]);
       if (nmLocator) {
-        return nmLocator;
+        const locator = structUtils.parseLocator(nmLocator);
+        return locator;
       }
     }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
When `nodeLinker` use `pnpm linker` and a dependency package have `postinstall` script, the script command is `yarn [command]`,  
run `yarn install` will throw error `xxx doesn't seem to have been installed - running an install there might help`
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
restore InstallState before call function `installersCustomData.get`.
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [*] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [*] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [*] I will check that all automated PR checks pass before the PR gets reviewed.
