### PR TITLE
fix(cli): correct the cli's dev version to match semver spec

### DIFF
--- a/.yarn/versions/fecc5928.yml
+++ b/.yarn/versions/fecc5928.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-cli/sources/boot-cli-dev.js
+++ b/packages/yarnpkg-cli/sources/boot-cli-dev.js
@@ -9,7 +9,7 @@ if (fs.existsSync(pnpFile))
 require(`@yarnpkg/monorepo/scripts/setup-ts-execution`);
 
 // Exposes the CLI version as like for the bundle
-global.YARN_VERSION = `${require(`@yarnpkg/cli/package.json`).version}.dev`;
+global.YARN_VERSION = `${require(`@yarnpkg/cli/package.json`).version}-dev`;
 
 // Inject the plugins in the runtime. With Webpack that would be through
 // val-loader which would execute pluginConfiguration.raw.js, so in Node


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

[citgm](https://github.com/nodejs/citgm) will check the yarn version during installation step. And yarn cli's dev version is `x.x.x.dev` which can't be recognized by [semver](https://github.com/semver/semver)

So I would like to change it to `x.x.x-dev`

The related PR of [citgm](https://github.com/nodejs/citgm) is https://github.com/nodejs/citgm/pull/905

**How did you fix it?**
<!-- A detailed description of your implementation. -->
change the cli dev version format to `x.x.x-dev`
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
