### PR TITLE
fix: leave symlinks alone when cleaning up

### DIFF
--- a/.yarn/versions/d50b1bb7.yml
+++ b/.yarn/versions/d50b1bb7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-pnpm": patch

--- a/.yarn/versions/d50b1bb7.yml
+++ b/.yarn/versions/d50b1bb7.yml
@@ -1,2 +1,23 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -384,6 +384,11 @@ async function cleanNodeModules(nmPath: PortablePath, extraneous: Map<PortablePa
 
 async function removeIfEmpty(dir: PortablePath) {
   try {
+    const stat = await xfs.lstatPromise(dir);
+
+    if (stat.isSymbolicLink())
+      return;
+
     await xfs.rmdirPromise(dir);
   } catch (error) {
     if (error.code !== `ENOENT` && error.code !== `ENOTEMPTY`) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`3.2.0` crashes with 

```
Error: ENOTDIR: not a directory, rmdir '/<path>/node_modules'\n"
```
at the end of the linting phase. 

...

**How did you fix it?**

PnpmLinker's `removeIfEmpty` now ignores symlinks 
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
- [ ]  Cover fix with a test
