### PR TITLE
refactor(cli): Extract duplicated code into getInstallState helper

### DIFF
--- a/.yarn/versions/bb960140.yml
+++ b/.yarn/versions/bb960140.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -120,16 +120,7 @@ export default class AddCommand extends BaseCommand {
   packages = Option.Rest();
 
   async execute() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {configuration, project, cache, workspace} = await this.getInstallState();
 
     const fixed = this.fixed;
     const interactive = this.interactive ?? configuration.get(`preferInteractive`);

--- a/packages/plugin-essentials/sources/commands/link.ts
+++ b/packages/plugin-essentials/sources/commands/link.ts
@@ -1,7 +1,7 @@
-import {BaseCommand, WorkspaceRequiredError}                      from '@yarnpkg/cli';
-import {Cache, Configuration, Project, StreamReport, structUtils} from '@yarnpkg/core';
-import {npath, ppath}                                             from '@yarnpkg/fslib';
-import {Command, Option, Usage, UsageError}                       from 'clipanion';
+import {BaseCommand, WorkspaceRequiredError}               from '@yarnpkg/cli';
+import {Configuration, Project, StreamReport, structUtils} from '@yarnpkg/core';
+import {npath, ppath}                                      from '@yarnpkg/fslib';
+import {Command, Option, Usage, UsageError}                from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class LinkCommand extends BaseCommand {
@@ -38,16 +38,7 @@ export default class LinkCommand extends BaseCommand {
   destinations = Option.Rest();
 
   async execute() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {configuration, project, cache} = await this.getInstallState();
 
     const topLevelWorkspace = project.topLevelWorkspace;
     const linkedWorkspaces = [];

--- a/packages/plugin-essentials/sources/commands/remove.ts
+++ b/packages/plugin-essentials/sources/commands/remove.ts
@@ -1,13 +1,13 @@
-import {BaseCommand, WorkspaceRequiredError}                    from '@yarnpkg/cli';
-import {Configuration, Cache, Descriptor, Project, formatUtils} from '@yarnpkg/core';
-import {StreamReport, Workspace, InstallMode}                   from '@yarnpkg/core';
-import {structUtils}                                            from '@yarnpkg/core';
-import {Command, Option, Usage, UsageError}                     from 'clipanion';
-import micromatch                                               from 'micromatch';
-import * as t                                                   from 'typanion';
+import {BaseCommand}                          from '@yarnpkg/cli';
+import {Descriptor, formatUtils}              from '@yarnpkg/core';
+import {StreamReport, Workspace, InstallMode} from '@yarnpkg/core';
+import {structUtils}                          from '@yarnpkg/core';
+import {Command, Option, Usage, UsageError}   from 'clipanion';
+import micromatch                             from 'micromatch';
+import * as t                                 from 'typanion';
 
-import * as suggestUtils                                        from '../suggestUtils';
-import {Hooks}                                                  from '..';
+import * as suggestUtils                      from '../suggestUtils';
+import {Hooks}                                from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class RemoveCommand extends BaseCommand {
@@ -58,16 +58,7 @@ export default class RemoveCommand extends BaseCommand {
   patterns = Option.Rest();
 
   async execute() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {project, configuration, workspace, cache} = await this.getInstallState();
 
     const affectedWorkspaces = this.all
       ? project.workspaces

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -1,14 +1,14 @@
-import {BaseCommand, WorkspaceRequiredError}                                                            from '@yarnpkg/cli';
-import {IdentHash, structUtils}                                                                         from '@yarnpkg/core';
-import {Project, StreamReport, Workspace, InstallMode}                                                  from '@yarnpkg/core';
-import {Cache, Configuration, Descriptor, LightReport, MessageName, MinimalResolveOptions, formatUtils} from '@yarnpkg/core';
-import {Command, Option, Usage, UsageError}                                                             from 'clipanion';
-import {prompt}                                                                                         from 'enquirer';
-import micromatch                                                                                       from 'micromatch';
-import * as t                                                                                           from 'typanion';
+import {BaseCommand}                                                              from '@yarnpkg/cli';
+import {IdentHash, structUtils}                                                   from '@yarnpkg/core';
+import {StreamReport, Workspace, InstallMode}                                     from '@yarnpkg/core';
+import {Descriptor, LightReport, MessageName, MinimalResolveOptions, formatUtils} from '@yarnpkg/core';
+import {Command, Option, Usage, UsageError}                                       from 'clipanion';
+import {prompt}                                                                   from 'enquirer';
+import micromatch                                                                 from 'micromatch';
+import * as t                                                                     from 'typanion';
 
-import * as suggestUtils                                                                                from '../suggestUtils';
-import {Hooks}                                                                                          from '..';
+import * as suggestUtils                                                          from '../suggestUtils';
+import {Hooks}                                                                    from '..';
 
 // eslint-disable-next-line arca/no-default-export
 export default class UpCommand extends BaseCommand {
@@ -104,16 +104,7 @@ export default class UpCommand extends BaseCommand {
   }
 
   async executeUpRecursive() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {configuration, project, cache} = await this.getInstallState();
 
     const allDescriptors = [...project.storedDescriptors.values()];
 
@@ -152,16 +143,7 @@ export default class UpCommand extends BaseCommand {
   }
 
   async executeUpClassic() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {cache, configuration, project} = await this.getInstallState();
 
     const fixed = this.fixed;
     const interactive = this.interactive ?? configuration.get(`preferInteractive`);

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -1,12 +1,12 @@
-import {BaseCommand, WorkspaceRequiredError}                                                                                            from '@yarnpkg/cli';
-import {Cache, Configuration, Project, HardDependencies, formatUtils, miscUtils, structUtils, Descriptor, DescriptorHash, StreamReport} from '@yarnpkg/core';
-import * as libuiUtils                                                                                                                  from '@yarnpkg/libui/sources/libuiUtils';
-import type {SubmitInjectedComponent}                                                                                                   from '@yarnpkg/libui/sources/misc/renderForm';
-import {suggestUtils}                                                                                                                   from '@yarnpkg/plugin-essentials';
-import {Command, Usage}                                                                                                                 from 'clipanion';
-import {diffWords}                                                                                                                      from 'diff';
-import semver                                                                                                                           from 'semver';
-import {WriteStream}                                                                                                                    from 'tty';
+import {BaseCommand}                                                                                     from '@yarnpkg/cli';
+import {HardDependencies, formatUtils, miscUtils, structUtils, Descriptor, DescriptorHash, StreamReport} from '@yarnpkg/core';
+import * as libuiUtils                                                                                   from '@yarnpkg/libui/sources/libuiUtils';
+import type {SubmitInjectedComponent}                                                                    from '@yarnpkg/libui/sources/misc/renderForm';
+import {suggestUtils}                                                                                    from '@yarnpkg/plugin-essentials';
+import {Command, Usage}                                                                                  from 'clipanion';
+import {diffWords}                                                                                       from 'diff';
+import semver                                                                                            from 'semver';
+import {WriteStream}                                                                                     from 'tty';
 
 const SIMPLE_SEMVER = /^((?:[\^~]|>=?)?)([0-9]+)(\.[0-9]+)(\.[0-9]+)((?:-\S+)?)$/;
 
@@ -49,16 +49,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     const {Box, Text} = await import(`ink`);
     const {default: React, useEffect, useRef, useState} = await import(`react`);
 
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {configuration, project, cache, workspace} = await this.getInstallState();
 
     // 7 = 1-line command written by the user
     //   + 2-line prompt

--- a/packages/plugin-version/sources/commands/version/apply.ts
+++ b/packages/plugin-version/sources/commands/version/apply.ts
@@ -1,9 +1,9 @@
-import {BaseCommand, WorkspaceRequiredError} from '@yarnpkg/cli';
-import {Cache, Configuration, MessageName}   from '@yarnpkg/core';
-import {Project, StreamReport}               from '@yarnpkg/core';
-import {Command, Option, Usage}              from 'clipanion';
+import {BaseCommand}            from '@yarnpkg/cli';
+import {MessageName}            from '@yarnpkg/core';
+import {StreamReport}           from '@yarnpkg/core';
+import {Command, Option, Usage} from 'clipanion';
 
-import * as versionUtils                     from '../../versionUtils';
+import * as versionUtils        from '../../versionUtils';
 
 // eslint-disable-next-line arca/no-default-export
 export default class VersionApplyCommand extends BaseCommand {
@@ -57,16 +57,7 @@ export default class VersionApplyCommand extends BaseCommand {
   });
 
   async execute() {
-    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, this.context.cwd);
-    const cache = await Cache.find(configuration);
-
-    if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
-
-    await project.restoreInstallState({
-      restoreResolutions: false,
-    });
+    const {project, cache, configuration, workspace} = await this.getInstallState();
 
     const applyReport = await StreamReport.start({
       configuration,

--- a/packages/yarnpkg-cli/sources/tools/BaseCommand.ts
+++ b/packages/yarnpkg-cli/sources/tools/BaseCommand.ts
@@ -1,8 +1,31 @@
-import {CommandContext}  from '@yarnpkg/core';
-import {Command, Option} from 'clipanion';
+import {Cache, CommandContext, Configuration, Project, Workspace} from '@yarnpkg/core';
+import {Command, Option}                                          from 'clipanion';
+
+import {WorkspaceRequiredError}                                   from './WorkspaceRequiredError';
+
+export type InstallState = {
+  project: Project;
+  cache: Cache;
+  configuration: Configuration;
+  workspace: Workspace;
+};
 
 export abstract class BaseCommand extends Command<CommandContext> {
   cwd = Option.String(`--cwd`, {hidden: true});
 
   abstract execute(): Promise<number | void>;
+
+  protected async getInstallState(): Promise<InstallState> {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
+    const cache = await Cache.find(configuration);
+
+    if (!workspace)
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
+
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
+    return {configuration, project, cache, workspace};
+  }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

There was a bit of duplicated code between a lot of the commands.

**How did you fix it?**

Added a new helper function to `BaseCommand`.

The name isn't the greatest, but I'm open to suggestions.

**Checklist**

- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
