### PR TITLE
Fixes the "yarn up" command when the dependency doesnt need upgrades

### DIFF
--- a/.yarn/versions/47902e08.yml
+++ b/.yarn/versions/47902e08.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/up.test.ts
@@ -3,6 +3,40 @@ import {Filename, ppath, xfs} from '@yarnpkg/fslib';
 describe(`Commands`, () => {
   describe(`up`, () => {
     test(
+      `it should bump dependency ranges to their latest`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `^1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`up`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toStrictEqual({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
+      `it shouldn't do anything when the dependency is already the latest`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `^2.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`up`, `no-deps`);
+
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toStrictEqual({
+          dependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+        });
+      }),
+    );
+
+    test(
       `it should upgrade all dependencies matching a glob pattern (scope & star)`,
       makeTemporaryEnv({
         dependencies: {

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -326,7 +326,9 @@ export default class UpCommand extends BaseCommand {
       } else {
         const resolver = configuration.makeResolver();
         const resolveOptions: MinimalResolveOptions = {project, resolver};
-        const bound = resolver.bindDescriptor(current, workspace.anchoredLocator, resolveOptions);
+
+        const normalizedDependency = configuration.normalizeDependency(current);
+        const bound = resolver.bindDescriptor(normalizedDependency, workspace.anchoredLocator, resolveOptions);
 
         project.forgetResolution(bound);
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `yarn up` command was broken when run on dependency already up-to-date since #4305.

**How did you fix it?**

Normalizes the descriptor before passing it to `forgetResolution`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
