### PR TITLE
Faster copy through index

### DIFF
--- a/.yarn/versions/7a2baa8b.yml
+++ b/.yarn/versions/7a2baa8b.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/fslib": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - vscode-zipfs
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-fslib/sources/algorithms/copyPromise.ts
+++ b/packages/yarnpkg-fslib/sources/algorithms/copyPromise.ts
@@ -2,7 +2,7 @@ import {Stats}             from 'fs';
 
 import {FakeFS}            from '../FakeFS';
 import * as constants      from '../constants';
-import {Path, convertPath} from '../path';
+import {Path, convertPath, PortablePath} from '../path';
 
 const defaultTime = new Date(constants.SAFE_TIME * 1000);
 const defaultTimeMs = defaultTime.getTime();
@@ -200,10 +200,11 @@ async function copyFileViaIndex<P1 extends Path, P2 extends Path>(prelayout: Ope
 
   prelayout.push(async () => {
     if (!indexStat) {
-      await destinationFs.lockPromise(indexPath, async () => {
+        const tempPath = `${indexPath}.${(Math.random() * 0x100000000).toString(16).padStart(8, `0`)}` as P1;
+
         const content = await sourceFs.readFilePromise(source);
-        await destinationFs.writeFilePromise(indexPath, content);
-      });
+        await destinationFs.writeFilePromise(tempPath, content);
+        await destinationFs.renamePromise(tempPath, indexPath);
     }
 
     if (!destinationStat) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

We were using `lockPromise` to write files into the cache; since there was a lot of files to write, and we did this for each one, it was very expensive.

**How did you fix it?**

Experimenting with instead "moving" the file from a temporary path to the final one once the write is finished.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
