### PR TITLE
fix(compat): `react-scripts`

### DIFF
--- a/.yarn/versions/778bfffd.yml
+++ b/.yarn/versions/778bfffd.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -790,19 +790,33 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/JuniorTour/vue-template-babel-compiler/pull/40
-  [`vue-template-babel-compiler@*`, {
+  [`vue-template-babel-compiler@<1.2.0`, {
     peerDependencies: {
       [`vue-template-compiler`]: `^2.6.0`,
     },
   }],
-  [`@parcel/transformer-image@*`, {
+  // https://github.com/parcel-bundler/parcel/pull/7977
+  [`@parcel/transformer-image@<2.5.0`, {
     peerDependencies: {
       [`@parcel/core`]: `*`,
     },
   }],
-  [`@parcel/transformer-js@*`, {
+  // https://github.com/parcel-bundler/parcel/pull/7977
+  [`@parcel/transformer-js@<2.5.0`, {
     peerDependencies: {
       [`@parcel/core`]: `*`,
+    },
+  }],
+  // This doesn't have an upstream PR.
+  // The auto types causes two instances of eslint-config-react-app,
+  // one that has access to @types/eslint and one that doesn't.
+  // ESLint doesn't allow the same plugin to show up multiple times so it throws.
+  // As a temporary workaround until create-react-app fixes their ESLint
+  // setup we make eslint a peer dependency /w fallback.
+  // TODO: Lock the range when create-react-app fixes their ESLint setup
+  [`react-scripts@*`, {
+    peerDependencies: {
+      [`eslint`]: `*`,
     },
   }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `create-react-app` e2e test broke in https://github.com/yarnpkg/berry/pull/4253

**How did you fix it?**

As a temporary workaround until `create-react-app` fixes their ESLint setup make `eslint` a peer dependency /w fallback.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.