### PR TITLE
chore: remove release entries for `@yarnpkg/json-proxy`

### DIFF
--- a/.yarn/versions/11abead6.yml
+++ b/.yarn/versions/11abead6.yml
@@ -35,7 +35,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
   - "@yarnpkg/extensions"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnpify"
   - "@yarnpkg/sdks"

--- a/.yarn/versions/39ddc77a.yml
+++ b/.yarn/versions/39ddc77a.yml
@@ -33,7 +33,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/sdks"
   - "@yarnpkg/shell"

--- a/.yarn/versions/434fcaba.yml
+++ b/.yarn/versions/434fcaba.yml
@@ -30,7 +30,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/cli"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnp"
   - "@yarnpkg/pnpify"

--- a/.yarn/versions/4ef8937b.yml
+++ b/.yarn/versions/4ef8937b.yml
@@ -33,7 +33,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
   - "@yarnpkg/extensions"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnpify"
   - "@yarnpkg/sdks"

--- a/.yarn/versions/64fa7941.yml
+++ b/.yarn/versions/64fa7941.yml
@@ -33,7 +33,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/sdks"
   - "@yarnpkg/shell"

--- a/.yarn/versions/7d95d0bf.yml
+++ b/.yarn/versions/7d95d0bf.yml
@@ -33,7 +33,6 @@ declined:
   - vscode-zipfs
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnpify"
   - "@yarnpkg/sdks"

--- a/.yarn/versions/7e1696fd.yml
+++ b/.yarn/versions/7e1696fd.yml
@@ -32,7 +32,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/sdks"
   - "@yarnpkg/shell"

--- a/.yarn/versions/7f506ae4.yml
+++ b/.yarn/versions/7f506ae4.yml
@@ -31,7 +31,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnpify"
   - "@yarnpkg/sdks"

--- a/.yarn/versions/80053b5a.yml
+++ b/.yarn/versions/80053b5a.yml
@@ -33,7 +33,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
   - "@yarnpkg/extensions"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnpify"
   - "@yarnpkg/sdks"

--- a/.yarn/versions/80ae97a2.yml
+++ b/.yarn/versions/80ae97a2.yml
@@ -5,7 +5,6 @@ releases:
   "@yarnpkg/doctor": patch
   "@yarnpkg/esbuild-plugin-pnp": patch
   "@yarnpkg/fslib": patch
-  "@yarnpkg/json-proxy": patch
   "@yarnpkg/libui": patch
   "@yarnpkg/libzip": patch
   "@yarnpkg/parsers": patch

--- a/.yarn/versions/bf825c43.yml
+++ b/.yarn/versions/bf825c43.yml
@@ -29,7 +29,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/core"
   - "@yarnpkg/doctor"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnp"
   - "@yarnpkg/pnpify"

--- a/.yarn/versions/d7ae2216.yml
+++ b/.yarn/versions/d7ae2216.yml
@@ -6,7 +6,6 @@ releases:
   "@yarnpkg/esbuild-plugin-pnp": major
   "@yarnpkg/eslint-config": major
   "@yarnpkg/fslib": major
-  "@yarnpkg/json-proxy": major
   "@yarnpkg/libui": major
   "@yarnpkg/libzip": major
   "@yarnpkg/nm": major

--- a/.yarn/versions/dc69403b.yml
+++ b/.yarn/versions/dc69403b.yml
@@ -34,7 +34,6 @@ declined:
   - "@yarnpkg/builder"
   - "@yarnpkg/doctor"
   - "@yarnpkg/extensions"
-  - "@yarnpkg/json-proxy"
   - "@yarnpkg/nm"
   - "@yarnpkg/pnpify"
   - "@yarnpkg/sdks"


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/yarnpkg/berry/pull/4707 removed `@yarnpkg/json-proxy` but didn't remove the references to it in the release files (probably because VSCode is set to ignore the `.yarn` folder when searching).

Fixes https://github.com/yarnpkg/berry/runs/7814553654?check_suite_focus=true#step:6:32

**How did you fix it?**

Removed the references.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.