### PR TITLE
ci: don't continue running when cancelled

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -46,4 +46,4 @@ jobs:
         yarn build
         yarn test
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-create-vue-workflow.yml
+++ b/.github/workflows/e2e-create-vue-workflow.yml
@@ -50,4 +50,4 @@ jobs:
 
         yarn build
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -33,4 +33,4 @@ jobs:
         yarn dlx create-docusaurus@latest my-website-ts classic --typescript && cd my-website-ts
         yarn build
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-eslint-workflow.yml
+++ b/.github/workflows/e2e-eslint-workflow.yml
@@ -51,4 +51,4 @@ jobs:
         echo 'const f = () => 42;' | tee ko.ts
         ! yarn eslint ko.ts
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-fsevents-workflow.yml
+++ b/.github/workflows/e2e-fsevents-workflow.yml
@@ -182,4 +182,4 @@ jobs:
 
         yarn node ./test.js
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -55,4 +55,4 @@ jobs:
 
         yarn next build
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-preact-cli-workflow.yml
+++ b/.github/workflows/e2e-preact-cli-workflow.yml
@@ -41,4 +41,4 @@ jobs:
         yarn
         yarn build
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-snowpack-workflow.yml
+++ b/.github/workflows/e2e-snowpack-workflow.yml
@@ -38,4 +38,4 @@ jobs:
         cat package.json | jq '.scripts.pnpify="tsc"' | tee package.json
         yarn build
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/e2e-webpack-workflow.yml
+++ b/.github/workflows/e2e-webpack-workflow.yml
@@ -52,7 +52,7 @@ jobs:
         yarn webpack
         [[ "$(node dist/main.js)" = "Hello raw-loader" ]]
       if: |
-        always()
+        success() || failure()
 
     - name: 'ts-loader'
       run: |
@@ -72,7 +72,7 @@ jobs:
         yarn webpack
         [[ "$(node dist/main.js)" = "Hello ts-loader" ]]
       if: |
-        always()
+        success() || failure()
 
     - name: 'less-loader'
       run: |
@@ -95,7 +95,7 @@ jobs:
         ls dist | grep ".svg"
         ls dist | grep ".woff2"
       if: |
-        always()
+        success() || failure()
 
     - name: 'less-loader + thread-loader'
       run: |
@@ -122,4 +122,4 @@ jobs:
         ls dist | grep ".svg"
         ls dist | grep ".woff2"
       if: |
-        always()
+        success() || failure()

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -42,7 +42,7 @@ jobs:
         fi
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
       env:
         TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
@@ -59,7 +59,7 @@ jobs:
         fi
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
       env:
         TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
@@ -71,7 +71,7 @@ jobs:
         fi
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
       env:
         TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
@@ -83,7 +83,7 @@ jobs:
         fi
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
       env:
         TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
@@ -95,7 +95,7 @@ jobs:
         fi
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
       env:
         TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
@@ -107,7 +107,7 @@ jobs:
         fi
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
       env:
         TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
 
@@ -116,35 +116,35 @@ jobs:
         node ./scripts/run-yarn.js version check
       shell: bash
       if: |
-        always() && github.event.pull_request != ''
+        (success() || failure()) && github.event.pull_request != ''
 
     - name: 'Check for linting errors (fix w/ "yarn test:lint --fix")'
       run: |
         node ./scripts/run-yarn.js test:lint
       shell: bash
       if: |
-        always()
+        success() || failure()
 
     - name: 'Check for unmet constraints (fix w/ "yarn constraints --fix")'
       run: |
         node ./scripts/run-yarn.js constraints
       shell: bash
       if: |
-        always()
+        success() || failure()
 
     - name: 'Check for type errors'
       run: |
         node ./scripts/run-yarn.js typecheck:all
       shell: bash
       if: |
-        always()
+        success() || failure()
 
     - name: 'Check for duplicate dependencies (fix w/ "yarn dedupe")'
       run: |
         node ./scripts/run-yarn.js dedupe --check
       shell: bash
       if: |
-        always()
+        success() || failure()
 
   build:
     name: 'Build artifacts'
@@ -178,7 +178,7 @@ jobs:
       run: |
         node ./scripts/run-yarn.js package:vscode-zipfs
       if: |
-        always()
+        success() || failure()
 
     - uses: actions/upload-artifact@v2
       with:
@@ -228,4 +228,4 @@ jobs:
         node ./scripts/run-yarn.js test:unit
       shell: bash
       if: |
-        always()
+        success() || failure()


### PR DESCRIPTION
**What's the problem this PR addresses?**

When cancelling a workflow it will continue running steps using `always()` which requires another cancelation and is quite annoying. This became more prominent with https://github.com/yarnpkg/berry/pull/4286.

**How did you fix it?**

Replaced `always()` with `success() || failure()` which matches what https://github.com/yarnpkg/berry/pull/3643 wanted.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.