### PR TITLE
extensions should support Node.js 12

### DIFF
--- a/.yarn/versions/0a3f31d4.yml
+++ b/.yarn/versions/0a3f31d4.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/cli"

--- a/constraints.pro
+++ b/constraints.pro
@@ -46,7 +46,8 @@ gen_enforced_field(WorkspaceCwd, 'license', 'BSD-2-Clause').
 
 % This rule will enforce that all packages must have an correct engines.node field
 % Keep in sync with the range inside packages/yarnpkg-cli/sources/main.ts
-gen_enforced_field(WorkspaceCwd, 'engines.node', '>=14.15.0').
+gen_enforced_field(WorkspaceCwd, 'engines.node', '>=14.15.0') :-
+  WorkspaceCwd \= 'packages/yarnpkg-extensions'.
 
 % Required to make the package work with the GitHub Package Registry
 gen_enforced_field(WorkspaceCwd, 'repository.type', 'git').

--- a/packages/yarnpkg-extensions/package.json
+++ b/packages/yarnpkg-extensions/package.json
@@ -26,7 +26,7 @@
     "/lib/**/*"
   ],
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=12.22.0"
   },
   "stableVersion": "1.0.0"
 }


### PR DESCRIPTION
We used this package in https://github.com/teambit/bit, which supports Node.js 12. This is just a dictionary, so it should be fine to support Node.js 12.

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
