### PR TITLE
refactor(libui)!: require `renderForm` streams to be specified

### DIFF
--- a/.yarn/versions/27f02004.yml
+++ b/.yarn/versions/27f02004.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/libui": major
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The following changes only affect people writing Yarn plugins:
 
 - The `getCustomDataKey` function in `Installer` from `@yarnpkg/core` has been moved to `Linker`.
 
+- `renderForm`'s `options` argument is now required to enforce that custom streams are always specified.
+
 ### Compatibility
 
 - The patched filesystem now supports `ftruncate`.

--- a/packages/yarnpkg-libui/sources/misc/renderForm.tsx
+++ b/packages/yarnpkg-libui/sources/misc/renderForm.tsx
@@ -9,14 +9,13 @@ type InferProps<T extends React.ComponentType> = T extends React.ComponentType<i
 
 export type SubmitInjectedComponent<T, C extends React.ComponentType = React.ComponentType> = React.ComponentType<InferProps<C> & { useSubmit: (value: T) => void }>;
 
-// TODO: make the streams required in the next major so that people don't forget to pass them
 export type RenderFormOptions = {
-  stdin?: Readable;
-  stdout?: Writable;
-  stderr?: Writable;
+  stdin: Readable;
+  stdout: Writable;
+  stderr: Writable;
 };
 
-export async function renderForm<T, C extends React.ComponentType = React.ComponentType>(UserComponent: SubmitInjectedComponent<T, C>, props: InferProps<C>, {stdin, stdout, stderr}: RenderFormOptions = {}) {
+export async function renderForm<T, C extends React.ComponentType = React.ComponentType>(UserComponent: SubmitInjectedComponent<T, C>, props: InferProps<C>, {stdin, stdout, stderr}: RenderFormOptions) {
   let returnedValue: T | undefined;
 
   const useSubmit = (value: T) => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

4.x TODO item: make `renderForm`'s streams required so that people don't forget to specify custom streams. This is consistent with what we do in other parts of the codebase that accept streams.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made the `options` argument required.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
