### PR TITLE
chore: add lint rule for `semver.validRange` and `semver.Range`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,4 +24,18 @@ module.exports = {
       },
     },
   ],
+  rules: {
+    'no-restricted-properties': [2,
+      {
+        object: `semver`,
+        property: `validRange`,
+        message: `Use 'semverUtils.validRange' instead`,
+      },
+      {
+        object: `semver`,
+        property: `Range`,
+        message: `Use 'semverUtils.validRange' instead`,
+      },
+    ],
+  },
 };

--- a/.yarn/versions/e2989261.yml
+++ b/.yarn/versions/e2989261.yml
@@ -1,0 +1,3 @@
+declined:
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/core"

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -1,5 +1,5 @@
 import {Cache, DescriptorHash, Descriptor, Ident, Locator, Manifest, Project, ThrowReport, Workspace, FetchOptions, ResolveOptions, Configuration} from '@yarnpkg/core';
-import {formatUtils, structUtils}                                                                                                                  from '@yarnpkg/core';
+import {formatUtils, structUtils, semverUtils}                                                                                                     from '@yarnpkg/core';
 import {PortablePath, ppath, xfs}                                                                                                                  from '@yarnpkg/fslib';
 import semver                                                                                                                                      from 'semver';
 
@@ -209,7 +209,7 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
     throw new Error(`Invalid maxResults (${maxResults})`);
 
   const [requestRange, requestTag] = request.range !== `unknown`
-    ? fixed || semver.validRange(request.range) || !request.range.match(/^[a-z0-9._-]+$/i)
+    ? fixed || semverUtils.validRange(request.range) || !request.range.match(/^[a-z0-9._-]+$/i)
       ? [request.range, `latest`]
       : [`unknown`, request.range]
     : [`unknown`, `latest`];

--- a/packages/yarnpkg-core/sources/semverUtils.ts
+++ b/packages/yarnpkg-core/sources/semverUtils.ts
@@ -25,6 +25,7 @@ export function satisfiesWithPrereleases(version: string | null, range: string, 
   let semverRange = satisfiesWithPrereleasesCache.get(key);
   if (typeof semverRange === `undefined`) {
     try {
+      // eslint-disable-next-line no-restricted-properties
       semverRange = new semver.Range(range, {includePrerelease: true, loose});
     } catch {
       return false;
@@ -74,6 +75,7 @@ export function validRange(potentialRange: string): semver.Range | null {
     return range;
 
   try {
+    // eslint-disable-next-line no-restricted-properties
     range = new semver.Range(potentialRange);
   } catch {
     range = null;


### PR DESCRIPTION
**What's the problem this PR addresses?**

We shouldn't have to remember to use `semverUtils.validRange` instead of `semver.validRange` / `semver.Range`.

Ref https://github.com/yarnpkg/berry/pull/2890#issuecomment-840747821

**How did you fix it?**

Make ESLint remember it for us.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.