### PR TITLE
refactor(parsers): use const for vars `data` and `sort`

### DIFF
--- a/.yarn/versions/768814ed.yml
+++ b/.yarn/versions/768814ed.yml
@@ -1,0 +1,11 @@
+releases:
+  "@yarnpkg/parsers": patch
+
+declined:
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-parsers/sources/syml.ts
+++ b/packages/yarnpkg-parsers/sources/syml.ts
@@ -55,7 +55,7 @@ function stringifyValue(value: any, indentLevel: number, newLineIfObject: boolea
   }
 
   if (typeof value === `object` && value) {
-    const [data, sort] = (value instanceof PreserveOrdering)
+    const [data, sort] = value instanceof PreserveOrdering
       ? [value.data, false]
       : [value, true];
 

--- a/packages/yarnpkg-parsers/sources/syml.ts
+++ b/packages/yarnpkg-parsers/sources/syml.ts
@@ -55,16 +55,9 @@ function stringifyValue(value: any, indentLevel: number, newLineIfObject: boolea
   }
 
   if (typeof value === `object` && value) {
-    let data: any;
-    let sort: boolean;
-
-    if (value instanceof PreserveOrdering) {
-      data = value.data;
-      sort = false;
-    } else {
-      data = value;
-      sort = true;
-    }
+    const [data, sort] = (value instanceof PreserveOrdering)
+      ? [value.data, false]
+      : [value, true];
 
     const indent = `  `.repeat(indentLevel);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variables `data` and `sort` in parsers can be declared as const, and assigned values in a conditional operator using TypeScript tuples.

**How did you fix it?**

Use const for variables `data` and `sort`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
