### PR TITLE
chore: use `not_planned` reason for stale issues

### DIFF
--- a/.github/workflows/stale-workflow.yml
+++ b/.github/workflows/stale-workflow.yml
@@ -25,6 +25,8 @@ jobs:
         days-before-stale: 30
         days-before-close: 5
 
+        close-issue-reason: not_planned
+
         only-labels: 'bug'
 
         stale-issue-label: 'stale'
@@ -43,6 +45,8 @@ jobs:
 
         days-before-stale: 30
         days-before-close: 5
+
+        close-issue-reason: not_planned
 
         only-labels: 'waiting for feedback'
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Stale issues are currently closed as `completed`, when they should be closed as `not_planned`, according to their respective descriptions:
![image](https://user-images.githubusercontent.com/32596136/184887992-95e48fcd-5e6e-4645-8539-c322d8b115c8.png)


**How did you fix it?**
<!-- A detailed description of your implementation. -->

Used the https://github.com/actions/stale#close-issue-reason parameter of the action.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
