### PR TITLE
fix(fslib): handle file path buffers

### DIFF
--- a/.yarn/versions/1f3cd0b2.yml
+++ b/.yarn/versions/1f3cd0b2.yml
@@ -1,0 +1,3 @@
+releases:
+  "@yarnpkg/fslib": minor
+  "@yarnpkg/plugin-patch": patch

--- a/packages/plugin-patch/sources/patchUtils.ts
+++ b/packages/plugin-patch/sources/patchUtils.ts
@@ -277,8 +277,8 @@ export async function extractPackageToDisk(locator: Locator, {cache, project}: {
 }
 
 export async function diffFolders(folderA: PortablePath, folderB: PortablePath) {
-  const folderAN = npath.fromPortablePath(folderA).replace(/\\/g, `/`);
-  const folderBN = npath.fromPortablePath(folderB).replace(/\\/g, `/`);
+  const folderAN = npath.fromPortablePath(folderA).toString().replace(/\\/g, `/`);
+  const folderBN = npath.fromPortablePath(folderB).toString().replace(/\\/g, `/`);
 
   const {stdout, stderr} = await execUtils.execvp(`git`, [`-c`, `core.safecrlf=false`, `diff`, `--src-prefix=a/`, `--dst-prefix=b/`, `--ignore-cr-at-eol`, `--full-index`, `--no-index`, `--no-renames`, `--text`, folderAN, folderBN], {
     cwd: npath.toPortablePath(process.cwd()),
@@ -302,8 +302,8 @@ export async function diffFolders(folderA: PortablePath, folderB: PortablePath) 
 
 
   const normalizePath = folderAN.startsWith(`/`)
-    ? (p: NativePath) => p.slice(1)
-    : (p: NativePath) => p;
+    ? (p: string) => p.slice(1)
+    : (p: string) => p;
 
   return stdout
     .replace(new RegExp(`(a|b)(${miscUtils.escapeRegExp(`/${normalizePath(folderAN)}/`)})`, `g`), `$1/`)

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -135,13 +135,13 @@ function fromPortablePath(p: PortablePath): NativePath {
   else
     return p as NativePath;
 
-  return p.replace(/\//g, `\\`);
+  return p.replace(/\//g, `\\`) as NativePath;
 }
 
 // Path should look like "N:/berry/scripts/plugin-pack.js"
 // And transform to "/N:/berry/scripts/plugin-pack.js"
 function toPortablePath(p: Path): PortablePath {
-  p = p.toString()
+  p = p.toString();
   if (process.platform !== `win32`)
     return p as PortablePath;
 

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -7,7 +7,7 @@ enum PathType {
 }
 
 export type PortablePath = string & { __pathType: PathType.File | PathType.Portable };
-export type NativePath = string & { __pathType?: PathType.File | PathType.Native };
+export type NativePath = (string | Buffer) & { __pathType?: PathType.File | PathType.Native };
 
 export const PortablePath = {
   root: `/` as PortablePath,
@@ -51,8 +51,8 @@ ppath.resolve = (...segments: Array<PortablePath | Filename>) => {
 };
 
 const contains = function <T extends Path>(pathUtils: PathUtils<T>, from: T, to: T) {
-  from = pathUtils.normalize(from);
-  to = pathUtils.normalize(to);
+  from = pathUtils.normalize(from.toString());
+  to = pathUtils.normalize(to.toString());
 
   if (from === to)
     return `.` as T;
@@ -111,7 +111,7 @@ export interface PathUtils<P extends Path> {
 }
 
 export interface ConvertUtils {
-  fromPortablePath: (p: Path) => NativePath;
+  fromPortablePath: (p: PortablePath) => NativePath;
   toPortablePath: (p: Path) => PortablePath;
 }
 
@@ -123,7 +123,7 @@ const UNC_PORTABLE_PATH_REGEXP = /^\/unc\/(\.dot\/)?(.*)$/;
 
 // Path should look like "/N:/berry/scripts/plugin-pack.js"
 // And transform to "N:\berry\scripts\plugin-pack.js"
-function fromPortablePath(p: Path): NativePath {
+function fromPortablePath(p: PortablePath): NativePath {
   if (process.platform !== `win32`)
     return p as NativePath;
 
@@ -141,6 +141,7 @@ function fromPortablePath(p: Path): NativePath {
 // Path should look like "N:/berry/scripts/plugin-pack.js"
 // And transform to "/N:/berry/scripts/plugin-pack.js"
 function toPortablePath(p: Path): PortablePath {
+  p = p.toString()
   if (process.platform !== `win32`)
     return p as PortablePath;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Resolves https://github.com/yarnpkg/berry/issues/1818

I was getting build errors similar to the below. This is because yarn assumes every filesystem path is provided as a string, but Node's internal version of `rimraf` allows them to be buffers.

```
Executing task: yarn run build 

vite v3.1.3 building for production...
✓ 42 modules transformed.
p.replace is not a function

[vite:dts] Start generate declaration files...
[vite:dts] Declaration files built in 1275ms.

error during build:
TypeError: p.replace is not a function
    at Object.toPortablePath (C:\Users\dan\Source\vue-maplibre-gl\.pnp.cjs:3194:9)
    at PosixFS.mapToBase (C:\Users\dan\Source\vue-maplibre-gl\.pnp.cjs:5765:18)
    at PosixFS.rmdirSync (C:\Users\dan\Source\vue-maplibre-gl\.pnp.cjs:5676:39)
    at URLFS.rmdirSync (C:\Users\dan\Source\vue-maplibre-gl\.pnp.cjs:5676:24)
    at _rmdirSync (node:internal/fs/rimraf:260:21)
    at rimrafSync (node:internal/fs/rimraf:193:7)
    at node:internal/fs/rimraf:253:9
    at Array.forEach (<anonymous>)
    at _rmdirSync (node:internal/fs/rimraf:250:7)
    at rimrafSync (node:internal/fs/rimraf:193:7)
```

**How did you fix it?**
I made the `NativePath` type admit `Buffer`s, and ensure that these buffers are stringified as part of the conversion to `PortablePath`. Note that paths are assumed to be UTF8, which is a similar restriction as https://nodejs.org/api/fs.html#fspromisesrealpathpath-options

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
