### PR TITLE
ci: update pnpm store location

### DIFF
--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -141,7 +141,7 @@ case $PACKAGE_MANAGER in
   pnpm)
     setup-pnpm
     bench install-full-cold \
-      --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.pnpm-store' \
+      --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.local/share/pnpm/store' \
       'pnpm install'
     bench install-cache-only \
       --prepare 'rm -rf node_modules pnpm-lock.yaml' \


### PR DESCRIPTION
**What's the problem this PR addresses?**

The location of the pnpm store changed in v7 (https://github.com/pnpm/pnpm/releases/tag/v7.0.0) so the benchmark isn't testing a "full cold" install anymore.

**How did you fix it?**

Updated the store location.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.