### PR TITLE
Implements `--check-resolutions`

### DIFF
--- a/.yarn/versions/1f93b69c.yml
+++ b/.yarn/versions/1f93b69c.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-essentials": major
+  "@yarnpkg/plugin-exec": major
+  "@yarnpkg/plugin-file": major
+  "@yarnpkg/plugin-git": major
+  "@yarnpkg/plugin-http": major
+  "@yarnpkg/plugin-link": major
+  "@yarnpkg/plugin-npm": major
+  "@yarnpkg/plugin-patch": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/checkResolutions.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/checkResolutions.test.ts
@@ -48,8 +48,6 @@ describe(`Features`, () => {
 
         await xfs.writeJsonPromise(manifestPath, manifestData);
 
-        throw new Error(42);
-
         const check = run(`install`, `--check-resolutions`);
         if (valid) {
           await check;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/checkResolutions.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/checkResolutions.test.ts
@@ -1,0 +1,62 @@
+import {structUtils}              from '@yarnpkg/core';
+import {Filename, ppath, xfs}     from '@yarnpkg/fslib';
+import {parseSyml, stringifySyml} from '@yarnpkg/parsers';
+
+const tests: Array<[initial: string, replacement: string, valid: boolean]> = [
+  [`no-deps@npm:^1.0.0`, `no-deps@npm:2.0.0`, false],
+  [`no-deps@npm:^1.0.0`, `no-deps@npm:1.0.0`, true],
+
+  [`no-deps@npm:^1.0.0`, `no-deps-bins@npm:1.0.0`, false],
+  [`no-deps@npm:no-deps-bins@^1.0.0`, `no-deps-bins@npm:1.0.0`, true],
+
+  [`util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=4bcc600d20e3a53ea27fa52c4d1fc49cc2d0eabb`, `util-deprecate@https://github.com/yarnpkg/util-deprecate.git`, false],
+  [`util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=4bcc600d20e3a53ea27fa52c4d1fc49cc2d0eabb`, `util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=475fb6857cd23fafff20c1be846c1350abf8e6d4`, false],
+  [`util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=4bcc600d20e3a53ea27fa52c4d1fc49cc2d0eabb`, `util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=4bcc600d20e3a53ea27fa52c4d1fc49cc2d0eabb`, true],
+];
+
+describe(`Features`, () => {
+  for (const [initial, replacement, valid] of tests) {
+    it(
+      `should ${valid ? `allow` : `prevent`} resolving "${initial}" with "${replacement}"`,
+      makeTemporaryEnv({}, {
+        // We don't care about this flag; in an actual attack,
+        // the hash would be correct
+        checksumBehavior: `ignore`,
+      }, async ({path, run, source}) => {
+        await run(`add`, replacement);
+
+        const lockfilePath = ppath.join(path, Filename.lockfile);
+        const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
+        const lockfileData = parseSyml(lockfileContent);
+
+        lockfileData[initial] = {
+          version: lockfileData[replacement].version,
+          resolution: replacement,
+          languageName: lockfileData[replacement].languageName,
+          linkType: lockfileData[replacement].linkType,
+        };
+
+        await xfs.writeFilePromise(lockfilePath, stringifySyml(lockfileData));
+
+        const manifestPath = ppath.join(path, Filename.manifest);
+        const manifestData = await xfs.readJsonPromise(manifestPath);
+
+        const descriptor = structUtils.parseDescriptor(initial);
+        manifestData.dependencies = {
+          [structUtils.stringifyIdent(descriptor)]: descriptor.range,
+        };
+
+        await xfs.writeJsonPromise(manifestPath, manifestData);
+
+        throw new Error(42);
+
+        const check = run(`install`, `--check-resolutions`);
+        if (valid) {
+          await check;
+        } else {
+          await expect(check).rejects.toThrow(/YN0078/);
+        }
+      }),
+    );
+  }
+});

--- a/packages/gatsby/content/advanced/error-codes.md
+++ b/packages/gatsby/content/advanced/error-codes.md
@@ -368,3 +368,19 @@ A package is specified in its manifest (through the [`os`](/configuration/manife
 Some native packages may be excluded from the install if they signal they don't support the systems the project is intended for. This detection is typically based on your current system parameters, but it can be configured using the [`supportedArchitectures` config option](/configuration/yarnrc#supportedArchitectures). If your os or cpu are missing from this list, Yarn will skip the packages and raise a warning.
 
 Note that all fields from `supportedArchitectures` default to `current`, which is a dynamic value depending on your local parameters. For instance, if you wish to support "my current os, whatever it is, plus linux", you can set `supportedArchitectures.os` to `["current", "linux"]`.
+
+## YN0078 - `RESOLUTION_MISMATCH`
+
+Starting from Yarn 4, Yarn will automatically enable the `--check-resolutions` flag on CI when it detects the current environment is a pull request. Under this mode, Yarn will check that the lockfile resolutions are consistent with what the initial range is. For example, given an initial dependency of `foo@npm:^1.0.0`:
+
+- `foo@npm:1.2.0` is a valid resolution
+- `foo@npm:2.0.0` isn't a valid resolution, because it doesn't match the expected semver range
+- `bar@npm:1.2.0` isn't a valid resolution either, because the name doesn't match
+
+This error should never trigger under normal circumstances, as Yarn should always generate satisfying resolutions given a dependency. If you hit it nonetheless, it may be either of two things:
+
+- Yarn has a bug. It may happen! Review the mismatch to be sure and, in case you have a doubt, ping us on Discord and we'll tell you whether it's something to worry about (before doing that, take a quick look at our [repository issues](https://github.com/yarnpkg/berry/issues?q=is%3Aissue+is%3Aopen+YN0078) in case someone reported the same behaviour).
+
+- Or you might have someone doing strange things on your lockfile. It might be a mistake (for example someone manually modifying a lockfile for debug but forgetting to revert the changes), or a problem (for example a malicious users trying to perform some sort of [supply chain attack](https://en.wikipedia.org/wiki/Supply_chain_attack)).
+
+If the use case appears legit (for example if the bug comes from Yarn), you can bypass the check on PRs by adding a `--no-check-resolutions` flag to your `yarn install` command. But be careful: this is a security feature; disabling it may have consequences.

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -70,6 +70,10 @@ export default class YarnCommand extends BaseCommand {
     description: `Always refetch the packages and ensure that their checksums are consistent`,
   });
 
+  checkResolutions = Option.Boolean(`--check-resolutions`, {
+    description: `Validates that the package resolutions are coherent`,
+  });
+
   inlineBuilds = Option.Boolean(`--inline-builds`, {
     description: `Verbosely print the output of the build steps of dependencies`,
   });
@@ -313,13 +317,15 @@ export default class YarnCommand extends BaseCommand {
     // the Configuration and Install classes). Feel free to open an issue
     // in order to ask for design feedback before writing features.
 
+    const checkResolutions = this.checkResolutions ?? CI.isPR ?? false;
+
     const report = await StreamReport.start({
       configuration,
       json: this.json,
       stdout: this.context.stdout,
       includeLogs: true,
     }, async (report: StreamReport) => {
-      await project.install({cache, report, immutable, mode: this.mode});
+      await project.install({cache, report, immutable, checkResolutions, mode: this.mode});
     });
 
     return report.exitCode();

--- a/packages/plugin-exec/sources/ExecResolver.ts
+++ b/packages/plugin-exec/sources/ExecResolver.ts
@@ -60,8 +60,13 @@ export class ExecResolver implements Resolver {
     return [execUtils.makeLocator(descriptor, {parentLocator, path, generatorHash, protocol: PROTOCOL})];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-file/sources/FileResolver.ts
+++ b/packages/plugin-file/sources/FileResolver.ts
@@ -1,4 +1,4 @@
-import {miscUtils, structUtils, hashUtils}               from '@yarnpkg/core';
+import {miscUtils, structUtils, hashUtils, Package}      from '@yarnpkg/core';
 import {LinkType}                                        from '@yarnpkg/core';
 import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
 import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
@@ -72,8 +72,13 @@ export class FileResolver implements Resolver {
     return [fileUtils.makeLocator(descriptor, {parentLocator, path, folderHash, protocol: PROTOCOL})];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-file/sources/TarballFileResolver.ts
+++ b/packages/plugin-file/sources/TarballFileResolver.ts
@@ -1,10 +1,10 @@
-import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
-import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
-import {LinkType}                                        from '@yarnpkg/core';
-import {miscUtils, structUtils}                          from '@yarnpkg/core';
-import {npath}                                           from '@yarnpkg/fslib';
+import {Resolver, ResolveOptions, MinimalResolveOptions, Package} from '@yarnpkg/core';
+import {Descriptor, Locator, Manifest}                            from '@yarnpkg/core';
+import {LinkType}                                                 from '@yarnpkg/core';
+import {miscUtils, structUtils}                                   from '@yarnpkg/core';
+import {npath}                                                    from '@yarnpkg/fslib';
 
-import {FILE_REGEXP, TARBALL_REGEXP, PROTOCOL}           from './constants';
+import {FILE_REGEXP, TARBALL_REGEXP, PROTOCOL}                    from './constants';
 
 export class TarballFileResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {
@@ -55,8 +55,13 @@ export class TarballFileResolver implements Resolver {
     return [structUtils.makeLocator(descriptor, `${PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-http/sources/TarballHttpResolver.ts
+++ b/packages/plugin-http/sources/TarballHttpResolver.ts
@@ -1,9 +1,9 @@
-import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
-import {Descriptor, Locator, Manifest}                   from '@yarnpkg/core';
-import {LinkType}                                        from '@yarnpkg/core';
-import {miscUtils, structUtils}                          from '@yarnpkg/core';
+import {Resolver, ResolveOptions, MinimalResolveOptions, Package} from '@yarnpkg/core';
+import {Descriptor, Locator, Manifest}                            from '@yarnpkg/core';
+import {LinkType}                                                 from '@yarnpkg/core';
+import {miscUtils, structUtils}                                   from '@yarnpkg/core';
 
-import {PROTOCOL_REGEXP, TARBALL_REGEXP}                 from './constants';
+import {PROTOCOL_REGEXP, TARBALL_REGEXP}                          from './constants';
 
 export class TarballHttpResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {
@@ -42,8 +42,13 @@ export class TarballHttpResolver implements Resolver {
     return [structUtils.convertDescriptorToLocator(descriptor)];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-link/sources/LinkResolver.ts
+++ b/packages/plugin-link/sources/LinkResolver.ts
@@ -41,8 +41,13 @@ export class LinkResolver implements Resolver {
     return [structUtils.makeLocator(descriptor, `${LINK_PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions): Promise<Package> {

--- a/packages/plugin-link/sources/RawLinkResolver.ts
+++ b/packages/plugin-link/sources/RawLinkResolver.ts
@@ -1,10 +1,10 @@
-import {Resolver, ResolveOptions, MinimalResolveOptions} from '@yarnpkg/core';
-import {Descriptor, Locator}                             from '@yarnpkg/core';
-import {LinkType}                                        from '@yarnpkg/core';
-import {structUtils}                                     from '@yarnpkg/core';
-import {npath}                                           from '@yarnpkg/fslib';
+import {Resolver, ResolveOptions, MinimalResolveOptions, Package} from '@yarnpkg/core';
+import {Descriptor, Locator}                                      from '@yarnpkg/core';
+import {LinkType}                                                 from '@yarnpkg/core';
+import {structUtils}                                              from '@yarnpkg/core';
+import {npath}                                                    from '@yarnpkg/fslib';
 
-import {RAW_LINK_PROTOCOL}                               from './constants';
+import {RAW_LINK_PROTOCOL}                                        from './constants';
 
 export class RawLinkResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {
@@ -41,8 +41,13 @@ export class RawLinkResolver implements Resolver {
     return [structUtils.makeLocator(descriptor, `${RAW_LINK_PROTOCOL}${npath.toPortablePath(path)}`)];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/plugin-npm/sources/NpmRemapResolver.ts
+++ b/packages/plugin-npm/sources/NpmRemapResolver.ts
@@ -44,12 +44,12 @@ export class NpmRemapResolver implements Resolver {
     return await opts.resolver.getCandidates(nextDescriptor, dependencies, opts);
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
     const nextDescriptor = opts.project.configuration.normalizeDependency(
       structUtils.parseDescriptor(descriptor.range.slice(PROTOCOL.length), true),
     );
 
-    return opts.resolver.getSatisfying(nextDescriptor, references, opts);
+    return opts.resolver.getSatisfying(nextDescriptor, dependencies, locators, opts);
   }
 
   resolve(locator: Locator, opts: ResolveOptions): never {

--- a/packages/plugin-npm/tests/NpmSemverResolver.test.ts
+++ b/packages/plugin-npm/tests/NpmSemverResolver.test.ts
@@ -7,16 +7,19 @@ describe(`NpmSemverResolver`, () => {
     it(`should match when the reference contains a __archiveUrl`, async () => {
       const resolver = new NpmSemverResolver();
 
-      const reference = `npm:1.0.0::__archiveUrl=foo.tgz`;
+      const ident = structUtils.makeIdent(null, `foo`);
+      const descriptor = structUtils.makeDescriptor(ident, `npm:*`);
+      const locator = structUtils.makeLocator(ident, `npm:1.0.0::__archiveUrl=foo.tgz`);
 
       const results = await resolver.getSatisfying(
-        structUtils.makeDescriptor(structUtils.makeIdent(null, `foo`), `*`),
-        [reference],
+        descriptor,
+        {},
+        [locator],
         null as any,
       );
 
-      expect(results.length).toEqual(1);
-      expect(results[0].reference).toEqual(reference);
+      expect(results.locators.length).toEqual(1);
+      expect(results.locators[0].locatorHash).toEqual(locator.locatorHash);
     });
   });
 });

--- a/packages/plugin-patch/sources/PatchResolver.ts
+++ b/packages/plugin-patch/sources/PatchResolver.ts
@@ -63,8 +63,13 @@ export class PatchResolver implements Resolver {
     return [patchUtils.makeLocator(descriptor, {parentLocator, sourcePackage, patchPaths, patchHash})];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions): Promise<Package> {

--- a/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
+++ b/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
@@ -140,8 +140,13 @@ export class LegacyMigrationResolver implements Resolver {
     return await this.resolver.getCandidates(normalizedDescriptor, dependencies, opts);
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions): Promise<never> {

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -80,6 +80,7 @@ export enum MessageName {
   PROLOG_INSTANTIATION_ERROR = 75,
   INCOMPATIBLE_ARCHITECTURE = 76,
   GHOST_ARCHITECTURE = 77,
+  RESOLUTION_MISMATCH = 78,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {

--- a/packages/yarnpkg-core/sources/MultiResolver.ts
+++ b/packages/yarnpkg-core/sources/MultiResolver.ts
@@ -45,10 +45,10 @@ export class MultiResolver implements Resolver {
     return await resolver.getCandidates(descriptor, dependencies, opts);
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
     const resolver = this.getResolverByDescriptor(descriptor, opts);
 
-    return resolver.getSatisfying(descriptor, references, opts);
+    return resolver.getSatisfying(descriptor, dependencies, locators, opts);
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/yarnpkg-core/sources/Resolver.ts
+++ b/packages/yarnpkg-core/sources/Resolver.ts
@@ -134,18 +134,22 @@ export interface Resolver {
    * Note that the parameter references aren't guaranteed to be supported by
    * the resolver, so they'll probably need to be filtered beforehand.
    *
-   * The returned array must be sorted in such a way that the preferred
+   * The returned array should be sorted in such a way that the preferred
    * locators are first. This will cause the resolution algorithm to prioritize
-   * them if possible (it doesn't guarantee that they'll end up being used).
-   *
-   * If the operation is unsupported by the resolver (i.e. if it can't be statically
-   * determined which references satisfy the target descriptor), `null` should be returned.
+   * them if possible (it doesn't guarantee that they'll end up being used). If
+   * the resolver is unable to provide a definite order (for example like the
+   * `file:` protocol resolver, where ordering references would make no sense),
+   * the `sorted` field should be set to `false`.
    *
    * @param descriptor The target descriptor.
+   * @param dependencies The resolution dependencies and their resolutions.
    * @param references The candidate references.
    * @param opts The resolution options.
    */
-  getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions): Promise<Array<Locator> | null>;
+  getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions): Promise<{
+    locators: Array<Locator>;
+    sorted: boolean;
+  }>;
 
   /**
    * This function will, given a locator, return the full package definition

--- a/packages/yarnpkg-core/sources/RunInstallPleaseResolver.ts
+++ b/packages/yarnpkg-core/sources/RunInstallPleaseResolver.ts
@@ -34,7 +34,7 @@ export class RunInstallPleaseResolver implements Resolver {
     throw new ReportError(MessageName.MISSING_LOCKFILE_ENTRY, `This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile`);
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions): Promise<never> {
+  async getSatisfying(descriptor: Descriptor, dependencies: unknown, locators: Array<Locator>, opts: ResolveOptions): Promise<never> {
     throw new ReportError(MessageName.MISSING_LOCKFILE_ENTRY, `This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile`);
   }
 

--- a/packages/yarnpkg-core/sources/VirtualResolver.ts
+++ b/packages/yarnpkg-core/sources/VirtualResolver.ts
@@ -54,7 +54,7 @@ export class VirtualResolver implements Resolver {
     throw new Error(`Assertion failed: calling "getCandidates" on a virtual descriptor is unsupported`);
   }
 
-  async getSatisfying(descriptor: Descriptor, candidates: Array<string>, opts: ResolveOptions): Promise<never> {
+  async getSatisfying(descriptor: Descriptor, dependencies: unknown, candidates: Array<Locator>, opts: ResolveOptions): Promise<never> {
     // It's unsupported because packages inside the dependency tree should
     // only become virtual AFTER they have all been resolved, by which point
     // you shouldn't need to call `getSatisfying` anymore.

--- a/packages/yarnpkg-core/sources/WorkspaceResolver.ts
+++ b/packages/yarnpkg-core/sources/WorkspaceResolver.ts
@@ -1,7 +1,7 @@
 import {PortablePath}                                    from '@yarnpkg/fslib';
 
 import {Resolver, ResolveOptions, MinimalResolveOptions} from './Resolver';
-import {Descriptor, Locator}                             from './types';
+import {Descriptor, Locator, Package}                    from './types';
 import {LinkType}                                        from './types';
 
 export class WorkspaceResolver implements Resolver {
@@ -43,8 +43,13 @@ export class WorkspaceResolver implements Resolver {
     return [workspace.anchoredLocator];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -226,17 +226,17 @@ export class BufferStream extends Transform {
   }
 }
 
-type Deferred = {
-  promise: Promise<void>;
-  resolve: () => void;
+export type Deferred<T = void> = {
+  promise: Promise<T>;
+  resolve: (val: T) => void;
   reject: (err: Error) => void;
 };
 
-function makeDeferred(): Deferred {
-  let resolve: () => void;
+export function makeDeferred<T = void>(): Deferred<T> {
+  let resolve: (val: T) => void;
   let reject: (err: Error) => void;
 
-  const promise = new Promise<void>((resolveFn, rejectFn) => {
+  const promise = new Promise<T>((resolveFn, rejectFn) => {
     resolve = resolveFn;
     reject = rejectFn;
   });

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -473,8 +473,8 @@ type ParseRangeReturnType<Opts extends ParseRangeOptions> =
  * Parses a range into its constituents. Ranges typically follow these forms,
  * with both `protocol` and `bindings` being optionals:
  *
- * <protocol>:<selector>::<bindings>
- * <protocol>:<source>#<selector>::<bindings>
+ *     <protocol>:<selector>::<bindings>
+ *     <protocol>:<source>#<selector>::<bindings>
  *
  * The selector is intended to "refine" the source, and is required. The source
  * itself is optional (for instance we don't need it for npm packages, but we
@@ -523,6 +523,25 @@ export function parseRange<Opts extends ParseRangeOptions>(range: string, opts?:
     // @ts-expect-error
     params,
   };
+}
+
+/**
+ * Parses a range into its constituents. Ranges typically follow these forms,
+ * with both `protocol` and `bindings` being optionals:
+ *
+ *     <protocol>:<selector>::<bindings>
+ *     <protocol>:<source>#<selector>::<bindings>
+ *
+ * The selector is intended to "refine" the source, and is required. The source
+ * itself is optional (for instance we don't need it for npm packages, but we
+ * do for git dependencies).
+ */
+export function tryParseRange<Opts extends ParseRangeOptions>(range: string, opts?: Opts): ParseRangeReturnType<Opts> | null {
+  try {
+    return parseRange(range, opts);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/yarnpkg-core/tests/TestPlugin.ts
+++ b/packages/yarnpkg-core/tests/TestPlugin.ts
@@ -33,8 +33,13 @@ export class UnboundDescriptorResolver implements Resolver {
     return [structUtils.convertDescriptorToLocator(descriptor)];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions) {
@@ -96,8 +101,13 @@ export class ResolutionDependencyResolver implements Resolver {
     return [structUtils.convertDescriptorToLocator(descriptor)];
   }
 
-  async getSatisfying(descriptor: Descriptor, references: Array<string>, opts: ResolveOptions) {
-    return null;
+  async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {
+    const [locator] = await this.getCandidates(descriptor, dependencies, opts);
+
+    return {
+      locators: locators.filter(candidate => candidate.locatorHash === locator.locatorHash),
+      sorted: false,
+    };
   }
 
   async resolve(locator: Locator, opts: ResolveOptions): Promise<Package> {


### PR DESCRIPTION
**What's the problem this PR addresses?**

If an attacker changes the `resolutions` field in the lockfile, Yarn will take it relatively well and just assume the new resolution is the truth. As a result they can easily inject malicious code inside a large lockfile update, and they'll be very difficult to spot - even #4299 wouldn't protect against that, as Yarn would just refetch the compromised package resolution rather than the original one.

**How did you fix it?**

The `getSatisfying` function (previously only used for `yarn dedupe`) will now be used to check that the resolution locators are valid for a given descriptor (for example `bar@1.0.0` isn't a valid resolution for `foo@^1.0.0` since they have different idents, but it is a valid resolution for `bar@^1.0.0` or even `foo@npm:bar@1.0.0`).

In order to allow for this, I had to change the signature of the `getSatisfying` function:

- It now accepts the resolution dependencies (required for the resolvers like `patch:` / `exec:` to compute their derivation)
- It now accepts an array of locators (required because otherwise we can't check the idents)
- It now returns a `sorted` property (required because sorting still doesn't make sense in many resolvers)

More tests need to be written (I wrote a few to cover the main ones, ie Git and npm), but I'm not sure I'll write them all in this PR alone.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
