### PR TITLE
fix: update pnp file to fix chore testing error

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -45884,13 +45884,6 @@ function EOPNOTSUPP(reason) {
 function ERR_DIR_CLOSED() {
   return makeError$1(`ERR_DIR_CLOSED`, `Directory handle was closed`);
 }
-class LibzipError extends Error {
-  constructor(message, code) {
-    super(message);
-    this.name = `Libzip Error`;
-    this.code = code;
-  }
-}
 
 const DEFAULT_MODE = S_IFREG | 420;
 class StatEntry {
@@ -53347,6 +53340,13 @@ function makeEmptyArchive() {
     0,
     0
   ]);
+}
+class LibzipError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = `Libzip Error`;
+    this.code = code;
+  }
 }
 class ZipFS extends BasePortableFakeFS {
   constructor(source, opts = {}) {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

My other PR In chore testing got an error, after I rebase it on master branch.

I tried to checkout to the master branch and found the same error, so I guess some PRs may have forgotten to update the pnp file.

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Run the `yarn` command to update pnp file.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
