### PR TITLE
fix(core): support migrating resolutions from JFrog Artifactory registries regardless of the domain

### DIFF
--- a/.yarn/versions/032af3c1.yml
+++ b/.yarn/versions/032af3c1.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/.yarn/versions/032af3c1.yml
+++ b/.yarn/versions/032af3c1.yml
@@ -1,12 +1,12 @@
 releases:
   "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
-  "@yarnpkg/plugin-essentials": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
   - "@yarnpkg/plugin-exec"
   - "@yarnpkg/plugin-file"
   - "@yarnpkg/plugin-git"

--- a/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
+++ b/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
@@ -24,8 +24,8 @@ export const IMPORTED_PATTERNS: Array<[RegExp, (version: string, ...args: Array<
   [/^https:\/\/npm\.pkg\.github\.com\/download\/(?:@[^/]+)\/(?:[^/]+)\/(?:[^/]+)\/(?:[0-9a-f]+)(?:#|$)/, version => `npm:${version}`],
   // FontAwesome too; what is it with these registries that made them think using a different url pattern was a good idea?
   [/^https:\/\/npm\.fontawesome\.com\/(?:@[^/]+)\/([^/]+)\/-\/([^/]+)\/\1-\2.tgz(?:#|$)/, version => `npm:${version}`],
-  // JFrog
-  [/^https?:\/\/(?:[^\\.]+)\.jfrog\.io\/.*\/(@[^/]+)\/([^/]+)\/-\/\1\/\2-(?:[.\d\w-]+)\.tgz(?:#|$)/, (version, $0) => structUtils.makeRange({protocol: `npm:`, source: null, selector: version, params: {__archiveUrl: $0}})],
+  // JFrog, or Artifactory deployments at arbitrary domain names
+  [/^https?:\/\/[^/]+\/.*\/(@[^/]+)\/([^/]+)\/-\/\1\/\2-(?:[.\d\w-]+)\.tgz(?:#|$)/, (version, $0) => structUtils.makeRange({protocol: `npm:`, source: null, selector: version, params: {__archiveUrl: $0}})],
 
   // These ones come from the old Yarn offline mirror - we assume they came from npm
   [/^[^/]+\.tgz#[0-9a-f]+$/, version => `npm:${version}`],

--- a/packages/yarnpkg-core/tests/LegacyMigrationResolver.test.ts
+++ b/packages/yarnpkg-core/tests/LegacyMigrationResolver.test.ts
@@ -20,6 +20,12 @@ describe(`LegacyMigrationResolver`, () => {
       resolved: `https://company.jfrog.io/company/api/npm/registry-name/@scope/package-name/-/@scope/package-name-1.0.0.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34`,
       expected: `npm:1.0.0::__archiveUrl=https%3A%2F%2Fcompany.jfrog.io%2Fcompany%2Fapi%2Fnpm%2Fregistry-name%2F%40scope%2Fpackage-name%2F-%2F%40scope%2Fpackage-name-1.0.0.tgz%23`,
     },
+    // TODO issue url
+    {
+      version: `1.0.0`,
+      resolved: `https://packages.example.com/artifactory/api/npm/registry-name/@scope/package-name/-/@scope/package-name-1.0.0.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34`,
+      expected: `npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.example.com%2Fartifactory%2Fapi%2Fnpm%2Fregistry-name%2F%40scope%2Fpackage-name%2F-%2F%40scope%2Fpackage-name-1.0.0.tgz%23`,
+    },
     // https://github.com/yarnpkg/berry/issues/902#issuecomment-732360991
     {
       version: `0.1.9`,

--- a/packages/yarnpkg-core/tests/LegacyMigrationResolver.test.ts
+++ b/packages/yarnpkg-core/tests/LegacyMigrationResolver.test.ts
@@ -20,7 +20,7 @@ describe(`LegacyMigrationResolver`, () => {
       resolved: `https://company.jfrog.io/company/api/npm/registry-name/@scope/package-name/-/@scope/package-name-1.0.0.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34`,
       expected: `npm:1.0.0::__archiveUrl=https%3A%2F%2Fcompany.jfrog.io%2Fcompany%2Fapi%2Fnpm%2Fregistry-name%2F%40scope%2Fpackage-name%2F-%2F%40scope%2Fpackage-name-1.0.0.tgz%23`,
     },
-    // TODO issue url
+    // https://github.com/yarnpkg/berry/pull/4702
     {
       version: `1.0.0`,
       resolved: `https://packages.example.com/artifactory/api/npm/registry-name/@scope/package-name/-/@scope/package-name-1.0.0.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

It's common for companies to host their packages at an Artifactory deployment on their own domain, like `packages.mycompany.com`. This has the same URL pattern as any other JFrog repository, but on a non-JFrog domain.

Currently, migrating a Yarn v1 project that uses such packages fails due to the package URLs in the lockfile not being recognized, blocking easy migration at my company.

Example URL:
```
https://packages.example.com/artifactory/api/npm/npm/@convoy/code-style/-/@convoy/code-style-19.0.0.tgz#b89d83150ba80ec03dffb6c025ceeb00a2443697
```

We currently work around this with `sed -i 's|/-/@convoy/|/-/|' yarn.lock` to essentially fake the standard URL format right before migration.

...

**How did you fix it?**

Update the regex for the JFrog URL format to allow arbitrary domain names.

Updated the relevant test case with such a URL.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

(I _think_ I set this correctly, reviewers please verify. I'm not 100% sure if any other packages need to be released vs declined)

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
