### PR TITLE
fix(audit)!: remove fallback to publish registries

### DIFF
--- a/.yarn/versions/9bb15e03.yml
+++ b/.yarn/versions/9bb15e03.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-npm": major
+  "@yarnpkg/plugin-npm-cli": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
 - The network settings configuration option has been renamed from `caFilePath` to `httpsCaFilePath`.
 - Set `nmMode` to `hardlinks-local` by default.
 - `yarn workspaces foreach` now automatically enables the `-v,--verbose` flag in interactive terminal environments.
+- `yarn npm audit` no longer takes into account publish registries. Use [`npmAuditRegistry`](https://yarnpkg.com/configuration/yarnrc#npmAuditRegistry) instead.
 
 ### **API Changes**
 
@@ -37,6 +38,8 @@ The following changes only affect people writing Yarn plugins:
 - The `getCustomDataKey` function in `Installer` from `@yarnpkg/core` has been moved to `Linker`.
 
 - `renderForm`'s `options` argument is now required to enforce that custom streams are always specified.
+
+- `npmConfigUtils.getAuditRegistry` no longer takes a `Manifest` as its first argument.
 
 ### Installs
 

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -142,9 +142,7 @@ export default class AuditCommand extends BaseCommand {
       dependencies,
     };
 
-    const registry = npmConfigUtils.getAuditRegistry(workspace.manifest, {
-      configuration,
-    });
+    const registry = npmConfigUtils.getAuditRegistry({configuration});
 
     let result!: npmAuditTypes.AuditResponse;
     const httpReport = await LightReport.start({

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -15,13 +15,8 @@ export function normalizeRegistry(registry: string) {
   return registry.replace(/\/$/, ``);
 }
 
-// TODO: Remove the fallback on publishConfig
-export function getAuditRegistry(manifest: Manifest, {configuration}: {configuration: Configuration}) {
-  const defaultRegistry = configuration.get(RegistryType.AUDIT_REGISTRY);
-  if (defaultRegistry !== null)
-    return normalizeRegistry(defaultRegistry);
-
-  return getPublishRegistry(manifest, {configuration});
+export function getAuditRegistry({configuration}: {configuration: Configuration}) {
+  return getDefaultRegistry({configuration, type: RegistryType.AUDIT_REGISTRY});
 }
 
 export function getPublishRegistry(manifest: Manifest, {configuration}: {configuration: Configuration}) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

4.x TODO item: removing the fallback to the publish registries inside `yarn npm audit`.

See https://github.com/yarnpkg/berry/pull/3583#discussion_r730413780 for the original discussion.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed the fallback and removed the `manifest` parameter of `npmConfigUtils.getAuditRegistry` since it isn't needed (consistent with `npmConfigUtils.getDefaultRegistry`).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
