### PR TITLE
Add `export` fields to manifests to prevent deep imports

### DIFF
--- a/.yarn/versions/eceb2ca1.yml
+++ b/.yarn/versions/eceb2ca1.yml
@@ -1,0 +1,41 @@
+releases:
+  "@yarnpkg/builder": major
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/doctor": major
+  "@yarnpkg/eslint-config": minor
+  "@yarnpkg/extensions": major
+  "@yarnpkg/fslib": major
+  "@yarnpkg/libzip": major
+  "@yarnpkg/nm": major
+  "@yarnpkg/parsers": major
+  "@yarnpkg/plugin-compat": major
+  "@yarnpkg/plugin-constraints": major
+  "@yarnpkg/plugin-dlx": major
+  "@yarnpkg/plugin-essentials": major
+  "@yarnpkg/plugin-exec": major
+  "@yarnpkg/plugin-file": major
+  "@yarnpkg/plugin-git": major
+  "@yarnpkg/plugin-github": major
+  "@yarnpkg/plugin-http": major
+  "@yarnpkg/plugin-init": major
+  "@yarnpkg/plugin-interactive-tools": major
+  "@yarnpkg/plugin-link": major
+  "@yarnpkg/plugin-nm": major
+  "@yarnpkg/plugin-npm": major
+  "@yarnpkg/plugin-npm-cli": major
+  "@yarnpkg/plugin-pack": major
+  "@yarnpkg/plugin-patch": major
+  "@yarnpkg/plugin-pnp": major
+  "@yarnpkg/plugin-pnpm": major
+  "@yarnpkg/plugin-stage": major
+  "@yarnpkg/plugin-typescript": major
+  "@yarnpkg/plugin-version": major
+  "@yarnpkg/plugin-workspace-tools": major
+  "@yarnpkg/pnp": major
+  "@yarnpkg/pnpify": major
+  "@yarnpkg/sdks": major
+  "@yarnpkg/shell": major
+
+declined:
+  - vscode-zipfs

--- a/.yarn/versions/eceb2ca1.yml
+++ b/.yarn/versions/eceb2ca1.yml
@@ -36,6 +36,4 @@ releases:
   "@yarnpkg/pnpify": major
   "@yarnpkg/sdks": major
   "@yarnpkg/shell": major
-
-declined:
-  - vscode-zipfs
+  vscode-zipfs: patch

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,6 @@ module.exports = {
     `<rootDir>/packages/gatsby/.cache`,
     `<rootDir>/packages/plugin-compat`,
   ],
-  setupFiles: [require.resolve(`@yarnpkg/cli/sources/polyfills.ts`)],
+  setupFiles: [require.resolve(`@yarnpkg/cli/polyfills`)],
   testTimeout: 50000,
 };

--- a/packages/acceptance-tests/pkg-tests-core/package.json
+++ b/packages/acceptance-tests/pkg-tests-core/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/finalhandler": "1.1.0",
     "@types/invariant": "^2.2.30",

--- a/packages/acceptance-tests/pkg-tests-specs/package.json
+++ b/packages/acceptance-tests/pkg-tests-specs/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "license": "BSD-2-Clause",
   "main": "./sources/index.js",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/yarnpkg/berry.git",

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/prunedNativeDeps.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/prunedNativeDeps.test.ts
@@ -1,5 +1,7 @@
-import {Filename, PortablePath, ppath, xfs}  from '@yarnpkg/fslib';
-import {RequestType, startRegistryRecording} from 'pkg-tests-core/sources/utils/tests';
+import {Filename, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
+import {tests}                              from 'pkg-tests-core';
+
+const {RequestType, startRegistryRecording} = tests;
 
 export {};
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,6 +2,10 @@
   "name": "@yarnpkg/eslint-config",
   "version": "1.0.0-rc.18",
   "license": "BSD-2-Clause",
+  "exports": {
+    ".": "./index.js",
+    "./react": "./react.js"
+  },
   "dependencies": {
     "@rushstack/eslint-patch": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "^5.3.1",

--- a/packages/gatsby/gatsby-plugin-yarn-introspection/gatsby-node.js
+++ b/packages/gatsby/gatsby-plugin-yarn-introspection/gatsby-node.js
@@ -19,8 +19,9 @@ exports.sourceNodes = async ({actions, createNodeId, createContentDigest}, opts)
     }
   });
 
+  const monorepoRoot = require.resolve(`@yarnpkg/monorepo/package.json`).replace(`/package.json`, ``);
   const data = await execute([
-    require.resolve(`@yarnpkg/monorepo/packages/yarnpkg-core/sources/Plugin.ts`),
+    require.resolve(`${monorepoRoot}/packages/yarnpkg-core/sources/Plugin.ts`),
     ...indexList,
   ]);
 

--- a/packages/gatsby/gatsby-plugin-yarn-introspection/gatsby-node.js
+++ b/packages/gatsby/gatsby-plugin-yarn-introspection/gatsby-node.js
@@ -19,9 +19,8 @@ exports.sourceNodes = async ({actions, createNodeId, createContentDigest}, opts)
     }
   });
 
-  const monorepoRoot = require.resolve(`@yarnpkg/monorepo/package.json`).replace(`/package.json`, ``);
   const data = await execute([
-    require.resolve(`${monorepoRoot}/packages/yarnpkg-core/sources/Plugin.ts`),
+    require.resolve(path.resolve(packageDirectory, `yarnpkg-core/sources/Plugin.ts`)),
     ...indexList,
   ]);
 

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -42,10 +42,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -4,6 +4,10 @@
   "stableVersion": "3.1.4",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "@yarnpkg/core": "workspace:^",
     "@yarnpkg/plugin-patch": "workspace:^"
@@ -36,7 +40,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-compat/package.json
+++ b/packages/plugin-compat/package.json
@@ -40,7 +40,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -36,7 +36,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -11,7 +11,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -42,10 +41,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -38,10 +38,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -9,6 +9,11 @@
     "directory": "packages/plugin-constraints"
   },
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -32,7 +37,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-constraints/sources/index.ts
+++ b/packages/plugin-constraints/sources/index.ts
@@ -1,9 +1,13 @@
-import {Plugin, SettingsType} from '@yarnpkg/core';
-import {PortablePath}         from '@yarnpkg/fslib';
+import {Plugin, SettingsType}   from '@yarnpkg/core';
+import {PortablePath}           from '@yarnpkg/fslib';
 
-import queryConstraints       from './commands/constraints/query';
-import sourceConstraints      from './commands/constraints/source';
-import constraints            from './commands/constraints';
+import ConstraintsQueryCommand  from './commands/constraints/query';
+import ConstraintsSourceCommand from './commands/constraints/source';
+import ConstraintsCheckCommand  from './commands/constraints';
+
+export {ConstraintsQueryCommand};
+export {ConstraintsSourceCommand};
+export {ConstraintsCheckCommand};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
@@ -20,9 +24,9 @@ const plugin: Plugin = {
     },
   },
   commands: [
-    queryConstraints,
-    sourceConstraints,
-    constraints,
+    ConstraintsQueryCommand,
+    ConstraintsSourceCommand,
+    ConstraintsCheckCommand,
   ],
 };
 

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -6,7 +6,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -38,10 +37,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -4,6 +4,11 @@
   "stableVersion": "3.1.3",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -28,7 +33,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -32,7 +32,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-dlx/package.json
+++ b/packages/plugin-dlx/package.json
@@ -34,10 +34,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-dlx/sources/index.ts
+++ b/packages/plugin-dlx/sources/index.ts
@@ -1,12 +1,15 @@
-import {Plugin} from '@yarnpkg/core';
+import {Plugin}      from '@yarnpkg/core';
 
-import create   from './commands/create';
-import dlx      from './commands/dlx';
+import CreateCommand from './commands/create';
+import DlxCommand    from './commands/dlx';
+
+export {CreateCommand};
+export {DlxCommand};
 
 const plugin: Plugin = {
   commands: [
-    create,
-    dlx,
+    CreateCommand,
+    DlxCommand,
   ],
 };
 

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -43,7 +43,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -45,10 +45,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/parsers": "workspace:^",
@@ -39,7 +44,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -5,7 +5,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -49,10 +48,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -10,7 +10,7 @@ import {runInNewContext}                                                        
 import {getAvailablePlugins}                                                               from './list';
 
 // eslint-disable-next-line arca/no-default-export
-export default class PluginDlCommand extends BaseCommand {
+export default class PluginImportCommand extends BaseCommand {
   static paths = [
     [`plugin`, `import`],
   ];

--- a/packages/plugin-essentials/sources/commands/plugin/import/sources.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import/sources.ts
@@ -14,7 +14,7 @@ const buildWorkflow = ({pluginName, noMinify}: {noMinify: boolean, pluginName: s
 ];
 
 // eslint-disable-next-line arca/no-default-export
-export default class PluginDlSourcesCommand extends BaseCommand {
+export default class PluginImportSourcesCommand extends BaseCommand {
   static paths = [
     [`plugin`, `import`, `from`, `sources`],
   ];

--- a/packages/plugin-essentials/sources/commands/plugin/list.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/list.ts
@@ -15,7 +15,7 @@ export async function getAvailablePlugins(configuration: Configuration, version:
 }
 
 // eslint-disable-next-line arca/no-default-export
-export default class PluginDlCommand extends BaseCommand {
+export default class PluginListCommand extends BaseCommand {
   static paths = [
     [`plugin`, `list`],
   ];

--- a/packages/plugin-essentials/sources/commands/plugin/runtime.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/runtime.ts
@@ -3,7 +3,7 @@ import {Configuration, StreamReport} from '@yarnpkg/core';
 import {Command, Option, Usage}      from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
-export default class PluginListCommand extends BaseCommand {
+export default class PluginRuntimeCommand extends BaseCommand {
   static paths = [
     [`plugin`, `runtime`],
   ];

--- a/packages/plugin-essentials/sources/commands/rebuild.ts
+++ b/packages/plugin-essentials/sources/commands/rebuild.ts
@@ -4,7 +4,7 @@ import {ThrowReport, structUtils, Project}             from '@yarnpkg/core';
 import {Command, Option, Usage}                        from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
-export default class RunCommand extends BaseCommand {
+export default class RebuildCommand extends BaseCommand {
   static paths = [
     [`rebuild`],
   ];

--- a/packages/plugin-essentials/sources/commands/runIndex.ts
+++ b/packages/plugin-essentials/sources/commands/runIndex.ts
@@ -4,7 +4,7 @@ import {miscUtils}                            from '@yarnpkg/core';
 import {inspect}                              from 'util';
 
 // eslint-disable-next-line arca/no-default-export
-export default class RunCommand extends BaseCommand {
+export default class RunIndexCommand extends BaseCommand {
   static paths = [
     [`run`],
   ];

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -2,49 +2,83 @@ import {Descriptor, Plugin, SettingsType, Package, formatUtils} from '@yarnpkg/c
 import {Workspace}                                              from '@yarnpkg/core';
 import {isCI}                                                   from 'ci-info';
 
-import add                                                      from './commands/add';
-import bin                                                      from './commands/bin';
-import cleanCache                                               from './commands/cache/clean';
-import getConfig                                                from './commands/config/get';
-import setConfig                                                from './commands/config/set';
-import unsetConfig                                              from './commands/config/unset';
-import config                                                   from './commands/config';
-import dedupe                                                   from './commands/dedupe';
-import clipanionEntry                                           from './commands/entries/clipanion';
-import helpEntry                                                from './commands/entries/help';
-import runEntry                                                 from './commands/entries/run';
-import versionEntry                                             from './commands/entries/version';
-import exec                                                     from './commands/exec';
-import explainPeerRequirements                                  from './commands/explain/peerRequirements';
-import explain                                                  from './commands/explain';
-import info                                                     from './commands/info';
-import install                                                  from './commands/install';
-import link                                                     from './commands/link';
-import node                                                     from './commands/node';
-import pluginImportSources                                      from './commands/plugin/import/sources';
-import pluginImport                                             from './commands/plugin/import';
-import pluginList                                               from './commands/plugin/list';
-import pluginRemove                                             from './commands/plugin/remove';
-import pluginRuntime                                            from './commands/plugin/runtime';
-import rebuild                                                  from './commands/rebuild';
-import remove                                                   from './commands/remove';
-import runIndex                                                 from './commands/runIndex';
-import run                                                      from './commands/run';
-import setResolutionPolicy                                      from './commands/set/resolution';
-import setVersionFromSources                                    from './commands/set/version/sources';
-import setVersionPolicy                                         from './commands/set/version';
-import unlink                                                   from './commands/unlink';
-import up                                                       from './commands/up';
-import why                                                      from './commands/why';
-import listWorkspaces                                           from './commands/workspaces/list';
-import workspace                                                from './commands/workspace';
+import AddCommand                                               from './commands/add';
+import BinCommand                                               from './commands/bin';
+import CacheCleanCommand                                        from './commands/cache/clean';
+import ConfigGetCommand                                         from './commands/config/get';
+import ConfigSetCommand                                         from './commands/config/set';
+import ConfigUnsetCommand                                       from './commands/config/unset';
+import ConfigCommand                                            from './commands/config';
+import DedupeCommand                                            from './commands/dedupe';
+import ClipanionCommand                                         from './commands/entries/clipanion';
+import HelpCommand                                              from './commands/entries/help';
+import EntryCommand                                             from './commands/entries/run';
+import VersionCommand                                           from './commands/entries/version';
+import ExecCommand                                              from './commands/exec';
+import ExplainPeerRequirementsCommand                           from './commands/explain/peerRequirements';
+import ExplainCommand                                           from './commands/explain';
+import InfoCommand                                              from './commands/info';
+import YarnCommand                                              from './commands/install';
+import LinkCommand                                              from './commands/link';
+import NodeCommand                                              from './commands/node';
+import PluginImportSourcesCommand                               from './commands/plugin/import/sources';
+import PluginImportCommand                                      from './commands/plugin/import';
+import PluginListCommand                                        from './commands/plugin/list';
+import PluginRemoveCommand                                      from './commands/plugin/remove';
+import PluginRuntimeCommand                                     from './commands/plugin/runtime';
+import RebuildCommand                                           from './commands/rebuild';
+import RemoveCommand                                            from './commands/remove';
+import RunIndexCommand                                          from './commands/runIndex';
+import RunCommand                                               from './commands/run';
+import SetResolutionCommand                                     from './commands/set/resolution';
+import SetVersionSourcesCommand                                 from './commands/set/version/sources';
+import SetVersionCommand                                        from './commands/set/version';
+import UnlinkCommand                                            from './commands/unlink';
+import UpCommand                                                from './commands/up';
+import WhyCommand                                               from './commands/why';
+import WorkspacesListCommand                                    from './commands/workspaces/list';
+import WorkspaceCommand                                         from './commands/workspace';
 import * as dedupeUtils                                         from './dedupeUtils';
 import * as suggestUtils                                        from './suggestUtils';
 
-export {
-  dedupeUtils,
-  suggestUtils,
-};
+export {AddCommand};
+export {BinCommand};
+export {CacheCleanCommand};
+export {ConfigGetCommand};
+export {ConfigSetCommand};
+export {ConfigUnsetCommand};
+export {ConfigCommand};
+export {DedupeCommand};
+export {ClipanionCommand};
+export {HelpCommand};
+export {EntryCommand};
+export {VersionCommand};
+export {ExecCommand};
+export {ExplainPeerRequirementsCommand};
+export {ExplainCommand};
+export {InfoCommand};
+export {YarnCommand};
+export {LinkCommand};
+export {NodeCommand};
+export {PluginImportSourcesCommand};
+export {PluginImportCommand};
+export {PluginListCommand};
+export {PluginRemoveCommand};
+export {PluginRuntimeCommand};
+export {RebuildCommand};
+export {RemoveCommand};
+export {RunIndexCommand};
+export {RunCommand};
+export {SetResolutionCommand};
+export {SetVersionSourcesCommand};
+export {SetVersionCommand};
+export {UnlinkCommand};
+export {UpCommand};
+export {WhyCommand};
+export {WorkspacesListCommand};
+export {WorkspaceCommand};
+export {dedupeUtils};
+export {suggestUtils};
 
 export interface Hooks {
   /**
@@ -134,42 +168,42 @@ const plugin: Plugin = {
     },
   },
   commands: [
-    cleanCache,
-    getConfig,
-    setConfig,
-    unsetConfig,
-    setResolutionPolicy,
-    setVersionFromSources,
-    setVersionPolicy,
-    listWorkspaces,
-    clipanionEntry,
-    helpEntry,
-    runEntry,
-    versionEntry,
-    add,
-    bin,
-    config,
-    dedupe,
-    exec,
-    explainPeerRequirements,
-    explain,
-    info,
-    install,
-    link,
-    unlink,
-    node,
-    pluginImportSources,
-    pluginImport,
-    pluginRemove,
-    pluginList,
-    pluginRuntime,
-    rebuild,
-    remove,
-    runIndex,
-    run,
-    up,
-    why,
-    workspace,
+    CacheCleanCommand,
+    ConfigGetCommand,
+    ConfigSetCommand,
+    ConfigUnsetCommand,
+    SetResolutionCommand,
+    SetVersionSourcesCommand,
+    SetVersionCommand,
+    WorkspacesListCommand,
+    ClipanionCommand,
+    HelpCommand,
+    EntryCommand,
+    VersionCommand,
+    AddCommand,
+    BinCommand,
+    ConfigCommand,
+    DedupeCommand,
+    ExecCommand,
+    ExplainPeerRequirementsCommand,
+    ExplainCommand,
+    InfoCommand,
+    YarnCommand,
+    LinkCommand,
+    UnlinkCommand,
+    NodeCommand,
+    PluginImportSourcesCommand,
+    PluginImportCommand,
+    PluginRemoveCommand,
+    PluginListCommand,
+    PluginRuntimeCommand,
+    RebuildCommand,
+    RemoveCommand,
+    RunIndexCommand,
+    RunCommand,
+    UpCommand,
+    WhyCommand,
+    WorkspaceCommand,
   ],
 };
 

--- a/packages/plugin-exec/package.json
+++ b/packages/plugin-exec/package.json
@@ -29,7 +29,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-exec/package.json
+++ b/packages/plugin-exec/package.json
@@ -31,10 +31,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-exec/package.json
+++ b/packages/plugin-exec/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "tslib": "^2.4.0"
@@ -25,7 +29,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-exec/sources/index.ts
+++ b/packages/plugin-exec/sources/index.ts
@@ -6,6 +6,8 @@ import * as execUtils         from './execUtils';
 
 export type {ExecEnv};
 export {execUtils};
+export {ExecFetcher};
+export {ExecResolver};
 
 const plugin: Plugin = {
   fetchers: [

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -30,10 +30,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "tslib": "^2.4.0"
@@ -24,7 +28,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-file/package.json
+++ b/packages/plugin-file/package.json
@@ -28,7 +28,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-file/sources/index.ts
+++ b/packages/plugin-file/sources/index.ts
@@ -7,6 +7,10 @@ import {TarballFileResolver} from './TarballFileResolver';
 import * as fileUtils        from './fileUtils';
 
 export {fileUtils};
+export {FileFetcher};
+export {FileResolver};
+export {TarballFileFetcher};
+export {TarballFileResolver};
 
 const plugin: Plugin = {
   fetchers: [

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@types/semver": "^7.1.0",
     "@yarnpkg/fslib": "workspace:^",
@@ -31,7 +35,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -35,7 +35,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-git/package.json
+++ b/packages/plugin-git/package.json
@@ -37,10 +37,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-git/sources/index.ts
+++ b/packages/plugin-git/sources/index.ts
@@ -60,6 +60,8 @@ const plugin: Plugin = {
 };
 
 export {gitUtils};
+export {GitFetcher};
+export {GitResolver};
 
 // eslint-disable-next-line arca/no-default-export
 export default plugin;

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -33,10 +33,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -31,7 +31,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-github/package.json
+++ b/packages/plugin-github/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "tslib": "^2.4.0"
@@ -27,7 +31,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-github/sources/index.ts
+++ b/packages/plugin-github/sources/index.ts
@@ -2,6 +2,10 @@ import {Plugin}            from '@yarnpkg/core';
 import {Hooks as GitHooks} from '@yarnpkg/plugin-git';
 
 import {GithubFetcher}     from './GithubFetcher';
+import * as githubUtils    from './githubUtils';
+
+export {githubUtils};
+export {GithubFetcher};
 
 const plugin: Plugin<GitHooks> = {
   hooks: {

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "tslib": "^2.4.0"
   },
@@ -23,7 +27,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -29,10 +29,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -27,7 +27,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-http/sources/index.ts
+++ b/packages/plugin-http/sources/index.ts
@@ -3,6 +3,9 @@ import {Plugin}              from '@yarnpkg/core';
 import {TarballHttpFetcher}  from './TarballHttpFetcher';
 import {TarballHttpResolver} from './TarballHttpResolver';
 
+export {TarballHttpFetcher};
+export {TarballHttpResolver};
+
 const plugin: Plugin = {
   fetchers: [
     TarballHttpFetcher,

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -5,7 +5,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -37,10 +36,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -33,10 +33,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -31,7 +31,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-init/package.json
+++ b/packages/plugin-init/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -27,7 +32,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-init/sources/index.ts
+++ b/packages/plugin-init/sources/index.ts
@@ -1,6 +1,8 @@
 import {Plugin, SettingsType} from '@yarnpkg/core';
 
-import init                   from './commands/init';
+import InitCommand            from './commands/init';
+
+export {InitCommand};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
@@ -35,7 +37,7 @@ const plugin: Plugin = {
     },
   },
   commands: [
-    init,
+    InitCommand,
   ],
 };
 

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -6,7 +6,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -50,10 +49,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -46,10 +46,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -4,6 +4,11 @@
   "stableVersion": "3.1.4",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/libui": "workspace:^",
     "algoliasearch": "^4.2.0",
@@ -40,7 +45,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-interactive-tools/package.json
+++ b/packages/plugin-interactive-tools/package.json
@@ -44,7 +44,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-interactive-tools/sources/index.ts
+++ b/packages/plugin-interactive-tools/sources/index.ts
@@ -1,12 +1,15 @@
-import {Plugin}           from '@yarnpkg/core';
+import {Plugin}                  from '@yarnpkg/core';
 
-import search             from './commands/search';
-import upgradeInteractive from './commands/upgrade-interactive';
+import SearchCommand             from './commands/search';
+import UpgradeInteractiveCommand from './commands/upgrade-interactive';
+
+export {SearchCommand};
+export {UpgradeInteractiveCommand};
 
 const plugin: Plugin = {
   commands: [
-    search,
-    upgradeInteractive,
+    SearchCommand,
+    UpgradeInteractiveCommand,
   ],
 };
 

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -30,10 +30,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "tslib": "^2.4.0"
@@ -24,7 +28,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-link/package.json
+++ b/packages/plugin-link/package.json
@@ -28,7 +28,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-link/sources/index.ts
+++ b/packages/plugin-link/sources/index.ts
@@ -5,6 +5,11 @@ import {LinkResolver}    from './LinkResolver';
 import {RawLinkFetcher}  from './RawLinkFetcher';
 import {RawLinkResolver} from './RawLinkResolver';
 
+export {LinkFetcher};
+export {LinkResolver};
+export {RawLinkFetcher};
+export {RawLinkResolver};
+
 const plugin: Plugin = {
   fetchers: [
     RawLinkFetcher,

--- a/packages/plugin-nm/package.json
+++ b/packages/plugin-nm/package.json
@@ -2,6 +2,10 @@
   "name": "@yarnpkg/plugin-nm",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/libzip": "workspace:^",
@@ -37,7 +41,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-nm/package.json
+++ b/packages/plugin-nm/package.json
@@ -43,10 +43,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-nm/package.json
+++ b/packages/plugin-nm/package.json
@@ -41,7 +41,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-nm/sources/index.ts
+++ b/packages/plugin-nm/sources/index.ts
@@ -6,6 +6,10 @@ import {NodeModulesLinker, NodeModulesMode} from './NodeModulesLinker';
 import {getGlobalHardlinksStore}            from './NodeModulesLinker';
 import {PnpLooseLinker}                     from './PnpLooseLinker';
 
+export {NodeModulesLinker};
+export {NodeModulesMode};
+export {PnpLooseLinker};
+
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     nmHoistingLimits: NodeModulesHoistingLimits;

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -5,7 +5,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -48,10 +47,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -42,7 +42,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -38,7 +43,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-npm-cli/package.json
+++ b/packages/plugin-npm-cli/package.json
@@ -44,10 +44,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -9,7 +9,7 @@ import * as npmAuditTypes                                                       
 import * as npmAuditUtils                                                          from '../../npmAuditUtils';
 
 // eslint-disable-next-line arca/no-default-export
-export default class AuditCommand extends BaseCommand {
+export default class NpmAuditCommand extends BaseCommand {
   static paths = [
     [`npm`, `audit`],
   ];

--- a/packages/plugin-npm-cli/sources/commands/npm/info.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/info.ts
@@ -27,7 +27,7 @@ interface PackageInformation extends CombinedPackument {
 }
 
 // eslint-disable-next-line arca/no-default-export
-export default class InfoCommand extends BaseCommand {
+export default class NpmInfoCommand extends BaseCommand {
   static paths = [
     [`npm`, `info`],
   ];

--- a/packages/plugin-npm-cli/sources/index.ts
+++ b/packages/plugin-npm-cli/sources/index.ts
@@ -1,17 +1,26 @@
 import {Plugin, SettingsType} from '@yarnpkg/core';
 
-import npmAudit               from './commands/npm/audit';
-import npmInfo                from './commands/npm/info';
-import npmLogin               from './commands/npm/login';
-import npmLogout              from './commands/npm/logout';
-import npmPublish             from './commands/npm/publish';
-import npmTagAdd              from './commands/npm/tag/add';
-import npmTagList             from './commands/npm/tag/list';
-import npmTagRemove           from './commands/npm/tag/remove';
-import npmWhoami              from './commands/npm/whoami';
+import NpmAuditCommand        from './commands/npm/audit';
+import NpmInfoCommand         from './commands/npm/info';
+import NpmLoginCommand        from './commands/npm/login';
+import NpmLogoutCommand       from './commands/npm/logout';
+import NpmPublishCommand      from './commands/npm/publish';
+import NpmTagAddCommand       from './commands/npm/tag/add';
+import NpmTagListCommand      from './commands/npm/tag/list';
+import NpmTagRemoveCommand    from './commands/npm/tag/remove';
+import NpmWhoamiCommand       from './commands/npm/whoami';
 import * as npmAuditUtils     from './npmAuditUtils';
 
 export {npmAuditUtils};
+export {NpmAuditCommand};
+export {NpmInfoCommand};
+export {NpmLoginCommand};
+export {NpmLogoutCommand};
+export {NpmPublishCommand};
+export {NpmTagAddCommand};
+export {NpmTagListCommand};
+export {NpmTagRemoveCommand};
+export {NpmWhoamiCommand};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
@@ -42,15 +51,15 @@ const plugin: Plugin = {
     },
   },
   commands: [
-    npmAudit,
-    npmInfo,
-    npmLogin,
-    npmLogout,
-    npmPublish,
-    npmTagAdd,
-    npmTagList,
-    npmTagRemove,
-    npmWhoami,
+    NpmAuditCommand,
+    NpmInfoCommand,
+    NpmLoginCommand,
+    NpmLogoutCommand,
+    NpmPublishCommand,
+    NpmTagAddCommand,
+    NpmTagListCommand,
+    NpmTagRemoveCommand,
+    NpmWhoamiCommand,
   ],
 };
 

--- a/packages/plugin-npm-cli/sources/index.ts
+++ b/packages/plugin-npm-cli/sources/index.ts
@@ -9,6 +9,9 @@ import npmTagAdd              from './commands/npm/tag/add';
 import npmTagList             from './commands/npm/tag/list';
 import npmTagRemove           from './commands/npm/tag/remove';
 import npmWhoami              from './commands/npm/whoami';
+import * as npmAuditUtils     from './npmAuditUtils';
+
+export {npmAuditUtils};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {

--- a/packages/plugin-npm-cli/tests/npmAuditUtils.test.js
+++ b/packages/plugin-npm-cli/tests/npmAuditUtils.test.js
@@ -1,4 +1,6 @@
-import {allSeverities, isError, getReportTree, getRequires, getDependencies} from '@yarnpkg/plugin-npm-cli/sources/npmAuditUtils';
+import {npmAuditUtils} from '@yarnpkg/plugin-npm-cli';
+
+const {allSeverities, isError, getReportTree, getRequires, getDependencies} = npmAuditUtils;
 
 describe(`npmAuditUtils`, () => {
   // Severity levels

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "enquirer": "^2.3.6",
@@ -31,7 +35,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -35,7 +35,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -37,10 +37,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -12,6 +12,11 @@ import * as npmPublishUtils                                    from './npmPublis
 export {npmConfigUtils};
 export {npmHttpUtils};
 export {npmPublishUtils};
+export {NpmHttpFetcher};
+export {NpmRemapResolver};
+export {NpmSemverFetcher};
+export {NpmSemverResolver};
+export {NpmTagResolver};
 
 export interface Hooks {
   /**

--- a/packages/plugin-npm/tests/npmHttpUtils.test.js
+++ b/packages/plugin-npm/tests/npmHttpUtils.test.js
@@ -1,5 +1,5 @@
 import {httpUtils}         from '@yarnpkg/core';
-import {get}               from '@yarnpkg/plugin-npm/sources/npmHttpUtils';
+import {npmHttpUtils}      from '@yarnpkg/plugin-npm';
 
 import {makeConfiguration} from './_makeConfiguration';
 
@@ -19,7 +19,7 @@ describe(`npmHttpUtils.get`, () => {
       it(`should craft the final path correctly (${registry} + ${path} = ${expected})`, async () => {
         const configuration = await makeConfiguration();
 
-        await get(path, {
+        await npmHttpUtils.get(path, {
           configuration,
           registry,
         });

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -36,7 +36,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -5,7 +5,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -42,10 +41,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -32,7 +37,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-pack/package.json
+++ b/packages/plugin-pack/package.json
@@ -38,10 +38,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -1,9 +1,10 @@
 import {Hooks as CoreHooks, Plugin, Workspace, structUtils} from '@yarnpkg/core';
 import {MessageName, ReportError}                           from '@yarnpkg/core';
 
-import pack                                                 from './commands/pack';
+import PackCommand                                          from './commands/pack';
 import * as packUtils                                       from './packUtils';
 
+export {PackCommand};
 export {packUtils};
 
 export interface Hooks {
@@ -91,7 +92,7 @@ const plugin: Plugin<CoreHooks & Hooks> = {
     beforeWorkspacePacking,
   },
   commands: [
-    pack,
+    PackCommand,
   ],
 };
 

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -33,7 +33,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -35,10 +35,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -4,6 +4,11 @@
   "stableVersion": "3.2.2",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/libzip": "workspace:^",
@@ -29,7 +34,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-patch/package.json
+++ b/packages/plugin-patch/package.json
@@ -6,7 +6,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -39,10 +38,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-patch/sources/index.ts
+++ b/packages/plugin-patch/sources/index.ts
@@ -8,6 +8,8 @@ import Patch                           from './commands/patch';
 import * as patchUtils                 from './patchUtils';
 
 export {patchUtils};
+export {PatchFetcher};
+export {PatchResolver};
 
 export interface Hooks {
   /**

--- a/packages/plugin-patch/sources/index.ts
+++ b/packages/plugin-patch/sources/index.ts
@@ -3,13 +3,15 @@ import {PortablePath}                  from '@yarnpkg/fslib';
 
 import {PatchFetcher}                  from './PatchFetcher';
 import {PatchResolver}                 from './PatchResolver';
-import PatchCommit                     from './commands/patchCommit';
-import Patch                           from './commands/patch';
+import PatchCommitCommand              from './commands/patchCommit';
+import PatchCommand                    from './commands/patch';
 import * as patchUtils                 from './patchUtils';
 
-export {patchUtils};
 export {PatchFetcher};
 export {PatchResolver};
+export {PatchCommitCommand};
+export {PatchCommand};
+export {patchUtils};
 
 export interface Hooks {
   /**
@@ -44,8 +46,8 @@ const plugin: Plugin = {
     },
   },
   commands: [
-    PatchCommit,
-    Patch,
+    PatchCommitCommand,
+    PatchCommand,
   ],
   fetchers: [
     PatchFetcher,

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -40,10 +40,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -4,6 +4,11 @@
   "stableVersion": "3.2.2",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@types/semver": "^7.1.0",
     "@yarnpkg/fslib": "workspace:^",
@@ -34,7 +39,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -38,7 +38,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -6,7 +6,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -44,10 +43,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -5,10 +5,11 @@ import semver                                              from 'semver';
 import {pathToFileURL}                                     from 'url';
 
 import {PnpLinker}                                         from './PnpLinker';
-import unplug                                              from './commands/unplug';
+import UnplugCommand                                       from './commands/unplug';
 import * as jsInstallUtils                                 from './jsInstallUtils';
 import * as pnpUtils                                       from './pnpUtils';
 
+export {UnplugCommand};
 export {jsInstallUtils};
 export {pnpUtils};
 
@@ -123,7 +124,7 @@ const plugin: Plugin<CoreHooks & StageHooks> = {
     PnpLinker,
   ],
   commands: [
-    unplug,
+    UnplugCommand,
   ],
 };
 

--- a/packages/plugin-pnpm/package.json
+++ b/packages/plugin-pnpm/package.json
@@ -36,10 +36,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-pnpm/package.json
+++ b/packages/plugin-pnpm/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/plugin-pnp": "workspace:^",
@@ -30,7 +34,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-pnpm/package.json
+++ b/packages/plugin-pnpm/package.json
@@ -34,7 +34,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-pnpm/sources/index.ts
+++ b/packages/plugin-pnpm/sources/index.ts
@@ -2,6 +2,8 @@ import {Plugin}     from '@yarnpkg/core';
 
 import {PnpmLinker} from './PnpmLinker';
 
+export {PnpmLinker};
+
 const plugin: Plugin = {
   linkers: [
     PnpmLinker,

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -5,7 +5,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -38,10 +37,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -32,7 +32,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -34,10 +34,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-stage/package.json
+++ b/packages/plugin-stage/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -28,7 +33,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-stage/sources/index.ts
+++ b/packages/plugin-stage/sources/index.ts
@@ -1,9 +1,10 @@
 import {Plugin, Project} from '@yarnpkg/core';
 import {PortablePath}    from '@yarnpkg/fslib';
 
-import stage             from './commands/stage';
+import StageCommand      from './commands/stage';
 import * as stageUtils   from './stageUtils';
 
+export {StageCommand};
 export {stageUtils};
 
 export interface Hooks {
@@ -15,7 +16,7 @@ export interface Hooks {
 
 const plugin: Plugin = {
   commands: [
-    stage,
+    StageCommand,
   ],
 };
 

--- a/packages/plugin-stage/sources/index.ts
+++ b/packages/plugin-stage/sources/index.ts
@@ -2,6 +2,9 @@ import {Plugin, Project} from '@yarnpkg/core';
 import {PortablePath}    from '@yarnpkg/fslib';
 
 import stage             from './commands/stage';
+import * as stageUtils   from './stageUtils';
+
+export {stageUtils};
 
 export interface Hooks {
   populateYarnPaths?: (

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -40,10 +40,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -3,6 +3,10 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/plugin-pack": "workspace:^",
@@ -34,7 +38,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -38,7 +38,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -43,7 +43,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -45,10 +45,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/libui": "workspace:^",
@@ -39,7 +44,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -5,7 +5,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -49,10 +48,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -1,11 +1,14 @@
 import {Plugin, SettingsType} from '@yarnpkg/core';
 import {PortablePath}         from '@yarnpkg/fslib';
 
-import versionApply           from './commands/version/apply';
-import versionCheck           from './commands/version/check';
-import version                from './commands/version';
+import VersionApplyCommand    from './commands/version/apply';
+import VersionCheckCommand    from './commands/version/check';
+import VersionCommand         from './commands/version';
 import * as versionUtils      from './versionUtils';
 
+export {VersionApplyCommand};
+export {VersionCheckCommand};
+export {VersionCommand};
 export {versionUtils};
 
 declare module '@yarnpkg/core' {
@@ -29,9 +32,9 @@ const plugin: Plugin = {
     },
   },
   commands: [
-    versionApply,
-    versionCheck,
-    version,
+    VersionApplyCommand,
+    VersionCheckCommand,
+    VersionCommand,
   ],
 };
 

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -4,6 +4,11 @@
   "stableVersion": "3.1.3",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
@@ -35,7 +40,18 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -6,7 +6,6 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -45,10 +44,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -41,10 +41,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/plugin-workspace-tools/package.json
+++ b/packages/plugin-workspace-tools/package.json
@@ -39,7 +39,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/plugin-workspace-tools/sources/commands/focus.ts
+++ b/packages/plugin-workspace-tools/sources/commands/focus.ts
@@ -4,7 +4,7 @@ import {structUtils}                                                      from '
 import {Command, Option, Usage}                                           from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
-export default class WorkspacesFocus extends BaseCommand {
+export default class WorkspacesFocusCommand extends BaseCommand {
   static paths = [
     [`workspaces`, `focus`],
   ];

--- a/packages/plugin-workspace-tools/sources/index.ts
+++ b/packages/plugin-workspace-tools/sources/index.ts
@@ -1,12 +1,15 @@
-import {Plugin} from '@yarnpkg/core';
+import {Plugin}                 from '@yarnpkg/core';
 
-import focus    from './commands/focus';
-import foreach  from './commands/foreach';
+import WorkspacesFocusCommand   from './commands/focus';
+import WorkspacesForeachCommand from './commands/foreach';
+
+export {WorkspacesFocusCommand};
+export {WorkspacesForeachCommand};
 
 const plugin: Plugin = {
   commands: [
-    focus,
-    foreach,
+    WorkspacesFocusCommand,
+    WorkspacesForeachCommand,
   ],
 };
 

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -5,8 +5,8 @@
   "license": "BSD-2-Clause",
   "bin": "./sources/boot-cli-dev.js",
   "exports": {
+    ".": "./sources/index.ts",
     "./cli": "./sources/boot-cli-dev.js",
-    "./command/*": "./sources/commands/*.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {
@@ -32,9 +32,9 @@
   "publishConfig": {
     "bin": "./lib/cli.js",
     "exports": {
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
       },
       "./cli": {
         "types": "./lib/cli.d.ts",

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -32,14 +32,8 @@
   "publishConfig": {
     "bin": "./lib/cli.js",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
-      "./cli": {
-        "types": "./lib/cli.d.ts",
-        "require": "./lib/cli.js"
-      },
+      ".": "./lib/index.js",
+      "./cli": "./lib/cli.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-builder/package.json
+++ b/packages/yarnpkg-builder/package.json
@@ -4,6 +4,11 @@
   "stableVersion": "3.2.3",
   "license": "BSD-2-Clause",
   "bin": "./sources/boot-cli-dev.js",
+  "exports": {
+    "./cli": "./sources/boot-cli-dev.js",
+    "./command/*": "./sources/commands/*.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/cli": "workspace:^",
     "@yarnpkg/core": "workspace:^",
@@ -25,7 +30,18 @@
     "release": "yarn npm publish"
   },
   "publishConfig": {
-    "bin": "./lib/cli.js"
+    "bin": "./lib/cli.js",
+    "exports": {
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./cli": {
+        "types": "./lib/cli.d.ts",
+        "require": "./lib/cli.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-builder/sources/index.ts
+++ b/packages/yarnpkg-builder/sources/index.ts
@@ -1,0 +1,7 @@
+import BuildBundleCommand from './commands/build/bundle';
+import BuildPluginCommand from './commands/build/plugin';
+import NewPluginCommand   from './commands/new/plugin';
+
+export {BuildBundleCommand};
+export {BuildPluginCommand};
+export {NewPluginCommand};

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -4,6 +4,10 @@
   "stableVersion": "3.2.2",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/core": "workspace:^",
     "@yarnpkg/fslib": "workspace:^",
@@ -60,7 +64,14 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
-    "bin": null
+    "bin": null,
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -67,10 +67,7 @@
     "types": "./lib/index.d.ts",
     "bin": null,
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -64,7 +64,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "bin": null,
     "exports": {
       ".": "./lib/index.js",

--- a/packages/yarnpkg-cli/package.json
+++ b/packages/yarnpkg-cli/package.json
@@ -6,6 +6,7 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
+    "./polyfills": "./sources/polyfills.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -4,6 +4,10 @@
   "stableVersion": "3.2.3",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "dependencies": {
     "@arcanis/slice-ansi": "^1.1.1",
@@ -61,7 +65,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -67,10 +67,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -65,7 +65,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -19,8 +19,10 @@ export type {ConfigurationValueMap, ConfigurationDefinitionMap}                 
 export type {Fetcher, FetchOptions, FetchResult, MinimalFetchOptions}                                     from './Fetcher';
 export {BuildType}                                                                                        from './Installer';
 export type {Installer, BuildDirective, InstallStatus, InstallPackageExtraApi, FinalizeInstallStatus}     from './Installer';
+export {LegacyMigrationResolver}                                                                          from './LegacyMigrationResolver';
 export {LightReport}                                                                                      from './LightReport';
 export type {Linker, LinkOptions, MinimalLinkOptions}                                                     from './Linker';
+export {LockfileResolver}                                                                                 from './LockfileResolver';
 export {Manifest}                                                                                         from './Manifest';
 export type {AllDependencies, HardDependencies, DependencyMeta, PeerDependencyMeta}                       from './Manifest';
 export {MessageName, parseMessageName, stringifyMessageName}                                              from './MessageName';

--- a/packages/yarnpkg-doctor/package.json
+++ b/packages/yarnpkg-doctor/package.json
@@ -3,6 +3,10 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "bin": "./sources/boot-cli-dev.js",
+  "exports": {
+    "./cli": "./sources/boot-cli-dev.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/cli": "workspace:^",
     "@yarnpkg/core": "workspace:^",
@@ -23,7 +27,14 @@
     "prepack": "run build:compile \"$(pwd)\""
   },
   "publishConfig": {
-    "bin": "./lib/cli.js"
+    "bin": "./lib/cli.js",
+    "exports": {
+      "./cli": {
+        "types": "./lib/cli.d.ts",
+        "require": "./lib/cli.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-doctor/package.json
+++ b/packages/yarnpkg-doctor/package.json
@@ -29,10 +29,7 @@
   "publishConfig": {
     "bin": "./lib/cli.js",
     "exports": {
-      "./cli": {
-        "types": "./lib/cli.d.ts",
-        "require": "./lib/cli.js"
-      },
+      "./cli": "./lib/cli.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-extensions/package.json
+++ b/packages/yarnpkg-extensions/package.json
@@ -4,6 +4,10 @@
   "stableVersion": "1.1.0",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "@yarnpkg/core": "workspace:^"
   },
@@ -21,7 +25,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-extensions/package.json
+++ b/packages/yarnpkg-extensions/package.json
@@ -25,7 +25,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/yarnpkg-extensions/package.json
+++ b/packages/yarnpkg-extensions/package.json
@@ -27,10 +27,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-fslib/package.json
+++ b/packages/yarnpkg-fslib/package.json
@@ -22,7 +22,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/yarnpkg-fslib/package.json
+++ b/packages/yarnpkg-fslib/package.json
@@ -24,10 +24,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-fslib/package.json
+++ b/packages/yarnpkg-fslib/package.json
@@ -4,6 +4,10 @@
   "stableVersion": "2.7.0",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "dependencies": {
     "@yarnpkg/libzip": "workspace:^",
@@ -18,7 +22,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-libzip/package.json
+++ b/packages/yarnpkg-libzip/package.json
@@ -6,12 +6,9 @@
   "browser": "./sources/async.ts",
   "exports": {
     ".": {
-      "node": "./sources/sync.ts",
       "browser": "./sources/async.ts",
       "default": "./sources/sync.ts"
     },
-    "./sync": "./sources/sync.ts",
-    "./async": "./sources/async.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -25,22 +22,14 @@
     "browser": "./lib/async.js",
     "exports": {
       ".": {
-        "node": {
-          "types": "./lib/sync.d.ts",
-          "require": "./lib/sync.js"
-        },
         "browser": {
           "types": "./lib/async.d.ts",
           "require": "./lib/async.js"
+        },
+        "default": {
+          "types": "./lib/sync.d.ts",
+          "require": "./lib/sync.js"
         }
-      },
-      "./sync": {
-        "types": "./lib/sync.d.ts",
-        "require": "./lib/sync.js"
-      },
-      "./async": {
-        "types": "./lib/async.d.ts",
-        "require": "./lib/async.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/yarnpkg-libzip/package.json
+++ b/packages/yarnpkg-libzip/package.json
@@ -22,14 +22,8 @@
     "browser": "./lib/async.js",
     "exports": {
       ".": {
-        "browser": {
-          "types": "./lib/async.d.ts",
-          "require": "./lib/async.js"
-        },
-        "default": {
-          "types": "./lib/sync.d.ts",
-          "require": "./lib/sync.js"
-        }
+        "browser": "./lib/async.js",
+        "default": "./lib/sync.js"
       },
       "./package.json": "./package.json"
     }

--- a/packages/yarnpkg-libzip/package.json
+++ b/packages/yarnpkg-libzip/package.json
@@ -4,6 +4,15 @@
   "license": "BSD-2-Clause",
   "main": "./sources/sync.ts",
   "browser": "./sources/async.ts",
+  "exports": {
+    ".": {
+      "node": "./sources/sync.ts",
+      "browser": "./sources/async.ts"
+    },
+    "./sync": "./sources/sync.ts",
+    "./async": "./sources/async.ts",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build:libzip:wasm": "cd ./artifacts && ./build.sh",
     "postpack": "rm -rf lib",
@@ -12,7 +21,28 @@
   },
   "publishConfig": {
     "main": "./lib/sync.js",
-    "browser": "./lib/async.js"
+    "browser": "./lib/async.js",
+    "exports": {
+      ".": {
+        "node": {
+          "types": "./lib/sync.d.ts",
+          "require": "./lib/sync.js"
+        },
+        "browser": {
+          "types": "./lib/async.d.ts",
+          "require": "./lib/async.js"
+        }
+      },
+      "./sync": {
+        "types": "./lib/sync.d.ts",
+        "require": "./lib/sync.js"
+      },
+      "./async": {
+        "types": "./lib/async.d.ts",
+        "require": "./lib/async.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-libzip/package.json
+++ b/packages/yarnpkg-libzip/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "node": "./sources/sync.ts",
-      "browser": "./sources/async.ts"
+      "browser": "./sources/async.ts",
+      "default": "./sources/sync.ts"
     },
     "./sync": "./sources/sync.ts",
     "./async": "./sources/async.ts",

--- a/packages/yarnpkg-nm/package.json
+++ b/packages/yarnpkg-nm/package.json
@@ -3,7 +3,6 @@
   "version": "4.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
-  "types": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
     "./package.json": "./package.json"
@@ -24,7 +23,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/yarnpkg-nm/package.json
+++ b/packages/yarnpkg-nm/package.json
@@ -26,10 +26,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-nm/package.json
+++ b/packages/yarnpkg-nm/package.json
@@ -4,6 +4,10 @@
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
   "types": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "dependencies": {
     "@yarnpkg/core": "workspace:^",
@@ -20,7 +24,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-parsers/package.json
+++ b/packages/yarnpkg-parsers/package.json
@@ -3,6 +3,10 @@
   "version": "3.0.0-rc.18",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "js-yaml": "^3.10.0",
     "tslib": "^2.4.0"
@@ -23,7 +27,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-parsers/package.json
+++ b/packages/yarnpkg-parsers/package.json
@@ -29,10 +29,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-parsers/package.json
+++ b/packages/yarnpkg-parsers/package.json
@@ -27,7 +27,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -6,6 +6,7 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
+    "./sources/esm-loader/loaderFlags": "./sources/esm-loader/loaderFlags.ts",
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -36,10 +36,7 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
+      ".": "./lib/index.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -4,6 +4,10 @@
   "stableVersion": "3.2.2",
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@types/node": "^18.7.6",
     "@yarnpkg/fslib": "workspace:^"
@@ -29,7 +33,14 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-pnp/package.json
+++ b/packages/yarnpkg-pnp/package.json
@@ -34,7 +34,6 @@
   },
   "publishConfig": {
     "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./package.json": "./package.json"

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -5,7 +5,6 @@
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
   "bin": "./sources/boot-cli-dev.js",
-  "types": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
     "./utils": "./sources/utils.ts",
@@ -33,7 +32,6 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "bin": "./lib/cli.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./utils": "./lib/utils.js",

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -6,6 +6,13 @@
   "main": "./sources/index.ts",
   "bin": "./sources/boot-cli-dev.js",
   "types": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./utils": "./sources/utils.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./cli": "./sources/cli.ts",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "dependencies": {
     "@yarnpkg/core": "workspace:^",
@@ -27,7 +34,26 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "bin": "./lib/cli.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./utils": {
+        "types": "./lib/utils.d.ts",
+        "require": "./lib/utils.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./cli": {
+        "types": "./lib/cli.d.ts",
+        "require": "./lib/cli.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*",

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -35,18 +35,9 @@
     "bin": "./lib/cli.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
-      "./utils": {
-        "types": "./lib/utils.d.ts",
-        "require": "./lib/utils.js"
-      },
-      "./cli": {
-        "types": "./lib/cli.d.ts",
-        "require": "./lib/cli.js"
-      },
+      ".": "./lib/index.js",
+      "./utils": "./lib/utils.js",
+      "./cli": "./lib/cli.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-pnpify/package.json
+++ b/packages/yarnpkg-pnpify/package.json
@@ -9,7 +9,6 @@
   "exports": {
     ".": "./sources/index.ts",
     "./utils": "./sources/utils.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./cli": "./sources/cli.ts",
     "./package.json": "./package.json"
   },
@@ -43,10 +42,6 @@
       "./utils": {
         "types": "./lib/utils.d.ts",
         "require": "./lib/utils.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./cli": {
         "types": "./lib/cli.d.ts",

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -36,7 +36,7 @@ export class NodeModulesFS extends ProxiedFS<NativePath, PortablePath> {
   }
 }
 
-interface PortableNodeModulesFSOptions extends NodeModulesTreeOptions {
+export interface PortableNodeModulesFSOptions extends NodeModulesTreeOptions {
   baseFs?: FakeFS<PortablePath>;
   pnpifyFs?: boolean;
 }

--- a/packages/yarnpkg-pnpify/sources/utils.ts
+++ b/packages/yarnpkg-pnpify/sources/utils.ts
@@ -1,0 +1,5 @@
+export {patchFs}                                                 from './index';
+export type {ResolvedPath}                                       from './resolveNodeModulesPath';
+export {resolveNodeModulesPath}                                  from './resolveNodeModulesPath';
+export type {NodeModulesFSOptions, PortableNodeModulesFSOptions} from './NodeModulesFS';
+export {NodeModulesFS, PortableNodeModulesFS}                    from './NodeModulesFS';

--- a/packages/yarnpkg-pnpify/sources/utils.ts
+++ b/packages/yarnpkg-pnpify/sources/utils.ts
@@ -1,3 +1,9 @@
+import RunCommand from './commands/RunCommand';
+import SdkCommand from './commands/SdkCommand';
+
+export {RunCommand};
+export {SdkCommand};
+
 export {patchFs}                                                 from './index';
 export type {ResolvedPath}                                       from './resolveNodeModulesPath';
 export {resolveNodeModulesPath}                                  from './resolveNodeModulesPath';

--- a/packages/yarnpkg-sdks/package.json
+++ b/packages/yarnpkg-sdks/package.json
@@ -5,6 +5,12 @@
   "main": "./sources/index.ts",
   "bin": "./sources/boot-cli-dev.js",
   "types": "./sources/index.ts",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./command/*": "./sources/commands/*.ts",
+    "./cli": "./sources/boot-cli-dev.js",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "dependencies": {
     "@yarnpkg/core": "workspace:^",
@@ -30,7 +36,22 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "bin": "./lib/cli.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./command/*": {
+        "types": "./lib/commands/*.d.ts",
+        "require": "./lib/commands/*.js"
+      },
+      "./cli": {
+        "types": "./lib/cli.d.ts",
+        "require": "./lib/cli.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-sdks/package.json
+++ b/packages/yarnpkg-sdks/package.json
@@ -37,14 +37,8 @@
     "bin": "./lib/cli.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
-      "./cli": {
-        "types": "./lib/cli.d.ts",
-        "require": "./lib/cli.js"
-      },
+      ".": "./lib/index.js",
+      "./cli": "./lib/cli.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-sdks/package.json
+++ b/packages/yarnpkg-sdks/package.json
@@ -7,7 +7,6 @@
   "types": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
-    "./command/*": "./sources/commands/*.ts",
     "./cli": "./sources/boot-cli-dev.js",
     "./package.json": "./package.json"
   },
@@ -41,10 +40,6 @@
       ".": {
         "types": "./lib/index.d.ts",
         "require": "./lib/index.js"
-      },
-      "./command/*": {
-        "types": "./lib/commands/*.d.ts",
-        "require": "./lib/commands/*.js"
       },
       "./cli": {
         "types": "./lib/cli.d.ts",

--- a/packages/yarnpkg-sdks/package.json
+++ b/packages/yarnpkg-sdks/package.json
@@ -4,7 +4,6 @@
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
   "bin": "./sources/boot-cli-dev.js",
-  "types": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
     "./cli": "./sources/boot-cli-dev.js",
@@ -35,7 +34,6 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "bin": "./lib/cli.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./cli": "./lib/cli.js",

--- a/packages/yarnpkg-sdks/sources/index.ts
+++ b/packages/yarnpkg-sdks/sources/index.ts
@@ -1,3 +1,5 @@
+import SdkCommand    from './commands/SdkCommand';
 import * as sdkUtils from './sdkUtils';
 
+export {SdkCommand};
 export {sdkUtils};

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -35,7 +35,6 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "bin": "./lib/cli.js",
-    "types": "./lib/index.d.ts",
     "exports": {
       ".": "./lib/index.js",
       "./cli": "./lib/cli.js",

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -37,14 +37,8 @@
     "bin": "./lib/cli.js",
     "types": "./lib/index.d.ts",
     "exports": {
-      ".": {
-        "types": "./lib/index.d.ts",
-        "require": "./lib/index.js"
-      },
-      "./cli": {
-        "types": "./lib/cli.d.ts",
-        "require": "./lib/cli.js"
-      },
+      ".": "./lib/index.js",
+      "./cli": "./lib/cli.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -5,6 +5,11 @@
   "license": "BSD-2-Clause",
   "main": "./sources/index.ts",
   "bin": "./sources/boot-cli-dev.js",
+  "exports": {
+    ".": "./sources/index.ts",
+    "./cli": "./sources/boot-cli-dev.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/parsers": "workspace:^",
@@ -30,7 +35,18 @@
   "publishConfig": {
     "main": "./lib/index.js",
     "bin": "./lib/cli.js",
-    "typings": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "require": "./lib/index.js"
+      },
+      "./cli": {
+        "types": "./lib/cli.d.ts",
+        "require": "./lib/cli.js"
+      },
+      "./package.json": "./package.json"
+    }
   },
   "files": [
     "/lib/**/*"

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -6,6 +6,7 @@ import {homedir}                                                                
 import {PassThrough, Readable, Writable}                                                                    from 'stream';
 import {promisify}                                                                                          from 'util';
 
+import EntryCommand                                                                                         from './commands/entry';
 import {ShellError}                                                                                         from './errors';
 import * as globUtils                                                                                       from './globUtils';
 import {createOutputStreamsWithPrefix, makeBuiltin, makeProcess}                                            from './pipe';
@@ -13,7 +14,9 @@ import {Handle, ProcessImplementation, ProtectedStream, Stdio, start, Pipe}     
 
 const setTimeoutPromise = promisify(setTimeout);
 
-export {globUtils, ShellError};
+export {EntryCommand};
+export {ShellError};
+export {globUtils};
 
 export type Glob = globUtils.Glob;
 

--- a/scripts/test-typescript-patch.js
+++ b/scripts/test-typescript-patch.js
@@ -16,14 +16,17 @@ const compilerOptions = ts.parseJsonSourceFileConfigFileContent(
 const compilerHost = ts.createCompilerHost(compilerOptions);
 const program = ts.createProgram(compilerOptions.fileNames, compilerOptions, compilerHost);
 const moduleSpecifierResolutionHost = ts.createModuleSpecifierResolutionHost(program, compilerHost);
-const rootSourceFile = program.getSourceFile(require.resolve(`@yarnpkg/core/sources/Project.ts`));
+
+const yarnCorePkgDir = require.resolve(`@yarnpkg/core/package.json`).replace(`/package.json`, ``);
+const fslibPkgDir = require.resolve(`@yarnpkg/fslib/package.json`).replace(`/package.json`, ``);
+const rootSourceFile = program.getSourceFile(require.resolve(`${yarnCorePkgDir}/sources/Project.ts`));
 
 const TESTS = [
-  [`@yarnpkg/core/sources/Configuration.ts`, `./Configuration`],
-  [`@yarnpkg/fslib/README.md`, `@yarnpkg/fslib/README.md`],
-  [`@yarnpkg/fslib/package.json`, `@yarnpkg/fslib/package.json`],
-  [`@yarnpkg/fslib/sources/ZipFS.ts`, `@yarnpkg/fslib/sources/ZipFS`],
-  [`@yarnpkg/fslib/sources/index.ts`, `@yarnpkg/fslib`],
+  [`${yarnCorePkgDir}/sources/Configuration.ts`, `./Configuration`],
+  [`${fslibPkgDir}/README.md`, `@yarnpkg/fslib/README.md`],
+  [`${fslibPkgDir}/package.json`, `@yarnpkg/fslib/package.json`],
+  [`${fslibPkgDir}/sources/ZipFS.ts`, `@yarnpkg/fslib/sources/ZipFS`],
+  [`${fslibPkgDir}/sources/index.ts`, `@yarnpkg/fslib`],
 ];
 
 for (const [test, expected] of TESTS) {


### PR DESCRIPTION
Todo:
- [x] fix anything that can't resolve (likely test).
- [x] Settle on what to do with `types` condition

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
This is help with 4.x as requested in https://github.com/yarnpkg/berry/issues/3591
This addresses the task `Add export fields to our manifests to prevent deep imports`

**How did you fix it?**
<!-- A detailed description of your implementation. -->
Added exports to all manifests.
Added exports for some things that were not exported before.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
