### PR TITLE
fix(esbuild): make `foo/bar` external if package `foo` is external

### DIFF
--- a/.yarn/versions/5e49f6c7.yml
+++ b/.yarn/versions/5e49f6c7.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -31,8 +31,18 @@ function isExternal(path: string, externals: Array<External>): boolean {
         return true;
       }
     } else {
-      if (path === external) {
+      if (path === external)
         return true;
+
+      // If the module "foo" has been marked as external, we also want to treat
+      // paths into that module such as "foo/bar" as external too.
+      // References:
+      // - https://github.com/evanw/esbuild/blob/537195ae84bee1510fac14235906d588084c39cd/internal/resolver/resolver.go#L651-L652
+      // - https://github.com/evanw/esbuild/blob/537195ae84bee1510fac14235906d588084c39cd/internal/resolver/resolver.go#L1688-L1691
+      if (!external.startsWith(`/`) && !external.startsWith(`./`) && !external.startsWith(`../`) && external !== `.` && external !== `..`) {
+        if (path.startsWith(`${external}/`)) {
+          return true;
+        }
       }
     }
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`esbuild` marks `rxjs/operators` as external if `rxjs` is external. Using the pnp esbuild plugin changes the behaviour and requires `rxjs/operators` to be explicitly marked as external.

**How did you fix it?**

Implement the check esbuild uses to make deep imports of externals also external.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
