### PR TITLE
docs: update `getSatisfying` JSDoc

### DIFF
--- a/.yarn/versions/11cf053f.yml
+++ b/.yarn/versions/11cf053f.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/core"

--- a/packages/yarnpkg-core/sources/Resolver.ts
+++ b/packages/yarnpkg-core/sources/Resolver.ts
@@ -123,8 +123,8 @@ export interface Resolver {
   getCandidates(descriptor: Descriptor, dependencies: Record<string, Package>, opts: ResolveOptions): Promise<Array<Locator>>;
 
   /**
-   * This function will, given a descriptor and a list of locator references,
-   * find out which of the references potentially satisfy the descriptor.
+   * This function will, given a descriptor and a list of locators,
+   * find out which of the locators potentially satisfy the descriptor.
    *
    * This function is different from `getCandidates`, as `getCandidates` will
    * resolve the descriptor into a list of locators (potentially using the network),
@@ -143,7 +143,7 @@ export interface Resolver {
    *
    * @param descriptor The target descriptor.
    * @param dependencies The resolution dependencies and their resolutions.
-   * @param references The candidate references.
+   * @param locators The candidate locators.
    * @param opts The resolution options.
    */
   getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions): Promise<{


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The JSDoc of `getSatisfying` still mentions passing an array of references as an argument, when it should now be an array of locators.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated the docs.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
