### PR TITLE
Resolves tags before storing them in the manifest

### DIFF
--- a/.yarn/versions/cfd4374c.yml
+++ b/.yarn/versions/cfd4374c.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -131,6 +131,45 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should add a new regular dependency to the current project (resolved tag)`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps@latest`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should add a new regular dependency to the current project (resolved tag)`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps@latest`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should add a new regular dependency to the current project (fixed tag)`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `-F`, `no-deps@latest`);
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `latest`,
+          },
+        });
+      }),
+    );
+
+    test(
       `it should upgrade the existing regular dependency in the current project (--prefer-dev)`,
       makeTemporaryEnv({
         dependencies: {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -602,7 +602,7 @@ describe(`Commands`, () => {
         expect(stdout).toContain(`no-deps-deprecated@npm:1.0.0 is deprecated: ¯\\_(ツ)_/¯\n`);
 
         // Check if the package is installed successfully
-        await expect(readManifest(path)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(path)).resolves.toMatchObject({
           dependencies: {
             [`no-deps-deprecated`]: `1.0.0`,
           },
@@ -619,7 +619,7 @@ describe(`Commands`, () => {
         expect(stdout).toContain(`no-deps-deprecated-whitespace@npm:1.0.0 is deprecated\n`);
 
         // Check if the package is installed successfully
-        await expect(readManifest(path)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(path)).resolves.toMatchObject({
           dependencies: {
             [`no-deps-deprecated-whitespace`]: `1.0.0`,
           },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -1,8 +1,7 @@
-import {PortablePath, xfs} from '@yarnpkg/fslib';
+import {Filename, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
 
 const {
   tests: {getPackageDirectoryPath},
-  yarn: {readManifest},
 } = require(`pkg-tests-core`);
 const {parseSyml} = require(`@yarnpkg/parsers`);
 
@@ -13,7 +12,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps@1.0.0`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `1.0.0`,
           },
@@ -26,7 +25,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -39,7 +38,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-T`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `~2.0.0`,
           },
@@ -52,7 +51,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-E`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `2.0.0`,
           },
@@ -66,7 +65,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
         await run(`add`, `no-deps`, `-C`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -80,7 +79,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `~2.0.0`,
           },
@@ -94,7 +93,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, ``);
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `2.0.0`,
           },
@@ -109,7 +108,7 @@ describe(`Commands`, () => {
 
         await run(`add`, packagePath);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: packagePath,
           },
@@ -122,7 +121,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-D`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -135,7 +134,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps@latest`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -148,7 +147,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps@latest`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -161,7 +160,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `-F`, `no-deps@latest`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `latest`,
           },
@@ -178,7 +177,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -195,7 +194,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -212,7 +211,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-D`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -229,7 +228,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -246,7 +245,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -259,7 +258,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `no-deps`, `-P`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           peerDependencies: {
             [`no-deps`]: `*`,
           },
@@ -303,7 +302,7 @@ describe(`Commands`, () => {
         await run(`add`, `no-deps`, `-D`);
         await run(`add`, `no-deps`, `-P`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           devDependencies: {
             [`no-deps`]: `^2.0.0`,
           },
@@ -346,7 +345,7 @@ describe(`Commands`, () => {
 
         await run(`add`, `no-deps@workspace:packages/no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:packages/no-deps`,
           },
@@ -369,7 +368,7 @@ describe(`Commands`, () => {
 
         await run(`add`, `no-deps@workspace:1.0.0`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:1.0.0`,
           },
@@ -391,7 +390,7 @@ describe(`Commands`, () => {
 
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:^`,
           },
@@ -413,7 +412,7 @@ describe(`Commands`, () => {
 
         await run(`add`, `no-deps`, `-T`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:~`,
           },
@@ -435,7 +434,7 @@ describe(`Commands`, () => {
 
         await run(`add`, `no-deps`, `-E`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:*`,
           },
@@ -458,7 +457,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
         await run(`add`, `no-deps`, `-C`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:^`,
           },
@@ -481,7 +480,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, `~`);
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:~`,
           },
@@ -504,7 +503,7 @@ describe(`Commands`, () => {
         await run(`config`, `set`, `defaultSemverRangePrefix`, ``);
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `workspace:*`,
           },
@@ -519,7 +518,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`add`, `no-deps`);
 
-        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps`]: `^2.0.0`,
           },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -602,7 +602,7 @@ describe(`Commands`, () => {
         expect(stdout).toContain(`no-deps-deprecated@npm:1.0.0 is deprecated: ¯\\_(ツ)_/¯\n`);
 
         // Check if the package is installed successfully
-        await expect(xfs.readJsonPromise(path)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps-deprecated`]: `1.0.0`,
           },
@@ -619,7 +619,7 @@ describe(`Commands`, () => {
         expect(stdout).toContain(`no-deps-deprecated-whitespace@npm:1.0.0 is deprecated\n`);
 
         // Check if the package is installed successfully
-        await expect(xfs.readJsonPromise(path)).resolves.toMatchObject({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
             [`no-deps-deprecated-whitespace`]: `1.0.0`,
           },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
@@ -41,7 +41,7 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should add a new regular dependency to the current project (resolved tag)`,
+      `it should upgrade regular dependencies to the current project (resolved tag)`,
       makeTemporaryEnv({
         dependencies: {
           [`no-deps`]: `1.0.0`,
@@ -58,7 +58,7 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should add a new regular dependency to the current project (fixed tag)`,
+      `it should upgrade regular dependencies to the current project (fixed tag)`,
       makeTemporaryEnv({
         dependencies: {
           [`no-deps`]: `1.0.0`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
@@ -1,4 +1,4 @@
-import {Filename, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
+import {Filename, ppath, xfs} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
   describe(`up`, () => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
@@ -1,6 +1,4 @@
-import {yarn} from 'pkg-tests-core';
-
-const {readManifest} = yarn;
+import {Filename, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
 
 describe(`Commands`, () => {
   describe(`up`, () => {
@@ -14,7 +12,7 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`up`, `@types/*`);
 
-        await expect(readManifest(path)).resolves.toStrictEqual({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toStrictEqual({
           dependencies: {
             [`@types/is-number`]: `^2.0.0`,
             [`@types/no-deps`]: `^2.0.0`,
@@ -33,10 +31,44 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`up`, `@types/*@1.0.0`);
 
-        await expect(readManifest(path)).resolves.toStrictEqual({
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toStrictEqual({
           dependencies: {
             [`@types/is-number`]: `1.0.0`,
             [`@types/no-deps`]: `1.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should add a new regular dependency to the current project (resolved tag)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`up`, `no-deps@latest`);
+
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should add a new regular dependency to the current project (fixed tag)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`add`, `-F`, `no-deps@latest`);
+
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
+          dependencies: {
+            [`no-deps`]: `latest`,
           },
         });
       }),

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -70,6 +70,10 @@ export default class AddCommand extends BaseCommand {
     description: `Format the output as an NDJSON stream`,
   });
 
+  fixed = Option.Boolean(`-F,--fixed`, false, {
+    description: `Store dependency tags as-is instead of resolving them`,
+  });
+
   exact = Option.Boolean(`-E,--exact`, false, {
     description: `Don't use any semver modifier on the resolved range`,
   });
@@ -127,6 +131,7 @@ export default class AddCommand extends BaseCommand {
       restoreResolutions: false,
     });
 
+    const fixed = this.fixed;
     const interactive = this.interactive ?? configuration.get(`preferInteractive`);
 
     const modifier = suggestUtils.getModifier(this, project);
@@ -165,7 +170,7 @@ export default class AddCommand extends BaseCommand {
         optional: this.optional,
       });
 
-      const suggestions = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, target, modifier, strategies, maxResults});
+      const suggestions = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, fixed, target, modifier, strategies, maxResults});
 
       return [request, suggestions, target] as const;
     }));

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -64,6 +64,10 @@ export default class UpCommand extends BaseCommand {
     description: `Offer various choices, depending on the detected upgrade paths`,
   });
 
+  fixed = Option.Boolean(`-F,--fixed`, false, {
+    description: `Store dependency tags as-is instead of resolving them`,
+  });
+
   exact = Option.Boolean(`-E,--exact`, false, {
     description: `Don't use any semver modifier on the resolved range`,
   });
@@ -159,6 +163,7 @@ export default class UpCommand extends BaseCommand {
       restoreResolutions: false,
     });
 
+    const fixed = this.fixed;
     const interactive = this.interactive ?? configuration.get(`preferInteractive`);
 
     const modifier = suggestUtils.getModifier(this, project);
@@ -203,7 +208,7 @@ export default class UpCommand extends BaseCommand {
                 workspace,
                 target,
                 existingDescriptor,
-                await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, target, modifier, strategies}),
+                await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, target, fixed, modifier, strategies}),
               ] as const;
             }));
 

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -204,11 +204,17 @@ export async function extractDescriptorFromPath(path: PortablePath, {cwd, worksp
   });
 }
 
-export async function getSuggestedDescriptors(request: Descriptor, {project, workspace, cache, target, modifier, strategies, maxResults = Infinity}: {project: Project, workspace: Workspace, cache: Cache, target: Target, modifier: Modifier, strategies: Array<Strategy>, maxResults?: number}): Promise<Results> {
+export async function getSuggestedDescriptors(request: Descriptor, {project, workspace, cache, target, fixed, modifier, strategies, maxResults = Infinity}: {project: Project, workspace: Workspace, cache: Cache, target: Target, fixed: boolean, modifier: Modifier, strategies: Array<Strategy>, maxResults?: number}): Promise<Results> {
   if (!(maxResults >= 0))
     throw new Error(`Invalid maxResults (${maxResults})`);
 
-  if (request.range !== `unknown`) {
+  const [requestRange, requestTag] = request.range !== `unknown`
+    ? fixed || semver.validRange(request.range) || !request.range.match(/^[a-z0-9._-]+$/i)
+      ? [request.range, `latest`]
+      : [`unknown`, request.range]
+    : [`unknown`, `latest`];
+
+  if (requestRange !== `unknown`) {
     return {
       suggestions: [{
         descriptor: request,
@@ -310,13 +316,7 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
 
       case Strategy.LATEST: {
         await trySuggest(async () => {
-          if (request.range !== `unknown`) {
-            suggested.push({
-              descriptor: request,
-              name: `Use ${structUtils.prettyRange(project.configuration, request.range)}`,
-              reason: `(explicit range requested)`,
-            });
-          } else if (target === Target.PEER) {
+          if (target === Target.PEER) {
             suggested.push({
               descriptor: structUtils.makeDescriptor(request, `*`),
               name: `Use *`,
@@ -329,7 +329,7 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
               reason: formatUtils.pretty(project.configuration, `(unavailable because enableNetwork is toggled off)`, `grey`),
             });
           } else {
-            let latest = await fetchDescriptorFrom(request, `latest`, {project, cache, workspace, preserveModifier: false});
+            let latest = await fetchDescriptorFrom(request, requestTag, {project, cache, workspace, preserveModifier: false});
 
             if (latest) {
               latest = applyModifier(latest, modifier);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Calling `yarn add foo@beta` will add `"foo": "beta"` in the manifest. While consistent in practice, this behaviour is generally unexpected and shouldn't be the default.

**How did you fix it?**

Semver tags will now be resolved prior to being saved into the manifest. The `-F,--fixed` flag will restore the original behaviour.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
