### PR TITLE
fix(dlx): don't report `UNUSED_PACKAGE_EXTENSION` warnings

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -10635,6 +10635,7 @@ const RAW_RUNTIME_STATE =
           ["@arcanis/slice-ansi", "npm:1.1.1"],\
           ["@rollup/plugin-commonjs", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#npm:21.0.1"],\
           ["@rollup/plugin-node-resolve", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#npm:11.2.1"],\
+          ["@types/comment-json", "npm:1.1.1"],\
           ["@types/cross-spawn", "npm:6.0.0"],\
           ["@types/diff", "npm:5.0.2"],\
           ["@types/lodash", "npm:4.14.172"],\
@@ -10656,6 +10657,7 @@ const RAW_RUNTIME_STATE =
           ["chalk", "npm:3.0.0"],\
           ["ci-info", "npm:3.2.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["comment-json", "npm:2.2.0"],\
           ["cross-spawn", "npm:7.0.3"],\
           ["diff", "npm:5.1.0"],\
           ["esbuild", [\
@@ -13298,14 +13300,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-634b5aefbf/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13320,14 +13320,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-413d1bb7ba/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13342,14 +13340,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-29dac376fa/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13364,14 +13360,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-cc1830b59a/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13386,14 +13380,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-d1ebf311c1/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:261c80968f83905e40b80f5f7b27c9a820efcfd23647733e32b44cd05d9ef12b818071d95555eec63b0ccbdc23a11bcc89146137a7ea2ac0a4c1f4d3c79b18be#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:5fe64685a823dfbb7fb4a2b3276cfc4aa0db65837fed2fdadbcc54cab047059324a7d9490b3913073dcf62fc9a7db324f81bcd6b03e1175843cddeba54bfcd85#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13408,14 +13400,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-97d4ea4b25/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13430,14 +13420,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-bb60ce87e8/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13452,14 +13440,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-7f277acb0d/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:35104c47575f2fe378d8d20383ae667f19d4dd801df8cc4c76848603aa6b4a2234a00142ff12fd557f6f48bd2810880e31c40c767010ea61a31fca302c2cc5e0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13474,14 +13460,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-9d35217da1/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13496,14 +13480,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-e0414135b3/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13518,14 +13500,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-52fff92e05/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13540,14 +13520,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-682df30633/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13562,14 +13540,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-082d4d1ed3/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13584,14 +13560,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-59486ea49a/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13606,14 +13580,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-622c1d58e5/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:b63ad861025672af62aed0e7c80dca4cfce3194ca046161e54fc14c498c39e3b82004ea844489c7a58d2f1a31867f388bf25b8128f5ccce46f35305e1f91e9ab#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13628,14 +13600,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-4af00ad8ad/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:e3ce0ce4b7f0796ca44011528cb9cdc133fc62a76363fea6de68497bae04bdbe5a6dd47e6b9f23c282eb8e4533d75e96cf378c943d07a4e78aae0b715f06a450#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13650,14 +13620,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-8748bb0aa3/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:86c95fabbcd56c56f5f2d2e080e64a1095e3fe233877aa9f7958f317f88a95627e0be2765e89c0cff02c9f08f27b64b7cbc9d5c3960c1df509d5e6ea98cca4f4#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13672,14 +13640,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-6d07f9c983/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13694,14 +13660,12 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@yarnpkg-plugin-init-virtual-8ab3e1714c/1/packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "packagePeers": [\
@@ -13716,12 +13680,10 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/plugin-init/",\
         "packageDependencies": [\
           ["@yarnpkg/plugin-init", "workspace:packages/plugin-init"],\
-          ["@types/lodash", "npm:4.14.172"],\
           ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
-          ["lodash", "npm:4.17.21"],\
           ["tslib", "npm:1.13.0"]\
         ],\
         "linkType": "SOFT"\

--- a/.yarn/versions/0be235bd.yml
+++ b/.yarn/versions/0be235bd.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-dlx": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/0be235bd.yml
+++ b/.yarn/versions/0be235bd.yml
@@ -1,14 +1,23 @@
 releases:
   "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
   "@yarnpkg/plugin-dlx": patch
+  "@yarnpkg/plugin-init": patch
+  "@yarnpkg/sdks": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-essentials"
-  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
   - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
   - "@yarnpkg/plugin-npm-cli"
   - "@yarnpkg/plugin-pack"
   - "@yarnpkg/plugin-patch"
@@ -19,5 +28,7 @@ declined:
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
   - "@yarnpkg/builder"
-  - "@yarnpkg/core"
   - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The following changes only affect people writing Yarn plugins:
 - The patched filesystem now supports `ftruncate`.
 - Updates the PnP compatibility layer for TypeScript 4.8 Beta
 
+### Bugfixes
+
+- `yarn dlx` will no longer report false-positive `UNUSED_PACKAGE_EXTENSION` warnings
+
 ## 3.2.1
 
 ### Installs

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -1,8 +1,8 @@
-import {BaseCommand, WorkspaceRequiredError}                       from '@yarnpkg/cli';
-import {Configuration, MessageName, Project, stringifyMessageName} from '@yarnpkg/core';
-import {scriptUtils, structUtils, formatUtils}                     from '@yarnpkg/core';
-import {NativePath, Filename, ppath, xfs, npath}                   from '@yarnpkg/fslib';
-import {Command, Option, Usage}                                    from 'clipanion';
+import {BaseCommand, WorkspaceRequiredError}                                  from '@yarnpkg/cli';
+import {Configuration, MessageName, miscUtils, Project, stringifyMessageName} from '@yarnpkg/core';
+import {scriptUtils, structUtils, formatUtils}                                from '@yarnpkg/core';
+import {NativePath, Filename, ppath, xfs, npath}                              from '@yarnpkg/fslib';
+import {Command, Option, Usage}                                               from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class DlxCommand extends BaseCommand {
@@ -59,6 +59,18 @@ export default class DlxCommand extends BaseCommand {
       // running something like `yarn dlx sb init`
       const enableGlobalCache = !(await Configuration.find(this.context.cwd, null, {strict: false})).get(`enableGlobalCache`);
 
+      const dlxConfiguration = {
+        enableGlobalCache,
+        enableTelemetry: false,
+        logFilters: [
+          // Don't warn if package extensions are unused in dlx projects
+          {
+            code: stringifyMessageName(MessageName.UNUSED_PACKAGE_EXTENSION),
+            level: formatUtils.LogLevel.Discard,
+          },
+        ],
+      };
+
       const sourceYarnrc = projectCwd !== null
         ? ppath.join(projectCwd, `.yarnrc.yml` as Filename)
         : null;
@@ -67,19 +79,7 @@ export default class DlxCommand extends BaseCommand {
         await xfs.copyFilePromise(sourceYarnrc, targetYarnrc);
 
         await Configuration.updateConfiguration(tmpDir, current => {
-          const nextConfiguration: {[key: string]: unknown} = {
-            ...current,
-            enableGlobalCache,
-            enableTelemetry: false,
-            logFilters: [
-              ...(current.logFilters ?? []) as Array<unknown>,
-              // Don't warn if package extensions are unused in dlx projects
-              {
-                code: stringifyMessageName(MessageName.UNUSED_PACKAGE_EXTENSION),
-                level: formatUtils.LogLevel.Discard,
-              },
-            ],
-          };
+          const nextConfiguration = miscUtils.toMerged(current, dlxConfiguration);
 
           if (Array.isArray(current.plugins)) {
             nextConfiguration.plugins = current.plugins.map((plugin: any) => {
@@ -102,7 +102,7 @@ export default class DlxCommand extends BaseCommand {
           return nextConfiguration;
         });
       } else {
-        await xfs.writeFilePromise(targetYarnrc, `enableGlobalCache: ${enableGlobalCache}\nenableTelemetry: false\n`);
+        await xfs.writeJsonPromise(targetYarnrc, dlxConfiguration);
       }
 
       const pkgs = this.packages ?? [this.command];

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -1,8 +1,8 @@
-import {BaseCommand, WorkspaceRequiredError}     from '@yarnpkg/cli';
-import {Configuration, Project}                  from '@yarnpkg/core';
-import {scriptUtils, structUtils}                from '@yarnpkg/core';
-import {NativePath, Filename, ppath, xfs, npath} from '@yarnpkg/fslib';
-import {Command, Option, Usage}                  from 'clipanion';
+import {BaseCommand, WorkspaceRequiredError}                       from '@yarnpkg/cli';
+import {Configuration, MessageName, Project, stringifyMessageName} from '@yarnpkg/core';
+import {scriptUtils, structUtils, formatUtils}                     from '@yarnpkg/core';
+import {NativePath, Filename, ppath, xfs, npath}                   from '@yarnpkg/fslib';
+import {Command, Option, Usage}                                    from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class DlxCommand extends BaseCommand {
@@ -71,6 +71,14 @@ export default class DlxCommand extends BaseCommand {
             ...current,
             enableGlobalCache,
             enableTelemetry: false,
+            logFilters: [
+              ...(current.logFilters ?? []) as Array<unknown>,
+              // Don't warn if package extensions are unused in dlx projects
+              {
+                code: stringifyMessageName(MessageName.UNUSED_PACKAGE_EXTENSION),
+                level: formatUtils.LogLevel.Discard,
+              },
+            ],
           };
 
           if (Array.isArray(current.plugins)) {

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
-    "lodash": "^4.17.15",
     "tslib": "^1.13.0"
   },
   "peerDependencies": {
@@ -14,7 +13,6 @@
     "@yarnpkg/core": "workspace:^"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.136",
     "@yarnpkg/cli": "workspace:^",
     "@yarnpkg/core": "workspace:^"
   },

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -3,7 +3,6 @@ import {Configuration, Manifest, miscUtils, Project, YarnVersion} from '@yarnpkg
 import {execUtils, scriptUtils, structUtils}                      from '@yarnpkg/core';
 import {xfs, ppath, Filename}                                     from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                       from 'clipanion';
-import merge                                                      from 'lodash/merge';
 import {inspect}                                                  from 'util';
 
 // eslint-disable-next-line arca/no-default-export
@@ -207,7 +206,7 @@ export default class InitCommand extends BaseCommand {
         },
       };
 
-      merge(editorConfigProperties, configuration.get(`initEditorConfig`));
+      miscUtils.mergeIntoTarget(editorConfigProperties, configuration.get(`initEditorConfig`));
 
       let editorConfigBody = `root = true\n`;
       for (const [selector, props] of Object.entries(editorConfigProperties)) {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^11.0.1",
+    "@types/comment-json": "^1.1.1",
     "@types/cross-spawn": "6.0.0",
     "@types/diff": "^5.0.0",
     "@types/lodash": "^4.14.136",
@@ -45,6 +46,7 @@
     "@yarnpkg/plugin-link": "workspace:^",
     "@yarnpkg/plugin-npm": "workspace:^",
     "@yarnpkg/plugin-pnp": "workspace:^",
+    "comment-json": "^2.2.0",
     "esbuild": "npm:esbuild-wasm@^0.11.20",
     "rollup": "^2.59.0",
     "rollup-plugin-esbuild": "^3.0.2",

--- a/packages/yarnpkg-core/tests/miscUtils.test.ts
+++ b/packages/yarnpkg-core/tests/miscUtils.test.ts
@@ -1,3 +1,5 @@
+import CJSON          from 'comment-json';
+
 import * as miscUtils from '../sources/miscUtils';
 
 describe(`miscUtils`, () => {
@@ -54,6 +56,101 @@ describe(`miscUtils`, () => {
       `~`,
     ])(`should return false for %s`, pathLike => {
       expect(miscUtils.isPathLike(pathLike)).toBe(false);
+    });
+  });
+
+  describe(`toMerged`, () => {
+    it(`should merge 2 shallow objects without mutating any arguments`, () => {
+      const a = {a: 1};
+      const b = {b: 2};
+      const c = miscUtils.toMerged(a, b);
+
+      expect(a).toStrictEqual({a: 1});
+      expect(b).toStrictEqual({b: 2});
+      expect(c).toStrictEqual({a: 1, b: 2});
+    });
+
+    it(`should merge 2 deep objects without mutating any arguments`, () => {
+      const a = {n: {a: 1}};
+      const b = {n: {b: 2}};
+      const c = miscUtils.toMerged(a, b);
+
+      expect(a).toStrictEqual({n: {a: 1}});
+      expect(b).toStrictEqual({n: {b: 2}});
+      expect(c).toStrictEqual({n: {a: 1, b: 2}});
+    });
+
+    it(`should merge 2 arrays by concatenating their contents without mutating any arguments`, () => {
+      const a = [1, 2, 3];
+      const b = [4, 5, 6];
+      const c = miscUtils.toMerged(a, b);
+
+      expect(a).toStrictEqual([1, 2, 3]);
+      expect(b).toStrictEqual([4, 5, 6]);
+      expect(c).toStrictEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it(`should merge 2 objects of arrays by concatenating their contents without mutating any arguments`, () => {
+      const a = {n: [1, 2, 3]};
+      const b = {n: [4, 5, 6]};
+      const c = miscUtils.toMerged(a, b);
+
+      expect(a).toStrictEqual({n: [1, 2, 3]});
+      expect(b).toStrictEqual({n: [4, 5, 6]});
+      expect(c).toStrictEqual({n: [1, 2, 3, 4, 5, 6]});
+    });
+
+    it(`should merge identical elements in arrays (primitives)`, () => {
+      const a = {n: [1, 2, 3, 4]};
+      const b = {n: [4, 5, 6]};
+      const c = miscUtils.toMerged(a, b);
+
+      expect(c).toStrictEqual({n: [1, 2, 3, 4, 5, 6]});
+    });
+
+    it(`should merge identical elements in arrays (objects)`, () => {
+      const a = {n: [{a: 1}, {b: 2}]};
+      const b = {n: [{b: 2}, {c: 3}]};
+      const c = miscUtils.toMerged(a, b);
+
+      expect(c).toStrictEqual({n: [{a: 1}, {b: 2}, {c: 3}]});
+    });
+  });
+
+  describe(`mergeIntoTarget`, () => {
+    it(`should preserve comments when the target is an object created by comment-json`, () => {
+      const a = CJSON.parse(`{
+        // n
+        "n":
+        // array
+        [
+          // 1
+          1,
+          // 2
+          2,
+          // 3
+          3
+        ]
+      }`);
+      const b = {n: [4, 5, 6]};
+      const c = miscUtils.mergeIntoTarget(a, b);
+
+      expect(CJSON.stringify(c, null, 2)).toStrictEqual(CJSON.stringify(CJSON.parse(`{
+        // n
+        "n":
+        // array
+        [
+          // 1
+          1,
+          // 2
+          2,
+          // 3
+          3,
+          4,
+          5,
+          6
+        ]
+      }`), null, 2));
     });
   });
 });

--- a/packages/yarnpkg-sdks/sources/sdkUtils.ts
+++ b/packages/yarnpkg-sdks/sources/sdkUtils.ts
@@ -1,23 +1,7 @@
+import {miscUtils}                       from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
 import {PnpApi}                          from '@yarnpkg/pnp';
 import CJSON                             from 'comment-json';
-import mergeWith                         from 'lodash/mergeWith';
-
-export const merge = (cjsonData: unknown, patch: unknown) =>
-  mergeWith(cjsonData, patch, (cjsonValue: unknown, patchValue: unknown) => {
-    // We need to preserve comments in CommentArrays, so we can't use spread or Sets
-    if (Array.isArray(cjsonValue) && Array.isArray(patchValue)) {
-      for (const patchItem of patchValue) {
-        if (!cjsonValue.includes(patchItem)) {
-          cjsonValue.push(patchItem);
-        }
-      }
-
-      return cjsonValue;
-    }
-
-    return undefined;
-  });
 
 export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeFileName: PortablePath, patch: any) => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
@@ -30,7 +14,7 @@ export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeF
     : `{}`;
 
   const data = CJSON.parse(content);
-  const patched = `${CJSON.stringify(merge(data, patch), null, 2)}\n`;
+  const patched = `${CJSON.stringify(miscUtils.mergeIntoTarget(data, patch), null, 2)}\n`;
 
   await xfs.mkdirPromise(ppath.dirname(filePath), {recursive: true});
   await xfs.changeFilePromise(filePath, patched, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5491,6 +5491,7 @@ __metadata:
     "@arcanis/slice-ansi": "npm:^1.1.1"
     "@rollup/plugin-commonjs": "npm:^21.0.1"
     "@rollup/plugin-node-resolve": "npm:^11.0.1"
+    "@types/comment-json": "npm:^1.1.1"
     "@types/cross-spawn": "npm:6.0.0"
     "@types/diff": "npm:^5.0.0"
     "@types/lodash": "npm:^4.14.136"
@@ -5512,6 +5513,7 @@ __metadata:
     chalk: "npm:^3.0.0"
     ci-info: "npm:^3.2.0"
     clipanion: "npm:^3.2.0-rc.10"
+    comment-json: "npm:^2.2.0"
     cross-spawn: "npm:7.0.3"
     diff: "npm:^5.1.0"
     esbuild: "npm:esbuild-wasm@^0.11.20"
@@ -5963,12 +5965,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@yarnpkg/plugin-init@workspace:packages/plugin-init"
   dependencies:
-    "@types/lodash": "npm:^4.14.136"
     "@yarnpkg/cli": "workspace:^"
     "@yarnpkg/core": "workspace:^"
     "@yarnpkg/fslib": "workspace:^"
     clipanion: "npm:^3.2.0-rc.10"
-    lodash: "npm:^4.17.15"
     tslib: "npm:^1.13.0"
   peerDependencies:
     "@yarnpkg/cli": "workspace:^"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn dlx` reports `UNUSED_PACKAGE_EXTENSION` warnings when an extension is unused in the temporary project created by dlx, even if it is used in the actual project the command is run in.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made `dlx` filter out all `UNUSED_PACKAGE_EXTENSION` warnings via `logFilters` since they should only be about the main project.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
