### PR TITLE
fix(plugin-nm): handle `supportedArchitectures`

### DIFF
--- a/.yarn/versions/cb320125.yml
+++ b/.yarn/versions/cb320125.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The following changes only affect people writing Yarn plugins:
   - applies hoisting algorithm on aliased dependencies
   - reinstalls modules that have their directories removed from node_modules by the user
   - improves portal hoisting
+  - supports `supportedArchitectures`
 
 ### Bugfixes
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1722,4 +1722,31 @@ describe(`Node_Modules`, () => {
         });
       }),
   );
+
+  it(`should support supportedArchitectures`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          native: `1.0.0`,
+        },
+      },
+      async ({path, run}) => {
+        await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+          nodeLinker: `node-modules`,
+          supportedArchitectures: {
+            os: [`foo`],
+            cpu: [`x64`, `x86`],
+          },
+        });
+
+        await expect(run(`install`)).resolves.toMatchObject({code: 0});
+
+        await expect(xfs.readdirPromise(ppath.join(path, Filename.nodeModules))).resolves.toEqual([
+          `.yarn-state.yml`,
+          `native`,
+          `native-foo-x64`,
+          `native-foo-x86`,
+        ]);
+      }),
+  );
 });

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -148,7 +148,7 @@ class NodeModulesInstaller implements Installer {
     }
 
     // We don't link the package at all if it's for an unsupported platform
-    if (!jsInstallUtils.checkManifestCompatibility(pkg))
+    if (!structUtils.isPackageCompatible(pkg, this.opts.project.configuration.getSupportedArchitectures()))
       return {packageLocation: null, buildDirective: null};
 
     const packageDependencies = new Map<string, string | [string, string] | null>();


### PR DESCRIPTION
**What's the problem this PR addresses?**

We forgot to update the `node-modules` linker in https://github.com/yarnpkg/berry/pull/3575 to support `supportedArchitectures`.

Fixes https://github.com/yarnpkg/berry/issues/4323

**How did you fix it?**

Updated the linker to use `this.opts.project.configuration.getSupportedArchitectures()` to get the supported architectures.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.