### PR TITLE
feat: improve `yarn explain peer-requirements` output

### DIFF
--- a/.yarn/versions/29323e8e.yml
+++ b/.yarn/versions/29323e8e.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The following changes only affect people writing Yarn plugins:
 
 - `versionUtils.{fetchBase,fetchRoot,fetchChangedFiles}` have been moved from `@yarnpkg/plugin-version` to `@yarnpkg/plugin-git`. Use `gitUtils.{fetchBase,fetchRoot,fetchChangedFiles}` instead.
 
+### Commands
+
+- `yarn explain peer-requirements` now uses the same output format as `yarn explain`, resulting in no more useless `YN0000` line prefixes.
+
 ### Installs
 
 - The `pnpm` linker avoids creating symlinks that lead to loops on the file system, by moving them higher up in the directory structure.

--- a/packages/plugin-essentials/sources/commands/explain.ts
+++ b/packages/plugin-essentials/sources/commands/explain.ts
@@ -98,19 +98,17 @@ export default class ExplainCommand extends BaseCommand {
         this.context.stdout.write(`${header}\n\n${content}\n`);
       }
     } else {
-      const tree: treeUtils.TreeNode = {
-        children: miscUtils.mapAndFilter(Object.entries(MessageName), ([key, value]) => {
-          if (Number.isNaN(Number(key)))
-            return miscUtils.mapAndFilter.skip;
+      const list = miscUtils.mapAndFilter(Object.entries(MessageName), ([key, value]) => {
+        if (Number.isNaN(Number(key)))
+          return miscUtils.mapAndFilter.skip;
 
-          return {
-            label: stringifyMessageName(Number(key)),
-            value: formatUtils.tuple(formatUtils.Type.CODE, value as string),
-          };
-        }),
-      };
+        return {
+          label: stringifyMessageName(Number(key)),
+          value: formatUtils.tuple(formatUtils.Type.CODE, value as string),
+        };
+      });
 
-      treeUtils.emitTree(tree, {configuration, stdout: this.context.stdout, json: this.json});
+      treeUtils.emitList(list, {configuration, stdout: this.context.stdout, json: this.json});
     }
   }
 }

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -2418,7 +2418,7 @@ function applyVirtualResolutionMutations({
     }
   }
 
-  const warningSortCriterias: Array<((warning: Warning) => string)> = [
+  const warningSortCriteria: Array<((warning: Warning) => string)> = [
     warning => structUtils.prettyLocatorNoColors(warning.subject),
     warning => structUtils.stringifyIdent(warning.requested),
     warning => `${warning.type}`,
@@ -2430,7 +2430,7 @@ function applyVirtualResolutionMutations({
     },
     skipIfEmpty: true,
   }, () => {
-    for (const warning of miscUtils.sortMap(warnings, warningSortCriterias)) {
+    for (const warning of miscUtils.sortMap(warnings, warningSortCriteria)) {
       switch (warning.type) {
         case WarningType.NotProvided: {
           report.reportWarning(MessageName.MISSING_PEER_DEPENDENCY, `${

--- a/packages/yarnpkg-core/sources/treeUtils.ts
+++ b/packages/yarnpkg-core/sources/treeUtils.ts
@@ -83,8 +83,12 @@ export function treeNodeToJson(printTree: TreeNode) {
   return copyTree(printTree);
 }
 
-export function emitList(values: Array<formatUtils.Tuple>, {configuration, stdout, json}: {configuration: Configuration, stdout: Writable, json: boolean}) {
-  const children = values.map(value => ({value}));
+export function emitList(list: Array<formatUtils.Tuple | Omit<TreeNode, 'children'>>, {configuration, stdout, json}: {configuration: Configuration, stdout: Writable, json: boolean}) {
+  const children = list.map(value => (
+    Array.isArray(value)
+      ? {value}
+      : value
+  ) as TreeNode);
   emitTree({children}, {configuration, stdout, json});
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`yarn explain peer-requirements` printed useless `YN0000` prefixes before each peer requirement.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use `treeUtils` (what `yarn explain` uses).

Before:

![image](https://user-images.githubusercontent.com/32596136/182974115-a9c305c5-6d5a-43b7-bd0d-f4310950b41b.png)

After:

![image](https://user-images.githubusercontent.com/32596136/182974141-442ac20d-dbb1-4661-9d91-7221499f692f.png)

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
