### PR TITLE
feat(core): workspace resolution respects gitignored files/dirs

### DIFF
--- a/packages/yarnpkg-core/sources/Workspace.ts
+++ b/packages/yarnpkg-core/sources/Workspace.ts
@@ -64,6 +64,7 @@ export class Workspace {
     const relativeCwds = await globby(patterns, {
       cwd: npath.fromPortablePath(this.cwd),
       expandDirectories: false,
+      gitignore: true,
       onlyDirectories: true,
       onlyFiles: false,
       ignore: [`**/node_modules`, `**/.git`, `**/.yarn`],


### PR DESCRIPTION
**What's the problem this PR addresses?**

See https://github.com/yarnpkg/berry/issues/4572

**How did you fix it?**

As mentioned in the [issue linked above](https://github.com/yarnpkg/berry/issues/4572), one solution to (albeit non-backward compatible) would be to use pre-existing configuration exposed by the globbing library y'all utilize for workspace resolution.  In particular [globby](https://github.com/sindresorhus/globby) has [config for respecting gitignore](https://github.com/sindresorhus/globby#gitignore). 


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
