### PR TITLE
ci: test on node 18 instead of 17

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -196,7 +196,7 @@ jobs:
         include:
           - node: 16
             platform: ubuntu-latest
-          - node: 17
+          - node: 18
             platform: ubuntu-latest
 
     name: '${{matrix.platform}} w/ Node.js ${{matrix.node}}.x'


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node.js 18 has been released so we should test on it instead of Node.js 17

**How did you fix it?**

Updated the matrix.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.