### PR TITLE
test(pnp): escape path in `NODE_OPTIONS` env variable

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1457,7 +1457,7 @@ describe(`Plug'n'Play`, () => {
       await writeFile(`${path}/foo.js`, `console.log(42);`);
 
       await expect(
-        run(`node`, `-e`, `console.log(21);`, {env: {NODE_OPTIONS: `--require ${npath.fromPortablePath(path)}/foo`}}),
+        run(`node`, `-e`, `console.log(21);`, {env: {NODE_OPTIONS: `--require ${JSON.stringify(npath.join(npath.fromPortablePath(path), `foo`))}`}}),
       ).resolves.toMatchObject({
         // Note that '42' is present twice: the first one because Node executes Yarn, and the second one because Yarn spawns Node
         stdout: `42\n42\n21\n`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

One of the PnP tests fails when the path to the test folder contains whitespace.

Fixes one of the failing tests in https://github.com/nodejs/citgm/pull/905.
> Error: Cannot find module 'C:\Program'
https://ci.nodejs.org/job/citgm-smoker-nobuild/1242/nodes=win10-vs2019/testReport/junit/(root)/citgm/_yarnpkg_cli_v4_0_0_rc_6/


**How did you fix it?**

Use `JSON.stringify` to escape the path.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.