### PR TITLE
docs: add yarn corepack activation

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -26,6 +26,12 @@ Corepack isn't included with Node.js in versions before the 16.10; to address th
 npm i -g corepack
 ```
 
+## Activate Yarn
+
+```bash
+corepack prepare yarn@stable --activate
+```
+
 ## Initializing your project
 
 Just run the following command. It will generate some files inside your current directory; add them all to your next commit, and you'll be done!


### PR DESCRIPTION
**What's the problem this PR addresses?**
Installation requires a separate google search if you've never used `corepack`.

**How did you fix it?**
Added an "Activate Yarn" section to the documentation.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
