### PR TITLE
ci: fix the `create-vue` e2e test

### DIFF
--- a/.github/workflows/e2e-create-vue-workflow.yml
+++ b/.github/workflows/e2e-create-vue-workflow.yml
@@ -30,10 +30,6 @@ jobs:
         cd vue-project
         yarn
 
-        # TODO: Remove when the template is updated to use vue-tsc@>=0.30.3
-        # https://github.com/johnsoncodehk/volar/pull/851
-        yarn up vue-tsc
-
         yarn build
         yarn lint
 
@@ -44,10 +40,6 @@ jobs:
         yarn dlx create-vue@2 vue-project --default --typescript
         cd vue-project
         yarn
-
-        # TODO: Remove when the template is updated to use vue-tsc@>=0.30.3
-        # https://github.com/johnsoncodehk/volar/pull/851
-        yarn up vue-tsc
 
         yarn build
       if: |


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `create-vue` e2e test [started failing again](https://github.com/yarnpkg/berry/actions/runs/2493717491).

**How did you fix it?**

Remove the temporary `yarn up vue-tsc` fix since it's no longer needed and is now what is causing the errors.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.