### PR TITLE
fix(esbuild-plugin-pnp): respect resolveDir

### DIFF
--- a/.github/workflows/e2e-esbuild-workflow.yml
+++ b/.github/workflows/e2e-esbuild-workflow.yml
@@ -48,3 +48,26 @@ jobs:
 
         yarn ts-node --transpile-only build.js
         [[ "$(node dist/bundle.js)" = "Hello webpack" ]]
+
+        # Make sure we play nicely with esbuild plugins that create virtual modules with resolveDirs
+        echo "require('esbuild').build({bundle: true, format: 'cjs', target: 'node14', entryPoints: ['./src/main.js'], outfile: './dist/bundle.js', plugins: [require('./virtualModulePlugin'), require('@yarnpkg/esbuild-plugin-pnp').pnpPlugin()]})" > build.js
+        cat <<- "EOF" | tee virtualModulePlugin.js
+          const { resolve, dirname } = require('path');
+          module.exports = {
+            name: 'virtualModules',
+            setup(build) {
+              build.onResolve({ filter: /\?virtual$/ }, function({ path, importer }) {
+                const resolveDir = dirname(resolve(dirname(importer), path));
+                return { path, pluginData: { resolveDir }, namespace: 'virtual-module' };
+              });
+              build.onLoad({ filter: /\?virtual$/ }, function({ path, pluginData }) {
+                const specifier = path.replace(/\?virtual/, '');
+                return { resolveDir: pluginData.resolveDir, contents: `export * as virtual from ${JSON.stringify(specifier)}`, loader: 'js' };
+              });
+            }
+          }
+        EOF
+        echo "import {virtual} from './maths.js?virtual'; console.log(virtual.cube(6));" | tee src/main.js
+
+        yarn ts-node --transpile-only build.js
+        [[ "$(node dist/bundle.js)" = "216" ]]

--- a/.yarn/versions/662b766b.yml
+++ b/.yarn/versions/662b766b.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -139,9 +139,11 @@ export function pnpPlugin({
           conditions = conditionsRequire;
 
         // The entry point resolution uses an empty string
-        const effectiveImporter = args.importer
-          ? args.importer
-          : `${baseDir}/`;
+        const effectiveImporter = args.resolveDir
+          ? `${args.resolveDir}/`
+          : args.importer
+            ? args.importer
+            : `${baseDir}/`;
 
         const pnpApi = findPnpApi(effectiveImporter) as PnpApi | null;
         if (!pnpApi)


### PR DESCRIPTION
On-load callbacks can provide a custom `resolveDir` for virtual modules; if set, it should be used for resolving paths in that file. `importer` is only guaranteed to be a file system path if the namespace is `file`.

For context, see: https://esbuild.github.io/plugins/#on-resolve-arguments

**What's the problem this PR addresses?**

If another esbuild plugin creates virtual modules with relative imports, esbuild-plugin-pnp will incorrectly resolve them, since it assumes `importer` (the virtual module) is a real file path, and there are no such guarantees. This bug was observed after [integrating esbuild-plugin-pnp into remix core](https://github.com/remix-run/remix/pull/1316) and attempting to [convert virtual modules to use relative imports](https://github.com/remix-run/remix/pull/2027#issuecomment-1163085791).
 
**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated esbuild-plugin-pnp to use resolveDir (if set):
* For modules in the `file` namespace, this is equivalent to `path.dirname(importer)`, so the behavior there is unchanged
* For plugins that set a resolveDir, esbuild-plugin-pnp will now pick it up and use it <- **this is the fix**
* For plugins that don't set a resolveDir, esbuild-plugin-pnp will still fall back to `importer` and `baseDir`

Also added an end-to-end test to verify the behavior (fails on master, passes with the fix).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
