### PR TITLE
test: don't hardcode timeout interval

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -636,7 +636,7 @@ export type RunFunction = (
     run: Run;
     source: Source;
   }
-) => void;
+) => Promise<void>;
 
 export const generatePkgDriver = ({
   getName,
@@ -721,12 +721,12 @@ export const generatePkgDriver = ({
         try {
           // To pass [citgm](https://github.com/nodejs/citgm), we need to suppress timeout failures
           // So add env variable TEST_IGNORE_TIMEOUT_FAILURES to turn on this suppression
+          // TODO: investigate whether this is still needed.
           if (process.env.TEST_IGNORE_TIMEOUT_FAILURES) {
             await Promise.race([
               new Promise(resolve => {
-                // Maybe we should not hard code the timeout here
-                // resolve 1s ahead the jest timeout
-                setTimeout(resolve, 30000 - 1000);
+                // Resolve 1s ahead of the jest timeout
+                setTimeout(resolve, jasmine.DEFAULT_TIMEOUT_INTERVAL - 1000);
               }),
               fn!({path, run, source}),
             ]);


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

https://github.com/yarnpkg/berry/pull/4543 hardcoded the timeout interval, but it has already gotten out of sync due to https://github.com/yarnpkg/berry/pull/3669.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use `jasmine.DEFAULT_TIMEOUT_INTERVAL`.

I also added a `TODO` so that we don't forget to recheck whether this is still needed. (I have a feeling that the big-endian PR might've fixed all timeout issues).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
