### PR TITLE
chore(extensions): update list

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -27571,10 +27571,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3a3d727f294f75b7feef250cc863e2040b0c32120003a73c5a6ace12d01ff3d1dcfea351627bb317e9da46e90e2aada89fe027c9b34ec3e716fbe7f141770d4d#npm:4.1.6", {\
-        "packageLocation": "./.yarn/__virtual__/fork-ts-checker-webpack-plugin-virtual-911904ec98/0/cache/fork-ts-checker-webpack-plugin-npm-4.1.6-eab9dd8e44-9c239c593e.zip/node_modules/fork-ts-checker-webpack-plugin/",\
+      ["virtual:e9e12fad675116854a6aadcf0948af2306aea3bb9c008c272059efc32053fba84b6d56a36fdbda4a0fd3b8ab3c62326ddbee4d308c97a159d922d1f587f40b8b#npm:4.1.6", {\
+        "packageLocation": "./.yarn/__virtual__/fork-ts-checker-webpack-plugin-virtual-12f0b7bab8/0/cache/fork-ts-checker-webpack-plugin-npm-4.1.6-eab9dd8e44-9c239c593e.zip/node_modules/fork-ts-checker-webpack-plugin/",\
         "packageDependencies": [\
-          ["fork-ts-checker-webpack-plugin", "virtual:3a3d727f294f75b7feef250cc863e2040b0c32120003a73c5a6ace12d01ff3d1dcfea351627bb317e9da46e90e2aada89fe027c9b34ec3e716fbe7f141770d4d#npm:4.1.6"],\
+          ["fork-ts-checker-webpack-plugin", "virtual:e9e12fad675116854a6aadcf0948af2306aea3bb9c008c272059efc32053fba84b6d56a36fdbda4a0fd3b8ab3c62326ddbee4d308c97a159d922d1f587f40b8b#npm:4.1.6"],\
           ["@babel/code-frame", "npm:7.16.7"],\
           ["@types/eslint", null],\
           ["@types/typescript", null],\
@@ -27588,7 +27588,7 @@ const RAW_RUNTIME_STATE =
           ["tapable", "npm:1.1.3"],\
           ["typescript", null],\
           ["vue-template-compiler", null],\
-          ["webpack", null],\
+          ["webpack", "virtual:7243a2f0702f8452df413d5239831a2fe8f28104187d0cf79c049c7b9ba6c33bb036028e40e6b6352789084ab1637ba736da1e5086fe18a644f8aa27e1ca758a#npm:5.38.1"],\
           ["worker-rpc", "npm:0.1.1"]\
         ],\
         "packagePeers": [\
@@ -27991,7 +27991,7 @@ const RAW_RUNTIME_STATE =
           ["query-string", "npm:6.14.1"],\
           ["raw-loader", "virtual:7243a2f0702f8452df413d5239831a2fe8f28104187d0cf79c049c7b9ba6c33bb036028e40e6b6352789084ab1637ba736da1e5086fe18a644f8aa27e1ca758a#npm:4.0.2"],\
           ["react", "npm:16.13.1"],\
-          ["react-dev-utils", "npm:11.0.4"],\
+          ["react-dev-utils", "virtual:7243a2f0702f8452df413d5239831a2fe8f28104187d0cf79c049c7b9ba6c33bb036028e40e6b6352789084ab1637ba736da1e5086fe18a644f8aa27e1ca758a#npm:11.0.4"],\
           ["react-dom", "virtual:118b26a6cee620b5aa3e7e8d8b8e34cd9e486f75b92701001168da9be550fadd8c9d9b12643c642e2d528c2624fd8fe7e128eec9d715340efac44400432a0e0c#npm:16.13.1"],\
           ["react-refresh", "npm:0.9.0"],\
           ["redux", "npm:4.0.5"],\
@@ -38705,8 +38705,17 @@ const RAW_RUNTIME_STATE =
       ["npm:11.0.4", {\
         "packageLocation": "./.yarn/cache/react-dev-utils-npm-11.0.4-3a3d727f29-1fd0d10186.zip/node_modules/react-dev-utils/",\
         "packageDependencies": [\
-          ["react-dev-utils", "npm:11.0.4"],\
+          ["react-dev-utils", "npm:11.0.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:7243a2f0702f8452df413d5239831a2fe8f28104187d0cf79c049c7b9ba6c33bb036028e40e6b6352789084ab1637ba736da1e5086fe18a644f8aa27e1ca758a#npm:11.0.4", {\
+        "packageLocation": "./.yarn/__virtual__/react-dev-utils-virtual-e9e12fad67/0/cache/react-dev-utils-npm-11.0.4-3a3d727f29-1fd0d10186.zip/node_modules/react-dev-utils/",\
+        "packageDependencies": [\
+          ["react-dev-utils", "virtual:7243a2f0702f8452df413d5239831a2fe8f28104187d0cf79c049c7b9ba6c33bb036028e40e6b6352789084ab1637ba736da1e5086fe18a644f8aa27e1ca758a#npm:11.0.4"],\
           ["@babel/code-frame", "npm:7.10.4"],\
+          ["@types/typescript", null],\
+          ["@types/webpack", null],\
           ["address", "npm:1.1.2"],\
           ["browserslist", "npm:4.14.2"],\
           ["chalk", "npm:2.4.2"],\
@@ -38715,7 +38724,7 @@ const RAW_RUNTIME_STATE =
           ["escape-string-regexp", "npm:2.0.0"],\
           ["filesize", "npm:6.1.0"],\
           ["find-up", "npm:4.1.0"],\
-          ["fork-ts-checker-webpack-plugin", "virtual:3a3d727f294f75b7feef250cc863e2040b0c32120003a73c5a6ace12d01ff3d1dcfea351627bb317e9da46e90e2aada89fe027c9b34ec3e716fbe7f141770d4d#npm:4.1.6"],\
+          ["fork-ts-checker-webpack-plugin", "virtual:e9e12fad675116854a6aadcf0948af2306aea3bb9c008c272059efc32053fba84b6d56a36fdbda4a0fd3b8ab3c62326ddbee4d308c97a159d922d1f587f40b8b#npm:4.1.6"],\
           ["global-modules", "npm:2.0.0"],\
           ["globby", "npm:11.0.1"],\
           ["gzip-size", "npm:5.1.1"],\
@@ -38729,7 +38738,15 @@ const RAW_RUNTIME_STATE =
           ["recursive-readdir", "npm:2.2.2"],\
           ["shell-quote", "npm:1.7.2"],\
           ["strip-ansi", "npm:6.0.0"],\
-          ["text-table", "npm:0.2.0"]\
+          ["text-table", "npm:0.2.0"],\
+          ["typescript", null],\
+          ["webpack", "virtual:7243a2f0702f8452df413d5239831a2fe8f28104187d0cf79c049c7b9ba6c33bb036028e40e6b6352789084ab1637ba736da1e5086fe18a644f8aa27e1ca758a#npm:5.38.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/typescript",\
+          "@types/webpack",\
+          "typescript",\
+          "webpack"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -43616,6 +43633,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/unified-npm-8.4.2-27bc3af638-075cd5a339.zip/node_modules/unified/",\
         "packageDependencies": [\
           ["unified", "npm:8.4.2"],\
+          ["@types/unist", "npm:2.0.3"],\
           ["bail", "npm:1.0.3"],\
           ["extend", "npm:3.0.2"],\
           ["is-plain-obj", "npm:2.0.0"],\
@@ -43628,6 +43646,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/unified-npm-9.2.0-2edf64a14a-177ecc5987.zip/node_modules/unified/",\
         "packageDependencies": [\
           ["unified", "npm:9.2.0"],\
+          ["@types/unist", "npm:2.0.3"],\
           ["bail", "npm:1.0.3"],\
           ["extend", "npm:3.0.2"],\
           ["is-buffer", "npm:2.0.3"],\
@@ -43641,6 +43660,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/unified-npm-9.2.1-1e228147c2-cf0bd9cd02.zip/node_modules/unified/",\
         "packageDependencies": [\
           ["unified", "npm:9.2.1"],\
+          ["@types/unist", "npm:2.0.3"],\
           ["bail", "npm:1.0.3"],\
           ["extend", "npm:3.0.2"],\
           ["is-buffer", "npm:2.0.3"],\

--- a/.yarn/versions/c03bc2db.yml
+++ b/.yarn/versions/c03bc2db.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -878,4 +878,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       '@types/unist': `^2.0.0`,
     },
   }],
+  // https://github.com/ntkme/react-github-btn/pull/23
+  [`react-github-btn@<=1.3.0`, {
+    peerDependencies: {
+      react: `>=16.3.0`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -872,4 +872,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       vue: `^2`,
     },
   }],
+  // https://github.com/unifiedjs/unified/pull/146
+  [`unified@<10`, {
+    dependencies: {
+      '@types/unist': `^2.0.0`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -854,4 +854,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'react-dom': `>=16.3.0`,
     },
   }],
+  // https://github.com/jdesboeufs/connect-mongo/pull/458
+  [`connect-mongo@*`, {
+    peerDependencies: {
+      'express-session': `^1.17.1`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -336,6 +336,12 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'null-loader': `^3.0.0`,
     },
   }],
+  // https://github.com/vuetifyjs/vue-cli-plugins/pull/324
+  [`vue-cli-plugin-vuetify@>=2.4.3`, {
+    peerDependencies: {
+      vue: `*`,
+    },
+  }],
   // https://github.com/vuetifyjs/vue-cli-plugins/pull/155
   [`@vuetify/cli-plugin-utils@<=0.0.4`, {
     dependencies: {

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -841,4 +841,11 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       tabbable: `^5.3.2`,
     },
   }],
+  // https://github.com/bokuweb/react-rnd/pull/864
+  [`react-rnd@<10.3.7`, {
+    peerDependencies: {
+      react: `>=16.3.0`,
+      'react-dom': `>=16.3.0`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -898,4 +898,11 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       },
     },
   }],
+  // https://github.com/asyncapi/asyncapi-react/pull/614
+  [`@asyncapi/react-component@<=1.0.0-next.39`, {
+    peerDependencies: {
+      react: `>=16.8.0`,
+      'react-dom': `>=16.8.0`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -860,4 +860,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       'express-session': `^1.17.1`,
     },
   }],
+  // https://github.com/intlify/vue-i18n-next/commit/ed932b9e575807dc27c30573b280ad8ae48e98c9
+  [`vue-i18n@<9`, {
+    peerDependencies: {
+      vue: `^2`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -781,7 +781,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/vuejs/eslint-config-typescript/pull/39
-  [`@vue/eslint-config-typescript@*`, {
+  [`@vue/eslint-config-typescript@<11.0.0`, {
     peerDependenciesMeta: {
       typescript: optionalPeerDep,
     },

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -866,4 +866,10 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       vue: `^2`,
     },
   }],
+  // https://github.com/vuejs/router/commit/c2305083a8fcb42d1bb1f3f0d92f09930124b530
+  [`vue-router@<4`, {
+    peerDependencies: {
+      vue: `^2`,
+    },
+  }],
 ];

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -884,4 +884,18 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       react: `>=16.3.0`,
     },
   }],
+  // There are two candidates upstream, clean this up when either is merged.
+  // - https://github.com/facebook/create-react-app/pull/11526
+  // - https://github.com/facebook/create-react-app/pull/11716
+  [`react-dev-utils@*`, {
+    peerDependencies: {
+      typescript: `>=2.7`,
+      webpack: `>=4`,
+    },
+    peerDependenciesMeta: {
+      typescript: {
+        optional: true,
+      },
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Updates the extensions list to include
- https://github.com/bokuweb/react-rnd/pull/864
- https://github.com/vuetifyjs/vue-cli-plugins/pull/324
- https://github.com/jdesboeufs/connect-mongo/pull/458
- https://github.com/intlify/vue-i18n-next/commit/ed932b9e575807dc27c30573b280ad8ae48e98c9
- https://github.com/vuejs/router/commit/c2305083a8fcb42d1bb1f3f0d92f09930124b530
- https://github.com/unifiedjs/unified/pull/146
- https://github.com/ntkme/react-github-btn/pull/23
- https://github.com/facebook/create-react-app/pull/11716 / https://github.com/facebook/create-react-app/pull/11526
- https://github.com/asyncapi/asyncapi-react/pull/614

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.