### PR TITLE
docs: fix incorrect grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Yarn is a modern package manager split into various packages. Its novel architec
       </a>
     </td>
     <td>
-      <b><a href="https://www.cloudflare.com/">Cloudflare</a></b> has also been an historical partner. While we don't directly mirror the npm registry anymore, they still power our website to make its delivery as fast as possible.
+      <b><a href="https://www.cloudflare.com/">Cloudflare</a></b> has also been a historical partner. While we don't directly mirror the npm registry anymore, they still power our website to make its delivery as fast as possible.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
**What's the problem this PR addresses?**
Minor grammatical error in README file [here](https://github.com/yarnpkg/berry/blob/master/README.md?plain=1#L101) has been fixed. Grammatically, 'a historical' is the correct usage over 'an historical'.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Did not find any related issue open for the grammatical error.
...

**How did you fix it?**
Changed 'an' to 'a'. Now the sentence reads 'Cloudflare has also been a historical partner'.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
