### PR TITLE
Fixes `yarn version apply`

### DIFF
--- a/.yarn/versions/4704a5d3.yml
+++ b/.yarn/versions/4704a5d3.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -111,7 +111,7 @@ export default class VersionApplyCommand extends BaseCommand {
           if (this.all) {
             await versionUtils.clearVersionFiles(project);
           } else {
-            await versionUtils.updateVersionFiles(project);
+            await versionUtils.updateVersionFiles(project, [...filteredReleases.keys()]);
           }
         }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

We don't use `yarn version apply` much, and when trying to use it to bump the ZipFS extension I noticed it caused all release markers to be dropped (instead of just the ones relative to the package being bumped).

**How did you fix it?**

Fixed to only remove the entries relative to the packages being bumped.

A followup will be to write tests, but I want to make the release before that 🙂

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
