### PR TITLE
ci(e2e): use non-minified bundle

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,3 +1,9 @@
+inputs:
+  minify-bundle:
+    description: 'Whether to minify the bundle'
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -11,12 +17,12 @@ runs:
       id: cache-build
       with:
         path: packages/yarnpkg-cli/bundles/yarn.js
-        key: cli-bundle-${{ github.sha }}
+        key: cli-bundle-minified-${{ inputs.minify-bundle }}-${{ github.sha }}
 
     - name: 'Build the standard bundle'
       if: steps.cache-build.outputs.cache-hit != 'true'
       run: |
-        node ./scripts/run-yarn.js build:cli --no-minify
+        node ./scripts/run-yarn.js build:cli ${{ inputs.minify-bundle == 'false' && '--no-minify' || '' }}
       shell: bash
     #endregion
 

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: 'Build the standard bundle'
       if: steps.cache-build.outputs.cache-hit != 'true'
       run: |
-        node ./scripts/run-yarn.js build:cli
+        node ./scripts/run-yarn.js build:cli --no-minify
       shell: bash
     #endregion
 

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -2,7 +2,7 @@ inputs:
   minify-bundle:
     description: 'Whether to minify the bundle'
     required: false
-    default: 'true'
+    default: 'false'
 
 runs:
   using: composite

--- a/.github/workflows/benchmark-workflow.yml
+++ b/.github/workflows/benchmark-workflow.yml
@@ -37,7 +37,7 @@ jobs:
 
     - uses: ./.github/actions/prepare
       with:
-        minify-bundle: false
+        minify-bundle: true
 
     - name: 'Install Hyperfine'
       run: |

--- a/.github/workflows/benchmark-workflow.yml
+++ b/.github/workflows/benchmark-workflow.yml
@@ -36,6 +36,8 @@ jobs:
     - uses: actions/checkout@master
 
     - uses: ./.github/actions/prepare
+      with:
+        minify-bundle: false
 
     - name: 'Install Hyperfine'
       run: |


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The E2E tests use a minified bundle, which makes it a lot harder to read stack traces if something goes wrong with Yarn.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Build a bundle with `--no-minify` instead.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
