### PR TITLE
Adds tests accidentally removed in #4305

### DIFF
--- a/packages/yarnpkg-core/tests/Configuration.test.ts
+++ b/packages/yarnpkg-core/tests/Configuration.test.ts
@@ -1,7 +1,7 @@
-import {xfs, PortablePath}     from '@yarnpkg/fslib';
-import NpmPlugin               from '@yarnpkg/plugin-npm';
+import {xfs, PortablePath}                 from '@yarnpkg/fslib';
+import NpmPlugin                           from '@yarnpkg/plugin-npm';
 
-import {Configuration, SECRET} from '../sources/Configuration';
+import {Configuration, SECRET, TAG_REGEXP} from '../sources/Configuration';
 
 async function initializeConfiguration<T>(value: {[key: string]: any}, cb: (dir: PortablePath) => Promise<T>) {
   return await xfs.mktempPromise(async dir => {
@@ -10,6 +10,20 @@ async function initializeConfiguration<T>(value: {[key: string]: any}, cb: (dir:
     return await cb(dir);
   });
 }
+
+describe(`TAG_REGEXP`, () => {
+  const validTags = [
+    `canary`,
+    `latest`,
+    `next`,
+    `legacy_v1`,
+  ];
+
+  it(`should allow all valid tags`, () => {
+    const badTags = validTags.filter(tag => !TAG_REGEXP.test(tag));
+    expect(badTags.length).toBe(0);
+  });
+});
 
 describe(`Configuration`, () => {
   it(`should hide secrets`, async () => {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I accidentally removed tests in #4305:
https://github.com/yarnpkg/berry/pull/4305/files#diff-4d98124b51058e4b1b729f3792a00957ad367e76324658eb510d2eedc5e7a406

**How did you fix it?**

Add them back

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
