### PR TITLE
feat(plugin-patch): Expose Commands and Add Temp Path

### DIFF
--- a/.yarn/versions/e834d604.yml
+++ b/.yarn/versions/e834d604.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-patch": patch

--- a/.yarn/versions/e834d604.yml
+++ b/.yarn/versions/e834d604.yml
@@ -1,2 +1,6 @@
 releases:
   "@yarnpkg/plugin-patch": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/cli"

--- a/packages/plugin-patch/sources/commands/patch.ts
+++ b/packages/plugin-patch/sources/commands/patch.ts
@@ -32,6 +32,8 @@ export default class PatchCommand extends BaseCommand {
 
   package = Option.String();
 
+  tempPatchPath: string = ``;
+
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
@@ -76,10 +78,13 @@ export default class PatchCommand extends BaseCommand {
     }, async report => {
       const unpatchedLocator = patchUtils.ensureUnpatchedLocator(locator);
       const temp = await patchUtils.extractPackageToDisk(locator, {cache, project});
+      const tempPath = npath.fromPortablePath(temp);
+
+      this.tempPatchPath = tempPath;
 
       report.reportJson({
         locator: structUtils.stringifyLocator(unpatchedLocator),
-        path: npath.fromPortablePath(temp),
+        path: tempPath,
       });
 
       const updateString = this.update
@@ -88,7 +93,7 @@ export default class PatchCommand extends BaseCommand {
 
       report.reportInfo(MessageName.UNNAMED, `Package ${structUtils.prettyLocator(configuration, unpatchedLocator)} got extracted with success${updateString}!`);
       report.reportInfo(MessageName.UNNAMED, `You can now edit the following folder: ${formatUtils.pretty(configuration, npath.fromPortablePath(temp), `magenta`)}`);
-      report.reportInfo(MessageName.UNNAMED, `Once you are done run ${formatUtils.pretty(configuration, `yarn patch-commit -s ${process.platform === `win32` ? `"` : ``}${npath.fromPortablePath(temp)}${process.platform === `win32` ? `"` : ``}`, `cyan`)} and Yarn will store a patchfile based on your changes.`);
+      report.reportInfo(MessageName.UNNAMED, `Once you are done run ${formatUtils.pretty(configuration, `yarn patch-commit -s ${process.platform === `win32` ? `"` : ``}${tempPath}${process.platform === `win32` ? `"` : ``}`, `cyan`)} and Yarn will store a patchfile based on your changes.`);
     });
   }
 }

--- a/packages/plugin-patch/sources/index.ts
+++ b/packages/plugin-patch/sources/index.ts
@@ -9,6 +9,8 @@ import * as patchUtils                 from './patchUtils';
 
 export {patchUtils};
 
+export {PatchCommit, Patch};
+
 export interface Hooks {
   /**
    * Registers a builtin patch that can be referenced using the dedicated


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
This PR aims to improve the ability to write plugins that pertain to "patching" with Yarn.

In the [Clipanion docs](https://mael.dev/clipanion/docs/tips#adding-options-to-existing-commands) there is a section about how to `add options to an existing command`. In order to do this, as you may know, you need access to the original Command and then you can extend from that. 

Yarn berry does not expose either command in its `plugin-patch` package - which forced me to have to copy/paste them into my codebase (after a few failed attempts to work around it). 

Since the expected practice is to extend the command you're plugging - then I think its reasonable to export these command so they may be extended. 

---

This PR also includes another change - related to `patch` plug-ability. The `temp` folder path is not stored anywhere accessible from within the command. This makes sense - as it was never exposed and if it was needed it could be quickly modified within the existing file. 

With the exposure of these classes - its also helpful to have to path to which the patch was written to. An example that may help is - the plugin I'm writing will automatically open your "preferred editor" if set (much like `git` does - [see `core.editor`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)). 
 
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

- `export` both commands in this package
- added a variable to the `patch` class to expose to extended commands

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
