### PR TITLE
ci: fix the typescript e2e test

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -259,6 +259,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/eslint-config", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/eslint-config"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/libzip", "virtual:b73ceab179a3b4f89c4a5be81bd0c20a80eda623489cb284f304cc8104dbb771916bbc246d0ba809faebd8459cb6554cf114954badb021279ea7aee216456122#workspace:packages/yarnpkg-libzip"],\
           ["@yarnpkg/sdks", "workspace:packages/yarnpkg-sdks"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["eslint", "npm:8.2.0"],\
@@ -11193,6 +11194,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/eslint-config", "virtual:e470d99b1e4fdf4c5db5d090ff5472cdeba0404b7ffd31cd2efab3493dd184c67bc45f60c2ef1c040e2c41afe38c6280bffc5df2fbe3aefaa2b6eacf685ab07c#workspace:packages/eslint-config"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/libzip", "virtual:b73ceab179a3b4f89c4a5be81bd0c20a80eda623489cb284f304cc8104dbb771916bbc246d0ba809faebd8459cb6554cf114954badb021279ea7aee216456122#workspace:packages/yarnpkg-libzip"],\
           ["@yarnpkg/sdks", "workspace:packages/yarnpkg-sdks"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["eslint", "npm:8.2.0"],\

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@yarnpkg/core": "workspace:^",
     "@yarnpkg/eslint-config": "workspace:^",
     "@yarnpkg/fslib": "workspace:^",
+    "@yarnpkg/libzip": "workspace:^",
     "@yarnpkg/sdks": "workspace:^",
     "clipanion": "^3.2.0-rc.10",
     "eslint": "^8.2.0",

--- a/scripts/test-typescript-patch.js
+++ b/scripts/test-typescript-patch.js
@@ -19,13 +19,14 @@ const moduleSpecifierResolutionHost = ts.createModuleSpecifierResolutionHost(pro
 
 const yarnCorePkgDir = require.resolve(`@yarnpkg/core/package.json`).replace(`/package.json`, ``);
 const fslibPkgDir = require.resolve(`@yarnpkg/fslib/package.json`).replace(`/package.json`, ``);
+const libzipPkgDir = require.resolve(`@yarnpkg/libzip/package.json`).replace(`/package.json`, ``);
 const rootSourceFile = program.getSourceFile(require.resolve(`${yarnCorePkgDir}/sources/Project.ts`));
 
 const TESTS = [
   [`${yarnCorePkgDir}/sources/Configuration.ts`, `./Configuration`],
   [`${fslibPkgDir}/README.md`, `@yarnpkg/fslib/README.md`],
   [`${fslibPkgDir}/package.json`, `@yarnpkg/fslib/package.json`],
-  [`${fslibPkgDir}/sources/ZipFS.ts`, `@yarnpkg/fslib/sources/ZipFS`],
+  [`${libzipPkgDir}/sources/ZipFS.ts`, `@yarnpkg/libzip/sources/ZipFS`],
   [`${fslibPkgDir}/sources/index.ts`, `@yarnpkg/fslib`],
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5860,6 +5860,7 @@ __metadata:
     "@yarnpkg/core": "workspace:^"
     "@yarnpkg/eslint-config": "workspace:^"
     "@yarnpkg/fslib": "workspace:^"
+    "@yarnpkg/libzip": "workspace:^"
     "@yarnpkg/sdks": "workspace:^"
     clipanion: "npm:^3.2.0-rc.10"
     eslint: "npm:^8.2.0"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Related https://github.com/yarnpkg/berry/pull/4853

I've noticed these days that master branch CI always has errors. ([github action log](https://github.com/yarnpkg/berry/actions/workflows/e2e-typescript-workflow.yml))

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

After checking, I found some small things that we have missed

1. Update the path to `libzip` in  `scripts/test-typescript-patch.js`
2. Add `@yarnpkg/libzip`  to `@yarnpkg/monorepo`  devDependencies
3. Run `yarn node ./scripts/test-typescript-patch.js` to confirm that it has been fixed

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
