### PR TITLE
refactor: deprecate `FormatType`

### DIFF
--- a/.yarn/versions/2be8c391.yml
+++ b/.yarn/versions/2be8c391.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -1,14 +1,14 @@
-import {BaseCommand, WorkspaceRequiredError}                                                 from '@yarnpkg/cli';
-import {Cache, Configuration, Descriptor, FormatType, formatUtils, LightReport, MessageName} from '@yarnpkg/core';
-import {Project, StreamReport, Workspace, Ident, InstallMode}                                from '@yarnpkg/core';
-import {structUtils}                                                                         from '@yarnpkg/core';
-import {PortablePath}                                                                        from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}                                                  from 'clipanion';
-import {prompt}                                                                              from 'enquirer';
-import * as t                                                                                from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                                     from '@yarnpkg/cli';
+import {Cache, Configuration, Descriptor, formatUtils, LightReport, MessageName} from '@yarnpkg/core';
+import {Project, StreamReport, Workspace, Ident, InstallMode}                    from '@yarnpkg/core';
+import {structUtils}                                                             from '@yarnpkg/core';
+import {PortablePath}                                                            from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                                      from 'clipanion';
+import {prompt}                                                                  from 'enquirer';
+import * as t                                                                    from 'typanion';
 
-import * as suggestUtils                                                                     from '../suggestUtils';
-import {Hooks}                                                                               from '..';
+import * as suggestUtils                                                         from '../suggestUtils';
+import {Hooks}                                                                   from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class AddCommand extends BaseCommand {
@@ -162,10 +162,10 @@ export default class AddCommand extends BaseCommand {
 
       const unsupportedPrefix = pseudoDescriptor.match(/^(https?:|git@github)/);
       if (unsupportedPrefix)
-        throw new UsageError(`It seems you are trying to add a package using a ${formatUtils.pretty(configuration, `${unsupportedPrefix[0]}...`, FormatType.RANGE)} url; we now require package names to be explicitly specified.\nTry running the command again with the package name prefixed: ${formatUtils.pretty(configuration, `yarn add`, FormatType.CODE)} ${formatUtils.pretty(configuration, structUtils.makeDescriptor(structUtils.makeIdent(null, `my-package`), `${unsupportedPrefix[0]}...`), FormatType.DESCRIPTOR)}`);
+        throw new UsageError(`It seems you are trying to add a package using a ${formatUtils.pretty(configuration, `${unsupportedPrefix[0]}...`, formatUtils.Type.RANGE)} url; we now require package names to be explicitly specified.\nTry running the command again with the package name prefixed: ${formatUtils.pretty(configuration, `yarn add`, formatUtils.Type.CODE)} ${formatUtils.pretty(configuration, structUtils.makeDescriptor(structUtils.makeIdent(null, `my-package`), `${unsupportedPrefix[0]}...`), formatUtils.Type.DESCRIPTOR)}`);
 
       if (!request)
-        throw new UsageError(`The ${formatUtils.pretty(configuration, pseudoDescriptor, FormatType.CODE)} string didn't match the required format (package-name@range). Did you perhaps forget to explicitly reference the package name?`);
+        throw new UsageError(`The ${formatUtils.pretty(configuration, pseudoDescriptor, formatUtils.Type.CODE)} string didn't match the required format (package-name@range). Did you perhaps forget to explicitly reference the package name?`);
 
       const target = suggestTarget(workspace, request, {
         dev: this.dev,

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -1,13 +1,13 @@
-import {BaseCommand, WorkspaceRequiredError}                                from '@yarnpkg/cli';
-import {Configuration, Cache, Descriptor, Project, formatUtils, FormatType} from '@yarnpkg/core';
-import {StreamReport, Workspace, InstallMode}                               from '@yarnpkg/core';
-import {structUtils}                                                        from '@yarnpkg/core';
-import {Command, Option, Usage, UsageError}                                 from 'clipanion';
-import micromatch                                                           from 'micromatch';
-import * as t                                                               from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                    from '@yarnpkg/cli';
+import {Configuration, Cache, Descriptor, Project, formatUtils} from '@yarnpkg/core';
+import {StreamReport, Workspace, InstallMode}                   from '@yarnpkg/core';
+import {structUtils}                                            from '@yarnpkg/core';
+import {Command, Option, Usage, UsageError}                     from 'clipanion';
+import micromatch                                               from 'micromatch';
+import * as t                                                   from 'typanion';
 
-import * as suggestUtils                                                    from '../suggestUtils';
-import {Hooks}                                                              from '..';
+import * as suggestUtils                                        from '../suggestUtils';
+import {Hooks}                                                  from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class RemoveCommand extends BaseCommand {
@@ -149,7 +149,7 @@ export default class RemoveCommand extends BaseCommand {
       : `this`;
 
     if (unreferencedPatterns.length > 0)
-      throw new UsageError(`${patterns} ${formatUtils.prettyList(configuration, unreferencedPatterns, FormatType.CODE)} ${dont} match any packages referenced by ${which} workspace`);
+      throw new UsageError(`${patterns} ${formatUtils.prettyList(configuration, unreferencedPatterns, formatUtils.Type.CODE)} ${dont} match any packages referenced by ${which} workspace`);
 
     if (hasChanged) {
       await configuration.triggerMultipleHooks(

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,9 +1,9 @@
-import {BaseCommand}                                                                                      from '@yarnpkg/cli';
-import {Configuration, StreamReport, MessageName, Report, Manifest, FormatType, YarnVersion, ReportError} from '@yarnpkg/core';
-import {execUtils, formatUtils, httpUtils, miscUtils, semverUtils}                                        from '@yarnpkg/core';
-import {Filename, PortablePath, ppath, xfs, npath}                                                        from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}                                                               from 'clipanion';
-import semver                                                                                             from 'semver';
+import {BaseCommand}                                                                          from '@yarnpkg/cli';
+import {Configuration, StreamReport, MessageName, Report, Manifest, YarnVersion, ReportError} from '@yarnpkg/core';
+import {execUtils, formatUtils, httpUtils, miscUtils, semverUtils}                            from '@yarnpkg/core';
+import {Filename, PortablePath, ppath, xfs, npath}                                            from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                                                   from 'clipanion';
+import semver                                                                                 from 'semver';
 
 export type Tags = {
   latest: Record<string, string>;
@@ -131,10 +131,10 @@ export default class SetVersionCommand extends BaseCommand {
         const filePrefix = `file://`;
 
         if (bundleRef.url.startsWith(filePrefix)) {
-          report.reportInfo(MessageName.UNNAMED, `Retrieving ${formatUtils.pretty(configuration, bundleRef.url, FormatType.PATH)}`);
+          report.reportInfo(MessageName.UNNAMED, `Retrieving ${formatUtils.pretty(configuration, bundleRef.url, formatUtils.Type.PATH)}`);
           return await xfs.readFilePromise(bundleRef.url.slice(filePrefix.length) as PortablePath);
         } else {
-          report.reportInfo(MessageName.UNNAMED, `Downloading ${formatUtils.pretty(configuration, bundleRef.url, FormatType.URL)}`);
+          report.reportInfo(MessageName.UNNAMED, `Downloading ${formatUtils.pretty(configuration, bundleRef.url, formatUtils.Type.URL)}`);
           return await httpUtils.get(bundleRef.url, {configuration});
         }
       };

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -1,14 +1,14 @@
-import {BaseCommand, WorkspaceRequiredError}                                                                        from '@yarnpkg/cli';
-import {IdentHash, structUtils}                                                                                     from '@yarnpkg/core';
-import {Project, StreamReport, Workspace, InstallMode}                                                              from '@yarnpkg/core';
-import {Cache, Configuration, Descriptor, LightReport, MessageName, MinimalResolveOptions, formatUtils, FormatType} from '@yarnpkg/core';
-import {Command, Option, Usage, UsageError}                                                                         from 'clipanion';
-import {prompt}                                                                                                     from 'enquirer';
-import micromatch                                                                                                   from 'micromatch';
-import * as t                                                                                                       from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                                                            from '@yarnpkg/cli';
+import {IdentHash, structUtils}                                                                         from '@yarnpkg/core';
+import {Project, StreamReport, Workspace, InstallMode}                                                  from '@yarnpkg/core';
+import {Cache, Configuration, Descriptor, LightReport, MessageName, MinimalResolveOptions, formatUtils} from '@yarnpkg/core';
+import {Command, Option, Usage, UsageError}                                                             from 'clipanion';
+import {prompt}                                                                                         from 'enquirer';
+import micromatch                                                                                       from 'micromatch';
+import * as t                                                                                           from 'typanion';
 
-import * as suggestUtils                                                                                            from '../suggestUtils';
-import {Hooks}                                                                                                      from '..';
+import * as suggestUtils                                                                                from '../suggestUtils';
+import {Hooks}                                                                                          from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UpCommand extends BaseCommand {
@@ -223,9 +223,9 @@ export default class UpCommand extends BaseCommand {
     }
 
     if (unreferencedPatterns.length > 1)
-      throw new UsageError(`Patterns ${formatUtils.prettyList(configuration, unreferencedPatterns, FormatType.CODE)} don't match any packages referenced by any workspace`);
+      throw new UsageError(`Patterns ${formatUtils.prettyList(configuration, unreferencedPatterns, formatUtils.Type.CODE)} don't match any packages referenced by any workspace`);
     if (unreferencedPatterns.length > 0)
-      throw new UsageError(`Pattern ${formatUtils.prettyList(configuration, unreferencedPatterns, FormatType.CODE)} doesn't match any packages referenced by any workspace`);
+      throw new UsageError(`Pattern ${formatUtils.prettyList(configuration, unreferencedPatterns, formatUtils.Type.CODE)} doesn't match any packages referenced by any workspace`);
 
     const allSuggestions = await Promise.all(allSuggestionsPromises);
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -87,7 +87,13 @@ export type SupportedArchitectures = {
   libc: Array<string> | null;
 };
 
+/**
+ * @deprecated Use {@link formatUtils.Type}
+ */
 export type FormatType = formatUtils.Type;
+/**
+ * @deprecated Use {@link formatUtils.Type}
+ */
 export const FormatType = formatUtils.Type;
 
 export type BaseSettingsDefinition<T extends SettingsType = SettingsType> = {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -12,7 +12,7 @@ import v8                                                               from 'v8
 import zlib                                                             from 'zlib';
 
 import {Cache, CacheOptions}                                            from './Cache';
-import {Configuration, FormatType}                                      from './Configuration';
+import {Configuration}                                                  from './Configuration';
 import {Fetcher, FetchOptions}                                          from './Fetcher';
 import {Installer, BuildDirective, BuildType, InstallStatus}            from './Installer';
 import {LegacyMigrationResolver}                                        from './LegacyMigrationResolver';
@@ -924,7 +924,7 @@ export class Project {
           }-${
             process.arch
           }) is supported by this package, but is missing from the ${
-            formatUtils.pretty(this.configuration, `supportedArchitectures`, FormatType.SETTING)
+            formatUtils.pretty(this.configuration, `supportedArchitectures`, formatUtils.Type.SETTING)
           } setting`);
         }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

It doesn't make sense to have `FormatType` as a standalone export anymore, now that it can be used as `formatUtils.Type`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Replaced all occurrences and deprecated it. I didn't completely remove it since I think it makes sense to keep it deprecated for a major so that plugin authors have time to migrate.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
