### PR TITLE
feat(workspaces): add a name flag to workspaces list command

### DIFF
--- a/.yarn/versions/bf8c2677.yml
+++ b/.yarn/versions/bf8c2677.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
+  "@yarnpkg/plugin-workspace-tools": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/list.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/list.test.js
@@ -361,6 +361,33 @@ describe(`Commands`, () => {
       }),
     );
   });
+
+  describe(`workspace list --name`, () => {
+    test(
+      `list workspaces by package name`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await writeJson(`${path}/packages/workspace-a/package.json`, {
+            name: `workspace-a`,
+            version: `1.0.0`,
+          });
+
+          await writeJson(`${path}/packages/workspace-b/package.json`, {
+            name: `@test/workspace-b`,
+            version: `1.0.0`,
+          });
+
+          const listCommand = await run(`workspaces`, `list`, `--name`);
+          expect(listCommand.stdout).toContain(`workspace-a`);
+          expect(listCommand.stdout).toContain(`@test/workspace-b`);
+        },
+      ),
+    );
+  });
 });
 
 async function setupWorkspaces(path) {

--- a/packages/plugin-essentials/sources/commands/workspaces/list.ts
+++ b/packages/plugin-essentials/sources/commands/workspaces/list.ts
@@ -17,6 +17,8 @@ export default class WorkspacesListCommand extends BaseCommand {
 
       - If \`--since\` is set, Yarn will only list workspaces that have been modified since the specified ref. By default Yarn will use the refs specified by the \`changesetBaseRefs\` configuration option.
 
+      - If \`--name\` is set, Yarn will print workspace package names rather than directory location.
+
       - If \`-R,--recursive\` is set, Yarn will find workspaces to run the command on by recursively evaluating \`dependencies\` and \`devDependencies\` fields, instead of looking at the \`workspaces\` fields.
 
       - If \`--no-private\` is set, Yarn will not list any workspaces that have the \`private\` field set to \`true\`.
@@ -27,6 +29,11 @@ export default class WorkspacesListCommand extends BaseCommand {
 
   since = Option.String(`--since`, {
     description: `Only include workspaces that have been changed since the specified ref.`,
+    tolerateBoolean: true,
+  });
+
+  name = Option.String(`--name`, {
+    description: `List packages by package name.`,
     tolerateBoolean: true,
   });
 
@@ -77,7 +84,7 @@ export default class WorkspacesListCommand extends BaseCommand {
           const mismatchedWorkspaceDependencies = new Set<Descriptor>();
 
           for (const dependencyType of Manifest.hardDependencies) {
-            for (const [identHash, descriptor]  of manifest.getForScope(dependencyType)) {
+            for (const [identHash, descriptor] of manifest.getForScope(dependencyType)) {
               const matchingWorkspace = project.tryWorkspaceByDescriptor(descriptor);
 
               if (matchingWorkspace === null) {
@@ -101,7 +108,7 @@ export default class WorkspacesListCommand extends BaseCommand {
           };
         }
 
-        report.reportInfo(null, `${workspace.relativeCwd}`);
+        report.reportInfo(null, `${this.name && manifest.name ? structUtils.stringifyIdent(manifest.name) : workspace.relativeCwd}`);
         report.reportJson({
           location: workspace.relativeCwd,
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn workspaces list` provides all workspaces by directory but to get the package names, one must parse the json output using: `yarn workspaces list --json | jq '.name'`.  As other yarn workspace commands require the name rather than the directory location, a flag on the list output to print name would be ideal for streamlining this workflow.

<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Closes #3505

**How did you fix it?**
<!-- A detailed description of your implementation. -->

This PR adds a `--name` flag to `yarn workspaces list` along with corresponding test.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
