### PR TITLE
fix(nm): don't hoist dependency with transitive peers past its parent

### DIFF
--- a/.yarn/versions/0343d951.yml
+++ b/.yarn/versions/0343d951.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/nm": patch

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -300,12 +300,13 @@ const buildPackageTree = (pnp: PnpApi, options: NodeModulesTreeOptions): { packa
     }
 
     const isExternalSoftLinkPackage = isExternalSoftLink(pkg, locator, pnp, topPkgPortableLocation);
+    const isWorkspaceWithTransitivePeers = locator.reference.includes(`workspace:`) && [...pkg.packagePeers].some(a => parentPkg.packagePeers.has(a));
 
     if (!node) {
       let dependencyKind = HoisterDependencyKind.REGULAR;
       if (isExternalSoftLinkPackage)
         dependencyKind = HoisterDependencyKind.EXTERNAL_SOFT_LINK;
-      else if (pkg.linkType === LinkType.SOFT && locator.name.endsWith(WORKSPACE_NAME_SUFFIX))
+      else if (pkg.linkType === LinkType.SOFT && locator.name.endsWith(WORKSPACE_NAME_SUFFIX) || isWorkspaceWithTransitivePeers)
         dependencyKind = HoisterDependencyKind.WORKSPACE;
 
 

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -555,6 +555,12 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
               reason = `- peer dependency ${prettyPrintLocator(parentDepNode.locator)} from parent ${prettyPrintLocator(parent.locator)} was not hoisted to ${reasonRoot}`;
             }
           }
+        } else if (
+          !parentDepNode
+          && parent.peerNames.has(name) &&
+          [...node.references].every(a => !parent.references.has(a))
+        ) {
+          arePeerDepsSatisfied = false;
         }
       }
       if (!arePeerDepsSatisfied) {

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -555,12 +555,6 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
               reason = `- peer dependency ${prettyPrintLocator(parentDepNode.locator)} from parent ${prettyPrintLocator(parent.locator)} was not hoisted to ${reasonRoot}`;
             }
           }
-        } else if (
-          !parentDepNode
-          && parent.peerNames.has(name) &&
-          [...node.references].every(a => !parent.references.has(a))
-        ) {
-          arePeerDepsSatisfied = false;
         }
       }
       if (!arePeerDepsSatisfied) {

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -386,14 +386,9 @@ const getSortedRegularDependencies = (node: HoisterWorkTree): Set<HoisterWorkTre
  * @param rootNodePathLocators a set of locators for nodes that lead from the top of the tree up to root node
  * @param options hoisting options
  */
-const hoistTo = (tree: HoisterWorkTree, rootNodePath: Array<HoisterWorkTree>, rootNodePathLocators: Set<Locator>, parentShadowedNodes: ShadowedNodes, options: InternalHoistOptions, seenNodes: Set<HoisterWorkTree> = new Set()): {anotherRoundNeeded: boolean, isGraphChanged: boolean} => {
+const hoistTo = (tree: HoisterWorkTree, rootNodePath: Array<HoisterWorkTree>, rootNodePathLocators: Set<Locator>, parentShadowedNodes: ShadowedNodes, options: InternalHoistOptions): {anotherRoundNeeded: boolean, isGraphChanged: boolean} => {
   const rootNode = rootNodePath[rootNodePath.length - 1];
-  if (seenNodes.has(rootNode))
-    return {anotherRoundNeeded: false, isGraphChanged: false};
-  seenNodes.add(rootNode);
-
   const preferenceMap = buildPreferenceMap(rootNode);
-
   const hoistIdentMap = getHoistIdentMap(rootNode, preferenceMap);
 
   const usedDependencies = tree == rootNode ? new Map() :
@@ -543,10 +538,9 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
 
   if (isHoistable) {
     let arePeerDepsSatisfied = true;
-    const checkList = new Set(node.peerNames);
     for (let idx = nodePath.length - 1; idx >= 1; idx--) {
       const parent = nodePath[idx];
-      for (const name of checkList) {
+      for (const name of node.peerNames) {
         if (parent.peerNames.has(name) && parent.originalDependencies.has(name))
           continue;
 
@@ -562,7 +556,6 @@ const getNodeHoistInfo = (rootNode: HoisterWorkTree, rootNodePathLocators: Set<L
             }
           }
         }
-        checkList.delete(name);
       }
       if (!arePeerDepsSatisfied) {
         break;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
Dependencies which have peer dependency satisfied by its parent peer dependency must not be hoisted.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
https://github.com/yarnpkg/berry/issues/4434

**How did you fix it?**
<!-- A detailed description of your implementation. -->
While checking if parent has dependency which satisfies current dependency's peer, we should also check if parent has the same peer dependency. If so we should check if parent is not the same package as current dependency. If all of the above is true we should mark dependency as non-hoistable.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.
I've set only direct package version.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
