### PR TITLE
docs: use explicit version instead of `next` tag for `typedoc`

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -84,7 +84,7 @@
     "remark-parse": "^6.0.3",
     "tinycolor2": "^1.4.1",
     "tslib": "^2.4.0",
-    "typedoc": "next",
+    "typedoc": "0.17.0-3",
     "typedoc-neo-theme": "^1.0.7",
     "typedoc-plugin-yarn": "portal:./typedoc-plugin-yarn",
     "typescript": "4.8.0-beta",

--- a/packages/gatsby/typedoc-plugin-yarn/package.json
+++ b/packages/gatsby/typedoc-plugin-yarn/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "typedoc": "next",
+    "typedoc": "0.17.0-3",
     "typescript": "^3.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,7 +5708,7 @@ __metadata:
     remark-parse: "npm:^6.0.3"
     tinycolor2: "npm:^1.4.1"
     tslib: "npm:^2.4.0"
-    typedoc: "npm:next"
+    typedoc: "npm:0.17.0-3"
     typedoc-neo-theme: "npm:^1.0.7"
     typedoc-plugin-yarn: "portal:./typedoc-plugin-yarn"
     typescript: "npm:4.8.0-beta"
@@ -25524,7 +25524,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "typedoc-plugin-yarn@portal:./typedoc-plugin-yarn::locator=%40yarnpkg%2Fgatsby%40workspace%3Apackages%2Fgatsby"
   dependencies:
-    typedoc: "npm:next"
+    typedoc: "npm:0.17.0-3"
     typescript: "npm:^3.8.3"
   languageName: node
   linkType: soft
@@ -25550,7 +25550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:next":
+"typedoc@npm:0.17.0-3":
   version: 0.17.0-3
   resolution: "typedoc@npm:0.17.0-3"
   dependencies:


### PR DESCRIPTION
**What's the problem this PR addresses?**

We're depending on `typedoc@next` but that tag doesn't exist anymore.

**How did you fix it?**

Use an explicit version.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.