### PR TITLE
fix(esbuild-plugin-pnp): return `resolveDir` from `onLoad`

### DIFF
--- a/.yarn/versions/d54e2225.yml
+++ b/.yarn/versions/d54e2225.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/esbuild-plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/.yarn/versions/d54e2225.yml
+++ b/.yarn/versions/d54e2225.yml
@@ -1,13 +1,5 @@
 releases:
-  "@yarnpkg/builder": patch
   "@yarnpkg/esbuild-plugin-pnp": patch
 
 declined:
-  - "@yarnpkg/plugin-constraints"
-  - "@yarnpkg/plugin-exec"
-  - "@yarnpkg/plugin-interactive-tools"
-  - "@yarnpkg/plugin-stage"
-  - "@yarnpkg/plugin-typescript"
-  - "@yarnpkg/plugin-version"
-  - "@yarnpkg/plugin-workspace-tools"
-  - "@yarnpkg/cli"
+  - "@yarnpkg/builder"

--- a/packages/esbuild-plugin-pnp/sources/index.ts
+++ b/packages/esbuild-plugin-pnp/sources/index.ts
@@ -1,6 +1,7 @@
 import {PnpApi}                                                                             from '@yarnpkg/pnp';
 import type {OnLoadArgs, OnLoadResult, OnResolveArgs, OnResolveResult, Plugin, PluginBuild} from 'esbuild';
 import * as fs                                                                              from 'fs';
+import path                                                                                 from 'path';
 
 const matchAll = /()/;
 const defaultExtensions = [`.tsx`, `.ts`, `.jsx`, `.mjs`, `.cjs`, `.js`, `.css`, `.json`];
@@ -54,6 +55,12 @@ async function defaultOnLoad(args: OnLoadArgs): Promise<OnLoadResult> {
   return {
     contents: await fs.promises.readFile(args.path),
     loader: `default`,
+    // For regular imports in the `file` namespace, resolveDir is the directory the
+    // file being resolved lives in. For all other virtual modules, this defaults to
+    // empty string: ""
+    // A sensible value for pnp imports is the same as the `file` namespace, as pnp
+    // still resolves to files on disk (in the cache).
+    resolveDir: path.dirname(args.path),
   };
 }
 


### PR DESCRIPTION
A fix in the same area as #4569, for the `esbuild-plugin-pnp`, regarding the `resolveDir` property

**What's the problem this PR addresses?**
Many plugins use the `resolveDir` argument in the `onResolve` callback (e.g. to find the absolute path of an imported relative module like in the [Remix compiler](https://github.com/remix-run/remix/blob/main/packages/remix-dev/compiler/plugins/emptyModulesPlugin.ts#L18)

Currently, plugins that rely on modules loaded with yarn pnp, get an empty `resolveDir` passed to the `onResolve` callback.

It would make sense to, when loading modules with pnp, default the `resolveDir` to the directory of the current module/file being loaded, as it also lives on disk. This brings us closer in behaviour to the default `file` namespaced modules too.

**How did you fix it?**
In the default `onLoad` callback in the esbuild plugin, we can return the directory the file (`args.path`) being loaded lives in.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
