### PR TITLE
Soften CI coverage

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -5,6 +5,13 @@ on:
     - 'cherry-pick/**'
   pull_request:
 
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{github.workflow}}-${{github.ref}}-${{github.ref != 'refs/heads/master' || github.run_number}}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{startsWith(github.ref, 'refs/pull/')}}
+
 name: 'Integration'
 jobs:
   chore:
@@ -190,13 +197,16 @@ jobs:
       fail-fast: false
       matrix:
         node:
-        - 14
         - 16
-        - 17
         platform:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+        include:
+          - node: 14
+            platform: ubuntu-latest
+          - node: 17
+            platform: ubuntu-latest
 
     name: '${{matrix.platform}} w/ Node.js ${{matrix.node}}.x'
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -197,13 +197,13 @@ jobs:
       fail-fast: false
       matrix:
         node:
-        - 16
+        - 14
         platform:
         - ubuntu-latest
         - windows-latest
         - macos-latest
         include:
-          - node: 14
+          - node: 16
             platform: ubuntu-latest
           - node: 17
             platform: ubuntu-latest


### PR DESCRIPTION
**What's the problem this PR addresses?**

We currently run the full testsuite on all three systems, on all supported Node versions. Windows and OSX are very slow, making us wait significantly longer before being able to get all the results. The problem becomes worse when multiple PRs are merged quickly, as it swamps the runners which then become even more sluggish.

**How did you fix it?**

- Cancel runs when pushing multiple commits in PRs one after the other
- Only run Windows / OSX tests on the first LTS we support

It might make sense to later introduce scheduled tests that would run all the tests.
