### PR TITLE
docs: clarify the zero-installs requirements

### DIFF
--- a/packages/gatsby/content/features/zero-installs.md
+++ b/packages/gatsby/content/features/zero-installs.md
@@ -25,7 +25,9 @@ Note that these challenges are not unique to Yarn — you may remember a time wh
 
 In order to make a project zero-install, you must be able to use it as soon as you clone it. This is very easy starting from Yarn 2!
 
-- First, ensure that your project is using [Plug'n'Play](/features/pnp) to resolve dependencies via the cache folder and **not** from `node_modules`.
+- First, check that you are using Yarn 2 or later using `yarn --version`. You can change the version with [`yarn set version <version>`](/cli/set/version/)
+
+- Next, ensure that your project is using [Plug'n'Play](/features/pnp) to resolve dependencies via the cache folder and **not** from `node_modules`.
 
   - While in theory you could check-in your `node_modules` folder rather than the cache, in practice the `node_modules` contains a gigantic amount of files that frequently change location and mess with Git's optimizations. By contrast, the Yarn cache contains exactly one file per package, that only change when the packages themselves change.
 


### PR DESCRIPTION
Clarifies zero-installs version requirement in the first step of the documentation; change proposed due to others' frustrations.

**What's the problem this PR addresses?**

Some people, not naming Chris specifically, don't notice the mention of a version requirement in the opening sentence of the configuration instructions. This is quite common when people aren't familiar with a tool and can lead to excessive frustration, which should be minimised at all costs.

**How did you fix it?**

This commit makes the version requirement - and what to do if it isn't satisfied - very clear by adding it as the first step. Now one truly has to be blind to miss it.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
