### PR TITLE
chore(compat): lock `@apollographql/apollo-tools` range

### DIFF
--- a/.yarn/versions/72a5ce52.yml
+++ b/.yarn/versions/72a5ce52.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -146,7 +146,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/apollographql/apollo-tooling/pull/2049
-  [`@apollographql/apollo-tools@*`, {
+  [`@apollographql/apollo-tools@<=0.5.2`, {
     peerDependencies: {
       graphql: `^14.2.1 || ^15.0.0`,
     },


### PR DESCRIPTION
Updating this entry in response to https://github.com/apollographql/apollo-tooling/pull/2049

**What's the problem this PR addresses?**
Up until and including `@apollographql/apollo-tools@0.5.2`, the package didn't specify its peer dependency on `graphql` which is the reason for this exception in the first place.

As of `v0.5.3` this package now includes its peer dependency correctly and shouldn't need any hardcoded exceptions made for it.

**How did you fix it?**
I specified the version range that this exception applies to (`*` is no longer correct)

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
