### PR TITLE
Adds a note about workspaces in the `enableScripts` documentation

### DIFF
--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -171,7 +171,7 @@
     },
     "enableScripts": {
       "_package": "@yarnpkg/core",
-      "description": "If false, Yarn will not execute the `postInstall` scripts when installing the project. Note that you can now also disable scripts on a per-package basis thanks to `dependenciesMeta`.",
+      "description": "If false, Yarn will not execute the `postinstall` scripts from third-party packages when installing the project (workspaces will still see their postinstall scripts evaluated, as they're assumed to be safe if you're running an install within them). Note that you can now also disable scripts on a per-package basis thanks to `dependenciesMeta`.",
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `enableScripts` setting currently [only applies to third-party packages](https://github.com/yarnpkg/berry/blob/f0e21079535302229314b08bb214ed9f9d157c6b/packages/yarnpkg-core/sources/Project.ts#L1080-L1106). I believe it's because we ideally would want installs to be made with `enableScripts` set to false by default (for security reasons), but there's no point into blocking the workspaces' `postinstall` scripts by default (since it doesn't improve security).

Closes https://github.com/yarnpkg/berry/issues/4780
Ref https://github.com/yarnpkg/berry/issues/4386
Ref https://github.com/yarnpkg/berry/issues/4547

**How did you fix it?**

Updated the documentation.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
