### PR TITLE
fix(esbuild): resolve to ESM when requested

### DIFF
--- a/.yarn/versions/2eafeb47.yml
+++ b/.yarn/versions/2eafeb47.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/builder"

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -104,11 +104,29 @@ export function pnpPlugin({
 
       const externals = parseExternals(build.initialOptions.external ?? []);
 
-      const isPlatformNode = (build.initialOptions.platform ?? `browser`) === `node`;
+      const platform = build.initialOptions.platform ?? `browser`;
+      const isPlatformNode = platform === `node`;
+
+      // Reference: https://github.com/evanw/esbuild/blob/537195ae84bee1510fac14235906d588084c39cd/internal/resolver/resolver.go#L238-L253
+      const conditionsDefault = new Set(build.initialOptions.conditions);
+      conditionsDefault.add(`default`);
+      if (platform === `browser` || platform === `node`)
+        conditionsDefault.add(platform);
+      const conditionsImport = new Set(conditionsDefault);
+      conditionsImport.add(`import`);
+      const conditionsRequire = new Set(conditionsDefault);
+      conditionsRequire.add(`require`);
 
       build.onResolve({filter}, args => {
         if (isExternal(args.path, externals))
           return {external: true};
+
+        // Reference: https://github.com/evanw/esbuild/blob/537195ae84bee1510fac14235906d588084c39cd/internal/resolver/resolver.go#L1495-L1502
+        let conditions = conditionsDefault;
+        if (args.kind === `dynamic-import` || args.kind === `import-statement`)
+          conditions = conditionsImport;
+        else if (args.kind === `require-call` || args.kind === `require-resolve`)
+          conditions = conditionsRequire;
 
         // The entry point resolution uses an empty string
         const effectiveImporter = args.importer
@@ -124,6 +142,7 @@ export function pnpPlugin({
         let error;
         try {
           path = pnpApi.resolveRequest(args.path, effectiveImporter, {
+            conditions,
             considerBuiltins: isPlatformNode,
             extensions,
           });


### PR DESCRIPTION
**What's the problem this PR addresses?**

ESBuild uses package exports to load files based on whether import or require was used.
Configuring the PnP plugin breaks this behaviour, always resorting to CJS/require code.

**How did you fix it?**

Copy the logic ESBuild uses to decide on what conditions to pass in its resolution

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
