### PR TITLE
fix(essentials): yarn add `--peer` and `--dev` do not work when used together

### DIFF
--- a/.yarn/versions/0d3ddb4d.yml
+++ b/.yarn/versions/0d3ddb4d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/add.test.ts
@@ -331,6 +331,22 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should add a new peer dependency and a new development dependency to the current project when using --peer and --dev together`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await run(`add`, `no-deps`, `-D`, `-P`);
+
+        await expect(xfs.readJsonPromise(ppath.join(path, Filename.manifest))).resolves.toMatchObject({
+          devDependencies: {
+            [`no-deps`]: `^2.0.0`,
+          },
+          peerDependencies: {
+            [`no-deps`]: `*`,
+          },
+        });
+      }),
+    );
+
+    test(
       `it should add a node-gyp dependency to the lockfile if a script uses it`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await run(`add`, `inject-node-gyp`);

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -174,9 +174,9 @@ export default class AddCommand extends BaseCommand {
         optional: this.optional,
       });
 
-      const suggestions = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, fixed, target, modifier, strategies, maxResults});
+      const suggestedDescriptors = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, fixed, target, modifier, strategies, maxResults});
 
-      return {request, suggestions, target};
+      return {request, suggestedDescriptors, target};
     }));
 
     const checkReport = await LightReport.start({
@@ -184,7 +184,7 @@ export default class AddCommand extends BaseCommand {
       stdout: this.context.stdout,
       suggestInstall: false,
     }, async report => {
-      for (const {request, suggestions: {suggestions, rejections}} of allSuggestions) {
+      for (const {request, suggestedDescriptors: {suggestions, rejections}} of allSuggestions) {
         const nonNullSuggestions = suggestions.filter(suggestion => {
           return suggestion.descriptor !== null;
         });
@@ -224,7 +224,7 @@ export default class AddCommand extends BaseCommand {
       Descriptor,
     ]> = [];
 
-    for (const {suggestions: {suggestions}, target} of allSuggestions) {
+    for (const {suggestedDescriptors: {suggestions}, target} of allSuggestions) {
       let selected: Descriptor;
 
       const nonNullSuggestions = suggestions.filter(suggestion => {

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -167,17 +167,20 @@ export default class AddCommand extends BaseCommand {
       if (!request)
         throw new UsageError(`The ${formatUtils.pretty(configuration, pseudoDescriptor, formatUtils.Type.CODE)} string didn't match the required format (package-name@range). Did you perhaps forget to explicitly reference the package name?`);
 
-      const target = suggestTarget(workspace, request, {
+      const targetList = suggestTargetList(workspace, request, {
         dev: this.dev,
         peer: this.peer,
         preferDev: this.preferDev,
         optional: this.optional,
       });
 
-      const suggestedDescriptors = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, fixed, target, modifier, strategies, maxResults});
+      const results = await Promise.all(targetList.map(async target => {
+        const suggestedDescriptors = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, fixed, target, modifier, strategies, maxResults});
+        return {request, suggestedDescriptors, target};
+      }));
 
-      return {request, suggestedDescriptors, target};
-    }));
+      return results;
+    })).then(results => results.flat());
 
     const checkReport = await LightReport.start({
       configuration,
@@ -327,7 +330,7 @@ export default class AddCommand extends BaseCommand {
   }
 }
 
-function suggestTarget(workspace: Workspace, ident: Ident, {dev, peer, preferDev, optional}: {dev: boolean, peer: boolean, preferDev: boolean, optional: boolean}) {
+function suggestTargetList(workspace: Workspace, ident: Ident, {dev, peer, preferDev, optional}: {dev: boolean, peer: boolean, preferDev: boolean, optional: boolean}) {
   const hasRegular = workspace.manifest[suggestUtils.Target.REGULAR].has(ident.identHash);
   const hasDev = workspace.manifest[suggestUtils.Target.DEVELOPMENT].has(ident.identHash);
   const hasPeer = workspace.manifest[suggestUtils.Target.PEER].has(ident.identHash);
@@ -346,16 +349,23 @@ function suggestTarget(workspace: Workspace, ident: Ident, {dev, peer, preferDev
   if ((dev || preferDev) && optional)
     throw new UsageError(`Package "${structUtils.prettyIdent(workspace.project.configuration, ident)}" cannot simultaneously be a dev dependency and an optional dependency`);
 
-
+  // When the program executes this line, the command is expected to be legal
+  const targetList = [];
   if (peer)
-    return suggestUtils.Target.PEER;
+    targetList.push(suggestUtils.Target.PEER);
   if (dev || preferDev)
-    return suggestUtils.Target.DEVELOPMENT;
+    targetList.push(suggestUtils.Target.DEVELOPMENT);
+  if (optional)
+    targetList.push(suggestUtils.Target.REGULAR);
 
-  if (hasRegular)
-    return suggestUtils.Target.REGULAR;
+  // The user explicitly define the targets
+  if (targetList.length > 0)
+    return targetList;
+
+  // The user does not define the targets, find it from the `workspace.manifest`
   if (hasDev)
-    return suggestUtils.Target.DEVELOPMENT;
-
-  return suggestUtils.Target.REGULAR;
+    return [suggestUtils.Target.DEVELOPMENT];
+  if (hasPeer)
+    return [suggestUtils.Target.PEER];
+  return [suggestUtils.Target.REGULAR];
 }

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -176,7 +176,7 @@ export default class AddCommand extends BaseCommand {
 
       const suggestions = await suggestUtils.getSuggestedDescriptors(request, {project, workspace, cache, fixed, target, modifier, strategies, maxResults});
 
-      return [request, suggestions, target] as const;
+      return {request, suggestions, target};
     }));
 
     const checkReport = await LightReport.start({
@@ -184,7 +184,7 @@ export default class AddCommand extends BaseCommand {
       stdout: this.context.stdout,
       suggestInstall: false,
     }, async report => {
-      for (const [request, {suggestions, rejections}] of allSuggestions) {
+      for (const {request, suggestions: {suggestions, rejections}} of allSuggestions) {
         const nonNullSuggestions = suggestions.filter(suggestion => {
           return suggestion.descriptor !== null;
         });
@@ -224,7 +224,7 @@ export default class AddCommand extends BaseCommand {
       Descriptor,
     ]> = [];
 
-    for (const [/*request*/, {suggestions}, target] of allSuggestions) {
+    for (const {suggestions: {suggestions}, target} of allSuggestions) {
       let selected: Descriptor;
 
       const nonNullSuggestions = suggestions.filter(suggestion => {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Yarn add `--peer` and `--dev` do not work when used together

Resolves #4691
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Let the return value of the `suggestTarget` function of the `packages/plugin-essentials/sources/commands/add.ts` file change from `suggestUtils.Target` to `suggestUtils.Target[]`, It is possible to add different types of dependencies at once

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
