### PR TITLE
Prefer using exclusively Corepack when possible

### DIFF
--- a/.yarn/versions/2847fa24.yml
+++ b/.yarn/versions/2847fa24.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -27,7 +27,7 @@ interface RunDriverOptions extends Record<string, any> {
   cwd?: PortablePath;
   projectFolder?: PortablePath;
   registryUrl: string;
-  env?: Record<string, string>;
+  env?: Record<string, string | undefined>;
 }
 
 export type PackageRunDriver = (

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
@@ -1,0 +1,130 @@
+import {xfs, ppath, PortablePath, Filename} from '@yarnpkg/fslib';
+
+const yarnrcRegexp = /^yarnPath:/;
+
+describe(`Commands`, () => {
+  describe(`set version`, () => {
+    test(
+      `it shouldn't set yarnPath if corepack is enabled and the version is semver`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: `/path/to/corepack`},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `3.0.0`);
+        await check(path, {corepackVersion: `3.0.0`, usePath: false});
+      }),
+    );
+
+    test(
+      `it should set yarnPath if corepack is disabled, even when the version is semver`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `3.0.0`);
+        await check(path, {corepackVersion: `3.0.0`, usePath: true});
+      }),
+    );
+
+    test(
+      `it should always set yarnPath if one already exists`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: `/path/to/corepack`},
+      }, async ({path, run, source}) => {
+        // To force yarnPath to be set; followed by a sanity check
+        await run(`set`, `version`, `3.0.0`, {env: {COREPACK_ROOT: undefined}});
+        await check(path, {corepackVersion: `3.0.0`, usePath: true});
+
+        await run(`set`, `version`, `3.0.0`);
+        await check(path, {corepackVersion: `3.0.0`, usePath: true});
+      }),
+    );
+
+    test(
+      `it should always set yarnPath if --yarn-path is set`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: `/path/to/corepack`},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `3.0.0`, `--yarn-path`);
+        await check(path, {corepackVersion: `3.0.0`, usePath: true});
+      }),
+    );
+
+    test(
+      `it should never set yarnPath if --no-yarn-path is set`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `3.0.0`, `--no-yarn-path`);
+        await check(path, {corepackVersion: `3.0.0`, usePath: false});
+      }),
+    );
+
+    test(
+      `it should prevent using --no-yarn-path with arbitrary files`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        const yarnIndirection = ppath.join(path, `custom-yarn.cjs` as Filename);
+        await xfs.writeFilePromise(yarnIndirection, ``);
+
+        await expect(run(`set`, `version`, yarnIndirection, `--no-yarn-path`)).rejects.toThrow();
+      }),
+    );
+
+    test(
+      `it should set yarnPath if the version is an arbitrary file`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        const yarnIndirection = ppath.join(path, `custom-yarn.cjs` as Filename);
+        await xfs.writeFilePromise(yarnIndirection, ``);
+
+        await run(`set`, `version`, yarnIndirection);
+        await check(path, {corepackVersion: /[0-9]+\./, usePath: true});
+      }),
+    );
+  });
+});
+
+async function check(path: PortablePath, checks: {corepackVersion: string | RegExp, usePath: boolean}) {
+  const releasesPath = ppath.join(path, `.yarn/releases` as PortablePath);
+  const yarnrcPath = ppath.join(path, Filename.rc);
+  const manifestPath = ppath.join(path, Filename.manifest);
+
+  let releases: Array<string> | null;
+  try {
+    releases = await xfs.readdirPromise(releasesPath);
+  } catch (err) {
+    if (err.code === `ENOENT`) {
+      releases = null;
+    } else {
+      throw err;
+    }
+  }
+
+  let yarnrcFile;
+  try {
+    yarnrcFile = await xfs.readFilePromise(yarnrcPath, `utf8`);
+  } catch (err) {
+    if (err.code === `ENOENT`) {
+      yarnrcFile = ``;
+    } else {
+      throw err;
+    }
+  }
+
+  if (checks.usePath)
+    expect(releases).toHaveLength(1);
+  else
+    expect(releases).toEqual(null);
+
+  if (checks.usePath)
+    expect(yarnrcFile).toMatch(yarnrcRegexp);
+  else
+    expect(yarnrcFile).not.toMatch(yarnrcRegexp);
+
+  await expect(xfs.readJsonPromise(manifestPath)).resolves.toMatchObject({
+    packageManager: checks.corepackVersion instanceof RegExp
+      ? expect.stringMatching(`yarn@${checks.corepackVersion.source}`)
+      : `yarn@${checks.corepackVersion}`,
+  });
+}

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -70,7 +70,7 @@ export default class SetVersionCommand extends BaseCommand {
     ]],
   });
 
-  useYarnPath = Option.Boolean(`--yarn-path`, false, {
+  useYarnPath = Option.Boolean(`--yarn-path`, {
     description: `Set the yarnPath setting even if the version can be accessed by Corepack`,
   });
 
@@ -175,7 +175,13 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
   const isTaggedYarnVersion = miscUtils.isTaggedYarnVersion(bundleVersion);
 
   const yarnPath = configuration.get(`yarnPath`);
-  const updateFile = yarnPath || !isTaggedYarnVersion || useYarnPath;
+  let updateFile = yarnPath || !isTaggedYarnVersion || yarnPath;
+
+  if (typeof yarnPath === `undefined`) {
+    report.reportWarning(MessageName.UNNAMED, `You don't seem to have ${formatUtils.applyHyperlink(configuration, `Corepack`, `https://nodejs.org/api/corepack.html`)} enabled; we'll have to rely on ${formatUtils.applyHyperlink(configuration, `yarnPath`, `https://yarnpkg.com/configuration/yarnrc#yarnPath`)} instead`);
+    updateFile = true;
+  }
+
 
   if (updateFile) {
     const bundleBuffer = await fetchBuffer();

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -127,13 +127,12 @@ export default class SetVersionCommand extends BaseCommand {
       stdout: this.context.stdout,
       includeLogs: !this.context.quiet,
     }, async (report: StreamReport) => {
-<<<<<<< Updated upstream
       const fetchBuffer = async () => {
         const filePrefix = `file://`;
 
         if (bundleRef.url.startsWith(filePrefix)) {
           report.reportInfo(MessageName.UNNAMED, `Retrieving ${formatUtils.pretty(configuration, bundleRef.url, FormatType.PATH)}`);
-          return await xfs.readFilePromise(npath.toPortablePath(bundleRef.url.slice(filePrefix.length)));
+          return await xfs.readFilePromise(bundleRef.url.slice(filePrefix.length) as PortablePath);
         } else {
           report.reportInfo(MessageName.UNNAMED, `Downloading ${formatUtils.pretty(configuration, bundleRef.url, FormatType.URL)}`);
           return await httpUtils.get(bundleRef.url, {configuration});
@@ -141,20 +140,6 @@ export default class SetVersionCommand extends BaseCommand {
       };
 
       await setVersion(configuration, bundleRef.version, fetchBuffer, {report, useYarnPath: this.useYarnPath});
-=======
-      const filePrefix = `file://`;
-
-      let bundleBuffer: Buffer;
-      if (bundleUrl.startsWith(filePrefix)) {
-        report.reportInfo(MessageName.UNNAMED, `Downloading ${formatUtils.pretty(configuration, bundleUrl, FormatType.URL)}`);
-        bundleBuffer = await xfs.readFilePromise(bundleUrl.slice(filePrefix.length) as PortablePath);
-      } else {
-        report.reportInfo(MessageName.UNNAMED, `Retrieving ${formatUtils.pretty(configuration, bundleUrl, FormatType.PATH)}`);
-        bundleBuffer = await httpUtils.get(bundleUrl, {configuration});
-      }
-
-      await setVersion(configuration, null, bundleBuffer, {report});
->>>>>>> Stashed changes
     });
 
     return report.exitCode();

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -19,7 +19,9 @@ export default class SetVersionCommand extends BaseCommand {
   static usage: Usage = Command.Usage({
     description: `lock the Yarn version used by the project`,
     details: `
-      This command will download a specific release of Yarn directly from the Yarn GitHub repository, will store it inside your project, and will change the \`yarnPath\` settings from your project \`.yarnrc.yml\` file to point to the new file.
+      This command will set a specific release of Yarn to be used by Corepack: https://nodejs.org/api/corepack.html.
+
+      By default it only will set the \`packageManager\` field at the root of your project, but if the referenced release cannot be represented this way, if you already have \`yarnPath\` configured, or if you set the \`--yarn-path\` command line flag, then the release will also be downloaded from the Yarn GitHub repository, stored inside your project, and referenced via the \`yarnPath\` settings from your project \`.yarnrc.yml\` file.
 
       A very good use case for this command is to enforce the version of Yarn used by the any single member of your team inside a same project - by doing this you ensure that you have control on Yarn upgrades and downgrades (including on your deployment servers), and get rid of most of the headaches related to someone using a slightly different version and getting a different behavior than you.
 

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -112,7 +112,7 @@ export default class SetVersionCommand extends BaseCommand {
     else if (this.version.match(/^https?:/))
       bundleRef = {url: this.version, version: `remote`};
     else if (this.version.match(/^\.{0,2}[\\/]/) || npath.isAbsolute(this.version))
-      bundleRef = {url: `file://${npath.resolve(this.version)}`, version: `file`};
+      bundleRef = {url: `file://${ppath.resolve(npath.toPortablePath(this.version))}`, version: `file`};
     else if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`))
       bundleRef = getRef(`https://repo.yarnpkg.com/{}/packages/yarnpkg-cli/bin/yarn.js`, this.version);
     else if (semverUtils.satisfiesWithPrereleases(this.version, `^0.x || ^1.x`))
@@ -127,6 +127,7 @@ export default class SetVersionCommand extends BaseCommand {
       stdout: this.context.stdout,
       includeLogs: !this.context.quiet,
     }, async (report: StreamReport) => {
+<<<<<<< Updated upstream
       const fetchBuffer = async () => {
         const filePrefix = `file://`;
 
@@ -140,6 +141,20 @@ export default class SetVersionCommand extends BaseCommand {
       };
 
       await setVersion(configuration, bundleRef.version, fetchBuffer, {report, useYarnPath: this.useYarnPath});
+=======
+      const filePrefix = `file://`;
+
+      let bundleBuffer: Buffer;
+      if (bundleUrl.startsWith(filePrefix)) {
+        report.reportInfo(MessageName.UNNAMED, `Downloading ${formatUtils.pretty(configuration, bundleUrl, FormatType.URL)}`);
+        bundleBuffer = await xfs.readFilePromise(bundleUrl.slice(filePrefix.length) as PortablePath);
+      } else {
+        report.reportInfo(MessageName.UNNAMED, `Retrieving ${formatUtils.pretty(configuration, bundleUrl, FormatType.PATH)}`);
+        bundleBuffer = await httpUtils.get(bundleUrl, {configuration});
+      }
+
+      await setVersion(configuration, null, bundleBuffer, {report});
+>>>>>>> Stashed changes
     });
 
     return report.exitCode();

--- a/packages/plugin-essentials/sources/commands/set/version/sources.ts
+++ b/packages/plugin-essentials/sources/commands/set/version/sources.ts
@@ -107,7 +107,7 @@ export default class SetVersionSourcesCommand extends BaseCommand {
       const bundlePath = ppath.resolve(target, `packages/yarnpkg-cli/bundles/yarn.js` as PortablePath);
       const bundleBuffer = await xfs.readFilePromise(bundlePath);
 
-      await setVersion(configuration, `sources`, bundleBuffer, {
+      await setVersion(configuration, `sources`, async () => bundleBuffer, {
         report,
       });
 

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -84,11 +84,13 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
     });
 
     const isSameBinary = async () =>
-      yarnPath === selfPath ||
-      Buffer.compare(...await Promise.all([
-        tryRead(yarnPath),
-        tryRead(selfPath),
-      ])) === 0;
+      yarnPath && (
+        yarnPath === selfPath ||
+        Buffer.compare(...await Promise.all([
+          tryRead(yarnPath),
+          tryRead(selfPath),
+        ])) === 0
+      );
 
     // Avoid unnecessary spawn when run directly
     if (!ignorePath && !ignoreCwd && await isSameBinary()) {

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -73,7 +73,7 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
       strict: false,
     });
 
-    const yarnPath: PortablePath = configuration.get(`yarnPath`);
+    const yarnPath = configuration.get(`yarnPath`);
     const ignorePath = configuration.get(`ignorePath`);
     const ignoreCwd = configuration.get(`ignoreCwd`);
 

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -83,15 +83,16 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
       return Buffer.of();
     });
 
-    const isSameBinary = async () =>
-      yarnPath === selfPath ||
+    const isDifferentBinary = async () =>
+      yarnPath &&
+      yarnPath !== selfPath &&
       Buffer.compare(...await Promise.all([
         tryRead(yarnPath),
         tryRead(selfPath),
-      ])) === 0;
+      ])) !== 0;
 
     // Avoid unnecessary spawn when run directly
-    if (!ignorePath && !ignoreCwd && await isSameBinary()) {
+    if (!ignorePath && !ignoreCwd && !await isDifferentBinary()) {
       process.env.YARN_IGNORE_PATH = `1`;
       process.env.YARN_IGNORE_CWD = `1`;
 

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -83,16 +83,15 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
       return Buffer.of();
     });
 
-    const isDifferentBinary = async () =>
-      yarnPath &&
-      yarnPath !== selfPath &&
+    const isSameBinary = async () =>
+      yarnPath === selfPath ||
       Buffer.compare(...await Promise.all([
         tryRead(yarnPath),
         tryRead(selfPath),
-      ])) !== 0;
+      ])) === 0;
 
     // Avoid unnecessary spawn when run directly
-    if (!ignorePath && !ignoreCwd && !await isDifferentBinary()) {
+    if (!ignorePath && !ignoreCwd && await isSameBinary()) {
       process.env.YARN_IGNORE_PATH = `1`;
       process.env.YARN_IGNORE_CWD = `1`;
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -543,7 +543,7 @@ export type MapConfigurationValue<T extends object> = miscUtils.ToMapValue<T>;
 export interface ConfigurationValueMap {
   lastUpdateCheck: string | null;
 
-  yarnPath: PortablePath;
+  yarnPath: PortablePath | null;
   ignorePath: boolean;
   ignoreCwd: boolean;
 
@@ -897,6 +897,8 @@ export type FindProjectOptions = {
 };
 
 export class Configuration {
+  public static deleteProperty = Symbol();
+
   public static telemetry: TelemetryManager | null = null;
 
   public startingCwd: PortablePath;
@@ -1265,7 +1267,11 @@ export class Configuration {
         if (currentValue === nextValue)
           continue;
 
-        replacement[key] = nextValue;
+        if (nextValue === Configuration.deleteProperty)
+          delete replacement[key];
+        else
+          replacement[key] = nextValue;
+
         patched = true;
       }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node 14 will soon be the new Node LTS. Since it ships with Corepack, we don't need to store the version file unless users already expect really want it.

**How did you fix it?**

The new code detects whether there's a `yarnPath` setting. If there is, it assumes that the version file will be needed. Otherwise, it just updates the `packageManager` field.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
