### PR TITLE
refactor(nm): return object with linkType and target

### DIFF
--- a/.yarn/versions/5f099b36.yml
+++ b/.yarn/versions/5f099b36.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/nm": patch
+
+declined:
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -463,15 +463,14 @@ function getTargetLocatorPath(locator: PhysicalPackageLocator, pnp: PnpApi, opti
   if (info === null)
     throw new Error(`Assertion failed: Expected the package to be registered`);
 
-  // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
-  // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
-  // To make this fs layout work with legacy tools we make
-  // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
-  // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
-  const linkType = options.pnpifyFs ? LinkType.SOFT : info.linkType;
-  const target = options.pnpifyFs
-    ? npath.toPortablePath(info.packageLocation)
-    : getRealPackageLocation(info, locator, pnp);
+  const [linkType, target] = options.pnpifyFs
+    // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
+    // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
+    // To make this fs layout work with legacy tools we make
+    // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
+    // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
+    ? [LinkType.SOFT, npath.toPortablePath(info.packageLocation)]
+    : [info.linkType, getRealPackageLocation(info, locator, pnp)];
 
   return {linkType, target};
 }

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -463,20 +463,16 @@ function getTargetLocatorPath(locator: PhysicalPackageLocator, pnp: PnpApi, opti
   if (info === null)
     throw new Error(`Assertion failed: Expected the package to be registered`);
 
-  let linkType;
-  let target;
-  if (options.pnpifyFs) {
-    // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
-    // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
-    // To make this fs layout work with legacy tools we make
-    // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
-    // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
-    target = npath.toPortablePath(info.packageLocation);
-    linkType = LinkType.SOFT;
-  } else {
-    target = getRealPackageLocation(info, locator, pnp);
-    linkType = info.linkType;
-  }
+  // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
+  // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
+  // To make this fs layout work with legacy tools we make
+  // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
+  // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
+  const linkType = options.pnpifyFs ? LinkType.SOFT : info.linkType;
+  const target = options.pnpifyFs
+    ? npath.toPortablePath(info.packageLocation)
+    : getRealPackageLocation(info, locator, pnp);
+
   return {linkType, target};
 }
 

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -463,16 +463,14 @@ function getTargetLocatorPath(locator: PhysicalPackageLocator, pnp: PnpApi, opti
   if (info === null)
     throw new Error(`Assertion failed: Expected the package to be registered`);
 
-  const [linkType, target] = options.pnpifyFs
+  return options.pnpifyFs
     // In case of pnpifyFs we represent modules as symlinks to archives in NodeModulesFS
     // `/home/user/project/foo` is a symlink to `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo`
     // To make this fs layout work with legacy tools we make
     // `/home/user/project/.yarn/.cache/foo.zip/node_modules/foo/node_modules` (which normally does not exist inside archive) a symlink to:
     // `/home/user/project/node_modules/foo/node_modules`, so that the tools were able to access it
-    ? [LinkType.SOFT, npath.toPortablePath(info.packageLocation)]
-    : [info.linkType, getRealPackageLocation(info, locator, pnp)];
-
-  return {linkType, target};
+    ? {linkType: LinkType.SOFT, target: npath.toPortablePath(info.packageLocation)}
+    : {linkType: info.linkType, target: getRealPackageLocation(info, locator, pnp)};
 }
 
 /**


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variables `target` and `linkType` are declared as let and their values are populated in an if-else.

**How did you fix it?**

Change `target` and `linkType` to const, and use a conditional (ternary) operator instead.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
