### PR TITLE
Implements `--refresh-lockfile`

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -32,8 +32,6 @@ jobs:
       run: |
         node ./scripts/run-yarn.js --immutable --immutable-cache
       shell: bash
-      env:
-        YARN_ENABLE_NETWORK: 0
 
     - name: 'Check that the cache files are consistent with their remote sources'
       run: |

--- a/.yarn/versions/bcc9db40.yml
+++ b/.yarn/versions/bcc9db40.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -80,6 +80,107 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should update the lockfile when using --refresh-lockfile`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        // Sanity check
+        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+          name: `one-fixed-dep`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `1.0.0`,
+            },
+          },
+        });
+
+        const lockfilePath = ppath.join(path, Filename.lockfile);
+        const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: 1.0.0/, `no-deps: 2.0.0`);
+        await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
+
+        await run(`install`);
+
+        // Sanity check
+        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+          name: `one-fixed-dep`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `2.0.0`,
+            },
+          },
+        });
+
+        await run(`install`, `--refresh-lockfile`);
+
+        // Actual test
+        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+          name: `one-fixed-dep`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `1.0.0`,
+            },
+          },
+        });
+      }),
+    );
+
+    test(
+      `it should block invalid lockfiles when using --refresh-lockfile with --immutable`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        const lockfilePath = ppath.join(path, Filename.lockfile);
+        const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: 1.0.0/, `no-deps: 2.0.0`);
+        await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
+
+        await run(`install`);
+
+        await expect(run(`install`, `--immutable`, `--refresh-lockfile`)).rejects.toThrow(/YN0028/);
+      }),
+    );
+
+    test(
+      `it should enable --refresh-lockfile --immutable by default in PR CIs`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        const lockfilePath = ppath.join(path, Filename.lockfile);
+        const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: 1.0.0/, `no-deps: 2.0.0`);
+        await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
+
+        await run(`install`);
+
+        await expect(run(`install`, {
+          env: {
+            GITHUB_ACTIONS: `true`,
+            GITHUB_EVENT_NAME: `pull_request`,
+          },
+        })).rejects.toThrow(/YN0028/);
+      }),
+    );
+
+    test(
       `it should accept to add files to the cache when using --immutable without --immutable-cache`,
       makeTemporaryEnv({
         dependencies: {

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -32,6 +32,8 @@ export default class YarnCommand extends BaseCommand {
 
       If the \`--immutable-cache\` option is set, Yarn will abort with an error exit code if the cache folder was to be modified (either because files would be added, or because they'd be removed).
 
+      If the \`--refresh-lockfile\` option is set, Yarn will keep the same resolution for the packages currently in the lockfile but will refresh their metadata. If used together with \`--immutable\`, it can validate that the lockfile information are consistent. This flag is enabled by default when Yarn detects it runs within a pull request context.
+
       If the \`--check-cache\` option is set, Yarn will always refetch the packages and will ensure that their checksum matches what's 1/ described in the lockfile 2/ inside the existing cache files (if present). This is recommended as part of your CI workflow if you're both following the Zero-Installs model and accepting PRs from third-parties, as they'd otherwise have the ability to alter the checked-in packages before submitting them.
 
       If the \`--inline-builds\` option is set, Yarn will verbosely print the output of the build steps of your dependencies (instead of writing them into individual files). This is likely useful mostly for debug purposes only when using Docker-like environments.
@@ -66,7 +68,11 @@ export default class YarnCommand extends BaseCommand {
     description: `Abort with an error exit code if the cache folder was to be modified`,
   });
 
-  checkCache = Option.Boolean(`--check-cache`, false, {
+  refreshLockfile = Option.Boolean(`--refresh-lockfile`, {
+    description: `Refresh the package metadata stored in the lockfile`,
+  });
+
+  checkCache = Option.Boolean(`--check-cache`, {
     description: `Always refetch the packages and ensure that their checksums are consistent`,
   });
 
@@ -304,6 +310,9 @@ export default class YarnCommand extends BaseCommand {
     await project.restoreInstallState({
       restoreResolutions: false,
     });
+
+    if (this.refreshLockfile ?? CI.isPR)
+      project.lockfileNeedsRefresh = true;
 
     // Important: Because other commands also need to run installs, if you
     // get in a situation where you need to change this file in order to


### PR DESCRIPTION
**What's the problem this PR addresses?**

Lockfiles changes that are part of PRs submitted by third-parties may be compromised and contain metadata that don't match reality. This could lead to maintainers unknowingly starting to depend on packages they don't control / don't trust.

The current solution is to either review the whole lockfile (which is doable, but impractical for large changes, like when upgrading all `@babel` dependencies in a repository), regenerate the lockfile from scratch (high friction), or hope for third-party tools like Snyk to detect issues.

**How did you fix it?**

This diff adds a new flag, `--refresh-lockfile`, which will keep resolutions in place but will resolve the associated metadata anew (this is the same thing we do when we bump the lockfile version, to regenerate the missing fields).

Because both this flag and `--immutable` are enabled by default on PRs CI, projects upgrading to Yarn 4 will automatically be protected from compromised package metadata.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
