### PR TITLE
chore(extensions): Add `webpack` optional peerDependency to xo

### DIFF
--- a/.yarn/versions/cd54fce4.yml
+++ b/.yarn/versions/cd54fce4.yml
@@ -4,6 +4,7 @@ releases:
   "@yarnpkg/plugin-compat": patch
 
 declined:
+  - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"
   - "@yarnpkg/plugin-init"

--- a/.yarn/versions/cd54fce4.yml
+++ b/.yarn/versions/cd54fce4.yml
@@ -1,2 +1,23 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/cd54fce4.yml
+++ b/.yarn/versions/cd54fce4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/extensions": patch

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -904,7 +904,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/xojs/xo/pull/678
-  [`xo**`, {
+  [`xo@*`, {
     peerDependencies: {
       webpack: `>=1.11.0`,
     },

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -893,9 +893,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       webpack: `>=4`,
     },
     peerDependenciesMeta: {
-      typescript: {
-        optional: true,
-      },
+      typescript: optionalPeerDep,
     },
   }],
   // https://github.com/asyncapi/asyncapi-react/pull/614
@@ -903,6 +901,15 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     peerDependencies: {
       react: `>=16.8.0`,
       'react-dom': `>=16.8.0`,
+    },
+  }],
+  // https://github.com/xojs/xo/pull/678
+  [`xo**`, {
+    peerDependencies: {
+      webpack: `>=1.11.0`,
+    },
+    peerDependenciesMeta: {
+      webpack: optionalPeerDep,
     },
   }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**
`xo` depends on `eslint-import-resolver-webpack`, but only calls into it conditionally.
So while `eslint-import-resolver-webpack` has a peer dependency on webpack, `xo` has an optional one.

Upstream PR: https://github.com/xojs/xo/pull/678

...

**How did you fix it?**
Added a new package extension for `xo`

...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
