### PR TITLE
docs: Append `yarn-plugin-pin-deps` to Contrib plugins

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -101,4 +101,6 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**yarn-plugin-version-tools**](https://github.com/indooorsman/yarn-plugins#yarn-plugin-version-tools) by [**indooorsman**](https://github.com/indooorsman) - yarn plugin that is almost same with `@yarnpkg/plugin-version` but add a **`--preid`** option for bumping **prerelease** version.
 
+- [**yarn-plugin-pin-deps**](https://github.com/splitgraph/yarn-plugin-pin-deps) by [**Splitgraph**](https://github.com/splitgraph) - Pin dependencies to their currently resolved exact version. This plugin will find any dependencies referenced with a semver identifier, and will update `package.json` to replace that identifier with the exact version of the package currently resolved in the lockfile for that reference.
+
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!


### PR DESCRIPTION
**What's the problem this PR addresses?**
This PR adds a new plugin to the list of "contrib plugins". The plugin is [`yarn-plugin-pin-deps`](https://github.com/splitgraph/yarn-plugin-pin-deps), which adds a command `yarn pin-deps`. This command will find any dependencies referenced with a semver identifier, and will update `package.json` to replace that identifier with the exact version of the package currently resolved in the lockfile for that reference.

We've been using it "in production" for 1+ year and I recently migrated it to support Yarn 3, so I decided to also take the opportunity to package it as a plugin. It's worked well for our purposes, where the original goal was to migrate a mono-repo to use pinned dependencies. By it's nature it isn't something we use often, but we do occasionally use it to pin some dependency we accidentally installed without `-E` a few commits prior (granted, if I didn't have this plugin, I'd just remove the package and install it again - but it does help for migrating many dependencies all at once).

It's possible this plugin is not even necessary, or there is a way to accomplish this dependency pinning with basic yarn commands, but I'm not aware of it (at least, it was certainly not possible when I originally wrote this plugin). It's also possible that is has some oversight in how it pins dependencies that will cause weird bugs, but if so, I have not encountered it yet.

Please do let me know if there is  better-supported way to pin dependencies to their currently resolved versions, so that I can delete the plugin 😄 

**How did you fix it?**
I followed the "open a PR" link and used the wonderful GitHub editor to append a link to the plugin 😄 I hope I did not break any formatting.

**Checklist**
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [X] I have set the packages that need to be released for my changes to be effective.
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
