### PR TITLE
fix(cli): propagate proper exit status code when running yarnPath binary

### DIFF
--- a/.yarn/versions/e0fbb587.yml
+++ b/.yarn/versions/e0fbb587.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/lib.ts
+++ b/packages/yarnpkg-cli/sources/lib.ts
@@ -1,6 +1,6 @@
 import {Configuration, CommandContext, PluginConfiguration, TelemetryManager, semverUtils, miscUtils, YarnVersion} from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs}                                                                           from '@yarnpkg/fslib';
-import {execFileSync}                                                                                              from 'child_process';
+import {execFileSync, type SpawnSyncReturns}                                                                       from 'child_process';
 import {isCI}                                                                                                      from 'ci-info';
 import {Cli, UsageError}                                                                                           from 'clipanion';
 
@@ -83,7 +83,7 @@ function runYarnPath(cli: YarnCli, argv: Array<string>, {yarnPath}: {yarnPath: P
   try {
     execFileSync(process.execPath, [npath.fromPortablePath(yarnPath), ...argv], yarnPathExecOptions);
   } catch (err) {
-    return (err.code as number) ?? 1;
+    return (err as SpawnSyncReturns<void>).status ?? 1;
   }
 
   return 0;


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fixes a scenario w/ Yarn CLI where a non-zero exit code is ignored (and `exitCode = 1` is used instead), when running a command using `yarn` binary specified by `yarnPath`.

**How did you fix it?**
Apparently [current implementation](https://github.com/yarnpkg/berry/blob/a66e528506168f7bfaa4fa9fc02b8edb226e47d4/packages/yarnpkg-cli/sources/main.ts#L107-L111) uses a `error.code` property, which does not exist on the `Error` that the underlying [`child_process.execFileSync()`](https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options) throws, when a child process exits w/ a non-zero exit status. The `error.status` should be used instead, as per Node.js API documentation:

> If the process times out or has a non-zero exit code, this method will throw an [Error](https://nodejs.org/api/errors.html#class-error) that will include the full result of the underlying [child_process.spawnSync()](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options).

```
interface SpawnSyncReturns<T> {
    pid: number;
    output: Array<T | null>;
    stdout: T;
    stderr: T;
    status: number | null;
    signal: NodeJS.Signals | null;
    error?: Error | undefined;
}
```

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
