### PR TITLE
fix(sdks): update for VSCode 1.66

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -18,6 +18,7 @@ const moduleWrapper = tsserver => {
   const pnpApi = require(`pnpapi`);
 
   const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const isPortal = str => str.startsWith("portal:/");
   const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
 
   const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
@@ -44,7 +45,7 @@ const moduleWrapper = tsserver => {
       const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
       if (resolved) {
         const locator = pnpApi.findPackageLocator(resolved);
-        if (locator && dependencyTreeRoots.has(`${locator.name}@${locator.reference}`)) {
+        if (locator && (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) || isPortal(locator.reference))) {
           str = resolved;
         }
       }
@@ -60,16 +61,8 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // Update Oct 8 2021: VSCode changed their format in 1.61.
-          // Before | ^zip:/c:/foo/bar.zip/package.json
-          // After  | ^/zip//c:/foo/bar.zip/package.json
-          //
-          case `vscode <1.61`: {
-            str = `^zip:${str}`;
-          } break;
-
           case `vscode`: {
-            str = `^/zip/${str}`;
+            str = `^/zip${str}`;
           } break;
 
           // To make "go to definition" work,
@@ -159,9 +152,6 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
-          hostInfo += ` <1.61`;
-        }
       }
 
       const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -61,6 +61,22 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
+          // Update 2021-10-08: VSCode changed their format in 1.61.
+          // Before | ^zip:/c:/foo/bar.zip/package.json
+          // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          // Update 2022-04-06: VSCode changed the format in 1.66.
+          // Before | ^/zip//c:/foo/bar.zip/package.json
+          // After  | ^/zip/c:/foo/bar.zip/package.json
+          //
+          case `vscode <1.61`: {
+            str = `^zip:${str}`;
+          } break;
+
+          case `vscode <1.66`: {
+            str = `^/zip/${str}`;
+          } break;
+
           case `vscode`: {
             str = `^/zip${str}`;
           } break;
@@ -152,6 +168,13 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
+          if (/(\/|-)1\.([1-5][0-9]|60)\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.61`;
+          } else if (/(\/|-)1\.(6[1-5])\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.66`;
+          }
+        }
       }
 
       const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -18,6 +18,7 @@ const moduleWrapper = tsserver => {
   const pnpApi = require(`pnpapi`);
 
   const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const isPortal = str => str.startsWith("portal:/");
   const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
 
   const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
@@ -44,7 +45,7 @@ const moduleWrapper = tsserver => {
       const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
       if (resolved) {
         const locator = pnpApi.findPackageLocator(resolved);
-        if (locator && dependencyTreeRoots.has(`${locator.name}@${locator.reference}`)) {
+        if (locator && (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) || isPortal(locator.reference))) {
           str = resolved;
         }
       }
@@ -60,16 +61,8 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // Update Oct 8 2021: VSCode changed their format in 1.61.
-          // Before | ^zip:/c:/foo/bar.zip/package.json
-          // After  | ^/zip//c:/foo/bar.zip/package.json
-          //
-          case `vscode <1.61`: {
-            str = `^zip:${str}`;
-          } break;
-
           case `vscode`: {
-            str = `^/zip/${str}`;
+            str = `^/zip${str}`;
           } break;
 
           // To make "go to definition" work,
@@ -159,9 +152,6 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
-          hostInfo += ` <1.61`;
-        }
       }
 
       const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -61,6 +61,22 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
+          // Update 2021-10-08: VSCode changed their format in 1.61.
+          // Before | ^zip:/c:/foo/bar.zip/package.json
+          // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          // Update 2022-04-06: VSCode changed the format in 1.66.
+          // Before | ^/zip//c:/foo/bar.zip/package.json
+          // After  | ^/zip/c:/foo/bar.zip/package.json
+          //
+          case `vscode <1.61`: {
+            str = `^zip:${str}`;
+          } break;
+
+          case `vscode <1.66`: {
+            str = `^/zip/${str}`;
+          } break;
+
           case `vscode`: {
             str = `^/zip${str}`;
           } break;
@@ -152,6 +168,13 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
+          if (/(\/|-)1\.([1-5][0-9]|60)\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.61`;
+          } else if (/(\/|-)1\.(6[1-5])\./.test(process.env.VSCODE_IPC_HOOK)) {
+            hostInfo += ` <1.66`;
+          }
+        }
       }
 
       const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {

--- a/.yarn/versions/4a257e90.yml
+++ b/.yarn/versions/4a257e90.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -88,16 +88,8 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               //
               // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
               //
-              // Update Oct 8 2021: VSCode changed their format in 1.61.
-              // Before | ^zip:/c:/foo/bar.zip/package.json
-              // After  | ^/zip//c:/foo/bar.zip/package.json
-              //
-              case \`vscode <1.61\`: {
-                str = \`^zip:\${str}\`;
-              } break;
-
               case \`vscode\`: {
-                str = \`^/zip/\${str}\`;
+                str = \`^/zip\${str}\`;
               } break;
 
               // To make "go to definition" work,
@@ -187,9 +179,6 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
             typeof parsedMessage.arguments.hostInfo === \`string\`
           ) {
             hostInfo = parsedMessage.arguments.hostInfo;
-            if (hostInfo === \`vscode\` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\\/1\\.([1-5][0-9]|60)\\./)) {
-              hostInfo += \` <1.61\`;
-            }
           }
 
           const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

VSCode 1.66 changed the format for in-memory file paths (again) in https://github.com/microsoft/vscode/commit/e04c70a676898301b543bd59147e1bfb033d8fb9.

Fixes https://github.com/yarnpkg/berry/issues/4304
Closes https://github.com/yarnpkg/berry/pull/4322

**How did you fix it?**

Updated the pattern and fixed the VSCode version detection on Windows and Linux.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.