### PR TITLE
feat: added home check and --skip-home-check to set version

### DIFF
--- a/.yarn/versions/28038744.yml
+++ b/.yarn/versions/28038744.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"


### PR DESCRIPTION
**What's the problem this PR addresses?**
Users should be blocked from accidentally running `yarn set version` from the home directory (`~`). This adds an error to that case unless a new `--skip-home-check` is specified.

Resolves #4426.

**How did you fix it?**
Checks `this.context.cwd` against [`homedir()`](https://nodejs.org/api/os.html#oshomedir) at the beginning of the `execute()` method.

I'm not confident I answered correctly on the version updates. 🤷 

**Testing**: I couldn't find any unit tests for `version.ts`, and it seems risky to run acceptance tests in the user's home directory. Is there a testing strategy this PR should go with? Help please?

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

Co-authored-by: @nikstern <nik@codecademy.com>
