### PR TITLE
docs: highlight the fact that the spec assumes the unix path format

### DIFF
--- a/packages/gatsby/content/advanced/pnp-spec.md
+++ b/packages/gatsby/content/advanced/pnp-spec.md
@@ -36,7 +36,13 @@ Extra features can then be designed, but are optional. For example, Yarn leverag
 
 All packages are uniquely referenced by **locators**. A locator is a combination of a **package ident**, which includes its scope if relevant, and a **package reference**, which can be seen as a unique ID used to distinguish different instances (or versions) of a same package. The package references should be treated as an opaque value: it doesn't matter from a resolution algorithm perspective that they start with `workspace:`, `virtual:`, `npm:`, or any other protocol.
 
-For portability reasons, all paths must be relative to the manifest folder (so that they can be the same regardless of the location of the project on disk), and all paths must use the unix path format (`/` as separators).
+### Portability
+
+For portability reasons, all paths inside of the manifests:
+- must use the unix path format (`/` as separators).
+- must be relative to the manifest folder (so that they can be the same regardless of the location of the project on disk).
+
+> **Important: This specification assumes all paths to have been normalized to the unix path format (`/` as separators).**
 
 ## Fallback
 
@@ -120,7 +126,7 @@ import {JsonDoc} from 'react-json-doc';
 2. If `specifier` is a Node.js builtin, then
 
     1. Set `resolved` to `specifier` itself and return it
-  
+
 3. Otherwise, if `specifier` is either an absolute path or a path prefixed with "./" or "../", then
 
     1. Set `resolved` to **NM_RESOLVE**(`specifier`, `parentURL`) and return it
@@ -278,9 +284,9 @@ Finding the right PnP manifest to use for a resolution isn't always trivial. The
     1. Let `pnpDataPath` be `directoryPath` concatenated with `/.pnp.data.json`
 
     2. Set `manifest` to `JSON.parse(readFile(pnpDataPath))`
-    
+
     3. Set `manifest.dirPath` to `directoryPath`
-    
+
     4. Return `manifest`
 
 5. Otherwise, if `directoryPath` is `/`, then
@@ -296,7 +302,7 @@ Finding the right PnP manifest to use for a resolution isn't always trivial. The
 1. If `specifier` starts with "@", then
 
     1. If `specifier` doesn't contain a "/" separator, then
-  
+
         1. Throw an error
 
     2. Otherwise,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We don't highlight the fact that the PnP spec assumes all paths to be normalized to the unix format (https://github.com/evanw/esbuild/issues/2462#issuecomment-1214253036).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Tweaked the docs. I've also renamed the file from `pnp-data.md` to `pnp-spec.md` to match the URL and to make it easier to find.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
