### PR TITLE
Add `#source=true&workspace=name` options to `@yarnpkg/plugin-http`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -13464,12 +13464,16 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-http", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-http"],\
           ["@types/yarnpkg__core", null],\
+          ["@types/yarnpkg__fslib", null],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
+          ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
           "@types/yarnpkg__core",\
-          "@yarnpkg/core"\
+          "@types/yarnpkg__fslib",\
+          "@yarnpkg/core",\
+          "@yarnpkg/fslib"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -13478,6 +13482,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-http", "workspace:packages/plugin-http"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
+          ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "linkType": "SOFT"\

--- a/.yarn/versions/64d0ed75.yml
+++ b/.yarn/versions/64d0ed75.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-http": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/gatsby/content/features/protocols.md
+++ b/packages/gatsby/content/features/protocols.md
@@ -13,19 +13,20 @@ description: An in-depth guide to Yarn's various protocols.
 
 The following protocols can be used by any dependency entry listed in the `dependencies` or `devDependencies` fields. While they work regardless of the context we strongly recommend you to only use semver ranges on published packages as they are the one common protocol whose semantic is clearly defined across all package managers.
 
-| Name          | Example                                 | Description                                                                                                                       |
-| ------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Semver        | `^1.2.3`                                | Resolves from the default registry                                                                                                 |
-| Tag           | `latest`                                | Resolves from the default registry                                                                                                 |
-| Npm alias     | `npm:name@...`                          | Resolves from the npm registry                                                                                                     |
-| Git           | `git@github.com:foo/bar.git`            | Downloads a public package from a Git repository                                                                                   |
-| GitHub        | `github:foo/bar`                        | Downloads a **public** package from GitHub                                                                                         |
-| GitHub        | `foo/bar`                               | Alias for the `github:` protocol                                                                                                   |
-| File          | `file:./my-package`                     | Copies the target location into the cache                                                                                         |
-| Link          | `link:./my-folder`                      | Creates a link to the `./my-folder` folder (ignore dependencies)                                                                   |
-| Patch         | `patch:left-pad@1.0.0#./my-patch.patch` | Creates a patched copy of the original package                                                                                     |
-| Portal        | `portal:./my-folder`                    | Creates a link to the `./my-folder` folder (follow dependencies)                                                                   |
-| Workspace     | `workspace:*`                           | Creates a link to a package in another workspace                                                                                   |
+| Name          | Example                                 | Description                                                                                                                      |
+|---------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Semver        | `^1.2.3`                                | Resolves from the default registry                                                                                               |
+| Tag           | `latest`                                | Resolves from the default registry                                                                                               |
+| Npm alias     | `npm:name@...`                          | Resolves from the npm registry                                                                                                   |
+| Git           | `git@github.com:foo/bar.git`            | Downloads a public package from a Git repository                                                                                 |
+| GitHub        | `github:foo/bar`                        | Downloads a **public** package from GitHub                                                                                       |
+| GitHub        | `foo/bar`                               | Alias for the `github:` protocol                                                                                                 |
+| File          | `file:./my-package`                     | Copies the target location into the cache                                                                                        |
+| Http          | `https://example.com/archive.tar.gz`    | Downloads a package from a http resource                                                                                         |
+| Link          | `link:./my-folder`                      | Creates a link to the `./my-folder` folder (ignore dependencies)                                                                 |
+| Patch         | `patch:left-pad@1.0.0#./my-patch.patch` | Creates a patched copy of the original package                                                                                   |
+| Portal        | `portal:./my-folder`                    | Creates a link to the `./my-folder` folder (follow dependencies)                                                                 |
+| Workspace     | `workspace:*`                           | Creates a link to a package in another workspace                                                                                 |
 | [Exec](#exec) | `exec:./my-generator-package`           | <sup>*Experimental & Plugin*</sup><br/>Instructs Yarn to execute the specified Node script and use its output as package content |
 
 ## Details
@@ -52,10 +53,42 @@ git@github.com:yarnpkg/berry.git#head=master
 
 - Yarn will use either of Yarn, npm, or pnpm to pack the repository, based on the repository style (ie we'll use Yarn if there's a `yarn.lock`, npm if there's a `package-lock.json`, or pnpm if there's a `pnpm-lock.yaml`)
 
-- Workspaces can be cloned as long as the remote repository uses Yarn or npm (npm@>=7.x has to be installed on the system); we can't support pnpm because it doesn't have equivalent for the [`workspace` command](/cli/workspace). Just reference the workspace by name in your range (you can optionally enforce the tag as well):
+- Workspaces can be cloned as long as the remote repository uses Yarn or npm (npm@>=7.x has to be installed on the system); we can't support pnpm because it doesn't have equivalent for the [`workspace` feature](/features/workspaces). Just reference the workspace by name in your range (you can optionally enforce the tag as well):
 
 ```
 git@github.com:yarnpkg/berry.git#workspace=@yarnpkg/shell&tag=@yarnpkg/shell/2.1.0
+```
+
+### Http
+
+The Http protocol allows for sourcing a dependency from any http server.
+
+Requests respect network rules defined in [configuration](/configuration/yarnrc).
+
+Only tarballs are supported for download.
+
+#### Tarball (.tar.gz|.tgz)
+
+A tarball is expected to contain the project's release, like from the result of [`pack`](/cli/pack).
+
+```
+https://registry.npmjs.org/@yarnpkg/plugin-http/-/plugin-http-2.2.1.tgz
+```
+
+##### Option (source)
+
+Optionally a tarball can be treated as if it contains source code. It will not use the tarball as-is but will extract then pack using [`pack`](/cli/pack).
+
+```
+https://github.com/yarnpkg/berry/archive/master.tar.gz#source=true
+```
+
+##### Option (workspace)
+
+If source is set to true a workspace may be set like with the git [protocol](#git).
+
+```
+https://github.com/yarnpkg/berry/archive/master.tar.gz#source=true&workspace=@yarnpkg/plugin-http
 ```
 
 ### Patch

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -7,10 +7,12 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/fslib": "workspace:^"
   },
   "devDependencies": {
-    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/fslib": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-http/sources/TarballHttpFetcher.ts
+++ b/packages/plugin-http/sources/TarballHttpFetcher.ts
@@ -1,6 +1,8 @@
 import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
 import {Locator}                                    from '@yarnpkg/core';
 import {httpUtils, structUtils, tgzUtils}           from '@yarnpkg/core';
+import {scriptUtils}                                from '@yarnpkg/core';
+import {PortablePath, CwdFS, ppath, xfs}            from '@yarnpkg/fslib';
 
 import {TARBALL_REGEXP, PROTOCOL_REGEXP}            from './constants';
 
@@ -37,15 +39,51 @@ export class TarballHttpFetcher implements Fetcher {
     };
   }
 
-  async fetchFromNetwork(locator: Locator, opts: FetchOptions) {
-    const sourceBuffer = await httpUtils.get(locator.reference, {
+  private async fetchFromNetwork(locator: Locator, opts: FetchOptions) {
+    const url = locator.reference;
+    const {
+      selector,
+    } = structUtils.parseRange(url, {
+      parseSelector: true,
+      requireProtocol: true,
+      requireSource: true,
+    });
+    const source = !!selector?.source;
+
+    let sourceBuffer = await httpUtils.get(url, {
       configuration: opts.project.configuration,
     });
+
+    if (source) {
+      const workspace = selector.workspace ? Array.isArray(selector.workspace) ? selector.workspace[0] : selector.workspace : undefined;
+      sourceBuffer = await this.packageWorkspace(sourceBuffer, workspace, locator, opts);
+    }
 
     return await tgzUtils.convertToZip(sourceBuffer, {
       compressionLevel: opts.project.configuration.get(`compressionLevel`),
       prefixPath: structUtils.getIdentVendorPath(locator),
       stripComponents: 1,
+    });
+  }
+
+  private async packageWorkspace(sourceBuffer: Buffer, workspace: string | undefined, locator: Locator, opts: FetchOptions) {
+    return await xfs.mktempPromise(async extractPath => {
+      const extractTarget = new CwdFS(extractPath);
+
+      await tgzUtils.extractArchiveTo(sourceBuffer, extractTarget, {
+        stripComponents: 1,
+      });
+
+      const packagePath = ppath.join(extractPath, `package.tgz` as PortablePath);
+
+      await scriptUtils.prepareExternalProject(extractPath, packagePath, {
+        configuration: opts.project.configuration,
+        report: opts.report,
+        workspace,
+        locator,
+      });
+
+      return await xfs.readFilePromise(packagePath);
     });
   }
 }

--- a/packages/plugin-http/sources/constants.ts
+++ b/packages/plugin-http/sources/constants.ts
@@ -1,3 +1,3 @@
-export const TARBALL_REGEXP = /^[^?]*\.(?:tar\.gz|tgz)(?:\?.*)?$/;
+export const TARBALL_REGEXP = /^[^?]*\.(?:tar\.gz|tgz)(?:\?.*)?(?:#.*)?$/;
 
 export const PROTOCOL_REGEXP = /^https?:/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6051,9 +6051,11 @@ __metadata:
   resolution: "@yarnpkg/plugin-http@workspace:packages/plugin-http"
   dependencies:
     "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/fslib": "workspace:^"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/fslib": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Update docs to include `http` protocol which was missing, docs includes new options.

Also fixed a broken link in the git details section of the protocols docs.

TODO:
- [ ] Add tests

**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
This adds extra logic to tarball downloads to be able to support source repos and workspace names within.
This is intended to support other plugins to fetching via this this new functionally along as directly via end-users.

This is a follow up to https://github.com/yarnpkg/berry/pull/2045 

https://github.com/Larry1123/berry/blob/PoC/tarballRefactor/packages/plugin-github/sources/githubUtils.ts#L92
https://github.com/Larry1123/berry/blob/PoC/tarballRefactor/packages/plugin-github/sources/GithubFetcher.ts#L18
These are an example of `@yarnpkg/plugin-github` making use of this feature, I intend to follow this PR with one based on that example that's updated to the most recent current `HEAD`. I also intend to follow up with a new `@yarnpkg/plugin-gitlab`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

If `#source` is provided as part of the url it will unpack the tar as if it was a repo. It will call `scriptUtils.prepareExternalProject` on the extracted project with a provided `#workspace=name` to pack the project.
More details on use can be found in the protocol docs page.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.


Another thing I am not sure if is wanted would be I add support for `.zip` for `@yarnpkg/plugin-http`, if so that would also build off the changes here, however it is unlikely to have yarn internal use as tarball covers internal use well already, it would be just a new way for users to make use of http.
