### PR TITLE
test(integration): tweak timeout

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -24,7 +24,7 @@ const staticServer = serveStatic(npath.fromPortablePath(require(`pkg-tests-fixtu
 // Testing things inside a big-endian container takes forever
 export const TEST_TIMEOUT = os.endianness() === `BE`
   ? 150000
-  : 45000;
+  : 50000;
 
 export type PackageEntry = Map<string, {path: string, packageJson: Record<string, any>}>;
 export type PackageRegistry = Map<string, PackageEntry>;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/git.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/git.test.js
@@ -183,7 +183,6 @@ describe(`Protocols`, () => {
           await expect(source(`require('npm-has-prepack')`)).resolves.toEqual(42);
         },
       ),
-      45000,
     );
 
     test(


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The `it should guarantee that all dependencies will be installed when using npm to setup npm repositories` test:
- manually specifies its timeout, bypassing the automatic timeout setting based on endianness, which sometimes makes the test timeout on BE (e.g. https://github.com/yarnpkg/berry/actions/runs/2883842363/jobs/4582779531#step:5:60).
- sometimes timeouts on windows (e.g. https://github.com/yarnpkg/berry/actions/runs/3074200372/jobs/4966840912#step:5:15)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

- Removed the manually specified timeout.
- Increased the timeout by 5 seconds on LE. If it's not enough we can increase it even more in the future.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
