### PR TITLE
docs(gatsby): Remove outdated information of `plugin-tutorial.mdx`

### DIFF
--- a/packages/gatsby/content/advanced/plugin-tutorial.mdx
+++ b/packages/gatsby/content/advanced/plugin-tutorial.mdx
@@ -145,8 +145,6 @@ In this example, we registered to the `setupScriptEnvironment` hook and used it 
 
 Hooks are numerous, and we're still working on them. Some might be added, removed, or changed, based on your feedback. So if you'd like to do something hooks don't allow you to do yet, come tell us!
 
-> **Note:** We don't yet have a list of hooks. If you're interested to improve this documentation by generating the hook list from our source code, please contact us on our Discord server!
-
 ## Using the Yarn API
 
 Most of Yarn's hooks are called with various arguments that tell you more about the context under which the hook is being called. The exact argument list is different for each hook, but in general they are of the types defined in the [`@yarnpkg/core` library](/api).


### PR DESCRIPTION


**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

related comment: https://github.com/yarnpkg/berry/issues/4880#issuecomment-1254127175

The [plugin-tutoria pagel](https://yarnpkg.com/advanced/plugin-tutorial) has a note

> Note: We don't yet have a list of hooks. If you're interested to improve this documentation by generating the hook list from our source code, please contact us on our Discord server!

But after checking, our hook list is quite complete, this note should be an outdated message.

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Remove it.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
