### PR TITLE
Make the local cache opt-in (rather than opt-out)

### DIFF
--- a/.yarn/versions/b2f24cb2.yml
+++ b/.yarn/versions/b2f24cb2.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-npm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/gatsby/content/advanced/lexicon.md
+++ b/packages/gatsby/content/advanced/lexicon.md
@@ -67,6 +67,14 @@ See also: the [`Linker` interface](https://github.com/yarnpkg/berry/blob/master/
 
 See also: the [`Installer` interface](https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/Installer.ts#L18)
 
+### Local Cache
+
+The local cache is a way to protect against registries going down by keeping a cache of your packages within your very project (often checked-in within the repository). While not always practical (it causes the repository size to grow, although we have ways to mitigate it significantly), it presents various interesting properties:
+
+- It doesn't require additional infrastructure, such as a [Verdaccio proxy](https://verdaccio.org/)
+- The install fetch step is as fast as it can be, with no data transfer at all
+- It lets you reach [zero-installs](https://yarnpkg.com/features/zero-installs) if you also use the PnP linker
+
 ### Locator
 
 A locator is a combination of a package name (for example `lodash`) and a package <abbr>reference</abbr> (for example `1.2.3`). Locators are used to identify a single unique package (interestingly, all valid locators also are valid <abbr>descriptors</abbr>).

--- a/packages/gatsby/content/advanced/lexicon.md
+++ b/packages/gatsby/content/advanced/lexicon.md
@@ -72,8 +72,11 @@ See also: the [`Installer` interface](https://github.com/yarnpkg/berry/blob/mast
 The local cache is a way to protect against registries going down by keeping a cache of your packages within your very project (often checked-in within the repository). While not always practical (it causes the repository size to grow, although we have ways to mitigate it significantly), it presents various interesting properties:
 
 - It doesn't require additional infrastructure, such as a [Verdaccio proxy](https://verdaccio.org/)
+- It doesn't require additional configuration, such as registry authentication
 - The install fetch step is as fast as it can be, with no data transfer at all
 - It lets you reach [zero-installs](https://yarnpkg.com/features/zero-installs) if you also use the PnP linker
+
+To enable the local cache, set [`enableGlobalCache`](/configuration/yarnrc#enableGlobalCache) to `false`, run an install, and add the new artifacts to your repository (you might want to [update your gitignore](/getting-started/qa#which-files-should-be-gitignored) accordingly).
 
 ### Locator
 

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -1,6 +1,6 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
-import {formatUtils, structUtils, tgzUtils}         from '@yarnpkg/core';
+import {structUtils, tgzUtils}                      from '@yarnpkg/core';
 import semver                                       from 'semver';
 
 import {PROTOCOL}                                   from './constants';

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -1,6 +1,6 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
-import {structUtils, tgzUtils}                      from '@yarnpkg/core';
+import {formatUtils, structUtils, tgzUtils}         from '@yarnpkg/core';
 import semver                                       from 'semver';
 
 import {PROTOCOL}                                   from './constants';
@@ -50,6 +50,7 @@ export class NpmHttpFetcher implements Fetcher {
       throw new Error(`Assertion failed: The archiveUrl querystring parameter should have been available`);
 
     const sourceBuffer = await npmHttpUtils.get(params.__archiveUrl, {
+      customErrorMessage: npmHttpUtils.customPackageError,
       configuration: opts.project.configuration,
       ident: locator,
     });

--- a/packages/plugin-npm/sources/NpmSemverFetcher.ts
+++ b/packages/plugin-npm/sources/NpmSemverFetcher.ts
@@ -50,6 +50,7 @@ export class NpmSemverFetcher implements Fetcher {
     let sourceBuffer;
     try {
       sourceBuffer = await npmHttpUtils.get(NpmSemverFetcher.getLocatorUrl(locator), {
+        customErrorMessage: npmHttpUtils.customPackageError,
         configuration: opts.project.configuration,
         ident: locator,
       });
@@ -58,6 +59,7 @@ export class NpmSemverFetcher implements Fetcher {
       // OK: https://registry.yarnpkg.com/@emotion%2fbabel-preset-css-prop/-/babel-preset-css-prop-10.0.7.tgz
       // KO: https://registry.yarnpkg.com/@xtuc%2fieee754/-/ieee754-1.2.0.tgz
       sourceBuffer = await npmHttpUtils.get(NpmSemverFetcher.getLocatorUrl(locator).replace(/%2f/g, `/`), {
+        customErrorMessage: npmHttpUtils.customPackageError,
         configuration: opts.project.configuration,
         ident: locator,
       });

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -48,6 +48,7 @@ export class NpmSemverResolver implements Resolver {
       throw new Error(`Expected a valid range, got ${descriptor.range.slice(PROTOCOL.length)}`);
 
     const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(descriptor), {
+      customErrorMessage: npmHttpUtils.customPackageError,
       configuration: opts.project.configuration,
       ident: descriptor,
       jsonResponse: true,
@@ -118,6 +119,7 @@ export class NpmSemverResolver implements Resolver {
       throw new ReportError(MessageName.RESOLVER_NOT_FOUND, `The npm semver resolver got selected, but the version isn't semver`);
 
     const registryData = await npmHttpUtils.get(npmHttpUtils.getIdentUrl(locator), {
+      customErrorMessage: npmHttpUtils.customPackageError,
       configuration: opts.project.configuration,
       ident: locator,
       jsonResponse: true,

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,11 +1,11 @@
 import {Configuration, Ident, formatUtils, httpUtils} from '@yarnpkg/core';
-import {MessageName, ReportError}        from '@yarnpkg/core';
-import {prompt}                          from 'enquirer';
-import {URL}                             from 'url';
+import {MessageName, ReportError}                     from '@yarnpkg/core';
+import {prompt}                                       from 'enquirer';
+import {URL}                                          from 'url';
 
-import {Hooks}                           from './index';
-import * as npmConfigUtils               from './npmConfigUtils';
-import {MapLike}                         from './npmConfigUtils';
+import {Hooks}                                        from './index';
+import * as npmConfigUtils                            from './npmConfigUtils';
+import {MapLike}                                      from './npmConfigUtils';
 
 export enum AuthType {
   NO_AUTH,

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,4 +1,4 @@
-import {Configuration, Ident, httpUtils} from '@yarnpkg/core';
+import {Configuration, Ident, formatUtils, httpUtils} from '@yarnpkg/core';
 import {MessageName, ReportError}        from '@yarnpkg/core';
 import {prompt}                          from 'enquirer';
 import {URL}                             from 'url';
@@ -42,8 +42,18 @@ export async function handleInvalidAuthenticationError(error: any, {attemptedAs,
   }
 }
 
-export function customPackageError(error: httpUtils.RequestError) {
-  return error.response?.statusCode === 404 ? `Package not found` : null;
+export function customPackageError(error: httpUtils.RequestError, configuration: Configuration) {
+  const statusCode = error.response?.statusCode;
+  if (!statusCode)
+    return null;
+
+  if (statusCode === 404)
+    return `Package not found`;
+
+  if (statusCode >= 500 && statusCode < 600)
+    return `The registry appears to be down (using a ${formatUtils.applyHyperlink(configuration, `local cache`, `https://yarnpkg.com/advanced/lexicon#local-cache`)} might have protected you against such outages)`;
+
+  return null;
 }
 
 export function getIdentUrl(ident: Ident) {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -214,7 +214,7 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
   enableGlobalCache: {
     description: `If true, the system-wide cache folder will be used regardless of \`cache-folder\``,
     type: SettingsType.BOOLEAN,
-    default: false,
+    default: true,
   },
 
   // Settings related to the output style


### PR DESCRIPTION
**What's the problem this PR addresses?**

The local cache was enabled in Yarn 2 in large part because people weren't aware that it existed. However, it adds a significant friction around new project creation, and I suspect it might not be as necessary as before (our users have been confronted to it for a while now, so discovery should have improved).

**How did you fix it?**

Local cache is now disabled by default. Tests aren't updated yet.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
