### PR TITLE
test: clear timeout after test finishes

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -729,13 +729,18 @@ export const generatePkgDriver = ({
           // So add env variable TEST_IGNORE_TIMEOUT_FAILURES to turn on this suppression
           // TODO: investigate whether this is still needed.
           if (process.env.TEST_IGNORE_TIMEOUT_FAILURES) {
+            let timer: NodeJS.Timeout | undefined;
             await Promise.race([
               new Promise(resolve => {
                 // Resolve 1s ahead of the jest timeout
-                setTimeout(resolve, TEST_TIMEOUT - 1000);
+                timer = setTimeout(resolve, TEST_TIMEOUT - 1000);
               }),
               fn!({path, run, source}),
-            ]);
+            ]).finally(() => {
+              if (timer) {
+                clearTimeout(timer);
+              }
+            });
             return;
           }
           await fn!({path, run, source});


### PR DESCRIPTION
**What's the problem this PR addresses?**

fix that test:integration cannot exit gracefully, for example, https://ci.nodejs.org/job/citgm-smoker-nobuild/1353/nodes=win10-vs2019/console

**How did you fix it?**

unref the timer

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
