### PR TITLE
fix(pnpm): pnpm linker no longer removes node_modules when nm linker is active

### DIFF
--- a/.yarn/versions/dafa68fb.yml
+++ b/.yarn/versions/dafa68fb.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 
 ## Master
 
+### Installs
+- The pnpm linker no longer tries to remove `node_modules` directory, when `node-modules` linker is active
+
 **Note:** features in `master` can be tried out by running `yarn set version from sources` in your project (existing contrib plugins are updated automatically, while new contrib plugins can be added by running `yarn plugin import from sources <name>`).
 
 ## 3.2.0

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -271,13 +271,13 @@ class PnpmInstaller implements Installer {
           removals.push(xfs.removePromise(ppath.join(storeLocation, record)));
 
       await Promise.all(removals);
+
+      // Wait for the package installs to catch up
+      await this.asyncActions.wait(),
+
+      await removeIfEmpty(storeLocation);
+      await removeIfEmpty(getNodeModulesLocation(this.opts.project));
     }
-
-    // Wait for the package installs to catch up
-    await this.asyncActions.wait(),
-
-    await removeIfEmpty(storeLocation);
-    await removeIfEmpty(getNodeModulesLocation(this.opts.project));
 
     return {
       customData: this.customData,

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -271,13 +271,14 @@ class PnpmInstaller implements Installer {
           removals.push(xfs.removePromise(ppath.join(storeLocation, record)));
 
       await Promise.all(removals);
-
-      // Wait for the package installs to catch up
-      await this.asyncActions.wait(),
-
-      await removeIfEmpty(storeLocation);
-      await removeIfEmpty(getNodeModulesLocation(this.opts.project));
     }
+
+    // Wait for the package installs to catch up
+    await this.asyncActions.wait();
+
+    await removeIfEmpty(storeLocation);
+    if (this.opts.project.configuration.get(`nodeLinker`) !== `node-modules`)
+      await removeIfEmpty(getNodeModulesLocation(this.opts.project));
 
     return {
       customData: this.customData,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The pnpm linker attempts to delete `node_modules` directory all the time, this causes install failure when Yarn has no permissions. This problem happens even when `node-modules` linker is active.

Fixes #4172
Fixes #4160

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Based on the evaluation of pnpm linker finalizeInstall code, seems this behavior - to manipulate node_modules directory- was not intended. I have updated it so that this code was not run.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
