### PR TITLE
Rewrites `yarn version`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -19201,6 +19201,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19235,6 +19236,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19269,6 +19271,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19303,6 +19306,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19337,6 +19341,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19371,6 +19376,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19405,6 +19411,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19439,6 +19446,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19473,6 +19481,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19507,6 +19516,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19541,6 +19551,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19575,6 +19586,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19609,6 +19621,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19643,6 +19656,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19677,6 +19691,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19711,6 +19726,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19745,6 +19761,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19779,6 +19796,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19813,6 +19831,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\
@@ -19844,6 +19863,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
+          ["enquirer", "npm:2.3.6"],\
           ["ink", "virtual:8d898fef98e932beba43b4d6618011f697787e7fd2f52624eb7daef58d4ae47c2c0be4a00e4cbfbae536ebdaf948ef2fd37ad5cb2fa89c56ad66c9e7ff10f073#patch:ink@npm%3A3.0.8#~/.yarn/patches/ink-npm-3.0.8-3a8005f59f.patch::version=3.0.8&hash=1e50c6"],\
           ["lodash", "npm:4.17.21"],\
           ["react", "npm:16.13.1"],\

--- a/packages/plugin-version/package.json
+++ b/packages/plugin-version/package.json
@@ -12,6 +12,7 @@
     "@yarnpkg/libui": "workspace:^",
     "@yarnpkg/parsers": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
+    "enquirer": "^2.3.6",
     "ink": "^3.0.8",
     "lodash": "^4.17.15",
     "react": "^16.13.1",

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -1,10 +1,24 @@
-import {BaseCommand, WorkspaceRequiredError} from '@yarnpkg/cli';
-import {Configuration, Project, Workspace}   from '@yarnpkg/core';
-import {Command, Option, Usage, UsageError}  from 'clipanion';
-import {prompt}                              from 'enquirer';
-import semver                                from 'semver';
+import {BaseCommand, WorkspaceRequiredError}                                                              from '@yarnpkg/cli';
+import {Configuration, execUtils, formatName, formatUtils, MessageName, Project, StreamReport, Workspace} from '@yarnpkg/core';
+import {gitUtils}                                                                                         from '@yarnpkg/plugin-git';
+import {Command, Option, Usage, UsageError}                                                               from 'clipanion';
+import {prompt}                                                                                           from 'enquirer';
+import semver                                                                                             from 'semver';
+import {setTimeout}                                                                                       from 'timers/promises';
 
-import * as versionUtils                     from '../versionUtils';
+import * as versionUtils                                                                                  from '../versionUtils';
+
+const semverColors: Record<versionUtils.ReleaseType, string> = {
+  [versionUtils.ReleaseType.Patch]: `green`,
+  [versionUtils.ReleaseType.Minor]: `yellow`,
+  [versionUtils.ReleaseType.Major]: `red`,
+};
+
+const semverStrategies = {
+  [versionUtils.ReleaseType.Patch]: `patch`,
+  [versionUtils.ReleaseType.Minor]: `minor`,
+  [versionUtils.ReleaseType.Major]: `major`,
+} as const;
 
 // eslint-disable-next-line arca/no-default-export
 export default class VersionCommand extends BaseCommand {
@@ -38,6 +52,10 @@ export default class VersionCommand extends BaseCommand {
     ]],
   });
 
+  init = Option.Boolean(`--init`, false, {
+    description: `If true, allow running the command on workspaces that don't currently have a version`,
+  });
+
   strategy = Option.String({
     required: false,
   });
@@ -59,27 +77,164 @@ export default class VersionCommand extends BaseCommand {
   }
 
   async executeImmediate({configuration, project, workspace}: {configuration: Configuration, project: Project, workspace: Workspace}) {
-    const initialVersion = `1.0.0`;
+    let initialVersion = workspace.manifest.version;
+    if (initialVersion === null) {
+      if (this.init) {
+        initialVersion = `0.0.0`;
+      } else {
+        throw new UsageError(`This workspace doesn't seem to have a version; to set one, use --init`);
+      }
+    }
 
-    const getChoice = (name: string, strategy: string) => {
-      const newVersion = semver.inc(initialVersion, strategy)!;
-      return {name: `${name} - ${newVersion}`, value: newVersion};
-    };
+    let runPublish = false;
 
-    const {version} = await prompt<{version: string}>({
-      type: `select`,
-      name: `version`,
-      message: `New version:`,
-      required: true,
-      choices: [
-        getChoice(`Major`, `major`),
-        getChoice(`Minor`, `minor`),
-        getChoice(`Patch`, `patch`),
-      ],
-      onCancel: () => process.exit(130),
+    const report = await StreamReport.start({
+      configuration,
+      stdout: this.context.stdout,
+    }, async stream => {
+      let prefix = stream.formatNameWithHyperlink(MessageName.UNNAMED);
+      prefix = `\x1b[0m${prefix}${prefix ? `: ` : ``}`;
+
+      const patchBlockers: Array<number> = [];
+      const minorBlockers: Array<number> = [];
+
+      const lastUpdateHash = await gitUtils.findLastPackageJsonUpdate(workspace.cwd);
+      if (lastUpdateHash) {
+        const pullRequests = await gitUtils.findPullRequestsSince(lastUpdateHash, {project, workspace});
+        if (pullRequests.length > 0) {
+          const pullRequestsWithReleaseTypes = await Promise.all(pullRequests.map(async pullRequest => ({
+            ...pullRequest,
+            releaseType: await versionUtils.findPullRequestReleaseType(pullRequest, {project}),
+          })));
+
+          const haveReleaseTypes = pullRequestsWithReleaseTypes.some(pullRequest => {
+            return pullRequest.releaseType !== null;
+          });
+
+          const deployablePullRequests: Array<{
+            name: string;
+            value: string;
+          }> = [];
+
+          for (const pullRequest of pullRequestsWithReleaseTypes) {
+            const releaseTypeLabel = haveReleaseTypes
+              ? pullRequest.releaseType !== null
+                ? `${formatUtils.pretty(configuration, pullRequest.releaseType, semverColors[pullRequest.releaseType])} - `
+                : `${formatUtils.pretty(configuration, `-----`, formatUtils.Type.NULL)} - `
+              : ``;
+
+            if (pullRequest.releaseType === versionUtils.ReleaseType.Major || pullRequest.releaseType === versionUtils.ReleaseType.Minor)
+              patchBlockers.push(pullRequest.number);
+            if (pullRequest.releaseType === versionUtils.ReleaseType.Minor)
+              minorBlockers.push(pullRequest.number);
+
+            deployablePullRequests.push({
+              name: `${releaseTypeLabel}#${pullRequest.number} - ${pullRequest.title}`,
+              value: pullRequest.hash,
+            });
+          }
+
+          const {deployedPullRequests} = await prompt<{deployedPullRequests: string}>({
+            type: `multiselect`,
+            name: `deployedPullRequests`,
+            message: `${prefix}Select the pull requests you wish to deploy (easier to select them all):`,
+            required: true,
+            choices: deployablePullRequests,
+            initial: deployablePullRequests.map((_, index) => index) as any as number,
+            result(this: any, names: Array<string>) {
+              return names.map(name => this.find(name).value);
+            },
+            onCancel: () => process.exit(130),
+          });
+
+          if (deployedPullRequests.length !== deployablePullRequests.length) {
+            throw new UsageError(`Deploying a subset of the changes isn't supported at this time`);
+          }
+        }
+      }
+
+      const getChoice = (name: string, strategy: versionUtils.ReleaseType) => {
+        const newVersion = semver.inc(initialVersion!, semverStrategies[strategy])!;
+        return {name: `${name} - ${newVersion}`, value: newVersion};
+      };
+
+      const {newVersion} = await prompt<{newVersion: versionUtils.ReleaseType}>({
+        type: `select`,
+        name: `newVersion`,
+        message: `${prefix}Please select the version you wish to release:`,
+        required: true,
+        choices: [
+          getChoice(`Major`, versionUtils.ReleaseType.Major),
+          getChoice(`Minor`, versionUtils.ReleaseType.Minor),
+          getChoice(`Patch`, versionUtils.ReleaseType.Patch),
+        ],
+        result(this: any, values) {
+          return this.find(values).value;
+        },
+        onCancel: () => process.exit(130),
+      });
+
+      workspace.manifest.version = newVersion;
+      await workspace.persistManifest();
+
+      await execUtils.execvp(`git`, [`commit`, `--all`, `-m`, `Release v${newVersion}`], {
+        cwd: workspace.cwd,
+        strict: true,
+      });
+
+      const newTags: Array<string> = [];
+      for (const pattern of configuration.get(`releaseTagPatterns`)) {
+        const newTag = pattern.replace(/\{version\}/g, newVersion);
+        newTags.push(newTag);
+
+        await execUtils.execvp(`git`, [`tag`, `--annotate`, `-m`, newTag, newTag], {
+          cwd: workspace.cwd,
+          strict: true,
+        });
+      }
+
+      const commitSuccessMessage = newTags.length > 0
+        ? `Release tagged as ${newTags.map(tag => formatUtils.pretty(configuration, tag, formatUtils.Type.CODE)).join(`, `)}; do you wish to publish it now?`
+        : `Release committed; do you wish to publish it now?`;
+
+      const {shouldPublish} = await prompt<{shouldPublish: boolean}>({
+        type: `confirm`,
+        name: `shouldPublish`,
+        message: `${prefix}${commitSuccessMessage}`,
+        initial: true,
+        required: true,
+        onCancel: () => process.exit(130),
+      });
+
+      if (!shouldPublish) {
+        stream.reportInfo(MessageName.UNNAMED, `Publish step skipped`);
+        return;
+      }
+
+      const newPublishCommand = workspace.manifest.scripts.has(`publish`)
+        ? `yarn run publish`
+        : `yarn npm publish`;
+
+      stream.reportInfo(MessageName.UNNAMED, `Publish requested; we'll run ${formatUtils.pretty(configuration, newPublishCommand, formatUtils.Type.CODE)} in a couple of seconds`);
+
+      await setTimeout(3000);
+
+      stream.reportSeparator();
+      runPublish = true;
     });
 
-    console.log(version);
+    if (report.hasErrors())
+      return report.exitCode();
+
+    if (runPublish) {
+      if (workspace.manifest.scripts.has(`publish`)) {
+        return await this.cli.run([`run`, `publish`]);
+      } else {
+        return await this.cli.run([`npm`, `publish`]);
+      }
+    }
+
+    return 0;
   }
 
   async executeDeferred({configuration, project, workspace}: {configuration: Configuration, project: Project, workspace: Workspace}) {

--- a/packages/plugin-version/sources/index.ts
+++ b/packages/plugin-version/sources/index.ts
@@ -1,10 +1,10 @@
-import {Plugin, SettingsType} from '@yarnpkg/core';
-import {PortablePath}         from '@yarnpkg/fslib';
+import {miscUtils, Plugin, SettingsType} from '@yarnpkg/core';
+import {PortablePath}                    from '@yarnpkg/fslib';
 
-import VersionApplyCommand    from './commands/version/apply';
-import VersionCheckCommand    from './commands/version/check';
-import VersionCommand         from './commands/version';
-import * as versionUtils      from './versionUtils';
+import VersionApplyCommand               from './commands/version/apply';
+import VersionCheckCommand               from './commands/version/check';
+import VersionCommand                    from './commands/version';
+import * as versionUtils                 from './versionUtils';
 
 export {VersionApplyCommand};
 export {VersionCheckCommand};
@@ -13,6 +13,8 @@ export {versionUtils};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
+    releaseTagPatterns: Array<string>;
+    releaseTypePatterns: miscUtils.ToMapValue<{patch: Array<string>, minor: Array<string>, major: Array<string>}>;
     deferredVersionFolder: PortablePath;
     preferDeferredVersions: boolean;
   }
@@ -20,6 +22,36 @@ declare module '@yarnpkg/core' {
 
 const plugin: Plugin = {
   configuration: {
+    releaseTagPatterns: {
+      description: `Patterns to use when generating the tags for the new releases`,
+      type: SettingsType.STRING,
+      default: [`{version}`],
+      isArray: true,
+    },
+    releaseTypePatterns: {
+      description: `Patterns to use to detect whether commits should lead to major / minor / patch version bumps`,
+      type: SettingsType.SHAPE,
+      properties: {
+        patch: {
+          description: `Patterns to use to detect whether commits must be deployed in patch releases or higher`,
+          type: SettingsType.STRING,
+          default: [`^fix(\\([^)]+\\))?:`],
+          isArray: true,
+        },
+        minor: {
+          description: `Patterns to use to detect whether commits must be deployed in minor releases or higher`,
+          type: SettingsType.STRING,
+          default: [`^feat(\\([^)]+\\))?:`],
+          isArray: true,
+        },
+        major: {
+          description: `Patterns to use to detect whether commits must be deployed in major releases`,
+          type: SettingsType.STRING,
+          default: [`^[a-z](\\([^)]\\))?!:`, `(^|\\n)\\s+BREAKING CHANGE:`],
+          isArray: true,
+        },
+      },
+    },
     deferredVersionFolder: {
       description: `Folder where are stored the versioning files`,
       type: SettingsType.ABSOLUTE_PATH,

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -677,14 +677,14 @@ export class StreamReport extends Report {
     return str;
   }
 
-  private formatName(name: MessageName | null) {
+  formatName(name: MessageName | null) {
     return formatName(name, {
       configuration: this.configuration,
       json: this.json,
     });
   }
 
-  private formatNameWithHyperlink(name: MessageName | null) {
+  formatNameWithHyperlink(name: MessageName | null) {
     return formatNameWithHyperlink(name, {
       configuration: this.configuration,
       json: this.json,

--- a/packages/yarnpkg-core/sources/execUtils.ts
+++ b/packages/yarnpkg-core/sources/execUtils.ts
@@ -62,6 +62,8 @@ export class ExecError extends PipeError {
 
     this.stdout = stdout;
     this.stderr = stderr;
+
+    console.log(this.stderr);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6305,6 +6305,7 @@ __metadata:
     "@yarnpkg/parsers": "workspace:^"
     "@yarnpkg/plugin-git": "workspace:^"
     clipanion: "npm:^3.2.0-rc.10"
+    enquirer: "npm:^2.3.6"
     ink: "npm:^3.0.8"
     lodash: "npm:^4.17.15"
     react: "npm:^16.13.1"


### PR DESCRIPTION
**What's the problem this PR addresses?**
The current `yarn version` immediate implementation doesn't work very well: it always uses the deferred mode internally, which is unnecessary for both simple repositories (it increases the complexity and bug surface) and large monorepos (which don't need to mix immediate and deferred versioning).

**How did you fix it?**
I'm rebuilding the `yarn version` workflow entirely. The end result isn't clear yet, but I'm basically looking for something like:

```
This are the PRs which are going to get deployed:
  - ...
Which version do you want to publish?
  - Major 9.0.0
  - Minor 8.1.0
  - Patch 8.0.1
Tags created; do you want to publish it now? [Y/n]
Running `yarn npm publish` in 5 seconds
```


**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
