### PR TITLE
perf(core): skip unnecessary `access` call in `fetchPackageFromCache`

### DIFF
--- a/.yarn/versions/2fb68a30.yml
+++ b/.yarn/versions/2fb68a30.yml
@@ -1,0 +1,33 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -358,7 +358,8 @@ export class Cache {
 
     const [shouldMock, cachePath, checksum] = await loadPackageThroughMutex();
 
-    this.markedFiles.add(cachePath);
+    if (!shouldMock)
+      this.markedFiles.add(cachePath);
 
     let zipFs: ZipFS | undefined;
 

--- a/packages/yarnpkg-core/sources/Cache.ts
+++ b/packages/yarnpkg-core/sources/Cache.ts
@@ -315,7 +315,7 @@ export class Cache {
         const tentativeCachePath = this.getLocatorPath(locator, expectedChecksum, opts);
 
         const cacheFileExists = tentativeCachePath !== null
-          ? await baseFs.existsPromise(tentativeCachePath)
+          ? this.markedFiles.has(tentativeCachePath) || await baseFs.existsPromise(tentativeCachePath)
           : false;
 
         const shouldMock = !!opts.mockedPackages?.has(locator.locatorHash) && (!this.check || !cacheFileExists);

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1884,8 +1884,6 @@ export class Project {
           : `${lastEntryRemoved} appeared to be unused and was removed`,
       );
     }
-
-    cache.markedFiles.clear();
   }
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

During the link step of an install the `Cache` will check if cache entries exists on disk even though it already checked that during the fetch step.

Ref https://github.com/yarnpkg/berry/issues/4057

**How did you fix it?**

Check if the cache entry is in `markedFiles` before checking the disk.

**Benchmark results**

On the gatsby benchmark this removes 1942 `access` syscalls

```
YARN_IGNORE_PATH=1 hyperfine -w 1 \
  "node ./cache.cjs --mode skip-build" \
  "node ./master.cjs --mode skip-build"
Benchmark 1: node ./cache.cjs --mode skip-build
  Time (mean ± σ):      1.621 s ±  0.009 s    [User: 2.344 s, System: 0.352 s]
  Range (min … max):    1.605 s …  1.637 s    10 runs

Benchmark 2: node ./master.cjs --mode skip-build
  Time (mean ± σ):      1.707 s ±  0.012 s    [User: 2.397 s, System: 0.429 s]
  Range (min … max):    1.692 s …  1.725 s    10 runs

Summary
  'node ./cache.cjs --mode skip-build' ran
    1.05 ± 0.01 times faster than 'node ./master.cjs --mode skip-build'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.