### PR TITLE
Don't use corepack when packing git dependencies

### DIFF
--- a/.yarn/versions/de90c997.yml
+++ b/.yarn/versions/de90c997.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `prepareExternalProject` function (which is used to pack git dependencies) is written under the assumption that it launches another instance of the same version of yarn that is currently running. However, the `makeScriptEnv` function, when running under corepack, may now launch another corepack instance of yarn (which may then launch a different version of yarn than is running, depending on the `packageManager` field of the `package.json` of the current working directory.)

This causes differences in behavior between yarn installed via corepack and yarn installed via npm, resulting in different checksums and causes failures with the default behavior of `checksumBehavior: throw`.

One case which is problematic is if the git dependency does not have a `packageManager` field in its `package.json`, as corepack yarn will read the `package.json`, see it is not set, and pack using v1, while non-corepack yarn will pack using whatever the currently running version of yarn is (berry.)

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

`makeScriptEnv` accepts an additional argument to determine if corepack should be used or not. Alternative proposals are welcome.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
