### PR TITLE
fix(plugin-constraints): use proportional prolog limit

### DIFF
--- a/.yarn/versions/c9075f14.yml
+++ b/.yarn/versions/c9075f14.yml
@@ -1,32 +1,34 @@
 releases:
-  "@yarnpkg/builder": patch
   "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
-  "@yarnpkg/doctor": patch
-  "@yarnpkg/extensions": patch
-  "@yarnpkg/nm": patch
-  "@yarnpkg/plugin-compat": patch
   "@yarnpkg/plugin-constraints": patch
-  "@yarnpkg/plugin-dlx": patch
-  "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-exec": patch
-  "@yarnpkg/plugin-file": patch
-  "@yarnpkg/plugin-git": patch
-  "@yarnpkg/plugin-github": patch
-  "@yarnpkg/plugin-http": patch
-  "@yarnpkg/plugin-init": patch
-  "@yarnpkg/plugin-interactive-tools": patch
-  "@yarnpkg/plugin-link": patch
-  "@yarnpkg/plugin-nm": patch
-  "@yarnpkg/plugin-npm": patch
-  "@yarnpkg/plugin-npm-cli": patch
-  "@yarnpkg/plugin-pack": patch
-  "@yarnpkg/plugin-patch": patch
-  "@yarnpkg/plugin-pnp": patch
-  "@yarnpkg/plugin-pnpm": patch
-  "@yarnpkg/plugin-stage": patch
-  "@yarnpkg/plugin-typescript": patch
-  "@yarnpkg/plugin-version": patch
-  "@yarnpkg/plugin-workspace-tools": patch
-  "@yarnpkg/pnpify": patch
-  "@yarnpkg/sdks": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/.yarn/versions/c9075f14.yml
+++ b/.yarn/versions/c9075f14.yml
@@ -1,0 +1,3 @@
+releases:
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-constraints": patch

--- a/.yarn/versions/c9075f14.yml
+++ b/.yarn/versions/c9075f14.yml
@@ -1,3 +1,32 @@
 releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
+  "@yarnpkg/doctor": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-compat": patch
   "@yarnpkg/plugin-constraints": patch
+  "@yarnpkg/plugin-dlx": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-file": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+  "@yarnpkg/plugin-http": patch
+  "@yarnpkg/plugin-init": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-link": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-patch": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+  "@yarnpkg/plugin-stage": patch
+  "@yarnpkg/plugin-typescript": patch
+  "@yarnpkg/plugin-version": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+  "@yarnpkg/pnpify": patch
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -81,6 +81,7 @@ export enum MessageName {
   INCOMPATIBLE_ARCHITECTURE = 76,
   GHOST_ARCHITECTURE = 77,
   RESOLUTION_MISMATCH = 78,
+  PROLOG_LIMIT_EXCEEDED = 79,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The constraints plugin might silently ignore constraints due to an hardcoded Prolog interpreter limit.

Fixes https://github.com/yarnpkg/berry/issues/1260

**How did you fix it?**
<!-- A detailed description of your implementation. -->

* The Prolog limit is now proportional to the number of packages in the workspace
* If the limit is exceeded, an error will be thrown, to avoid silencing actual errors

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
