### PR TITLE
Implements smart merge v2

### DIFF
--- a/.github/workflows/pr-smart-merge-apply.yml
+++ b/.github/workflows/pr-smart-merge-apply.yml
@@ -1,0 +1,68 @@
+on:
+  workflow_run:
+    workflows: ['Smart merge: Generate']
+    types:
+      - completed
+
+name: 'Smart merge: Apply'
+jobs:
+  apply:
+    name: 'Apply the update changeset'
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.workflow_run.head_sha}}
+
+      - name: 'Download the artifacts'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const fs = require(`fs`);
+
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id}},
+            });
+
+            const matchArtifact = artifacts.data.artifacts.filter(artifact => {
+              return artifact.name == `pr`;
+            })[0];
+
+            const download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: `zip`,
+            });
+
+            fs.writeFileSync(`${{github.workspace}}/pr.zip`, Buffer.from(download.data));
+
+      - name: Unpack the artifacts
+        run: unzip pr.zip
+
+      - name: Apply the changeset
+        run: |
+          PR_META=$(curl https://api.github.com/repos/yarnpkg/berry/pulls/'${{github.event.inputs.pr}}')
+
+          PR_REPO=$(jq -r .head.repo.full_name <<< "$PR_META")
+          PR_REF=$(jq -r .head.ref <<< "$PR_META")
+
+          git config user.name "Yarn Bot"
+          git config user.email nison.mael+yarnbot@gmail.com
+
+          git remote add pr-source https://'${{secrets.YARNBOT_TOKEN}}'@github.com/"$PR_REPO".git
+
+          git fetch --depth=1 pr-source "$PR_REF":local
+          git checkout local
+
+          git merge --no-commit origin/master || true
+          git apply pr/update.patch
+          git commit -m 'Auto-merge with master'
+
+          git push pr-source local:"$PR_REF"

--- a/.github/workflows/pr-smart-merge-generate.yml
+++ b/.github/workflows/pr-smart-merge-generate.yml
@@ -1,41 +1,24 @@
 on:
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: 'The pull request to update'
-        required: true
+  pull_request:
+    types: [labeled]
 
-name: 'Smart master merge'
+name: 'Smart merge: Generate'
 jobs:
-  merge:
-    name: 'Merge master into the PR'
+  generate:
+    name: 'Generate an update changeset'
     runs-on: ubuntu-latest
+    if: |
+      github.event.label.name == 'infra: pending update'
 
     steps:
-    - uses: actions/checkout@master
-      with:
-        ref: master
-        token: ${{secrets.YARNBOT_TOKEN}}
-        fetch-depth: 0
-
+    - uses: actions/checkout@v3
     - uses: ./.github/actions/prepare
 
-    - name: 'Update, commit, and upload the artifacts'
+    - name: 'Generate the changeset'
       run: |
-        PR_META=$(curl https://api.github.com/repos/yarnpkg/berry/pulls/'${{github.event.inputs.pr}}')
+        git fetch --depth=0 origin master
 
-        PR_REPO=$(jq -r .head.repo.full_name <<< "$PR_META")
-        PR_REF=$(jq -r .head.ref <<< "$PR_META")
-
-        git config user.name "Yarn Bot"
-        git config user.email nison.mael+yarnbot@gmail.com
-
-        git remote add pr-source https://'${{secrets.YARNBOT_TOKEN}}'@github.com/"$PR_REPO".git
-
-        git fetch pr-source "$PR_REF":local
-        git checkout local
-
-        if ! git merge origin/master; then
+        if ! git merge --no-commit origin/master; then
           export YARN_ENABLE_IMMUTABLE_INSTALLS=0
 
           if git diff --name-only --diff-filter=U | grep .pnp.cjs; then
@@ -63,9 +46,17 @@ jobs:
             git checkout --theirs packages/yarnpkg-parsers/sources/grammars/shell.js
             yarn grammar:shell
           fi
-
-          git add .pnp.cjs packages/yarnpkg-pnp/sources/hook.js packages/yarnpkg-pnp/sources/esm-loader/built-loader.js packages/yarnpkg-parsers/sources/grammars/shell.js
-          git commit -m 'Auto-merge with master'
         fi
 
-        git push pr-source local:"$PR_REF"
+        yarn test:lint --fix
+
+    - name: Generate the artifacts
+      run: |
+        mkdir -p pr
+        git diff > pr/update.patch
+
+    - name: Upload the artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pr
+        path: pr/

--- a/.github/workflows/pr-smart-merge-reset.yml
+++ b/.github/workflows/pr-smart-merge-reset.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request_target:
+    types: [labeled]
+
+name: 'Smart merge: Reset'
+jobs:
+  generate:
+    name: 'Remove the label'
+    runs-on: ubuntu-latest
+    if: |
+      github.event.label.name == 'infra: pending update'
+
+    steps:
+      - name: 'Remove the label'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               issue_number: context.pull_request.number,
+               name: `infra: pending update`,
+            });


### PR DESCRIPTION
**What's the problem this PR addresses?**

Smart merge currently requires to go into the `Actions` tab and pick the right action with the right parameters. Additionally it's not great in terms of security since the running code has access to the yarnbot token. Even with manual trigger, there's a decent chance someone could social-engineer us into running it on a malicious PR.

**How did you fix it?**

- The action is now triggered by adding the `infra: pending update` label to a PR
- Immediately, a privileged `pull_request_target` action will trigger and remove the label
- In parallel, an unprivileged `pull_request` trigger will generate a patchfile and store it as an artifact
- Once finished, a privileged `workflow_run` workflow will retrieve the patchfile and create the commit

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
