### PR TITLE
refactor!: remove deprecated versionUtils

### DIFF
--- a/.yarn/versions/2c936507.yml
+++ b/.yarn/versions/2c936507.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-version": major
+
+declined:
+  - "@yarnpkg/cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The following changes only affect people writing Yarn plugins:
 
 - `npmConfigUtils.getAuditRegistry` no longer takes a `Manifest` as its first argument.
 
-- `versionUtils.{fetchBase,fetchRoot,fetchChangedFiles}` have been removed. Use `gitUtils.{fetchBase,fetchRoot,fetchChangedFiles}` instead.
+- `versionUtils.{fetchBase,fetchRoot,fetchChangedFiles}` have been moved from `@yarnpkg/plugin-version` to `@yarnpkg/plugin-git`. Use `gitUtils.{fetchBase,fetchRoot,fetchChangedFiles}` instead.
 
 ### Installs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The following changes only affect people writing Yarn plugins:
 
 - `npmConfigUtils.getAuditRegistry` no longer takes a `Manifest` as its first argument.
 
+- `versionUtils.{fetchBase,fetchRoot,fetchChangedFiles}` have been removed. Use `gitUtils.{fetchBase,fetchRoot,fetchChangedFiles}` instead.
+
 ### Installs
 
 - The `pnpm` linker avoids creating symlinks that lead to loops on the file system, by moving them higher up in the directory structure.

--- a/packages/plugin-version/sources/versionUtils.ts
+++ b/packages/plugin-version/sources/versionUtils.ts
@@ -6,21 +6,6 @@ import {UsageError}                                                             
 import omit                                                                                                                                  from 'lodash/omit';
 import semver                                                                                                                                from 'semver';
 
-/**
- * @deprecated Use `gitUtils.fetchBase` instead
- */
-export const fetchBase = gitUtils.fetchBase;
-
-/**
- * @deprecated Use `gitUtils.fetchRoot` instead
- */
-export const fetchRoot = gitUtils.fetchRoot;
-
-/**
- * @deprecated Use `gitUtils.fetchChangedFiles` instead
- */
-export const fetchChangedFiles = gitUtils.fetchChangedFiles;
-
 // Basically we only support auto-upgrading the ranges that are very simple (^x.y.z, ~x.y.z, >=x.y.z, and of course x.y.z)
 const SUPPORTED_UPGRADE_REGEXP = /^(>=|[~^]|)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR removes the deprecated `versionUtils.{fetchBase,fetchRoot,fetchChangedFiles}` that have been moved to `gitUtils`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed them.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
