### PR TITLE
add extension for '@cypress/snapshot' dependency on 'debug'

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -50107,6 +50107,7 @@ var __objRest = (source, exclude) => {
 };
 const localFs = __spreadValues({}, fs__default.default);
 const nodeFs = new NodeFS(localFs);
+nodeFs.__test = true;
 const defaultRuntimeState = $$SETUP_STATE(hydrateRuntimeState);
 const defaultPnpapiResolution = __filename;
 const defaultFsLayer = new VirtualFS({

--- a/.yarn/versions/9f750ca7.yml
+++ b/.yarn/versions/9f750ca7.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -762,4 +762,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       '@vue/runtime-dom': `^3.2.26`,
     },
   }],
+  // https://github.com/cypress-io/snapshot/pull/159
+  [`@cypress/snapshot@*`, {
+    dependencies: {
+      debug: `^3.2.7`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`@cypress/snapshot` has a devDependency on `debug`, but uses `debug` during its `postinstall` step.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

* I opened [an issue](https://github.com/cypress-io/snapshot/issues/158) and [a PR](https://github.com/cypress-io/snapshot/issues/159) on the https://github.com/cypress-io/snapshot/ repo.
* I added an extension for the `debug` dependency.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
