### PR TITLE
test: disable flaky tests

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
@@ -4,7 +4,8 @@ const lsStore = async (path: PortablePath) => {
   return await xfs.readdirPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath);
 };
 
-describe(`Install Artifact Cleanup`, () => {
+// These tests randomly fail on the CI and until we figure out why they're just noise
+describe.skip(`Install Artifact Cleanup`, () => {
   describe(`pnpm linker`, () => {
     it(`should not generate a node_modules folder if it has nothing to put inside it`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
@@ -4,9 +4,9 @@ const lsStore = async (path: PortablePath) => {
   return await xfs.readdirPromise(`${path}/${Filename.nodeModules}/.store` as PortablePath);
 };
 
-// These tests randomly fail on the CI and until we figure out why they're just noise
-describe.skip(`Install Artifact Cleanup`, () => {
-  describe(`pnpm linker`, () => {
+describe(`Install Artifact Cleanup`, () => {
+  // These tests randomly fail on the CI and until we figure out why they're just noise
+  describe.skip(`pnpm linker`, () => {
     it(`should not generate a node_modules folder if it has nothing to put inside it`, makeTemporaryEnv({}, {
       nodeLinker: `pnpm`,
     }, async ({path, run, source}) => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The artifact cleanup tests randomly fail on the CI and until we figure out why they're just noise.

**How did you fix it?**

Disable them.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.