### PR TITLE
fix(docs): move Ukrainain banner to the home page only to not disrupt docs UX

### DIFF
--- a/packages/gatsby/src/components/header.js
+++ b/packages/gatsby/src/components/header.js
@@ -159,44 +159,6 @@ const MenuNavigation = styled.div`
   }
 `;
 
-const Banner = styled.div`
-  background-color: #5474c9;
-  display: flex;
-  flex: 1;
-  align-items: center;
-  justify-content: center;
-  padding: 1em;
-
-  > :first-child {
-    margin-right: 1em;
-  }
-`;
-
-const UkrainianFlag = styled.div`
-  width: 4em;
-  height: 3em;
-  background-image: linear-gradient(#0066cc 50%, #ffcc00 50%);
-`;
-
-const BannerTextContainer = styled.div`
-  flex: 1;
-
-  color: white;
-
-  a {
-    color: #fff;
-    text-decoration: underline;
-  }
-
-  > :first-child {
-    margin-top: 0;
-  }
-
-  > :last-child {
-    margin-bottom: 0;
-  }
-`;
-
 const MenuSearchBox = styled.div`
   display: none;
 
@@ -386,17 +348,6 @@ export const Header = ({children}) => {
           </a>
         </MenuSearchBox>
       </MenuContainer>
-      <Banner>
-        <UkrainianFlag />
-        <BannerTextContainer>
-          <p>
-            The Yarn team stands with the people of Ukraine during this heinous assault on their freedom, their independence, and their lives.
-          </p>
-          <p>
-            To support Ukraine in their time of need visit this <a href={`https://war.ukraine.ua/support-ukraine/`}>page</a>.
-          </p>
-        </BannerTextContainer>
-      </Banner>
       {children}
     </HeaderContainer>
   </>;

--- a/packages/gatsby/src/pages/index.js
+++ b/packages/gatsby/src/pages/index.js
@@ -155,6 +155,58 @@ const SellingPoint = ({imgUrl, children, href}) => <>
   </SellingPointContainer>
 </>;
 
+const Banner = styled.div`
+  background-color: #5474c9;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 1em;
+
+  > :first-child {
+    margin-right: 1em;
+  }
+`;
+
+const UkrainianFlag = styled.div`
+  width: 4em;
+  height: 3em;
+  background-image: linear-gradient(#0066cc 50%, #ffcc00 50%);
+`;
+
+const BannerTextContainer = styled.div`
+  flex: 1;
+
+  color: white;
+
+  a {
+    color: #fff;
+    text-decoration: underline;
+  }
+
+  > :first-child {
+    margin-top: 0;
+  }
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const UkrainianBanner = () =>
+  <Banner>
+    <UkrainianFlag />
+    <BannerTextContainer>
+      <p>
+The Yarn team stands with the people of Ukraine during this heinous assault on their freedom, their independence, and their lives.
+      </p>
+      <p>
+To support Ukraine in their time of need visit this <a href={`https://war.ukraine.ua/support-ukraine/`}>page</a>.
+      </p>
+    </BannerTextContainer>
+  </Banner>;
+
+
 const IndexPage = ({data, searchState, onSearchStateChange}) => {
   const [tags, setTags] = useState([]);
   const [owners, setOwners] = useState([]);
@@ -182,6 +234,8 @@ const IndexPage = ({data, searchState, onSearchStateChange}) => {
         />
 
         {!searchState.query && <>
+          <UkrainianBanner />
+
           <Hero>
             <SectionContent>
               <HeroTitle>


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I have added Ukrainian banner initially to all the pages of the website and into a fixed position. Unfortunately this disrupts docs UX, because the banner takes much of vertical space.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have left the banner on the home page only and made it a part of the content. I'm open to other ideas how to make the banner visible and not disrupt the docs UX on the same time.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
