### PR TITLE
ci: remove workaround for Angular PnP e2e test

### DIFF
--- a/.github/workflows/e2e-pnp-angular-workflow.yml
+++ b/.github/workflows/e2e-pnp-angular-workflow.yml
@@ -31,7 +31,4 @@ jobs:
 
         cd berry-angular
 
-        # TODO: Remove when https://github.com/angular/angular-cli/issues/16980#issuecomment-1006028280 is fixed
-        mkdir node_modules
-
         yarn ng build --aot


### PR DESCRIPTION
**What's the problem this PR addresses?**

The bug has been fixed upstream in https://github.com/angular/angular-cli/pull/23487 and https://github.com/ng-packagr/ng-packagr/pull/2367 so we can remove the workaround.

**How did you fix it?**

Removed it.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.