### PR TITLE
chore(nm): use for loop in buildTree fn

### DIFF
--- a/.yarn/versions/89ab2ac5.yml
+++ b/.yarn/versions/89ab2ac5.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/nm": patch
+
+declined:
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -565,8 +565,7 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
         const segments = nodeModulesLocation.split(`/`);
         const nodeModulesIdx = segments.indexOf(NODE_MODULES);
 
-        let segCount = segments.length - 1;
-        while (nodeModulesIdx >= 0 && segCount > nodeModulesIdx) {
+        for (let segCount = segments.length - 1; nodeModulesIdx >= 0 && segCount > nodeModulesIdx; segCount--) {
           const dirPath = npath.toPortablePath(segments.slice(0, segCount).join(ppath.sep));
           const targetDir = toFilename(segments[segCount]);
 
@@ -580,8 +579,6 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
               subdirs.dirList.add(targetDir);
             }
           }
-
-          segCount--;
         }
       }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variable `segCount` is used inside while loop, although it's initialized and incremented like a for loop

**How did you fix it?**

Use for loop instead of while loop in buildTree fn

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
