### PR TITLE
fix(compat): update `vue-loader` entry

### DIFF
--- a/.yarn/versions/e19f1175.yml
+++ b/.yarn/versions/e19f1175.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -498,10 +498,25 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/vuejs/vue-loader/pull/1853
-  [`vue-loader@<=16.3.1`, {
+  // https://github.com/vuejs/vue-loader/commit/089473af97077b8e14b3feff48d32d2733ad792c
+  [`vue-loader@<=16.3.3`, {
     peerDependencies: {
       '@vue/compiler-sfc': `^3.0.8`,
       webpack: `^4.1.0 || ^5.0.0-0`,
+    },
+    peerDependenciesMeta: {
+      '@vue/compiler-sfc': optionalPeerDep,
+    },
+  }],
+  // https://github.com/vuejs/vue-loader/pull/1944
+  [`vue-loader@^16.7.0`, {
+    peerDependencies: {
+      '@vue/compiler-sfc': `^3.0.8`,
+      vue: `^3.2.13`,
+    },
+    peerDependenciesMeta: {
+      '@vue/compiler-sfc': optionalPeerDep,
+      vue: optionalPeerDep,
     },
   }],
   // https://github.com/salesforce-ux/scss-parser/pull/43


### PR DESCRIPTION
**What's the problem this PR addresses?**

The compat entry for `vue-loader` needs to be updated

Fixes https://github.com/yarnpkg/berry/issues/4265

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.