### PR TITLE
feat: add `--mode` to `yarn workspaces focus`

### DIFF
--- a/.yarn/versions/81321644.yml
+++ b/.yarn/versions/81321644.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": minor


### PR DESCRIPTION
**What's the problem this PR addresses?**

Unlike `yarn install` the current implementation of `yarn workspaces focus` does not support passing through an `InstallMode` value.

Closes #3524

**How did you fix it?**

Copied over the flag + docs from `yarn install` and passed through to `project.install`.


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
