### PR TITLE
refactor(git): use const for protocol/request

### DIFF
--- a/.yarn/versions/d3f97928.yml
+++ b/.yarn/versions/d3f97928.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/plugin-git": patch
+
+declined:
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -84,16 +84,9 @@ export function splitRepoUrl(url: string): RepoUrlParts {
       return Object.prototype.hasOwnProperty.call(extra, protocol);
     });
 
-    let protocol: TreeishProtocols;
-    let request: string;
-
-    if (typeof requestedProtocol !== `undefined`) {
-      protocol = requestedProtocol;
-      request = extra[requestedProtocol]! as string;
-    } else {
-      protocol = TreeishProtocols.Head;
-      request = `HEAD`;
-    }
+    const [protocol, request] = typeof requestedProtocol !== `undefined`
+      ? [requestedProtocol, extra[requestedProtocol]! as string]
+      : [TreeishProtocols.Head, `HEAD`];
 
     for (const key of Object.values(TreeishProtocols))
       delete extra[key];
@@ -109,16 +102,9 @@ export function splitRepoUrl(url: string): RepoUrlParts {
     // Old-style: "#commit:abcdef" or "#abcdef"
     const colonIndex = subsequent.indexOf(`:`);
 
-    let protocol: string | null;
-    let request: string;
-
-    if (colonIndex === -1) {
-      protocol = null;
-      request = subsequent;
-    } else {
-      protocol = subsequent.slice(0, colonIndex);
-      request = subsequent.slice(colonIndex + 1);
-    }
+    const [protocol, request] = colonIndex === -1
+      ? [null, subsequent]
+      : [subsequent.slice(0, colonIndex), subsequent.slice(colonIndex + 1)];
 
     return {
       repo,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variables `protocol` and `request` can be converted into const, and get assigned under a conditional operator

**How did you fix it?**
<!-- A detailed description of your implementation. -->

use const for protocol/request

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
