### PR TITLE
Fixes the Parcel E2E test

### DIFF
--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -82,7 +82,7 @@ jobs:
         yarn add @parcel/transformer-yaml@nightly
 
         echo "import data from './data.yaml';console.log(data.berry.works.with[0]);" | tee index.js
-        echo "berry: {works: {with:  [Parcel]}}" | tee data.yaml
+        echo "berry: {works: {with: [Parcel]}}" | tee data.yaml
 
         yarn parcel build index.js
         [[ "$(node dist/index.js)" = "Parcel" ]]
@@ -91,7 +91,7 @@ jobs:
 
         # MDX
 
-        yarn add react react-dom react-select @mdx-js/mdx @mdx-js/react @parcel/transformer-mdx@nightly
+        yarn add react react-dom react-select @mdx-js/mdx @mdx-js/react@^1 @parcel/transformer-mdx@nightly
 
         echo "import page from './page.mdx'; console.log('MDX Built');" | tee index.js
         cat > page.mdx <<EOT

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
         # TypeScript (tsc)
 
-        yarn add -D @parcel/config-default@nightly @parcel/validator-typescript@nightly @types/lodash typescript
+        yarn add -D @parcel/core@nightly @parcel/config-default@nightly @parcel/validator-typescript@nightly @types/lodash typescript
 
         echo "{\"extends\": \"@parcel/config-default\", \"validators\": {\"*.{ts,tsx}\": [\"@parcel/validator-typescript\"]}}" | tee .parcelrc
 

--- a/.yarn/versions/3bf5a52e.yml
+++ b/.yarn/versions/3bf5a52e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/3bf5a52e.yml
+++ b/.yarn/versions/3bf5a52e.yml
@@ -1,11 +1,11 @@
 releases:
   "@yarnpkg/cli": patch
   "@yarnpkg/plugin-compat": patch
+  "@yarnpkg/plugin-essentials": patch
 
 declined:
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
-  - "@yarnpkg/plugin-essentials"
   - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
   - "@yarnpkg/plugin-nm"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.0.0-rc.1/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.0.0-rc.1/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.0.0-rc.1/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.0.0-rc.1/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "no-deps-backward-tags",
+    "version": "1.0.0-rc.1",
+    "dist-tags": {
+      "latest": "1.1.0",
+      "rc": "1.0.0-rc.1"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.1.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.1.0/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.1.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-deps-backward-tags-1.1.0/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "no-deps-backward-tags",
+    "version": "1.1.0",
+    "dist-tags": {
+      "latest": "1.1.0",
+      "rc": "1.0.0-rc.1"
+    }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -143,13 +143,13 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should add a new regular dependency to the current project (resolved tag)`,
+      `it should add a new regular dependency to the current project (resolved backward tag)`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        await run(`add`, `no-deps@latest`);
+        await run(`add`, `no-deps-backward-tags@rc`);
 
         await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
           dependencies: {
-            [`no-deps`]: `^2.0.0`,
+            [`no-deps-backward-tags`]: `1.0.0-rc.1`,
           },
         });
       }),

--- a/packages/plugin-compat/sources/extensions.ts
+++ b/packages/plugin-compat/sources/extensions.ts
@@ -807,6 +807,12 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       [`@parcel/core`]: `*`,
     },
   }],
+  // Experiment to unblock the usage of Parcel in E2E tests
+  [`parcel@*`, {
+    peerDependenciesMeta: {
+      [`@parcel/core`]: optionalPeerDep,
+    },
+  }],
   // This doesn't have an upstream PR.
   // The auto types causes two instances of eslint-config-react-app,
   // one that has access to @types/eslint and one that doesn't.


### PR DESCRIPTION
**What's the problem this PR addresses?**

See https://github.com/parcel-bundler/parcel/issues/7999

**How did you fix it?**

Adding `@parcel/core` to the dependencies. This way users can add it to their dep and unblock the parcelrc issue. However perhaps this should be added to the Parcel documentation?

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
