### PR TITLE
Adds a note about the `exports` field in the PnP spec

### DIFF
--- a/packages/gatsby/content/advanced/pnp-spec.md
+++ b/packages/gatsby/content/advanced/pnp-spec.md
@@ -119,6 +119,12 @@ import {JsonDoc} from 'react-json-doc';
 
 1. This function is specified in the [Node.js documentation](https://nodejs.org/api/esm.html#resolver-algorithm-specification)
 
+### RESOLVE_TO_QUALIFIED(`specifier`, `unqualified`, `parentURL`)
+
+1. This function is specified in the [Node.js documentation](https://nodejs.org/api/esm.html#resolver-algorithm-specification)
+
+    1. Note: This final resolution pass should start from `unqualified` rather than `specifier`, however some Node.js behavior (such as the [`exports` field](https://nodejs.org/api/packages.html#exports) remapping) are only triggered when the starting specifiers are [bare specifiers](https://nodejs.org/api/esm.html#terminology). It's to allow you to check that that the original `specifier` is forwarded to this function.
+
 ### PNP_RESOLVE(`specifier`, `parentURL`)
 
 1. Let `resolved` be **undefined**
@@ -137,7 +143,7 @@ import {JsonDoc} from 'react-json-doc';
 
     2. Let `unqualified` be **RESOLVE_TO_UNQUALIFIED**(`specifier`, `parentURL`)
 
-    3. Set `resolved` to **NM_RESOLVE**(`unqualified`, `parentURL`)
+    3. Set `resolved` to **RESOLVE_TO_QUALIFIED**(`specifier`, `unqualified`, `parentURL`)
 
 ### RESOLVE_TO_UNQUALIFIED(`specifier`, `parentURL`)
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The PnP spec defers to the Node.js specification, but it's easy to miss the subtleties caused by the [`exports` field](https://nodejs.org/api/packages.html#exports).

Ref: https://github.com/evanw/esbuild/issues/2473

**How did you fix it?**

I've added a note to make it clearer that some specific treatment will be needed.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
