### PR TITLE
[plugin-npm-cli]: Add ability to exclude packages, or ignore specific advisories in `yarn npm audit`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -15455,6 +15455,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15467,6 +15468,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15488,6 +15490,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15500,6 +15503,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15521,6 +15525,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15533,6 +15538,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15554,6 +15560,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15566,6 +15573,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15587,6 +15595,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:261c80968f83905e40b80f5f7b27c9a820efcfd23647733e32b44cd05d9ef12b818071d95555eec63b0ccbdc23a11bcc89146137a7ea2ac0a4c1f4d3c79b18be#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15599,6 +15608,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:261c80968f83905e40b80f5f7b27c9a820efcfd23647733e32b44cd05d9ef12b818071d95555eec63b0ccbdc23a11bcc89146137a7ea2ac0a4c1f4d3c79b18be#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15620,6 +15630,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15632,6 +15643,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15653,6 +15665,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15665,6 +15678,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15686,6 +15700,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15698,6 +15713,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15719,6 +15735,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15731,6 +15748,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15752,6 +15770,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15764,6 +15783,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15785,6 +15805,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15797,6 +15818,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15818,6 +15840,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15830,6 +15853,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15851,6 +15875,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15863,6 +15888,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15884,6 +15910,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15896,6 +15923,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15917,6 +15945,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:b63ad861025672af62aed0e7c80dca4cfce3194ca046161e54fc14c498c39e3b82004ea844489c7a58d2f1a31867f388bf25b8128f5ccce46f35305e1f91e9ab#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15929,6 +15958,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:b63ad861025672af62aed0e7c80dca4cfce3194ca046161e54fc14c498c39e3b82004ea844489c7a58d2f1a31867f388bf25b8128f5ccce46f35305e1f91e9ab#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15950,6 +15980,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15962,6 +15993,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -15983,6 +16015,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -15995,6 +16028,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -16016,6 +16050,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -16028,6 +16063,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -16049,6 +16085,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
@@ -16061,6 +16098,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\
@@ -16082,6 +16120,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-npm-cli", "workspace:packages/plugin-npm-cli"],\
           ["@npm/types", "npm:1.0.1"],\
+          ["@types/micromatch", "npm:4.0.1"],\
           ["@types/semver", "npm:7.1.0"],\
           ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
@@ -16090,6 +16129,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/plugin-pack", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/plugin-pack"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["enquirer", "npm:2.3.6"],\
+          ["micromatch", "npm:4.0.4"],\
           ["semver", "npm:7.3.5"],\
           ["tslib", "npm:1.13.0"],\
           ["typanion", "npm:3.3.2"]\

--- a/.yarn/versions/2e7530b2.yml
+++ b/.yarn/versions/2e7530b2.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
@@ -1,0 +1,25 @@
+export {};
+
+describe(`Commands`, () => {
+  describe(`npm audit`, () => {
+  // TODO
+  // test ignore as flag
+  // test exclude as flag
+  // test ignore as config
+  // test exclude as config
+  // test combinations
+  // test json
+  // test environment
+  // test severity
+  // test recursive
+    test.todo(`it should report vulnerable packages`);
+    test.todo(`it should exclude packages`);
+    test.todo(`it should only exclude excluded packages`);
+    test.todo(`it should ignore advisories`);
+    test.todo(`it should only ignore ignored advisories`);
+    test.todo(`it should return results as JSON`);
+    test.todo(`it should only use the specified environment`);
+    test.todo(`it should only use the specified severity level`);
+    test.todo(`it should recurse packages to audit`);
+  });
+});

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -450,6 +450,26 @@
       "enum": ["public", "restricted"],
       "examples": ["public"]
     },
+    "npmAuditExcludePackages": {
+      "_package": "@yarnpkg/plugin-npm-cli",
+      "description": "List of packages to exclude from `yarn npm audit`. Doesn't need to be defined, in which case no packages will be excluded. Can also be augmented by the `--exclude` flag.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "examples": ["known_insecure_package"]
+    },
+    "npmAuditIgnoreAdvisories": {
+      "_package": "@yarnpkg/plugin-npm-cli",
+      "description": "List of advisory ID's to ignore from `yarn npm audit` results. Doesn't need to be defined, in which case no advisories will be ignored. Can also be augmented by the `--ignore` flag.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "examples": ["1234567"]
+    },
     "npmPublishRegistry": {
       "_package": "@yarnpkg/plugin-npm",
       "description": "Defines the registry that must be used when pushing packages. Doesn't need to be defined, in which case the value of `npmRegistryServer` will be used. Overridden by `publishConfig.registry`.",

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -452,7 +452,7 @@
     },
     "npmAuditExcludePackages": {
       "_package": "@yarnpkg/plugin-npm-cli",
-      "description": "List of packages to exclude from `yarn npm audit`. Doesn't need to be defined, in which case no packages will be excluded. Can also be augmented by the `--exclude` flag.",
+      "description": "Array of glob patterns of packages to exclude from `yarn npm audit`. Doesn't need to be defined, in which case no packages will be excluded. Can also be augmented by the `--exclude` flag.",
       "type": "array",
       "items": {
         "type": "string"
@@ -462,7 +462,7 @@
     },
     "npmAuditIgnoreAdvisories": {
       "_package": "@yarnpkg/plugin-npm-cli",
-      "description": "List of advisory ID's to ignore from `yarn npm audit` results. Doesn't need to be defined, in which case no advisories will be ignored. Can also be augmented by the `--ignore` flag.",
+      "description": "Array of glob patterns of advisory ID's to ignore from `yarn npm audit` results. Doesn't need to be defined, in which case no advisories will be ignored. Can also be augmented by the `--ignore` flag.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -7,6 +7,7 @@
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
     "enquirer": "^2.3.6",
+    "micromatch": "^4.0.2",
     "semver": "^7.1.2",
     "tslib": "^1.13.0",
     "typanion": "^3.3.0"
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@npm/types": "^1.0.1",
+    "@types/micromatch": "^4.0.1",
     "@types/semver": "^7.1.0",
     "@yarnpkg/cli": "workspace:^",
     "@yarnpkg/core": "workspace:^",

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -156,9 +156,9 @@ export default class AuditCommand extends BaseCommand {
     for (const key of ignoredAdvisories) {
       const entry = result.advisories[key];
       delete result.advisories[key];
-      
+
       if (typeof entry !== `undefined`) {
-        result.metadata.vulnerabilities[value.severity] -= 1;
+        result.metadata.vulnerabilities[entry.severity] -= 1;
       }
     }
 

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -53,7 +53,7 @@ export default class AuditCommand extends BaseCommand {
       `yarn npm audit --exclude package1 --exclude package2`,
     ], [
       `Ignore specific advisories`,
-      `yarn npm audit --ignore GHSA-xxxx-xxxx-xxxx --exclude GHSA-xxxx-xxxx-xxxx`,
+      `yarn npm audit --ignore 1234567 --ignore 7654321`,
     ]],
   });
 

--- a/packages/plugin-npm-cli/sources/index.ts
+++ b/packages/plugin-npm-cli/sources/index.ts
@@ -13,6 +13,8 @@ import npmWhoami              from './commands/npm/whoami';
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     npmPublishAccess: string | null;
+    npmAuditExcludePackages: Array<string>;
+    npmAuditIgnoreAdvisories: Array<string>;
   }
 }
 
@@ -22,6 +24,18 @@ const plugin: Plugin = {
       description: `Default access of the published packages`,
       type: SettingsType.STRING,
       default: null,
+    },
+    npmAuditExcludePackages: {
+      description: `List of packages to exclude from npm audit`,
+      type: SettingsType.STRING,
+      default: [],
+      isArray: true,
+    },
+    npmAuditIgnoreAdvisories: {
+      description: `List of advisory IDs to exclude from npm audit`,
+      type: SettingsType.STRING,
+      default: [],
+      isArray: true,
     },
   },
   commands: [

--- a/packages/plugin-npm-cli/sources/index.ts
+++ b/packages/plugin-npm-cli/sources/index.ts
@@ -26,13 +26,13 @@ const plugin: Plugin = {
       default: null,
     },
     npmAuditExcludePackages: {
-      description: `List of packages to exclude from npm audit`,
+      description: `Array of glob patterns of packages to exclude from npm audit`,
       type: SettingsType.STRING,
       default: [],
       isArray: true,
     },
     npmAuditIgnoreAdvisories: {
-      description: `List of advisory IDs to exclude from npm audit`,
+      description: `Array of glob patterns of advisory IDs to exclude from npm audit`,
       type: SettingsType.STRING,
       default: [],
       isArray: true,

--- a/packages/plugin-npm-cli/sources/npmAuditTypes.ts
+++ b/packages/plugin-npm-cli/sources/npmAuditTypes.ts
@@ -57,7 +57,7 @@ export interface AuditAdvisory {
   recommendation: string;
   references: string;
   access: string;
-  severity: string;
+  severity: Severity;
   cwe: string;
   metadata: {
     module_type: string;

--- a/packages/plugin-npm-cli/sources/npmAuditUtils.ts
+++ b/packages/plugin-npm-cli/sources/npmAuditUtils.ts
@@ -157,6 +157,10 @@ export function getReportTree(result: npmAuditTypes.AuditResponse, severity?: np
       label: advisory.module_name,
       value: formatUtils.tuple(formatUtils.Type.RANGE, advisory.findings.map(finding => finding.version).join(`, `)),
       children: {
+        ID: {
+          label: `ID`,
+          value: formatUtils.tuple(formatUtils.Type.NUMBER, advisory.id),
+        },
         Issue: {
           label: `Issue`,
           value: formatUtils.tuple(formatUtils.Type.NO_HINT, advisory.title),

--- a/packages/plugin-npm-cli/sources/npmAuditUtils.ts
+++ b/packages/plugin-npm-cli/sources/npmAuditUtils.ts
@@ -62,7 +62,7 @@ function setDifference<T>(x: Set<T>, y: Set<T>): Set<T> {
 // - are present in the lockfile
 // - are a transitive dependency of some top-level devDependency
 // - are not a transitive dependency of some top-level production dependency
-export function getTransitiveDevDependencies(project: Project, workspace: Workspace, {all}: {all: boolean}): Set<DescriptorHash> {
+function getTransitiveDevDependencies(project: Project, workspace: Workspace, {all}: {all: boolean}): Set<DescriptorHash> {
   // Determine workspaces in scope
   const workspaces = all
     ? project.workspaces
@@ -103,7 +103,7 @@ export function getTransitiveDevDependencies(project: Project, workspace: Worksp
   return setDifference(developmentDependencies, productionDependencies);
 }
 
-export function transformDescriptorIterableToRequiresObject(descriptors: Iterable<Descriptor>) {
+function transformDescriptorIterableToRequiresObject(descriptors: Iterable<Descriptor>) {
   const data: {[key: string]: string} = {};
 
   for (const descriptor of descriptors)
@@ -112,9 +112,9 @@ export function transformDescriptorIterableToRequiresObject(descriptors: Iterabl
   return data;
 }
 
-export function getSeverityInclusions(severity?: npmAuditTypes.Severity): Set<npmAuditTypes.Severity> {
+function getSeverityInclusions(severity?: npmAuditTypes.Severity): Set<npmAuditTypes.Severity> {
   if (typeof severity === `undefined`)
-    return new Set();
+    return new Set(allSeverities);
 
   const severityIndex = allSeverities.indexOf(severity);
   const severities = allSeverities.slice(severityIndex);
@@ -122,7 +122,7 @@ export function getSeverityInclusions(severity?: npmAuditTypes.Severity): Set<np
   return new Set(severities);
 }
 
-export function filterVulnerabilities(vulnerabilities: npmAuditTypes.AuditVulnerabilities, severity?: npmAuditTypes.Severity) {
+function filterVulnerabilities(vulnerabilities: npmAuditTypes.AuditVulnerabilities, severity?: npmAuditTypes.Severity) {
   const inclusions = getSeverityInclusions(severity);
 
   const filteredVulnerabilities: Partial<npmAuditTypes.AuditVulnerabilities> = {};

--- a/packages/plugin-npm-cli/tests/npmAuditUtils.test.js
+++ b/packages/plugin-npm-cli/tests/npmAuditUtils.test.js
@@ -1,0 +1,195 @@
+import {allSeverities, isError, getReportTree, getRequires, getDependencies} from '@yarnpkg/plugin-npm-cli/sources/npmAuditUtils';
+
+describe(`npmAuditUtils`, () => {
+  // Severity levels
+  const lowOrHigher = [`low`, `moderate`, `high`, `critical`];
+  const moderateOrHigher = [`moderate`, `high`, `critical`];
+  const highOrHigher = [`high`, `critical`];
+  const criticalOrHigher = [`critical`];
+
+  describe(`allSeverities`, () => {
+    test(`it should include info`, () => expect(allSeverities).toContain(`info`));
+    test(`it should include low`, () => expect(allSeverities).toContain(`low`));
+    test(`it should include moderate`, () => expect(allSeverities).toContain(`moderate`));
+    test(`it should include high`, () => expect(allSeverities).toContain(`high`));
+    test(`it should include critical`, () => expect(allSeverities).toContain(`critical`));
+  });
+
+  describe(`isError`, () => {
+    // vulnerability objects
+    const none = {info: 0, low: 0, moderate: 0, high: 0, critical: 0};
+    const info = {info: 1, low: 0, moderate: 0, high: 0, critical: 0};
+    const low = {info: 0, low: 1, moderate: 0, high: 0, critical: 0};
+    const moderate = {info: 0, low: 0, moderate: 1, high: 0, critical: 0};
+    const high = {info: 0, low: 0, moderate: 0, high: 1, critical: 0};
+    const critical = {info: 0, low: 0, moderate: 0, high: 0, critical: 1};
+
+    test(`it should return false with no vulnerabilities`, () => {
+      expect(isError(none)).toBeFalsy();
+      for (const severity of allSeverities) {
+        expect(isError(none, severity)).toBeFalsy();
+      }
+    });
+
+    test(`it should return true with any vulnerabilities`, () => {
+      expect(isError(info)).toBeTruthy();
+      expect(isError(low)).toBeTruthy();
+      expect(isError(moderate)).toBeTruthy();
+      expect(isError(high)).toBeTruthy();
+      expect(isError(critical)).toBeTruthy();
+    });
+
+    test(`it should return true with vulnerabilities at or above requested severity`, () => {
+      for (const severity of allSeverities.filter(severity => !lowOrHigher.includes(severity)))
+        expect(isError(low, severity)).toBeTruthy();
+
+      for (const severity of allSeverities.filter(severity => !moderateOrHigher.includes(severity)))
+        expect(isError(moderate, severity)).toBeTruthy();
+
+      for (const severity of allSeverities.filter(severity => !highOrHigher.includes(severity)))
+        expect(isError(high, severity)).toBeTruthy();
+
+      for (const severity of allSeverities.filter(severity => !criticalOrHigher.includes(severity))) {
+        expect(isError(critical, severity)).toBeTruthy();
+      }
+    });
+
+    test(`it should return false with vulnerabilities below requested severity`, () => {
+      for (const severity of lowOrHigher)
+        expect(isError(info, severity)).toBeFalsy();
+
+      for (const severity of moderateOrHigher)
+        expect(isError(low, severity)).toBeFalsy();
+
+      for (const severity of highOrHigher)
+        expect(isError(moderate, severity)).toBeFalsy();
+
+      expect(isError(high, `critical`)).toBeFalsy();
+    });
+  });
+
+  describe(`getReportTree`, () => {
+    const id = 1337;
+    const title = `title`;
+    const url = `url`;
+    const vulnerable_versions = `vulnerable_versions`;
+    const patched_versions = `patched_versions`;
+    const recommendation = `recommendation`;
+    const version = `version`;
+    const path = `path`;
+    // vulnerability objects
+    const advisory = {id, title, url, vulnerable_versions, patched_versions, recommendation, findings: [{version, paths: [path]}]};
+    const info = {...advisory, module_name: `info_module`, severity: `info`};
+    const low = {...advisory, module_name: `low_module`, severity: `low`};
+    const moderate = {...advisory, module_name: `moderate_module`, severity: `moderate`};
+    const high = {...advisory, module_name: `high_module`, severity: `high`};
+    const critical = {...advisory, module_name: `critical_module`, severity: `critical`};
+    // expected values
+    const boilerplate = {children: {}};
+
+    test(`it should return a tree with just boilerplate with no vulnerabilities`, () => {
+      expect(getReportTree({advisories: {}})).toStrictEqual(boilerplate);
+      for (const severity of allSeverities) {
+        expect(getReportTree({advisories: {}}, severity)).toStrictEqual(boilerplate);
+      }
+    });
+
+    test(`it should return a tree with just boilerplate with only vulnerabilities below the requested minimum severity`, () => {
+      for (const severity of lowOrHigher)
+        expect(getReportTree({advisories: {idno: info}}, severity)).toStrictEqual(boilerplate);
+
+      for (const severity of moderateOrHigher) {
+        expect(getReportTree({advisories: {idno: low}}, severity)).toStrictEqual(boilerplate);
+        expect(getReportTree({advisories: {idno: info, idno2: low}}, severity)).toStrictEqual(boilerplate);
+      }
+      for (const severity of highOrHigher) {
+        expect(getReportTree({advisories: {idno: moderate}}, severity)).toStrictEqual(boilerplate);
+        expect(getReportTree({advisories: {idno: low, idno2: moderate}}, severity)).toStrictEqual(boilerplate);
+        expect(getReportTree({advisories: {idno: info, idno2: low, idno3: moderate}}, severity)).toStrictEqual(boilerplate);
+      }
+      expect(getReportTree({advisories: {idno: high}}, `critical`)).toStrictEqual(boilerplate);
+      expect(getReportTree({advisories: {idno: moderate, idno2: high}}, `critical`)).toStrictEqual(boilerplate);
+      expect(getReportTree({advisories: {idno: low, idno2: moderate, idno3: high}}, `critical`)).toStrictEqual(boilerplate);
+      expect(getReportTree({advisories: {idno: info, idno2: low, idno3: moderate, idno4: high}}, `critical`)).toStrictEqual(boilerplate);
+    });
+
+    test(`it should return a tree if there are vulnerabilities`, () => {
+      expect(getReportTree({advisories: {idno: info}})).not.toStrictEqual(boilerplate);
+      expect(getReportTree({advisories: {idno: low}})).not.toStrictEqual(boilerplate);
+      for (const severity of allSeverities.filter(severity => !lowOrHigher.includes(severity)))
+        expect(getReportTree({advisories: {idno: low}}, severity)).not.toStrictEqual(boilerplate);
+
+      expect(getReportTree({advisories: {idno: moderate}})).not.toStrictEqual(boilerplate);
+      for (const severity of allSeverities.filter(severity => !moderateOrHigher.includes(severity)))
+        expect(getReportTree({advisories: {idno: moderate}}, severity)).not.toStrictEqual(boilerplate);
+
+      expect(getReportTree({advisories: {idno: high}})).not.toStrictEqual(boilerplate);
+      for (const severity of allSeverities.filter(severity => !highOrHigher.includes(severity)))
+        expect(getReportTree({advisories: {idno: high}}, severity)).not.toStrictEqual(boilerplate);
+
+      expect(getReportTree({advisories: {idno: critical}})).not.toStrictEqual(boilerplate);
+      for (const severity of allSeverities.filter(severity => !criticalOrHigher.includes(severity))) {
+        expect(getReportTree({advisories: {idno: critical}}, severity)).not.toStrictEqual(boilerplate);
+      }
+    });
+
+    test(`it should return a tree only with the vulnerabilities above severity level`, () => {
+      expect(getReportTree({advisories: {idno: low, ignore: info}}, `low`)).not.toMatchObject({children: {info_module: {}}});
+      expect(getReportTree({advisories: {idno: moderate, ignore: info}}, `low`)).not.toMatchObject({children: {info_module: {}}});
+      expect(getReportTree({advisories: {idno: high, ignore: info}}, `low`)).not.toMatchObject({children: {info_module: {}}});
+      expect(getReportTree({advisories: {idno: critical, ignore: info}}, `low`)).not.toMatchObject({children: {info_module: {}}});
+
+      expect(getReportTree({advisories: {idno: moderate, ignore: low}}, `moderate`)).not.toMatchObject({children: {low_module: {}}});
+      expect(getReportTree({advisories: {idno: high, ignore: low}}, `moderate`)).not.toMatchObject({children: {low_module: {}}});
+      expect(getReportTree({advisories: {idno: critical, ignore: low}}, `moderate`)).not.toMatchObject({children: {low_module: {}}});
+
+      expect(getReportTree({advisories: {idno: high, ignore: moderate}}, `high`)).not.toMatchObject({children: {moderate_module: {}}});
+      expect(getReportTree({advisories: {idno: critical, ignore: moderate}}, `high`)).not.toMatchObject({children: {moderate_module: {}}});
+
+      expect(getReportTree({advisories: {idno: critical, ignore: high}}, `critical`)).not.toMatchObject({children: {high_module: {}}});
+    });
+
+    test(`it should return a tree with multiple vulnerabilities if above the severity level`, () => {
+      expect(getReportTree({advisories: {idno: critical, ignore: high}}, `high`)).toMatchObject({children: {critical_module: {}, high_module: {}}});
+    });
+
+    test(`it should return all expected fields in the tree`, () => {
+      // TODO this would be better suited to mocking out formatUtils and checking whether it is called with the appropriate values
+      const expected = {
+        children: {
+          info_module: {
+            label: `info_module`,
+            value: [version, `RANGE`],
+            children: {
+              ID: {label: `ID`, value: [id, `NUMBER`]},
+              Issue: {label: `Issue`, value: [title, `NO_HINT`]},
+              "Patched Versions": {label: `Patched Versions`, value: [patched_versions, `RANGE`]},
+              Recommendation: {label: `Recommendation`, value: [recommendation, `NO_HINT`]},
+              Severity: {label: `Severity`, value: [`info`, `NO_HINT`]},
+              URL: {label: `URL`, value: [url, `URL`]},
+              Via: {label: `Via`, value: [path, `NO_HINT`]},
+              "Vulnerable Versions": {label: `Vulnerable Versions`, value: [vulnerable_versions, `RANGE`]},
+            },
+          },
+        },
+      };
+      expect(getReportTree({advisories: {idno: info}})).toMatchObject(expected);
+    });
+  });
+
+  describe(`getRequires`, () => {
+    // TODO
+    // args: project, workspace, all, environment
+    // `all` selects either project.workspaces or the workspace arg
+    // `environment` call be all, dev, or production. this should limit the results
+    getRequires;
+  });
+
+  describe(`getDependencies`, () => {
+    // TODO
+    // args: project, workspace, all
+    // `all` selects either project.workspaces or the workspace arg
+    // calls getTransitiveDevDependencies to do the heavy lifting
+    getDependencies;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6030,6 +6030,7 @@ __metadata:
   resolution: "@yarnpkg/plugin-npm-cli@workspace:packages/plugin-npm-cli"
   dependencies:
     "@npm/types": "npm:^1.0.1"
+    "@types/micromatch": "npm:^4.0.1"
     "@types/semver": "npm:^7.1.0"
     "@yarnpkg/cli": "workspace:^"
     "@yarnpkg/core": "workspace:^"
@@ -6038,6 +6039,7 @@ __metadata:
     "@yarnpkg/plugin-pack": "workspace:^"
     clipanion: "npm:^3.2.0-rc.10"
     enquirer: "npm:^2.3.6"
+    micromatch: "npm:^4.0.2"
     semver: "npm:^7.1.2"
     tslib: "npm:^1.13.0"
     typanion: "npm:^3.3.0"


### PR DESCRIPTION
**What's the problem this PR addresses?**
Closes #4355

...

**How did you fix it?**
This PR adds a `--exclude` flag to the `yarn npm audit` command in the
`nmp-cli` plugin. This flag can be passed multiple times, and any package
listed will be removed from the list of packages audited.

This PR also adds a `--ignore` flag to `yarn npm audit`, which is an array
of ID's to ignore from the audit report.

In addition, the ID is presented in the tree output (as well as the JSON).
...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
