### PR TITLE
docs: update Node.js versions in migration guide

### DIFF
--- a/packages/gatsby/content/getting-started/migration.md
+++ b/packages/gatsby/content/getting-started/migration.md
@@ -110,9 +110,9 @@ All of this and more is documented in the following sections. In general, we adv
 
 ## General Advices
 
-### Upgrade to Node.js 12.x or newer
+### Upgrade to Node.js 14.x or newer
 
-Node.js 10.x reached its official End of Life in April 2021 and won't receive any further update. Yarn consequently doesn't support it anymore.
+Node.js 12.x reached its official End of Life in April 2022 and won't receive any further update. Yarn consequently doesn't support it anymore.
 
 ### Fix dependencies with `packageExtensions`
 


### PR DESCRIPTION
Node.js 12.x had also reached its EOL on 30 April 2022

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Node 12.x had also reached its official End Of Life on 30 April 2022 ([reference](https://nodejs.org/en/blog/release/v12.22.12/)) but the docs didn't mention it.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated the migration guide's *General Advices* section accordingly.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
