### PR TITLE
docs: add Node.js versions for `corepack prepare yarn@stable`

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -36,12 +36,6 @@ Corepack won't always have the latest Yarn release. You can make sure it does wi
 corepack prepare yarn@stable --activate
 ```
 
-You can also use Corepack to install the most recent canary (release candidate) release globally:
-
-```bash
-corepack prepare yarn@canary --activate
-```
-
 ### Node.js <16.17 or <18.6
 
 Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releases/latest), note the version number, and run:

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -26,12 +26,23 @@ Corepack isn't included with Node.js in versions before the 16.10; to address th
 npm i -g corepack
 ```
 
-## Activate Yarn
+## Ensuring Corepack's global Yarn is current
+
+Corepack won't always have the latest Yarn release. You can make sure it does with [`corepack prepare`](https://nodejs.org/api/corepack.html#upgrading-the-global-versions).
+
+### Node.js >=16.17 or >=18.6
 
 ```bash
 corepack prepare yarn@stable --activate
 ```
 
+### Node.js <16.17 or <18.6
+
+Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releases/latest), note the version number, and run:
+
+```bash
+corepack prepare pnpm@<version> --activate
+```
 ## Initializing your project
 
 Just run the following command. It will generate some files inside your current directory; add them all to your next commit, and you'll be done!

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -10,7 +10,7 @@ order: 2
 
 The preferred way to manage Yarn is through [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html), a new binary shipped with all Node.js releases starting from 16.10. It acts as an intermediary between you and Yarn, and lets you use different package manager versions across multiple projects without having to check-in the Yarn binary anymore.
 
-### Node.js >=16.10
+### Node.js ^16.10
 
 Corepack is included by default with all Node.js installs, but is currently opt-in. To enable it, run the following command:
 
@@ -30,7 +30,7 @@ npm i -g corepack
 
 Corepack won't always have the latest Yarn release. You can make sure it does with [`corepack prepare`](https://nodejs.org/api/corepack.html#upgrading-the-global-versions).
 
-### Node.js ^16.17 or >=18.6
+### Node.js ^16.17 or ^18.6
 
 ```bash
 corepack prepare yarn@stable --activate

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -30,7 +30,7 @@ npm i -g corepack
 
 Corepack won't always have the latest Yarn release. You can make sure it does with [`corepack prepare`](https://nodejs.org/api/corepack.html#upgrading-the-global-versions).
 
-### Node.js >=16.17 or >=18.6
+### Node.js ^16.17 or >=18.6
 
 ```bash
 corepack prepare yarn@stable --activate
@@ -41,7 +41,7 @@ corepack prepare yarn@stable --activate
 Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releases/latest), note the version number, and run:
 
 ```bash
-corepack prepare pnpm@<version> --activate
+corepack prepare yarn@<version> --activate
 ```
 ## Initializing your project
 

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -36,6 +36,12 @@ Corepack won't always have the latest Yarn release. You can make sure it does wi
 corepack prepare yarn@stable --activate
 ```
 
+You can also use Corepack to install the most recent canary (release candidate) release globally:
+
+```bash
+corepack prepare yarn@canary --activate
+```
+
 ### Node.js <16.17 or <18.6
 
 Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releases/latest), note the version number, and run:
@@ -43,6 +49,7 @@ Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releas
 ```bash
 corepack prepare yarn@<version> --activate
 ```
+
 ## Initializing your project
 
 Just run the following command. It will generate some files inside your current directory; add them all to your next commit, and you'll be done!

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -10,7 +10,7 @@ order: 2
 
 The preferred way to manage Yarn is through [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html), a new binary shipped with all Node.js releases starting from 16.10. It acts as an intermediary between you and Yarn, and lets you use different package manager versions across multiple projects without having to check-in the Yarn binary anymore.
 
-### Node.js ^16.10
+### Node.js >=16.10
 
 Corepack is included by default with all Node.js installs, but is currently opt-in. To enable it, run the following command:
 
@@ -26,11 +26,9 @@ Corepack isn't included with Node.js in versions before the 16.10; to address th
 npm i -g corepack
 ```
 
-## Ensuring Corepack's global Yarn is current
+## Updating the global Yarn version
 
-Corepack won't always have the latest Yarn release. You can make sure it does with [`corepack prepare`](https://nodejs.org/api/corepack.html#upgrading-the-global-versions).
-
-### Node.js ^16.17 or ^18.6
+### Node.js ^16.17 or >=18.6
 
 ```bash
 corepack prepare yarn@stable --activate


### PR DESCRIPTION
**What's the problem this PR addresses?**
Corepack won't always have the latest Yarn release installed globally. It would be helpful to provide instructions on how to go about ensuring it does.

https://github.com/yarnpkg/berry/pull/4815 attempted to address that, but was reverted because it didn't specify which versions of Node.js have Corepack >=0.12 (and thus support using a `dist-tag` instead of a version number when running `corepack prepare`).

...

**How did you fix it?**
Added new section to docs (based on https://github.com/yarnpkg/berry/pull/4815) providing appropriate commands depending on the version of Node.js.

As I'm writing this, I'm wondering if I should edit it slightly to clarify that the underlying reason it matters which version of Node.js you're using is because of the need to know if you are using Corepack >=0.12 or <0.12. I think it's possible to change the version of Corepack associated with a given Node.js install, though I'm guessing that would be pretty unusual unless you're using a pre-Corepack version of Node.js.

References:
[Corepack v0.120](https://github.com/nodejs/corepack/releases/tag/v0.12.0)
[Node.js v18.6.0](https://github.com/nodejs/node/releases/tag/v18.6.0)
[Node.js v16.17.0](https://github.com/nodejs/node/releases/tag/v16.17.0)

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
