### PR TITLE
docs: use monospace for fallback font of PT Mono

### DIFF
--- a/packages/gatsby/src/components/markdown.js
+++ b/packages/gatsby/src/components/markdown.js
@@ -162,7 +162,7 @@ const Content = styled.div`
 
     color: #007aa2;
 
-    font-family: "PT Mono";
+    font-family: "PT Mono", monospace;
   }
 
   pre code {

--- a/packages/gatsby/src/components/navigation.js
+++ b/packages/gatsby/src/components/navigation.js
@@ -87,7 +87,7 @@ const MenuEntry = styled(Link)`
 const Tag = styled.code`
   color: #007aa2;
 
-  font-family: "PT Mono";
+  font-family: "PT Mono", monospace;
 
   ${ifDesktop} {
     margin-left: auto;


### PR DESCRIPTION

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

some styles are missing fallback font for PT Mono.

so it would be `serif` if web fonts aren't avilable...

![image](https://user-images.githubusercontent.com/6533808/170418475-bf512800-7ff8-4887-8a9d-8ddd3795f763.png)


**How did you fix it?**
<!-- A detailed description of your implementation. -->

I just add `monospace` as fallback font to some styles that missing fallback font.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
