### PR TITLE
chore: remove @yarnpkg/core CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
-/packages/yarnpkg-core/ @arcanis
-
 # Security: Could otherwise change the checked-in artifacts
 /packages/*/bin/**/*.js @arcanis
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We've had internal discussions about it and @arcanis agreed to stop codeowning `@yarnpkg/core` to make it easier for us to merge small PRs affecting the core.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed it.

@arcanis Feel free to tweak the file yourself in case I misinterpreted what you said or you've changed your mind. :smile:

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
