### PR TITLE
fix(essentials): different error when importing built-in plugins

### DIFF
--- a/.yarn/versions/7b197f7e.yml
+++ b/.yarn/versions/7b197f7e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -23,5 +23,15 @@ describe(`Commands`, () => {
         await run(`hello`, `--email`, `postmaster@example.org`);
       }),
     );
+
+    test(
+      `it should detect attempts to import built-in plugins`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await expect(run(`plugin`, `import`, `workspace-tools`)).rejects.toMatchObject({
+          code: 1,
+          stdout: expect.stringContaining(`is already installed`),
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -83,8 +83,15 @@ export default class PluginDlCommand extends BaseCommand {
           const identStr = structUtils.stringifyIdent(locator);
           const data = await getAvailablePlugins(configuration, YarnVersion);
 
-          if (!Object.prototype.hasOwnProperty.call(data, identStr))
-            throw new ReportError(MessageName.PLUGIN_NAME_NOT_FOUND, `Couldn't find a plugin named "${identStr}" on the remote registry. Note that only the plugins referenced on our website (https://github.com/yarnpkg/berry/blob/master/plugins.yml) can be referenced by their name; any other plugin will have to be referenced through its public url (for example https://github.com/yarnpkg/berry/raw/master/packages/plugin-typescript/bin/%40yarnpkg/plugin-typescript.js).`);
+          if (!Object.prototype.hasOwnProperty.call(data, identStr)) {
+            let message = `Couldn't find a plugin named ${structUtils.prettyIdent(configuration, locator)} on the remote registry.\n`;
+            if (configuration.plugins.has(identStr))
+              message += `A plugin named ${structUtils.prettyIdent(configuration, locator)} is already installed; possibly attempting to import a built-in plugin.`;
+            else
+              message += `Note that only the plugins referenced on our website (${formatUtils.pretty(configuration, `https://github.com/yarnpkg/berry/blob/master/plugins.yml`, formatUtils.Type.URL)}) can be referenced by their name; any other plugin will have to be referenced through its public url (for example ${formatUtils.pretty(configuration, `https://github.com/yarnpkg/berry/raw/master/packages/plugin-typescript/bin/%40yarnpkg/plugin-typescript.js`, formatUtils.Type.URL)}).`;
+
+            throw new ReportError(MessageName.PLUGIN_NAME_NOT_FOUND, message);
+          }
 
           pluginSpec = identStr;
           pluginUrl = data[identStr].url;

--- a/packages/plugin-essentials/sources/commands/plugin/list.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/list.ts
@@ -10,7 +10,7 @@ export async function getAvailablePlugins(configuration: Configuration, version:
   const data = parseSyml(raw.toString());
 
   return Object.fromEntries(Object.entries(data).filter(([pluginName, pluginData]) => {
-    return !version || semverUtils.satisfiesWithPrereleases(version, pluginData.range ?? `<4.0.0`);
+    return !version || semverUtils.satisfiesWithPrereleases(version, pluginData.range ?? `<4.0.0-rc.1`);
   }));
 }
 

--- a/plugins.yml
+++ b/plugins.yml
@@ -17,42 +17,42 @@
 
 "@yarnpkg/plugin-constraints":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-constraints/bin/%40yarnpkg/plugin-constraints.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds a new command to Yarn (`yarn constraints`) to enforce lint rules across workspaces."
 
 "@yarnpkg/plugin-exec":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-exec/bin/%40yarnpkg/plugin-exec.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds a new protocol to Yarn (`exec:`) that dynamically generate packages instead of downloading them."
 
 "@yarnpkg/plugin-interactive-tools":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-interactive-tools/bin/%40yarnpkg/plugin-interactive-tools.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds various commands providing a more high-level control on your project through terminal interfaces."
 
 "@yarnpkg/plugin-stage":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-stage/bin/%40yarnpkg/plugin-stage.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds a new command to Yarn (`yarn stage`) to automatically stage & commit all Yarn-related files."
 
 "@yarnpkg/plugin-typescript":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-typescript/bin/%40yarnpkg/plugin-typescript.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds various utilities for a seamless TypeScript experience. Consult the plugin page for more details."
 
 "@yarnpkg/plugin-version":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-version/bin/%40yarnpkg/plugin-version.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds a new workflow to Yarn (`yarn version`) to efficiently manage releases in a monorepository."
 
 "@yarnpkg/plugin-workspace-tools":
   url: "https://github.com/yarnpkg/berry/raw/master/packages/plugin-workspace-tools/bin/%40yarnpkg/plugin-workspace-tools.js"
-  range: "<4.0.0"
+  range: "<4.0.0-rc.1"
   experimental: true
   description: "[Yarn <4 only] Adds various commands that make working with workspaces a more pleasing experience."


### PR DESCRIPTION
**What's the problem this PR addresses?**

- After https://github.com/yarnpkg/berry/pull/4253 running `yarn import plugin <built-in>` shows an unhelpful error.
- The SemVer range specified in https://github.com/yarnpkg/berry/pull/4331 doesn't match the canary releases

Closes https://github.com/yarnpkg/berry/issues/4396

**How did you fix it?**

- Update the error to indicate that the user is possibly attempting to import a built-in plugin.
- Updated the range to match canary releases

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.