### PR TITLE
chore(parsers): use string array in stringifyResolution

### DIFF
--- a/.yarn/versions/3961461f.yml
+++ b/.yarn/versions/3961461f.yml
@@ -1,0 +1,11 @@
+releases:
+  "@yarnpkg/parsers": patch
+
+declined:
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-parsers/sources/resolution.ts
+++ b/packages/yarnpkg-parsers/sources/resolution.ts
@@ -26,21 +26,21 @@ export function parseResolution(source: string): Resolution {
 }
 
 export function stringifyResolution(resolution: Resolution) {
-  let str = ``;
+  const strArr: Array<string> = [];
 
   if (resolution.from) {
-    str += resolution.from.fullName;
+    strArr.push(resolution.from.fullName);
 
     if (resolution.from.description)
-      str += `@${resolution.from.description}`;
+      strArr.push(`@${resolution.from.description}`);
 
-    str += `/`;
+    strArr.push(`/`);
   }
 
-  str += resolution.descriptor.fullName;
+  strArr.push(resolution.descriptor.fullName);
 
   if (resolution.descriptor.description)
-    str += `@${resolution.descriptor.description}`;
+    strArr.push(`@${resolution.descriptor.description}`);
 
-  return str;
+  return strArr.join(``);
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variable `str` in function `stringifyResolution` stores the final string using string concatenation.
Using Array.join() has better readability for this case, and is also [faster](https://stackoverflow.com/a/37063331).

**How did you fix it?**

Use Array.join() for populating string in stringifyResolution

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
