### PR TITLE
fix(plugin-pnp): wait for unplugging to finish before finalizing

### DIFF
--- a/.yarn/versions/d86fbacc.yml
+++ b/.yarn/versions/d86fbacc.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -286,6 +286,8 @@ export class PnpInstaller implements Installer {
         if (this.opts.project.tryWorkspaceByLocator(pkg))
           fallbackExclusionList.push({name: structUtils.stringifyIdent(pkg), reference: pkg.reference});
 
+    await this.asyncActions.wait();
+
     await this.finalizeInstallWithPnp({
       dependencyTreeRoots,
       enableTopLevelFallback,
@@ -295,8 +297,6 @@ export class PnpInstaller implements Installer {
       packageRegistry,
       shebang,
     });
-
-    await this.asyncActions.wait();
 
     return {
       customData: this.customData,


### PR DESCRIPTION
**What's the problem this PR addresses?**

There is a race condition in the PnP linker where it can end up trying to read the unplugged folder before it is created.

Fixes https://github.com/yarnpkg/berry/runs/5705475812?check_suite_focus=true#step:5:154
> Error: ENOENT: no such file or directory, scandir '/tmp/xfs-f4bc4a3d/.yarn/unplugged'

**How did you fix it?**

Wait for the unplugging to complete before calling `finalizeInstallWithPnp`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.