### PR TITLE
feat(foreach)!: automatically enable `--verbose` in tty environments

### DIFF
--- a/.yarn/versions/63ea7bc1.yml
+++ b/.yarn/versions/63ea7bc1.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-workspace-tools": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
   - Plugins cannot access the internal copy of Yup anymore (use [Typanion](https://github.com/arcanis/typanion) instead)
 - The network settings configuration option has been renamed from `caFilePath` to `httpsCaFilePath`.
 - Set `nmMode` to `hardlinks-local` by default.
-- `yarn workspaces foreach` now automatically enables the `-v,--verbose` in interactive terminal environments.
+- `yarn workspaces foreach` now automatically enables the `-v,--verbose` flag in interactive terminal environments.
 
 ### **API Changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
   - Plugins cannot access the internal copy of Yup anymore (use [Typanion](https://github.com/arcanis/typanion) instead)
 - The network settings configuration option has been renamed from `caFilePath` to `httpsCaFilePath`.
 - Set `nmMode` to `hardlinks-local` by default.
+- `yarn workspaces foreach` now automatically enables the `-v,--verbose` in interactive terminal environments.
 
 ### **API Changes**
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

One of the 4.x items in #3591: automatically enabling the `-v,--verbose` flag of `yarn workspaces foreach` inside TTY environments.

The reasoning behind this is the fact that it's a lot more useful to see what output comes from which workspace, and it's consistent with what we do in `@yarnpkg/shell` with background jobs (only enabling verbose output and prefixes in TTYs).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Added an `isTTY` check.

I've also tried to add tests for it, but I can't trick `child_process` / `cross-spawn` / `execUtils` into making the process think it's running inside a TTY.

Because of this, the only alternative I see is using `node-pty` and processing the output, which is something I wouldn't wish on my worst enemy, so no tests for now.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
