### PR TITLE
docs: add missing commas on configuration pages

### DIFF
--- a/packages/gatsby/src/components/json.tsx
+++ b/packages/gatsby/src/components/json.tsx
@@ -35,6 +35,8 @@ const theme: Theme = {
     return JSON.stringify(value);
   },
 
+  delimiter: `,`,
+
   keys: {
     suffix: `: `,
   },
@@ -42,14 +44,12 @@ const theme: Theme = {
   dictionaries: {
     leading: `{`,
     trailing: `}`,
-    suffix: `,`,
   },
 
   arrays: {
     leading: `[`,
     trailing: `]`,
     prefix: ``,
-    suffix: `,`,
   },
 };
 

--- a/packages/gatsby/src/components/syml.tsx
+++ b/packages/gatsby/src/components/syml.tsx
@@ -35,6 +35,8 @@ const theme: Theme = {
     return JSON.stringify(value);
   },
 
+  delimiter: ``,
+
   keys: {
     suffix: `: `,
   },
@@ -42,14 +44,12 @@ const theme: Theme = {
   dictionaries: {
     leading: ``,
     trailing: ``,
-    suffix: ``,
   },
 
   arrays: {
     leading: ``,
     trailing: ``,
     prefix: `-\u00a0`,
-    suffix: ``,
   },
 };
 

--- a/packages/gatsby/src/components/syntax.tsx
+++ b/packages/gatsby/src/components/syntax.tsx
@@ -22,6 +22,8 @@ export type Theme = {
   formatKey: (value: unknown) => string;
   formatValue: (value: unknown) => string;
 
+  delimiter: string;
+
   keys: {
     suffix: string;
   };
@@ -29,14 +31,12 @@ export type Theme = {
   dictionaries: {
     leading: string;
     trailing: string;
-    suffix: string;
   };
 
   arrays: {
     leading: string;
     trailing: string;
     prefix: string;
-    suffix: string;
   };
 };
 
@@ -108,7 +108,7 @@ const marginContainer = css`
     margin-bottom: -1.5em;
   }
 
-  &[data-dictionaries-suffix=""] > :last-child {
+  &[data-dictionaries-delimiter=""] > :last-child {
     margin-bottom: -2.5em;
   }
 `;
@@ -226,49 +226,45 @@ const Key = ({theme, name, anchorTarget}: KeyProps) => <>
   {theme.keys.suffix}
 </>;
 
-export type ArrayProps = KeyProps & {
-  suffix?: string;
-};
+export type ArrayProps = KeyProps;
 
-export const Array = ({theme, name, suffix, anchorTarget, children}: PropsWithChildren<ArrayProps>) => <div>
+export const Array = ({theme, name, anchorTarget, children}: PropsWithChildren<ArrayProps>) => <div>
   <div>{name && <><Key theme={theme} name={name} anchorTarget={anchorTarget} /></>}{theme.arrays.leading}</div>
   <div style={{position: `relative`, paddingLeft: `2em`, top: !(children as any).every((child: any) => child.type.BaseComponent === Scalar) ? `2em` : ``}}>
     {React.Children.map(children, (child, index) =>
       <div key={index} style={{display: `flex`}}>
         <div>{theme.arrays.prefix}</div>
         <div style={{width: `100%`}}>
-          {React.cloneElement(child as JSX.Element, {suffix: theme.arrays.suffix})}
+          {child}
         </div>
       </div>,
     )}
   </div>
-  <div>{theme.arrays.trailing}{suffix}</div>
+  <div>{theme.arrays.trailing}{theme.delimiter}</div>
 </div>;
 
 export type DictionaryProps = KeyProps & {
-  suffix?: string;
   margin: boolean;
 };
 
-export const Dictionary = ({theme, name, suffix, anchorTarget, children, margin}: PropsWithChildren<DictionaryProps>) => <div>
+export const Dictionary = ({theme, name, anchorTarget, children, margin}: PropsWithChildren<DictionaryProps>) => <div>
   <div>{name && <><Key theme={theme} name={name} anchorTarget={anchorTarget} /></>}{theme.dictionaries.leading}</div>
-  <div style={{paddingLeft: `2em`}} css={margin ? marginContainer : null} data-dictionaries-suffix={theme.dictionaries.suffix}>
+  <div style={{paddingLeft: `2em`}} css={margin ? marginContainer : null} data-dictionaries-delimiter={theme.delimiter}>
     {React.Children.map(children, (child, index) =>
       <React.Fragment key={index}>
-        {React.cloneElement(child as JSX.Element, {suffix: theme.dictionaries.suffix})}
+        {child}
       </React.Fragment>,
     )}
   </div>
-  <div>{theme.dictionaries.trailing}{suffix}</div>
+  <div>{theme.dictionaries.trailing}{theme.delimiter}</div>
 </div>;
 
 export type ScalarProps = KeyProps & {
-  suffix?: string;
   placeholder: unknown;
 };
 
-export const Scalar = ({theme, suffix, placeholder}: ScalarProps) => <div>
-  <span style={{color: getColorForScalar(theme, placeholder) ?? undefined}}>{theme.formatValue(placeholder)}</span>{suffix}
+export const Scalar = ({theme, placeholder}: ScalarProps) => <div>
+  <span style={{color: getColorForScalar(theme, placeholder) ?? undefined}}>{theme.formatValue(placeholder)}</span>{theme.delimiter}
 </div>;
 
 export type DictionaryPropertyProps = DescribeProps & DictionaryProps;
@@ -296,7 +292,7 @@ export type ScalarPropertyProps = DescribeProps & ScalarProps;
 export const ScalarProperty = ({theme, name, anchor = name, placeholder, description}: ScalarPropertyProps) => <>
   <Describe theme={theme} name={name} description={description} anchor={description ? anchor : null}>
     <div style={{marginRight: `-2vw`}}>
-      <Key theme={theme} name={name} anchorTarget={description ? anchor : null} /><span style={{color: getColorForScalar(theme, placeholder) ?? undefined}}>{theme.formatValue(placeholder)}</span>{theme.dictionaries.suffix}
+      <Key theme={theme} name={name} anchorTarget={description ? anchor : null} /><span style={{color: getColorForScalar(theme, placeholder) ?? undefined}}>{theme.formatValue(placeholder)}</span>{theme.delimiter}
     </div>
   </Describe>
 </>;


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

There are missing commas after array brackets and object braces on the manifest configuration page.

![image](https://user-images.githubusercontent.com/32596136/182932659-98db5b27-fcd3-4f62-9986-fb57e3d076d9.png)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Got rid of the `dictionaries.suffix` and `array.suffix` distinction since they're always the same for the formats we care about, which allows us to always use `theme.delimiter` and stop worrying about passing the `suffix` prop.

Technically there are also trailing commas to worry about, but I don't think they're important enough to be worth the extra complexity. Even if we decided in the future to stop displaying them, it would still make a lot more sense to use a different boolean toggle prop for it instead of keeping `suffix` as a prop.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
