### PR TITLE
fix(plugin-patch): avoid creating rename diffs

### DIFF
--- a/.yarn/versions/737b861b.yml
+++ b/.yarn/versions/737b861b.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -280,7 +280,7 @@ export async function diffFolders(folderA: PortablePath, folderB: PortablePath) 
   const folderAN = npath.fromPortablePath(folderA).replace(/\\/g, `/`);
   const folderBN = npath.fromPortablePath(folderB).replace(/\\/g, `/`);
 
-  const {stdout, stderr} = await execUtils.execvp(`git`, [`-c`, `core.safecrlf=false`, `diff`, `--src-prefix=a/`, `--dst-prefix=b/`, `--ignore-cr-at-eol`, `--full-index`, `--no-index`, `--text`, folderAN, folderBN], {
+  const {stdout, stderr} = await execUtils.execvp(`git`, [`-c`, `core.safecrlf=false`, `diff`, `--src-prefix=a/`, `--dst-prefix=b/`, `--ignore-cr-at-eol`, `--full-index`, `--no-index`, `--no-renames`, `--text`, folderAN, folderBN], {
     cwd: npath.toPortablePath(process.cwd()),
     env: {
       ...process.env,

--- a/packages/plugin-patch/tests/__snapshots__/diffFolders.test.ts.snap
+++ b/packages/plugin-patch/tests/__snapshots__/diffFolders.test.ts.snap
@@ -89,20 +89,80 @@ Array [
 `;
 
 exports[`diffFolders Makes and parses diff for 'rename' 1`] = `
-"diff --git a/foo.txt b/foo-new.txt
-similarity index 100%
-rename from foo.txt
-rename to foo-new.txt
+"diff --git a/foo-new.txt b/foo-new.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..257cc5642cb1a054f08cc83f2d943e56fd3ebe99
+--- /dev/null
++++ b/foo-new.txt
+@@ -0,0 +1 @@
++foo
+diff --git a/foo.txt b/foo.txt
+deleted file mode 100644
+index 257cc5642cb1a054f08cc83f2d943e56fd3ebe99..0000000000000000000000000000000000000000
+--- a/foo.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-foo
 "
 `;
 
 exports[`diffFolders Makes and parses diff for 'rename' 2`] = `
 Array [
   Object {
-    "fromPath": "foo.txt",
+    "hash": "257cc5642cb1a054f08cc83f2d943e56fd3ebe99",
+    "hunk": Object {
+      "header": Object {
+        "original": Object {
+          "length": 0,
+          "start": 1,
+        },
+        "patched": Object {
+          "length": 1,
+          "start": 1,
+        },
+      },
+      "parts": Array [
+        Object {
+          "lines": Array [
+            "foo",
+          ],
+          "noNewlineAtEndOfFile": false,
+          "type": "insertion",
+        },
+      ],
+    },
+    "mode": 420,
+    "path": "foo-new.txt",
     "semverExclusivity": null,
-    "toPath": "foo-new.txt",
-    "type": "rename",
+    "type": "file creation",
+  },
+  Object {
+    "hash": "257cc5642cb1a054f08cc83f2d943e56fd3ebe99",
+    "hunk": Object {
+      "header": Object {
+        "original": Object {
+          "length": 1,
+          "start": 1,
+        },
+        "patched": Object {
+          "length": 0,
+          "start": 1,
+        },
+      },
+      "parts": Array [
+        Object {
+          "lines": Array [
+            "foo",
+          ],
+          "noNewlineAtEndOfFile": false,
+          "type": "deletion",
+        },
+      ],
+    },
+    "mode": 420,
+    "path": "foo.txt",
+    "semverExclusivity": null,
+    "type": "file deletion",
   },
 ]
 `;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
helps to avoid https://github.com/yarnpkg/berry/issues/3341 by generating diffs without renames

**How did you fix it?**
<!-- A detailed description of your implementation. -->
passed [`--no-renames`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---no-renames) option when calling `git diff`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
