### PR TITLE
test: add env variable TEST_IGNORE_TIMEOUT_FAILURES to suppress timeo…

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -719,6 +719,19 @@ export const generatePkgDriver = ({
         };
 
         try {
+          // To pass [citgm](https://github.com/nodejs/citgm), we need to suppress timeout failures
+          // So add env variable TEST_IGNORE_TIMEOUT_FAILURES to turn on this suppression
+          if (process.env.TEST_IGNORE_TIMEOUT_FAILURES) {
+            await Promise.race([
+              new Promise(resolve => {
+                // Maybe we should not hard code the timeout here
+                // resolve 1s ahead the jest timeout
+                setTimeout(resolve, 30000 - 1000);
+              }),
+              fn!({path, run, source}),
+            ]);
+            return;
+          }
           await fn!({path, run, source});
         } catch (error) {
           error.message = `Temporary fixture folder: ${npath.fromPortablePath(path)}\n\n${error.message}`;


### PR DESCRIPTION
…ut failures

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
In order to pass [citgm](https://github.com/nodejs/citgm), we need to suppress timeout failures. See the discussion thread https://github.com/nodejs/citgm/pull/905#discussion_r880246064 



**How did you fix it?**
<!-- A detailed description of your implementation. -->
To add env variable `TEST_IGNORE_TIMEOUT_FAILURES` to turn on this kind of suppression

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
