### PR TITLE
Implements enableHardenedMode

### DIFF
--- a/.yarn/versions/2545ea9d.yml
+++ b/.yarn/versions/2545ea9d.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.js
@@ -1,4 +1,4 @@
-import {Filename, xfs, ppath} from '@yarnpkg/fslib';
+import {Filename, xfs, ppath, npath} from '@yarnpkg/fslib';
 
 const {
   fs: {writeJson, writeFile},
@@ -102,7 +102,7 @@ describe(`Commands`, () => {
 
         const lockfilePath = ppath.join(path, Filename.lockfile);
         const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
-        const modifiedLockfile = lockfileContent.replace(/no-deps: 1.0.0/, `no-deps: 2.0.0`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: "npm:1.0.0"/, `no-deps: "npm:2.0.0"`);
         await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
 
         await run(`install`);
@@ -146,7 +146,7 @@ describe(`Commands`, () => {
 
         const lockfilePath = ppath.join(path, Filename.lockfile);
         const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
-        const modifiedLockfile = lockfileContent.replace(/no-deps: 1.0.0/, `no-deps: 2.0.0`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: "npm:1.0.0"/, `no-deps: "npm:2.0.0"`);
         await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
 
         await run(`install`);
@@ -156,7 +156,7 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should enable --refresh-lockfile --immutable by default in PR CIs`,
+      `it should enable --refresh-lockfile --immutable by default in public PR CIs`,
       makeTemporaryEnv({
         dependencies: {
           [`one-fixed-dep`]: `1.0.0`,
@@ -166,8 +166,15 @@ describe(`Commands`, () => {
 
         const lockfilePath = ppath.join(path, Filename.lockfile);
         const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
-        const modifiedLockfile = lockfileContent.replace(/no-deps: 1.0.0/, `no-deps: 2.0.0`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: "npm:1.0.0"/, `no-deps: "npm:2.0.0"`);
         await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
+
+        const eventPath = ppath.join(path, `github-event-file.json`);
+        await xfs.writeJsonPromise(eventPath, {
+          repository: {
+            private: false,
+          },
+        });
 
         await run(`install`);
 
@@ -175,8 +182,43 @@ describe(`Commands`, () => {
           env: {
             GITHUB_ACTIONS: `true`,
             GITHUB_EVENT_NAME: `pull_request`,
+            GITHUB_EVENT_PATH: npath.fromPortablePath(eventPath),
           },
         })).rejects.toThrow(/YN0028/);
+      }),
+    );
+
+
+    test(
+      `it should not enable --refresh-lockfile --immutable in private PR CIs`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        const lockfilePath = ppath.join(path, Filename.lockfile);
+        const lockfileContent = await xfs.readFilePromise(lockfilePath, `utf8`);
+        const modifiedLockfile = lockfileContent.replace(/no-deps: "npm:1.0.0"/, `no-deps: "npm:2.0.0"`);
+        await xfs.writeFilePromise(lockfilePath, modifiedLockfile);
+
+        const eventPath = ppath.join(path, `github-event-file.json`);
+        await xfs.writeJsonPromise(eventPath, {
+          repository: {
+            private: true,
+          },
+        });
+
+        await run(`install`);
+
+        await run(`install`, {
+          env: {
+            GITHUB_ACTIONS: `true`,
+            GITHUB_EVENT_NAME: `pull_request`,
+            GITHUB_EVENT_PATH: npath.fromPortablePath(eventPath),
+          },
+        });
       }),
     );
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -315,8 +315,12 @@ export default class YarnCommand extends BaseCommand {
       restoreResolutions: false,
     });
 
-    if (this.refreshLockfile ?? CI.isPR)
+    const enableHardenedMode = configuration.get(`enableHardenedMode`);
+
+    if (this.refreshLockfile ?? enableHardenedMode)
       project.lockfileNeedsRefresh = true;
+
+    const checkResolutions = this.checkResolutions ?? enableHardenedMode;
 
     // Important: Because other commands also need to run installs, if you
     // get in a situation where you need to change this file in order to
@@ -325,8 +329,6 @@ export default class YarnCommand extends BaseCommand {
     // install logic should be implemented elsewhere (probably in either of
     // the Configuration and Install classes). Feel free to open an issue
     // in order to ask for design feedback before writing features.
-
-    const checkResolutions = this.checkResolutions ?? CI.isPR ?? false;
 
     const report = await StreamReport.start({
       configuration,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The new hardening logic was triggered on all PRs from all repositories - but when a repository is private, the assumption is that people who can access it can also be trusted, so hardening isn't needed there. Additionally, it could lead to problems when the remote registry cannot be reached (for example because it requires a verdaccio instance, etc).

**How did you fix it?**

Whether to enable hardening or not is now abstracted behind a `enableHardenedMode` setting, which is automatically set when Yarn detects the current environment is both a PR, and a public repository.

It only supports GitHub Actions for now, but people using other providers can force-enable the mode by adding `YARN_ENABLE_HARDENED_MODE=1` in their environment (which wasn't possible before).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
