### PR TITLE
fix(shell): wait for stdio streams of process to close

### DIFF
--- a/.yarn/versions/17a3b8fe.yml
+++ b/.yarn/versions/17a3b8fe.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-shell/sources/pipe.ts
+++ b/packages/yarnpkg-shell/sources/pipe.ts
@@ -100,7 +100,7 @@ export function makeProcess(name: string, args: Array<string>, opts: ShellOption
           }
         });
 
-        child.on(`exit`, code => {
+        child.on(`close`, code => {
           activeChildren.delete(child);
 
           if (activeChildren.size === 0) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@yarnpkg/shell` uses the `exit` event to know when a process finishes executing but the `exit` event can be called before the `stdio` streams are flushed which causes a race condition where it sometimes wont get the `stdout` value.

Fixes https://github.com/yarnpkg/berry/issues/3220

**How did you fix it?**

Switch from the `exit` event to the `close` event which is called after the `stdio` streams are closed.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.