### PR TITLE
chore(file): use const for path in getCandidates

### DIFF
--- a/.yarn/versions/f6c9fb9e.yml
+++ b/.yarn/versions/f6c9fb9e.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-file": patch
+
+declined:
+  - "@yarnpkg/cli"

--- a/packages/plugin-file/sources/TarballFileResolver.ts
+++ b/packages/plugin-file/sources/TarballFileResolver.ts
@@ -48,10 +48,9 @@ export class TarballFileResolver implements Resolver {
   }
 
   async getCandidates(descriptor: Descriptor, dependencies: unknown, opts: ResolveOptions) {
-    let path = descriptor.range;
-
-    if (path.startsWith(PROTOCOL))
-      path = path.slice(PROTOCOL.length);
+    const path = descriptor.range.startsWith(PROTOCOL)
+      ? descriptor.range.slice(PROTOCOL.length)
+      : descriptor.range;
 
     return [structUtils.makeLocator(descriptor, `${PROTOCOL}${npath.toPortablePath(path)}`)];
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variable `path` can be declared as const, and assigned values in a conditional operator

**How did you fix it?**

Use const for variable `path`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
