### PR TITLE
feat(plugin-essentials): support specifying multiple paths in `yarn link`

### DIFF
--- a/.yarn/versions/21659536.yml
+++ b/.yarn/versions/21659536.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -15,8 +15,8 @@ export default class LinkCommand extends BaseCommand {
       This command will set a new \`resolutions\` field in the project-level manifest and point it to the workspace at the specified location (even if part of another project).
     `,
     examples: [[
-      `Register a remote workspace for use in the current project`,
-      `$0 link ~/ts-loader`,
+      `Register one or more remote workspaces for use in the current project`,
+      `$0 link ~/ts-loader ~/jest`,
     ], [
       `Register all workspaces from a remote project for use in the current project`,
       `$0 link ~/jest --all`,
@@ -24,18 +24,18 @@ export default class LinkCommand extends BaseCommand {
   });
 
   all = Option.Boolean(`-A,--all`, false, {
-    description: `Link all workspaces belonging to the target project to the current one`,
+    description: `Link all workspaces belonging to the target projects to the current one`,
   });
 
   private = Option.Boolean(`-p,--private`, false, {
-    description: `Also link private workspaces belonging to the target project to the current one`,
+    description: `Also link private workspaces belonging to the target projects to the current one`,
   });
 
   relative = Option.Boolean(`-r,--relative`, false, {
     description: `Link workspaces using relative paths instead of absolute paths`,
   });
 
-  destination = Option.String();
+  destinations = Option.Rest();
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
@@ -49,36 +49,42 @@ export default class LinkCommand extends BaseCommand {
       restoreResolutions: false,
     });
 
-    const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(this.destination));
-
-    const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
-    const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
-
-    if (project.cwd === project2.cwd)
-      throw new UsageError(`Invalid destination; Can't link the project to itself`);
-
-    if (!workspace2)
-      throw new WorkspaceRequiredError(project2.cwd, absoluteDestination);
-
     const topLevelWorkspace = project.topLevelWorkspace;
     const linkedWorkspaces = [];
 
-    if (this.all) {
-      for (const workspace of project2.workspaces)
-        if (workspace.manifest.name && (!workspace.manifest.private || this.private))
-          linkedWorkspaces.push(workspace);
+    for (const destination of this.destinations) {
+      const absoluteDestination = ppath.resolve(this.context.cwd, npath.toPortablePath(destination));
 
-      if (linkedWorkspaces.length === 0) {
-        throw new UsageError(`No workspace found to be linked in the target project`);
+      const configuration2 = await Configuration.find(absoluteDestination, this.context.plugins, {useRc: false, strict: false});
+      const {project: project2, workspace: workspace2} = await Project.find(configuration2, absoluteDestination);
+
+      if (project.cwd === project2.cwd)
+        throw new UsageError(`Invalid destination '${destination}'; Can't link the project to itself`);
+
+      if (!workspace2)
+        throw new WorkspaceRequiredError(project2.cwd, absoluteDestination);
+
+      if (this.all) {
+        let found = false;
+        for (const workspace of project2.workspaces) {
+          if (workspace.manifest.name && (!workspace.manifest.private || this.private)) {
+            linkedWorkspaces.push(workspace);
+            found = true;
+          }
+        }
+
+        if (!found) {
+          throw new UsageError(`No workspace found to be linked in the target project: ${destination}`);
+        }
+      } else {
+        if (!workspace2.manifest.name)
+          throw new UsageError(`The target workspace at '${destination}' doesn't have a name and thus cannot be linked`);
+
+        if (workspace2.manifest.private && !this.private)
+          throw new UsageError(`The target workspace at '${destination}' is marked private - use the --private flag to link it anyway`);
+
+        linkedWorkspaces.push(workspace2);
       }
-    } else {
-      if (!workspace2.manifest.name)
-        throw new UsageError(`The target workspace doesn't have a name and thus cannot be linked`);
-
-      if (workspace2.manifest.private && !this.private)
-        throw new UsageError(`The target workspace is marked private - use the --private flag to link it anyway`);
-
-      linkedWorkspaces.push(workspace2);
     }
 
     for (const workspace of linkedWorkspaces) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I find myself often linking specific packages from a remote monorepo. I don't want to link _all_ the workspaces so I don't use `--all`. Right now I have to run `yarn link <path-1> && yarn link <path-2>`. I'd like to be able to run `yarn link <path-1> <path-2>`. Similar to `yarn unlink`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

We now iterate over all destinations which I've changed to a rest arg in clipanion.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
