### PR TITLE
Implements content addressing inside copyPromise

### DIFF
--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -115,6 +115,7 @@ class PnpmInstaller implements Installer {
 
   async installPackageHard(pkg: Package, fetchResult: FetchResult, api: InstallPackageExtraApi) {
     const pkgPath = getPackageLocation(pkg, {project: this.opts.project});
+    const indexPath = ppath.join(this.opts.project.configuration.get(`globalFolder`), `index` as Filename);
 
     this.customData.locatorByPath.set(pkgPath, structUtils.stringifyLocator(pkg));
     this.customData.pathByLocator.set(pkg.locatorHash, pkgPath);
@@ -126,7 +127,12 @@ class PnpmInstaller implements Installer {
       // that we can then create symbolic links to it later.
       await xfs.copyPromise(pkgPath, fetchResult.prefixPath, {
         baseFs: fetchResult.packageFs,
-        overwrite: false,
+        overwrite: true,
+        linkStrategy: {
+          type: `HardlinkFromIndex`,
+          indexPath,
+          autoRepair: true,
+        },
       });
     }));
 

--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -3,8 +3,8 @@ import * as statUtils from './statUtils';
 
 export {constants};
 
-export {LinkStrategy} from './algorithms/copyPromise';
-export {opendir}      from './algorithms/opendir';
+export type {LinkStrategy} from './algorithms/copyPromise';
+export {opendir}           from './algorithms/opendir';
 
 export {statUtils};
 


### PR DESCRIPTION
This PR is connected to #4533

**What's the problem this PR addresses?**

We want to support content-addressable cache when running installs. The implementation in #4533 is a great start, but implements this support inside a `copyPromise` function unique to the nm linker - subsequently importing it into the pnpm linker so that the two share the same code.

While avoiding code duplication is a good thing generally speaking, I strongly feel like we should leverage tools from the core (improving them if needed) rather than implement special-cases that we then reuse in multiple places. It doesn't give us as much freedom to implement behaviours tailored to specific use cases, but this cost is imo offset by the easier maintenance now that we have a clearly delimited core to rely on.

Note that this only covers the pnpm linker - the nm linker is a little special in that @larixer has definitely more experience there so I trust him to implement and maintain his own versions of our tools if really needed.

**How did you fix it?**

The main difference compared to #4533 is that I check whether the index is busted by just checking its mtime, rather than computing its checksum.

I have two further optimizations in mind, although they'll have to be implemented separately:

- I'm thinking we could use the Zip extra fields to precompute sha512 checksums for all files inside zip archives; this might then speedup the `checksumFilePromise` calls, which wouldn't need to fetch the file contents anymore.

- The copyFile implementation currently does a `write(dest, read(src))` instead of a `clone(dest, src)`. We should allow FakeFS implementation to know whether they are compatible for fast cloning (at minima by keeping track of whether the deepest underlying `baseFs` is `xfs`).

Performance-wise, using the Yarn repository as test subject, on my fairly slow machine:

```
Install pnpm w/ cold index    2m 39s
Install pnpm w/ hot index     52s
Install pnpm w/o index        40s
```

The `lockPromise` is probably where a lot of perfs are lost - I may try to replace it with `renamePromise` instead (I initially used `lockPromise` because I'd like to preserve the inode when repairing a modified file, so that the fix affects all packages on the machine).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
