### PR TITLE
test(fslib): add more tests for `ZipFS`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ package.tgz
 /vscode-case-study
 
 .idea
+
+coverage

--- a/packages/yarnpkg-fslib/tests/ZipFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/ZipFS.test.ts
@@ -847,4 +847,40 @@ describe(`ZipFS`, () => {
 
     zipFs.discardAndClose();
   });
+
+  it(`should throw ENOTDIR when trying to stat a file as a directory`, () => {
+    const zipFs = new ZipFS(null, {libzip: getLibzipSync()});
+
+    zipFs.writeFileSync(`/foo.txt` as PortablePath, ``);
+    expect(() => zipFs.statSync(`/foo.txt/` as PortablePath)).toThrowError(`ENOTDIR`);
+
+    zipFs.symlinkSync(`/foo.txt` as PortablePath, `/bar.txt` as PortablePath);
+    expect(() => zipFs.lstatSync(`/bar.txt/` as PortablePath)).toThrowError(`ENOTDIR`);
+
+    zipFs.discardAndClose();
+  });
+
+  it(`should throw ENOTDIR when trying to create a file when the dirname is a file`, () => {
+    const zipFs = new ZipFS(null, {libzip: getLibzipSync()});
+
+    zipFs.writeFileSync(`/foo.txt` as PortablePath, ``);
+    expect(() => zipFs.writeFileSync(`/foo.txt/bar.txt` as PortablePath, ``)).toThrowError(`ENOTDIR`);
+
+    zipFs.symlinkSync(`/foo.txt` as PortablePath, `/bar.txt` as PortablePath);
+    expect(() => zipFs.writeFileSync(`/bar.txt/baz.txt` as PortablePath, ``)).toThrowError(`ENOTDIR`);
+
+    zipFs.discardAndClose();
+  });
+
+  it(`should throw ENOENT when reading a file that doesn't exist`, () => {
+    const zipFs = new ZipFS(null, {libzip: getLibzipSync()});
+
+    // File doesn't exist
+    expect(() => zipFs.readFileSync(`/foo` as PortablePath, ``)).toThrowError(`ENOENT`);
+
+    // Parent entry doesn't exist
+    expect(() => zipFs.readFileSync(`/foo/bar` as PortablePath, ``)).toThrowError(`ENOENT`);
+
+    zipFs.discardAndClose();
+  });
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

ZipFS could do with some more tests.

**How did you fix it?**

Add some tests to cover `statSync` and `resolveFilename`.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.