### PR TITLE
fix(sdks): update for VSCode 1.68

### DIFF
--- a/.yarn/versions/0d403b34.yml
+++ b/.yarn/versions/0d403b34.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -88,13 +88,17 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
               //
               // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
               //
-              // Update 2021-10-08: VSCode changed their format in 1.61.
+              // 2021-10-08: VSCode changed the format in 1.61.
               // Before | ^zip:/c:/foo/bar.zip/package.json
               // After  | ^/zip//c:/foo/bar.zip/package.json
               //
-              // Update 2022-04-06: VSCode changed the format in 1.66.
+              // 2022-04-06: VSCode changed the format in 1.66.
               // Before | ^/zip//c:/foo/bar.zip/package.json
               // After  | ^/zip/c:/foo/bar.zip/package.json
+              //
+              // 2022-05-06: VSCode changed the format in 1.68
+              // Before | ^/zip/c:/foo/bar.zip/package.json
+              // After  | ^/zip//c:/foo/bar.zip/package.json
               //
               case \`vscode <1.61\`: {
                 str = \`^zip:\${str}\`;
@@ -104,8 +108,12 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
                 str = \`^/zip/\${str}\`;
               } break;
 
-              case \`vscode\`: {
+              case \`vscode <1.68\`: {
                 str = \`^/zip\${str}\`;
+              } break;
+
+              case \`vscode\`: {
+                str = \`^/zip/\${str}\`;
               } break;
 
               // To make "go to definition" work,
@@ -154,9 +162,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
           case \`vscode\`:
           default: {
-            return process.platform === \`win32\`
-              ? str.replace(/^\\^?(zip:|\\/zip)\\/+/, \`\`)
-              : str.replace(/^\\^?(zip:|\\/zip)\\/+/, \`/\`);
+            return str.replace(/^\\^?(zip:|\\/zip(\\/ts-nul-authority)?)\\/+/, process.platform === \`win32\` ? \`\` : \`/\`)
           } break;
         }
       }
@@ -196,10 +202,19 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
           ) {
             hostInfo = parsedMessage.arguments.hostInfo;
             if (hostInfo === \`vscode\` && process.env.VSCODE_IPC_HOOK) {
-              if (/(\\/|-)1\\.([1-5][0-9]|60)\\./.test(process.env.VSCODE_IPC_HOOK)) {
-                hostInfo += \` <1.61\`;
-              } else if (/(\\/|-)1\\.(6[1-5])\\./.test(process.env.VSCODE_IPC_HOOK)) {
-                hostInfo += \` <1.66\`;
+              const [, major, minor] = (process.env.VSCODE_IPC_HOOK.match(
+                // The RegExp from https://semver.org/ but without the caret at the start
+                /(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$/
+              ) ?? []).map(Number)
+
+              if (major === 1) {
+                if (minor < 61) {
+                  hostInfo += \` <1.61\`;
+                } else if (minor < 66) {
+                  hostInfo += \` <1.66\`;
+                } else if (minor < 68) {
+                  hostInfo += \` <1.68\`;
+                }
               }
             }
           }


### PR DESCRIPTION
**What's the problem this PR addresses?**

VSCode 1.68 changed the format for in-memory file paths in https://github.com/microsoft/vscode/pull/148940 and https://github.com/microsoft/vscode/pull/149125.

~~VSCode 1.68 isn't released yet so this is only noticeable in VSCode Insiders and since the version detection doesn't work with the Remote Development extensions I'll leave this as a draft until it has been released.~~

**How did you fix it?**

Updated the paths to match the new format.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.