### PR TITLE
chore(extensions): add `tabbable` dependency to `focus-trap-react`

### DIFF
--- a/.yarn/versions/adfd24fc.yml
+++ b/.yarn/versions/adfd24fc.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+  "@yarnpkg/plugin-constraints": patch
+  "@yarnpkg/plugin-dlx": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-init": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-patch": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+  "@yarnpkg/plugin-stage": patch
+  "@yarnpkg/plugin-typescript": patch
+  "@yarnpkg/plugin-version": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/adfd24fc.yml
+++ b/.yarn/versions/adfd24fc.yml
@@ -2,24 +2,23 @@ releases:
   "@yarnpkg/cli": patch
   "@yarnpkg/extensions": patch
   "@yarnpkg/plugin-compat": patch
-  "@yarnpkg/plugin-constraints": patch
-  "@yarnpkg/plugin-dlx": patch
-  "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-init": patch
-  "@yarnpkg/plugin-interactive-tools": patch
-  "@yarnpkg/plugin-nm": patch
-  "@yarnpkg/plugin-npm": patch
-  "@yarnpkg/plugin-npm-cli": patch
-  "@yarnpkg/plugin-pack": patch
-  "@yarnpkg/plugin-patch": patch
-  "@yarnpkg/plugin-pnp": patch
-  "@yarnpkg/plugin-pnpm": patch
-  "@yarnpkg/plugin-stage": patch
-  "@yarnpkg/plugin-typescript": patch
-  "@yarnpkg/plugin-version": patch
-  "@yarnpkg/plugin-workspace-tools": patch
 
 declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -835,4 +835,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       [`eslint`]: `*`,
     },
   }],
+  // https://github.com/focus-trap/focus-trap-react/pull/691
+  [`focus-trap-react@^8.0.0`, {
+    dependencies: {
+      tabbable: `^5.3.2`,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

focus-trap-react directly depends on tabbable, but relies on obtaining it transitively via its dependency on focus-trap. PR to resolve upstream here: https://github.com/focus-trap/focus-trap-react/pull/691

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added a new package extension for focus-trap-react.

~Note: I'm almost certain that I didn't apply the staged version changes correctly. I'm not sure exactly how the yarnpkg/extensions package is used, so I'm not totally sure how upgrading it should affect other packages! Happy to make any changes necessary to the version file.~ Thanks @merceyz!

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
