### PR TITLE
ci: benchmark latest npm

### DIFF
--- a/.github/workflows/benchmark-workflow.yml
+++ b/.github/workflows/benchmark-workflow.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         case ${{matrix.packageManager}} in
           npm)
-            npm install -g npm@^7;;
+            npm install -g npm;;
           pnpm)
             npm install -g pnpm;;
           classic)

--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -10,6 +10,11 @@ HERE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 cd "$BENCH_DIR"
 
+PACKAGE_MANAGER_BIN="${PACKAGE_MANAGER%-*}"
+PACKAGE_MANAGER_VERSION="$($PACKAGE_MANAGER_BIN --version)"
+
+echo "Package Manager: $PACKAGE_MANAGER_BIN@$PACKAGE_MANAGER_VERSION"
+
 bench() {
   SUBTEST_NAME=$1; shift
   echo "Testing $SUBTEST_NAME"
@@ -61,6 +66,8 @@ setup-pnpm() {
   >> "$BENCH_DIR/.npmrc" echo \
     "strict-peer-dependencies=false"
 }
+
+echo ""
 
 case $PACKAGE_MANAGER in
   classic)


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We've pinned the major npm version benchmarked to `npm@^7` back when the `latest` tag still pointed to `npm@6`. Today the latest tag points to npm 8, but we still benchmark npm 7.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've unpinned the npm version used in the benchmark. I've also added some logging to be able to tell which version is used by the benchmark.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
