### PR TITLE
chore(git): remove redundant variable match

### DIFF
--- a/.yarn/versions/95d4f806.yml
+++ b/.yarn/versions/95d4f806.yml
@@ -1,0 +1,9 @@
+releases:
+  "@yarnpkg/plugin-git": patch
+
+declined:
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -302,18 +302,16 @@ export async function fetchRoot(initialCwd: PortablePath) {
   // it may return long paths even when the cwd uses short paths, and we have no
   // way to detect it from Node (not even realpath).
 
-  let match: PortablePath | null = null;
-
   let cwd: PortablePath;
   let nextCwd = initialCwd;
   do {
     cwd = nextCwd;
     if (await xfs.existsPromise(ppath.join(cwd, `.git` as Filename)))
-      match = cwd;
+      return cwd;
     nextCwd = ppath.dirname(cwd);
-  } while (match === null && nextCwd !== cwd);
+  } while (nextCwd !== cwd);
 
-  return match;
+  return null;
 }
 
 export async function fetchBase(root: PortablePath, {baseRefs}: {baseRefs: Array<string>}) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

There's a redundant variable `match` in `fetchRoot` function which can be removed.

**How did you fix it?**

Removed the redundant variable `match`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
