### PR TITLE
fix(dlx): preserve tags

### DIFF
--- a/.yarn/versions/27b23f7e.yml
+++ b/.yarn/versions/27b23f7e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-dlx": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/dlx.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/dlx.test.js
@@ -150,5 +150,14 @@ describe(`Commands`, () => {
         });
       }),
     );
+
+    test(
+      `it should use the exact tag specified`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await expect(run(`dlx`, `-p`, `has-bin-entries`, `-p`, `no-deps-tags@rc`, `has-bin-entries`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`no-deps-tags@npm:1.0.0-rc.1`),
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -101,7 +101,7 @@ export default class DlxCommand extends BaseCommand {
 
       let command = structUtils.parseDescriptor(this.command).name;
 
-      const addExitCode = await this.cli.run([`add`, `--`, ...pkgs], {cwd: tmpDir, quiet: this.quiet});
+      const addExitCode = await this.cli.run([`add`, `--fixed`, `--`, ...pkgs], {cwd: tmpDir, quiet: this.quiet});
       if (addExitCode !== 0)
         return addExitCode;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

After https://github.com/yarnpkg/berry/pull/4291 `yarn dlx` stopped using the exact tag specified and instead resolved it to a SemVer range which breaks the SvelteKit e2e test.

**How did you fix it?**

Make `yarn dlx` use the exact version the tag points to.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.