### PR TITLE
Make `env` readonly in wrapScriptExecution

### DIFF
--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -80,7 +80,7 @@ export interface Hooks {
     project: Project,
     locator: Locator,
     scriptName: string,
-    extra: {script: string, args: Array<string>, cwd: PortablePath, env: ProcessEnvironment, stdin: Readable | null, stdout: Writable, stderr: Writable},
+    extra: {script: string, args: Array<string>, cwd: PortablePath, env: Readonly<ProcessEnvironment>, stdin: Readable | null, stdout: Writable, stderr: Writable},
   ) => Promise<() => Promise<number>>;
 
   /**
@@ -174,7 +174,7 @@ export interface Hooks {
   ) => Promise<void>;
 }
 
-export type Plugin<PluginHooks = any> = {
+export type Plugin<PluginHooks = Hooks> = {
   configuration?: Partial<ConfigurationDefinitionMap>;
   commands?: Array<CommandClass<CommandContext>>;
   fetchers?: Array<FetcherPlugin>;


### PR DESCRIPTION
Makes the `env` readonly as per @paul-soporan https://github.com/yarnpkg/berry/pull/4180#issuecomment-1059844748.

Also make the default `PluginHooks` be `Hooks` for better dev experience. Pit of success etc...

This change does not stop implementers from passing Any into PluginHooks
