### PR TITLE
fix(pnp): automatically unplug `open` and `opn`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -35804,7 +35804,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["open", [\
       ["npm:7.4.2", {\
-        "packageLocation": "./.yarn/cache/open-npm-7.4.2-a378c23959-b3619842c6.zip/node_modules/open/",\
+        "packageLocation": "./.yarn/unplugged/open-npm-7.4.2-a378c23959/node_modules/open/",\
         "packageDependencies": [\
           ["open", "npm:7.4.2"],\
           ["is-docker", "npm:2.2.1"],\

--- a/.yarn/versions/655b7b5f.yml
+++ b/.yarn/versions/655b7b5f.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -17,6 +17,9 @@ const FORCED_UNPLUG_PACKAGES = new Set([
   structUtils.makeIdent(null, `node-addon-api`).identHash,
   // Those ones contain native builds (*.node), and Node loads them through dlopen
   structUtils.makeIdent(null, `fsevents`).identHash,
+  // Contains native binaries
+  structUtils.makeIdent(null, `open`).identHash,
+  structUtils.makeIdent(null, `opn`).identHash,
 ]);
 
 export class PnpLinker implements Linker {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The package `open` doesn't work with PnP without users manually unplugging it.

Closes https://github.com/yarnpkg/berry/issues/856

**How did you fix it?**

Add `open` and `opn` to `FORCED_UNPLUG_PACKAGES`.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.