### PR TITLE
perf(pnp): enable strict mode in `.pnp.cjs`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable */
-
-try {
-  Object.freeze({}).detectStrictMode = true;
-} catch (error) {
-  throw new Error(`The whole PnP file got strict-mode-ified, which is known to break (Emscripten libraries aren't strict mode). This usually happens when the file goes through Babel.`);
-}
+"use strict";
 
 const RAW_RUNTIME_STATE =
 '{\

--- a/.yarn/versions/67cdb4e6.yml
+++ b/.yarn/versions/67cdb4e6.yml
@@ -1,0 +1,27 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-pnp/sources/generatePnpScript.ts
+++ b/packages/yarnpkg-pnp/sources/generatePnpScript.ts
@@ -10,12 +10,8 @@ import {PnpSettings}             from './types';
 export function generateLoader(shebang: string | null | undefined, loader: string) {
   return [
     shebang ? `${shebang}\n` : ``,
-    `/* eslint-disable */\n\n`,
-    `try {\n`,
-    `  Object.freeze({}).detectStrictMode = true;\n`,
-    `} catch (error) {\n`,
-    `  throw new Error(\`The whole PnP file got strict-mode-ified, which is known to break (Emscripten libraries aren't strict mode). This usually happens when the file goes through Babel.\`);\n`,
-    `}\n`,
+    `/* eslint-disable */\n`,
+    `"use strict";\n`,
     `\n`,
     loader,
     `\n`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `.pnp.cjs` file doesn't use strict mode because `Emscripten libraries aren't strict mode` but that isn't the case anymore.

**How did you fix it?**

Enabled strict mode.

**Benchmark result**

Doesn't do much for performance but either way:
```console
$ hyperfine "node -r ./.pnp-before.cjs -e 1" "node -r ./.pnp-after.cjs -e 1"
Benchmark 1: node -r ./.pnp-before.cjs -e 1
  Time (mean ± σ):      91.7 ms ±   2.7 ms    [User: 1.9 ms, System: 3.9 ms]
  Range (min … max):    89.6 ms …  99.7 ms    32 runs

Benchmark 2: node -r ./.pnp-after.cjs -e 1
  Time (mean ± σ):      91.0 ms ±   1.1 ms    [User: 0.5 ms, System: 1.6 ms]
  Range (min … max):    89.7 ms …  94.6 ms    31 runs

Summary
  'node -r ./.pnp-after.cjs -e 1' ran
    1.01 ± 0.03 times faster than 'node -r ./.pnp-before.cjs -e 1'
```


**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.