### PR TITLE
Fixes {} parsing inside shell scripts

### DIFF
--- a/.yarn/versions/8f3f5219.yml
+++ b/.yarn/versions/8f3f5219.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/parsers": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-parsers/sources/grammars/shell.js
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.js
@@ -319,8 +319,8 @@ function peg$parse(input, options) {
       peg$c173 = function() { return text() },
       peg$c174 = /^[$@*?#a-zA-Z0-9_\-]/,
       peg$c175 = peg$classExpectation(["$", "@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
-      peg$c176 = /^[(){}<>$|&; \t"']/,
-      peg$c177 = peg$classExpectation(["(", ")", "{", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
+      peg$c176 = /^[()}<>$|&; \t"']/,
+      peg$c177 = peg$classExpectation(["(", ")", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
       peg$c178 = /^[<>&; \t"']/,
       peg$c179 = peg$classExpectation(["<", ">", "&", ";", " ", "\t", "\"", "'"], false, false),
       peg$c180 = /^[ \t]/,
@@ -3525,7 +3525,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSpecialShellChars() {
-    var s0;
+    var s0, s1, s2;
 
     if (peg$c176.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
@@ -3533,6 +3533,29 @@ function peg$parse(input, options) {
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c177); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 123) {
+        s1 = peg$c29;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c30); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseS();
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;

--- a/packages/yarnpkg-parsers/sources/grammars/shell.js
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.js
@@ -267,64 +267,67 @@ function peg$parse(input, options) {
       peg$c123 = /^[0-9a-fA-f]/,
       peg$c124 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "f"]], false, false),
       peg$c125 = peg$anyExpectation(),
-      peg$c126 = "-",
-      peg$c127 = peg$literalExpectation("-", false),
-      peg$c128 = "+",
-      peg$c129 = peg$literalExpectation("+", false),
-      peg$c130 = ".",
-      peg$c131 = peg$literalExpectation(".", false),
-      peg$c132 = function(sign, left, right) { return { type: `number`, value: (sign === '-' ? -1 : 1) * parseFloat(left.join(``) + `.` + right.join(``)) } },
-      peg$c133 = function(sign, value) { return { type: `number`, value: (sign === '-' ? -1 : 1) *  parseInt(value.join(``)) } },
-      peg$c134 = function(variable) { return { type: `variable`, ...variable } },
-      peg$c135 = function(name) { return { type: `variable`, name } },
-      peg$c136 = function(value) { return value },
-      peg$c137 = "*",
-      peg$c138 = peg$literalExpectation("*", false),
-      peg$c139 = "/",
-      peg$c140 = peg$literalExpectation("/", false),
-      peg$c141 = function(left, op, right) { return { type: op === `*` ? `multiplication` : `division`, right } },
-      peg$c142 = function(left, rest) {
+      peg$c126 = "{}",
+      peg$c127 = peg$literalExpectation("{}", false),
+      peg$c128 = function() { return '{}' },
+      peg$c129 = "-",
+      peg$c130 = peg$literalExpectation("-", false),
+      peg$c131 = "+",
+      peg$c132 = peg$literalExpectation("+", false),
+      peg$c133 = ".",
+      peg$c134 = peg$literalExpectation(".", false),
+      peg$c135 = function(sign, left, right) { return { type: `number`, value: (sign === '-' ? -1 : 1) * parseFloat(left.join(``) + `.` + right.join(``)) } },
+      peg$c136 = function(sign, value) { return { type: `number`, value: (sign === '-' ? -1 : 1) *  parseInt(value.join(``)) } },
+      peg$c137 = function(variable) { return { type: `variable`, ...variable } },
+      peg$c138 = function(name) { return { type: `variable`, name } },
+      peg$c139 = function(value) { return value },
+      peg$c140 = "*",
+      peg$c141 = peg$literalExpectation("*", false),
+      peg$c142 = "/",
+      peg$c143 = peg$literalExpectation("/", false),
+      peg$c144 = function(left, op, right) { return { type: op === `*` ? `multiplication` : `division`, right } },
+      peg$c145 = function(left, rest) {
           return rest.reduce((left, right) => ({ left, ...right }), left)
         },
-      peg$c143 = function(left, op, right) { return { type: op === `+` ? `addition` : `subtraction`, right } },
-      peg$c144 = "$((",
-      peg$c145 = peg$literalExpectation("$((", false),
-      peg$c146 = "))",
-      peg$c147 = peg$literalExpectation("))", false),
-      peg$c148 = function(arithmetic) { return arithmetic },
-      peg$c149 = "$(",
-      peg$c150 = peg$literalExpectation("$(", false),
-      peg$c151 = function(command) { return command },
-      peg$c152 = "${",
-      peg$c153 = peg$literalExpectation("${", false),
-      peg$c154 = ":-",
-      peg$c155 = peg$literalExpectation(":-", false),
-      peg$c156 = function(name, arg) { return { name, defaultValue: arg } },
-      peg$c157 = ":-}",
-      peg$c158 = peg$literalExpectation(":-}", false),
-      peg$c159 = function(name) { return { name, defaultValue: [] } },
-      peg$c160 = ":+",
-      peg$c161 = peg$literalExpectation(":+", false),
-      peg$c162 = function(name, arg) { return { name, alternativeValue: arg } },
-      peg$c163 = ":+}",
-      peg$c164 = peg$literalExpectation(":+}", false),
-      peg$c165 = function(name) { return { name, alternativeValue: [] } },
-      peg$c166 = function(name) { return { name } },
-      peg$c167 = "$",
-      peg$c168 = peg$literalExpectation("$", false),
-      peg$c169 = function(pattern) { return options.isGlobPattern(pattern) },
-      peg$c170 = function(pattern) { return pattern },
-      peg$c171 = /^[a-zA-Z0-9_]/,
-      peg$c172 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
-      peg$c173 = function() { return text() },
-      peg$c174 = /^[$@*?#a-zA-Z0-9_\-]/,
-      peg$c175 = peg$classExpectation(["$", "@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
-      peg$c176 = /^[()}<>$|&; \t"']/,
-      peg$c177 = peg$classExpectation(["(", ")", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
-      peg$c178 = /^[<>&; \t"']/,
-      peg$c179 = peg$classExpectation(["<", ">", "&", ";", " ", "\t", "\"", "'"], false, false),
-      peg$c180 = /^[ \t]/,
-      peg$c181 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c146 = function(left, op, right) { return { type: op === `+` ? `addition` : `subtraction`, right } },
+      peg$c147 = "$((",
+      peg$c148 = peg$literalExpectation("$((", false),
+      peg$c149 = "))",
+      peg$c150 = peg$literalExpectation("))", false),
+      peg$c151 = function(arithmetic) { return arithmetic },
+      peg$c152 = "$(",
+      peg$c153 = peg$literalExpectation("$(", false),
+      peg$c154 = function(command) { return command },
+      peg$c155 = "${",
+      peg$c156 = peg$literalExpectation("${", false),
+      peg$c157 = ":-",
+      peg$c158 = peg$literalExpectation(":-", false),
+      peg$c159 = function(name, arg) { return { name, defaultValue: arg } },
+      peg$c160 = ":-}",
+      peg$c161 = peg$literalExpectation(":-}", false),
+      peg$c162 = function(name) { return { name, defaultValue: [] } },
+      peg$c163 = ":+",
+      peg$c164 = peg$literalExpectation(":+", false),
+      peg$c165 = function(name, arg) { return { name, alternativeValue: arg } },
+      peg$c166 = ":+}",
+      peg$c167 = peg$literalExpectation(":+}", false),
+      peg$c168 = function(name) { return { name, alternativeValue: [] } },
+      peg$c169 = function(name) { return { name } },
+      peg$c170 = "$",
+      peg$c171 = peg$literalExpectation("$", false),
+      peg$c172 = function(pattern) { return options.isGlobPattern(pattern) },
+      peg$c173 = function(pattern) { return pattern },
+      peg$c174 = /^[a-zA-Z0-9_]/,
+      peg$c175 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_"], false, false),
+      peg$c176 = function() { return text() },
+      peg$c177 = /^[$@*?#a-zA-Z0-9_\-]/,
+      peg$c178 = peg$classExpectation(["$", "@", "*", "?", "#", ["a", "z"], ["A", "Z"], ["0", "9"], "_", "-"], false, false),
+      peg$c179 = /^[()}<>$|&; \t"']/,
+      peg$c180 = peg$classExpectation(["(", ")", "}", "<", ">", "$", "|", "&", ";", " ", "\t", "\"", "'"], false, false),
+      peg$c181 = /^[<>&; \t"']/,
+      peg$c182 = peg$classExpectation(["<", ">", "&", ";", " ", "\t", "\"", "'"], false, false),
+      peg$c183 = /^[ \t]/,
+      peg$c184 = peg$classExpectation([" ", "\t"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2387,35 +2390,50 @@ function peg$parse(input, options) {
     }
     if (s2 === peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$currPos;
-      peg$silentFails++;
-      s4 = peg$parseSpecialShellChars();
-      peg$silentFails--;
-      if (s4 === peg$FAILED) {
-        s3 = void 0;
+      if (input.substr(peg$currPos, 2) === peg$c126) {
+        s3 = peg$c126;
+        peg$currPos += 2;
       } else {
-        peg$currPos = s3;
         s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c127); }
       }
       if (s3 !== peg$FAILED) {
-        if (input.length > peg$currPos) {
-          s4 = input.charAt(peg$currPos);
-          peg$currPos++;
+        peg$savedPos = s2;
+        s3 = peg$c128();
+      }
+      s2 = s3;
+      if (s2 === peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$currPos;
+        peg$silentFails++;
+        s4 = peg$parseSpecialShellChars();
+        peg$silentFails--;
+        if (s4 === peg$FAILED) {
+          s3 = void 0;
         } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c125); }
+          peg$currPos = s3;
+          s3 = peg$FAILED;
         }
-        if (s4 !== peg$FAILED) {
-          peg$savedPos = s2;
-          s3 = peg$c86(s4);
-          s2 = s3;
+        if (s3 !== peg$FAILED) {
+          if (input.length > peg$currPos) {
+            s4 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c125); }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s2;
+            s3 = peg$c86(s4);
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
         } else {
           peg$currPos = s2;
           s2 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
       }
     }
     if (s2 !== peg$FAILED) {
@@ -2451,35 +2469,50 @@ function peg$parse(input, options) {
         }
         if (s2 === peg$FAILED) {
           s2 = peg$currPos;
-          s3 = peg$currPos;
-          peg$silentFails++;
-          s4 = peg$parseSpecialShellChars();
-          peg$silentFails--;
-          if (s4 === peg$FAILED) {
-            s3 = void 0;
+          if (input.substr(peg$currPos, 2) === peg$c126) {
+            s3 = peg$c126;
+            peg$currPos += 2;
           } else {
-            peg$currPos = s3;
             s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c127); }
           }
           if (s3 !== peg$FAILED) {
-            if (input.length > peg$currPos) {
-              s4 = input.charAt(peg$currPos);
-              peg$currPos++;
+            peg$savedPos = s2;
+            s3 = peg$c128();
+          }
+          s2 = s3;
+          if (s2 === peg$FAILED) {
+            s2 = peg$currPos;
+            s3 = peg$currPos;
+            peg$silentFails++;
+            s4 = peg$parseSpecialShellChars();
+            peg$silentFails--;
+            if (s4 === peg$FAILED) {
+              s3 = void 0;
             } else {
-              s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c125); }
+              peg$currPos = s3;
+              s3 = peg$FAILED;
             }
-            if (s4 !== peg$FAILED) {
-              peg$savedPos = s2;
-              s3 = peg$c86(s4);
-              s2 = s3;
+            if (s3 !== peg$FAILED) {
+              if (input.length > peg$currPos) {
+                s4 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c125); }
+              }
+              if (s4 !== peg$FAILED) {
+                peg$savedPos = s2;
+                s3 = peg$c86(s4);
+                s2 = s3;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
             } else {
               peg$currPos = s2;
               s2 = peg$FAILED;
             }
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
           }
         }
       }
@@ -2500,19 +2533,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c126;
+      s1 = peg$c129;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 43) {
-        s1 = peg$c128;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
     }
     if (s1 === peg$FAILED) {
@@ -2543,11 +2576,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c130;
+          s3 = peg$c133;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+          if (peg$silentFails === 0) { peg$fail(peg$c134); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -2574,7 +2607,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c132(s1, s2, s4);
+            s1 = peg$c135(s1, s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2595,19 +2628,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c126;
+        s1 = peg$c129;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c127); }
+        if (peg$silentFails === 0) { peg$fail(peg$c130); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 43) {
-          s1 = peg$c128;
+          s1 = peg$c131;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c129); }
+          if (peg$silentFails === 0) { peg$fail(peg$c132); }
         }
       }
       if (s1 === peg$FAILED) {
@@ -2638,7 +2671,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c133(s1, s2);
+          s1 = peg$c136(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2653,7 +2686,7 @@ function peg$parse(input, options) {
         s1 = peg$parseVariable();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s1);
+          s1 = peg$c137(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -2661,7 +2694,7 @@ function peg$parse(input, options) {
           s1 = peg$parseIdentifier();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c135(s1);
+            s1 = peg$c138(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -2699,7 +2732,7 @@ function peg$parse(input, options) {
                     }
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c136(s3);
+                      s1 = peg$c139(s3);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2745,19 +2778,19 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 42) {
-          s5 = peg$c137;
+          s5 = peg$c140;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c138); }
+          if (peg$silentFails === 0) { peg$fail(peg$c141); }
         }
         if (s5 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 47) {
-            s5 = peg$c139;
+            s5 = peg$c142;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c140); }
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
         }
         if (s5 !== peg$FAILED) {
@@ -2771,7 +2804,7 @@ function peg$parse(input, options) {
             s7 = peg$parseArithmeticPrimary();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c141(s1, s5, s7);
+              s4 = peg$c144(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2800,19 +2833,19 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 42) {
-            s5 = peg$c137;
+            s5 = peg$c140;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c138); }
+            if (peg$silentFails === 0) { peg$fail(peg$c141); }
           }
           if (s5 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 47) {
-              s5 = peg$c139;
+              s5 = peg$c142;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c140); }
+              if (peg$silentFails === 0) { peg$fail(peg$c143); }
             }
           }
           if (s5 !== peg$FAILED) {
@@ -2826,7 +2859,7 @@ function peg$parse(input, options) {
               s7 = peg$parseArithmeticPrimary();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c141(s1, s5, s7);
+                s4 = peg$c144(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2847,7 +2880,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c142(s1, s2);
+        s1 = peg$c145(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2877,19 +2910,19 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 43) {
-          s5 = peg$c128;
+          s5 = peg$c131;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c129); }
+          if (peg$silentFails === 0) { peg$fail(peg$c132); }
         }
         if (s5 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s5 = peg$c126;
+            s5 = peg$c129;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
         }
         if (s5 !== peg$FAILED) {
@@ -2903,7 +2936,7 @@ function peg$parse(input, options) {
             s7 = peg$parseArithmeticTimesExpression();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c143(s1, s5, s7);
+              s4 = peg$c146(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2932,19 +2965,19 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 43) {
-            s5 = peg$c128;
+            s5 = peg$c131;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
+            if (peg$silentFails === 0) { peg$fail(peg$c132); }
           }
           if (s5 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s5 = peg$c126;
+              s5 = peg$c129;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c127); }
+              if (peg$silentFails === 0) { peg$fail(peg$c130); }
             }
           }
           if (s5 !== peg$FAILED) {
@@ -2958,7 +2991,7 @@ function peg$parse(input, options) {
               s7 = peg$parseArithmeticTimesExpression();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c143(s1, s5, s7);
+                s4 = peg$c146(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2979,7 +3012,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c142(s1, s2);
+        s1 = peg$c145(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2997,12 +3030,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c144) {
-      s1 = peg$c144;
+    if (input.substr(peg$currPos, 3) === peg$c147) {
+      s1 = peg$c147;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -3021,16 +3054,16 @@ function peg$parse(input, options) {
             s5 = peg$parseS();
           }
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c146) {
-              s5 = peg$c146;
+            if (input.substr(peg$currPos, 2) === peg$c149) {
+              s5 = peg$c149;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c147); }
+              if (peg$silentFails === 0) { peg$fail(peg$c150); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c148(s3);
+              s1 = peg$c151(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3060,12 +3093,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c149) {
-      s1 = peg$c149;
+    if (input.substr(peg$currPos, 2) === peg$c152) {
+      s1 = peg$c152;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c150); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseShellLine();
@@ -3079,7 +3112,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c151(s2);
+          s1 = peg$c154(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3101,22 +3134,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c152) {
-      s1 = peg$c152;
+    if (input.substr(peg$currPos, 2) === peg$c155) {
+      s1 = peg$c155;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c153); }
+      if (peg$silentFails === 0) { peg$fail(peg$c156); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c154) {
-          s3 = peg$c154;
+        if (input.substr(peg$currPos, 2) === peg$c157) {
+          s3 = peg$c157;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c158); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseCommandString();
@@ -3130,7 +3163,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c156(s2, s4);
+              s1 = peg$c159(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3154,26 +3187,26 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c152) {
-        s1 = peg$c152;
+      if (input.substr(peg$currPos, 2) === peg$c155) {
+        s1 = peg$c155;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseIdentifier();
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c157) {
-            s3 = peg$c157;
+          if (input.substr(peg$currPos, 3) === peg$c160) {
+            s3 = peg$c160;
             peg$currPos += 3;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c158); }
+            if (peg$silentFails === 0) { peg$fail(peg$c161); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c159(s2);
+            s1 = peg$c162(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3189,22 +3222,22 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c152) {
-          s1 = peg$c152;
+        if (input.substr(peg$currPos, 2) === peg$c155) {
+          s1 = peg$c155;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c153); }
+          if (peg$silentFails === 0) { peg$fail(peg$c156); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdentifier();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c160) {
-              s3 = peg$c160;
+            if (input.substr(peg$currPos, 2) === peg$c163) {
+              s3 = peg$c163;
               peg$currPos += 2;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c161); }
+              if (peg$silentFails === 0) { peg$fail(peg$c164); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parseCommandString();
@@ -3218,7 +3251,7 @@ function peg$parse(input, options) {
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c162(s2, s4);
+                  s1 = peg$c165(s2, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3242,26 +3275,26 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c152) {
-            s1 = peg$c152;
+          if (input.substr(peg$currPos, 2) === peg$c155) {
+            s1 = peg$c155;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c153); }
+            if (peg$silentFails === 0) { peg$fail(peg$c156); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseIdentifier();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c163) {
-                s3 = peg$c163;
+              if (input.substr(peg$currPos, 3) === peg$c166) {
+                s3 = peg$c166;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c164); }
+                if (peg$silentFails === 0) { peg$fail(peg$c167); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c165(s2);
+                s1 = peg$c168(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3277,12 +3310,12 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c152) {
-              s1 = peg$c152;
+            if (input.substr(peg$currPos, 2) === peg$c155) {
+              s1 = peg$c155;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c153); }
+              if (peg$silentFails === 0) { peg$fail(peg$c156); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parseIdentifier();
@@ -3296,7 +3329,7 @@ function peg$parse(input, options) {
                 }
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c166(s2);
+                  s1 = peg$c169(s2);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3313,17 +3346,17 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 36) {
-                s1 = peg$c167;
+                s1 = peg$c170;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c168); }
+                if (peg$silentFails === 0) { peg$fail(peg$c171); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parseIdentifier();
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c166(s2);
+                  s1 = peg$c169(s2);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3349,7 +3382,7 @@ function peg$parse(input, options) {
     s1 = peg$parseGlobText();
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c169(s1);
+      s2 = peg$c172(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -3357,7 +3390,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1);
+        s1 = peg$c173(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3459,41 +3492,6 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c171.test(input.charAt(peg$currPos))) {
-      s2 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c172); }
-    }
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        if (peg$c171.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c172); }
-        }
-      }
-    } else {
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c173();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseIdentifier() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    s1 = [];
     if (peg$c174.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
@@ -3517,7 +3515,42 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c173();
+      s1 = peg$c176();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseIdentifier() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (peg$c177.test(input.charAt(peg$currPos))) {
+      s2 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c178); }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        if (peg$c177.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c178); }
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c176();
     }
     s0 = s1;
 
@@ -3525,37 +3558,14 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSpecialShellChars() {
-    var s0, s1, s2;
+    var s0;
 
-    if (peg$c176.test(input.charAt(peg$currPos))) {
+    if (peg$c179.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c29;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c30); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseS();
-        if (s2 !== peg$FAILED) {
-          s1 = [s1, s2];
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
     }
 
     return s0;
@@ -3564,12 +3574,12 @@ function peg$parse(input, options) {
   function peg$parseGlobSpecialShellChars() {
     var s0;
 
-    if (peg$c178.test(input.charAt(peg$currPos))) {
+    if (peg$c181.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
 
     return s0;
@@ -3579,22 +3589,22 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = [];
-    if (peg$c180.test(input.charAt(peg$currPos))) {
+    if (peg$c183.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c180.test(input.charAt(peg$currPos))) {
+        if (peg$c183.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c181); }
+          if (peg$silentFails === 0) { peg$fail(peg$c184); }
         }
       }
     } else {

--- a/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
@@ -135,7 +135,7 @@ HexCodeChar
   = [0-9a-fA-f]
 
 PlainStringText
-  = chars:('\\' c:. { return c } / !SpecialShellChars c:. { return c })+ { return chars.join(``) }
+  = chars:('\\' c:. { return c } / '{}' { return '{}' } / !SpecialShellChars c:. { return c })+ { return chars.join(``) }
 
 ArithmeticPrimary
   = sign:('-' / '+')? left:[0-9]+ '.' right:[0-9]+ { return { type: `number`, value: (sign === '-' ? -1 : 1) * parseFloat(left.join(``) + `.` + right.join(``)) } }
@@ -181,7 +181,7 @@ Identifier
   = [$@*?#a-zA-Z0-9_-]+ { return text() }
 
 SpecialShellChars
-  = [(){}<>$|&; \t"']
+  = [()}<>$|&; \t"']
 
 GlobSpecialShellChars
   = [<>&; \t"']

--- a/packages/yarnpkg-parsers/tests/shell.test.ts
+++ b/packages/yarnpkg-parsers/tests/shell.test.ts
@@ -1,6 +1,12 @@
 import {parseShell, stringifyShell} from '../sources';
 
 const VALID_COMMANDS = [
+  `echo {`,
+  `echo {foo`,
+  `echo { foo`,
+  `echo {}`,
+  `echo foo{}bar`,
+
   // It should allow shell lines to end with semicolons
   `echo foo;`,
 
@@ -39,6 +45,9 @@ const VALID_COMMANDS = [
 ];
 
 const INVALID_COMMANDS = [
+  `echo }`,
+  `echo foo}`,
+
   // It shouldn't allow shell lines to start with semicolons.
   // Bash doesn't allow it, but ZSH and Fish do. We don't, because
   // we don't need the extra complexity. Also, it's more common to


### PR DESCRIPTION
**What's the problem this PR addresses?**

We didn't support passing `{}` into shell arguments.

Fixes https://github.com/yarnpkg/berry/issues/2670

**How did you fix it?**

Just a matter of removing `{` of the list of special characters (so we can write `echo {` or `echo {foo`), and adding a special case for `{}` (so we can write `echo {}` or `echo foo{}`). It seems that `echo }` isn't valid in zsh, so I didn't try to support it.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
