### PR TITLE
chore: lock Alpine version in `Dockerfile`s

### DIFF
--- a/scripts/actions/local-yarn-command/Dockerfile
+++ b/scripts/actions/local-yarn-command/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15
 
 LABEL "com.github.actions.name"="local-yarn-command"
 LABEL "com.github.actions.description"="Run a Yarn command using the checked-in build"
@@ -9,8 +9,8 @@ RUN apk add --no-cache bash nodejs rsync git
 
 # For building Sharp
 RUN apk add fftw-dev build-base autoconf python2 imagemagick --update-cache \
-    --repository https://alpine.global.ssl.fastly.net/alpine/edge/testing/ \
-    --repository https://alpine.global.ssl.fastly.net/alpine/edge/main
+  --repository https://alpine.global.ssl.fastly.net/alpine/edge/testing/ \
+  --repository https://alpine.global.ssl.fastly.net/alpine/edge/main
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/actions/make-commit/Dockerfile
+++ b/scripts/actions/make-commit/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15
 
 LABEL "com.github.actions.name"="make-commit"
 LABEL "com.github.actions.description"="Generates a commit with the given message"


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some of our `Dockerfile`s use `alpine:latest`.

Closes https://github.com/yarnpkg/berry/issues/4753
Closes https://github.com/yarnpkg/berry/pull/4755

**How did you fix it?**

Lock the version.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.