### PR TITLE
feat(shell): support whitespace-only commands

### DIFF
--- a/.yarn/versions/038526b5.yml
+++ b/.yarn/versions/038526b5.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/parsers": minor
+  "@yarnpkg/shell": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ The following changes only affect people writing Yarn plugins:
 
 - The patched filesystem now supports `fchown`.
 
+### Shell
+
+- The builtin shell now supports whitespace-only commands.
+
 ## 3.2.3
 
 ### Bugfixes

--- a/packages/yarnpkg-parsers/sources/grammars/shell.js
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.js
@@ -466,18 +466,32 @@ function peg$parse(input, options) {
   }
 
   function peg$parseStart() {
-    var s0, s1;
+    var s0, s1, s2;
 
     s0 = peg$currPos;
-    s1 = peg$parseShellLine();
-    if (s1 === peg$FAILED) {
-      s1 = null;
+    s1 = [];
+    s2 = peg$parseS();
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$parseS();
     }
     if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c0(s1);
+      s2 = peg$parseShellLine();
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c0(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-    s0 = s1;
 
     return s0;
   }

--- a/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
+++ b/packages/yarnpkg-parsers/sources/grammars/shell.pegjs
@@ -1,5 +1,5 @@
 Start
-  = line:ShellLine? { return line ? line : [] }
+  = S* line:ShellLine? { return line ? line : [] }
 
 ShellLine
   = command:CommandLine S* type:ShellLineType then:ShellLineThen? { return [ { command, type } ].concat(then || []) }

--- a/packages/yarnpkg-parsers/tests/shell.test.ts
+++ b/packages/yarnpkg-parsers/tests/shell.test.ts
@@ -45,6 +45,16 @@ const VALID_COMMANDS = [
 ];
 
 const INVALID_COMMANDS = [
+  // Empty shell lines
+  ...[
+    // Only fish supports these
+    `;;`,
+    `echo foo;;`,
+    // Only zsh and fish support these
+    `; ;`,
+    `echo foo; ;`,
+  ],
+
   `echo }`,
   `echo foo}`,
 
@@ -128,7 +138,7 @@ describe(`Shell parser`, () => {
   });
 
   describe(`String parse`, () => {
-    it(`should parse parse double quote string currectly`, () => {
+    it(`should parse parse double quote string correctly`, () => {
       for (const [original, raw] of DOUBLE_QUOTE_STRING_ESCAPE_TESTS) {
         expect(parseShell(`echo "${original}"`)).toStrictEqual([expect.objectContaining({
           command: expect.objectContaining({
@@ -143,7 +153,7 @@ describe(`Shell parser`, () => {
       }
     });
 
-    it(`should parse parse ANSI-C quote string currectly`, () => {
+    it(`should parse parse ANSI-C quote string correctly`, () => {
       for (const [original, raw] of ANSI_C_STRING_ESCAPE_TESTS) {
         expect(parseShell(`echo $'${original}'`)).toStrictEqual([expect.objectContaining({
           command: expect.objectContaining({

--- a/packages/yarnpkg-parsers/tests/shell.test.ts
+++ b/packages/yarnpkg-parsers/tests/shell.test.ts
@@ -137,8 +137,8 @@ describe(`Shell parser`, () => {
     });
   });
 
-  describe(`String parse`, () => {
-    it(`should parse parse double quote string correctly`, () => {
+  describe(`Strings`, () => {
+    it(`should parse double quoted strings correctly`, () => {
       for (const [original, raw] of DOUBLE_QUOTE_STRING_ESCAPE_TESTS) {
         expect(parseShell(`echo "${original}"`)).toStrictEqual([expect.objectContaining({
           command: expect.objectContaining({
@@ -153,7 +153,7 @@ describe(`Shell parser`, () => {
       }
     });
 
-    it(`should parse parse ANSI-C quote string correctly`, () => {
+    it(`should parse ANSI-C strings correctly`, () => {
       for (const [original, raw] of ANSI_C_STRING_ESCAPE_TESTS) {
         expect(parseShell(`echo $'${original}'`)).toStrictEqual([expect.objectContaining({
           command: expect.objectContaining({

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -87,22 +87,54 @@ const bufferResult = async (command: string, args: Array<string> = [], options: 
 
 describe(`Shell`, () => {
   describe(`Simple shell features`, () => {
-    it(`should support an empty string`, async () => {
-      await expect(bufferResult(
-        ``,
-      )).resolves.toMatchObject({
+    describe(`Empty commands`, () => {
+      const EMPTY_COMMAND_RESULT = {
         exitCode: 0,
         stdout: ``,
-      });
-    });
+      };
 
-    it(`should support an empty string when passing arguments`, async () => {
-      await expect(bufferResult(
-        ``,
-        [`hello`, `world`],
-      )).resolves.toMatchObject({
-        exitCode: 0,
-        stdout: ``,
+      it(`should support an empty string`, async () => {
+        await expect(bufferResult(
+          ``,
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+      });
+
+      it(`should support a whitespace-only string`, async () => {
+        await expect(bufferResult(
+          ` `,
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+
+        await expect(bufferResult(
+          `\t`,
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+
+        await expect(bufferResult(
+          `  \t   \t   \t  `,
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+      });
+
+      it(`should support an empty string when passing arguments`, async () => {
+        await expect(bufferResult(
+          ``,
+          [`hello`, `world`],
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+      });
+
+      it(`should support a whitespace-only string when passing arguments`, async () => {
+        await expect(bufferResult(
+          ` `,
+          [`hello`, `world`],
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+
+        await expect(bufferResult(
+          `\t`,
+          [`hello`, `world`],
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
+
+        await expect(bufferResult(
+          `  \t   \t   \t  `,
+          [`hello`, `world`],
+        )).resolves.toMatchObject(EMPTY_COMMAND_RESULT);
       });
     });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The shell doesn't support whitespace-only commands.

Fixes #4164.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Implemented support for them, but only for whitespace-only *commands*, not *shell lines*, given the fact that the latter are only supported by zsh and fish (but they aren't consistent with each other) and they're quite useless.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
