### PR TITLE
[Bug?]: ZipFS extension broken on VSCode 1.66

### DIFF
--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -2,7 +2,6 @@ import {npath, NativePath}            from '@yarnpkg/fslib';
 import path                           from 'path';
 import * as vscode                    from 'vscode';
 
-
 import {registerTerminalLinkProvider} from './TerminalLinkProvider';
 import {ZipFSProvider}                from './ZipFSProvider';
 

--- a/packages/vscode-zipfs/sources/index.ts
+++ b/packages/vscode-zipfs/sources/index.ts
@@ -1,11 +1,20 @@
-import {npath}                        from '@yarnpkg/fslib';
+import {npath, NativePath}            from '@yarnpkg/fslib';
+import path                           from 'path';
 import * as vscode                    from 'vscode';
+
 
 import {registerTerminalLinkProvider} from './TerminalLinkProvider';
 import {ZipFSProvider}                from './ZipFSProvider';
 
+
+export function parseUri(uri: vscode.Uri): NativePath {
+  const p = `${path.sep}${uri.authority}${path.sep}${uri.fsPath}` as NativePath;
+
+  return p;
+}
+
 function mount(uri: vscode.Uri) {
-  const zipUri = vscode.Uri.parse(`zip:${uri.fsPath}`);
+  const zipUri = vscode.Uri.parse(`zip:${parseUri(uri)}`);
 
   if (vscode.workspace.getWorkspaceFolder(zipUri) === undefined) {
     vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders!.length, 0, {


### PR DESCRIPTION
**What's the problem this PR addresses?**
A recent Vscode update broke ZipFS links.

Fixes #4304

...

**How did you fix it?**

It appears that the `vscode.URI.fsPath` helper (described as just [sugar](https://github.com/microsoft/vscode/blob/24e73f3551a59166d34d0deecbb623c24af67645/src/vs/base/common/uri.ts#L202)) no longer prepends the `authority`.

On macOS `/Users/owen/code` became `/owen/code`, which could not be found.

I can't find the specific commit where this change occurred, but this fix does resolve the issue.

I didn't apply this change to the `TerminalLinkProvider`, as I wasn't able to get a good repro setup going for that. I suspect it will need some kind of fix.

...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
