### PR TITLE
ci: run tests in parallel

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -218,7 +218,7 @@ jobs:
 
     - name: 'Run the integration tests'
       run: |
-        node ./scripts/run-yarn.js test:integration --runInBand
+        node ./scripts/run-yarn.js test:integration --maxWorkers=100%
       shell: bash
 
     - name: 'Run the unit tests'


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Running the integration tests on CI takes forever.

Now with https://github.com/nodejs/corepack/pull/84 fixed, there shouldn't be any issues that this could trigger.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Changed `--runInBand` to `--maxWorkers=100%` to speed it up.

According to the [GitHub Actions docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources):
- Windows and Linux runners have a 2C/2T CPU
- macOS runners have a 3C/3T CPU

I'll post a time comparison after the tests finish.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
