### PR TITLE
chore(bench): remove pnpm metadata cache in full-cold

### DIFF
--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -144,7 +144,7 @@ case $PACKAGE_MANAGER in
       --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.local/share/pnpm/store ~/.cache/pnpm' \
       'pnpm install'
     bench install-cache-only \
-      --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.cache/pnpm' \
+      --prepare 'rm -rf node_modules pnpm-lock.yaml' \
       'pnpm install'
     bench install-cache-and-lock \
       --prepare 'rm -rf node_modules' \

--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -141,10 +141,10 @@ case $PACKAGE_MANAGER in
   pnpm)
     setup-pnpm
     bench install-full-cold \
-      --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.local/share/pnpm/store' \
+      --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.local/share/pnpm/store ~/.cache/pnpm' \
       'pnpm install'
     bench install-cache-only \
-      --prepare 'rm -rf node_modules pnpm-lock.yaml' \
+      --prepare 'rm -rf node_modules pnpm-lock.yaml ~/.cache/pnpm' \
       'pnpm install'
     bench install-cache-and-lock \
       --prepare 'rm -rf node_modules' \


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Pnpm uses a request metadata cache so that it doesn't have to hit the network when rebuilding the lockfile unless the data is stale, but we don't clear it in the relevant benchmarks.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed [`~/.cache/pnpm`](https://pnpm.io/npmrc#cache-dir) in:
- full-cold, since this step needs to be fully cold
- ~~cache-only, since it's supposed to test how much it takes to resolve all packages (without caching)~~ Actually, we want `cache-only` to test real-life conditions so metadata caching is fair game.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
