### PR TITLE
docs: add reference to `libc` key in `supportedArchitectures` documentation

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -715,7 +715,7 @@
           "_exampleItems": ["current", "glibc", "musl"]
         }
       },
-      "_exampleKeys": ["os", "cpu"]
+      "_exampleKeys": ["os", "cpu", "libc"]
     },
     "telemetryInterval": {
       "_package": "@yarnpkg/core",


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `libc` field is useful when using some dependencies but it's missing from the documentation.

Closes #4256

...

**How did you fix it?**

I added the field in the exampleKeys of the JSON.
...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
