### PR TITLE
chore: update `actions/stale` to v5

### DIFF
--- a/.github/workflows/stale-workflow.yml
+++ b/.github/workflows/stale-workflow.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v5
       with:
         repo-token: ${{secrets.YARNBOT_TOKEN}}
 
@@ -32,7 +32,7 @@ jobs:
         stale-issue-label: 'stale'
         exempt-issue-labels: 'reproducible,upholded,good first issue,help wanted'
 
-    - uses: actions/stale@v3
+    - uses: actions/stale@v5
       with:
         repo-token: ${{secrets.YARNBOT_TOKEN}}
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Fixes https://github.com/yarnpkg/berry/pull/4759#issuecomment-1226992424.

Quoting @merceyz from https://github.com/yarnpkg/berry/pull/4759#issuecomment-1226994964:
> We need to update actions/stale, close-issue-reason was added in [v5.1.0](https://github.com/actions/stale/releases/tag/v5.1.0) but we're using v3.


**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated to `actions/stale@v5`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
