### PR TITLE
fix: use `MessageName.NETWORK_DISABLED` in `gitUtils` too

### DIFF
--- a/.yarn/versions/4aec9c76.yml
+++ b/.yarn/versions/4aec9c76.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-git": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -156,12 +156,17 @@ export function normalizeLocator(locator: Locator) {
   return structUtils.makeLocator(locator, normalizeRepoUrl(locator.reference));
 }
 
-export async function lsRemote(repo: string, configuration: Configuration) {
-  const normalizedRepoUrl = normalizeRepoUrl(repo, {git: true});
-
+export function validateRepoUrl(url: string, {configuration}: {configuration: Configuration}) {
+  const normalizedRepoUrl = normalizeRepoUrl(url, {git: true});
   const networkSettings = httpUtils.getNetworkSettings(`https://${GitUrlParse(normalizedRepoUrl).resource}`, {configuration});
   if (!networkSettings.enableNetwork)
-    throw new Error(`Request to '${normalizedRepoUrl}' has been blocked because of your configuration settings`);
+    throw new ReportError(MessageName.NETWORK_DISABLED, `Request to '${normalizedRepoUrl}' has been blocked because of your configuration settings`);
+
+  return normalizedRepoUrl;
+}
+
+export async function lsRemote(repo: string, configuration: Configuration) {
+  const normalizedRepoUrl = validateRepoUrl(repo, {configuration});
 
   const res = await git(`listing refs`, [`ls-remote`, normalizedRepoUrl], {
     cwd: configuration.startingCwd,
@@ -283,9 +288,7 @@ export async function clone(url: string, configuration: Configuration) {
     if (protocol !== `commit`)
       throw new Error(`Invalid treeish protocol when cloning`);
 
-    const normalizedRepoUrl = normalizeRepoUrl(repo, {git: true});
-    if (httpUtils.getNetworkSettings(`https://${GitUrlParse(normalizedRepoUrl).resource}`, {configuration}).enableNetwork === false)
-      throw new Error(`Request to '${normalizedRepoUrl}' has been blocked because of your configuration settings`);
+    const normalizedRepoUrl = validateRepoUrl(repo, {configuration});
 
     const directory = await xfs.mktempPromise();
     const execOpts = {cwd: directory, env: makeGitEnvironment()};


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

https://github.com/yarnpkg/berry/pull/4729 forgot to make the network errors in `gitUtils` use the newly introduced `MessageName` too.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made them use the new `MessageName` and extracted the logic to a new `validateRepoUrl` function to prevent duplication and so that we don't forget to do this again in the future.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
