### PR TITLE
feat: when initializing the `Configuration`, auto fetch the missing plugins

### DIFF
--- a/.yarn/versions/13f288ec.yml
+++ b/.yarn/versions/13f288ec.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/__snapshots__/check.test.ts.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/__snapshots__/check.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Commands plugin import it should run successfully and do nothing 1`] = `
+Object {
+  "code": 0,
+  "stderr": "",
+  "stdout": "➤ YN0000: Done
+",
+}
+`;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/__snapshots__/check.test.ts.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/__snapshots__/check.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Commands plugin import it should run successfully and do nothing 1`] = `
+exports[`Commands plugin check it should run successfully and do nothing 1`] = `
 Object {
   "code": 0,
   "stderr": "",

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
@@ -8,38 +8,42 @@ describe(`Commands`, () => {
     test(
       `it should run successfully and do nothing`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        const mockPluginPath = await createMockPlugin(path);
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await mockPluginServer(async mockServer => {
+          const mockPluginPath = await createMockPlugin(path);
+          const {pluginUrl, httpsCaFilePath} = mockServer;
 
-        await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-            checksum: await hashUtils.checksumFile(`${path}/${mockPluginPath}` as PortablePath),
-          }],
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            httpsCaFilePath,
+            plugins: [{
+              path: mockPluginPath,
+              spec: pluginUrl,
+              checksum: await hashUtils.checksumFile(`${path}/${mockPluginPath}` as PortablePath),
+            }],
+          });
+
+          await expect(run(`plugin`, `check`)).resolves.toMatchSnapshot();
         });
-
-        await expect(run(`plugin`, `check`)).resolves.toMatchSnapshot();
       }),
     );
 
     test(
       `it should print out the plugin when it has a different checksum`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        const mockPluginPath = await createMockPlugin(path);
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await mockPluginServer(async mockServer => {
+          const mockPluginPath = await createMockPlugin(path);
+          const {pluginUrl, httpsCaFilePath} = mockServer;
 
-        await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-            checksum: `I am wrong checksum 123456`,
-          }],
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            httpsCaFilePath,
+            plugins: [{
+              path: mockPluginPath,
+              spec: pluginUrl,
+              checksum: `I am wrong checksum 123456`,
+            }],
+          });
+
+          await expect(run(`plugin`, `check`)).rejects.toThrow(/is different/);
         });
-
-        await expect(run(`plugin`, `check`)).rejects.toThrow(/is different/);
       }),
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
@@ -1,0 +1,68 @@
+import {hashUtils}                          from '@yarnpkg/core';
+import {xfs, PortablePath}                  from '@yarnpkg/fslib';
+import {stringifySyml}                      from '@yarnpkg/parsers';
+
+import {createMockPlugin, mockPluginServer} from '../../features/plugins.utility';
+
+describe(`Commands`, () => {
+  describe(`plugin import`, () => {
+    test(
+      `it should run successfully and do nothing`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const mockPluginPath = await createMockPlugin(path);
+        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+            checksum: hashUtils.checksumFile(`${path}/${mockPluginPath}` as PortablePath),
+          }],
+        }));
+        await expect(
+          run(`plugin`, `check`),
+        ).resolves.toMatchSnapshot();
+      }),
+    );
+
+    test(
+      `it should print out the plugin when it has a different checksum`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const mockPluginPath = await createMockPlugin(path);
+        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+            checksum: `I am wrong checksum 123456`,
+          }],
+        }));
+
+        const {code, stdout} = await run(`plugin`, `check`);
+        expect(code).toEqual(0);
+        expect(stdout.match(/is different/g)).not.toBeNull();
+      }),
+    );
+
+    test(
+      `it should throw an error when it finds some plugins in the CI environment that have a different checksum`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const mockPluginPath = await createMockPlugin(path);
+        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+            checksum: `I am wrong checksum 123456`,
+          }],
+        }));
+
+        await expect(
+          run(`plugin`, `check`, {env: {CI: `1`}}),
+        ).rejects.toThrow();
+      }),
+    );
+  });
+});

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
@@ -1,27 +1,26 @@
 import {hashUtils}                          from '@yarnpkg/core';
 import {xfs, PortablePath}                  from '@yarnpkg/fslib';
-import {stringifySyml}                      from '@yarnpkg/parsers';
 
 import {createMockPlugin, mockPluginServer} from '../../features/plugins.utility';
 
 describe(`Commands`, () => {
-  describe(`plugin import`, () => {
+  describe(`plugin check`, () => {
     test(
       `it should run successfully and do nothing`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const mockPluginPath = await createMockPlugin(path);
         const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
-        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+
+        await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
           httpsCaFilePath,
           plugins: [{
             path: mockPluginPath,
             spec: pluginUrl,
-            checksum: hashUtils.checksumFile(`${path}/${mockPluginPath}` as PortablePath),
+            checksum: await hashUtils.checksumFile(`${path}/${mockPluginPath}` as PortablePath),
           }],
-        }));
-        await expect(
-          run(`plugin`, `check`),
-        ).resolves.toMatchSnapshot();
+        });
+
+        await expect(run(`plugin`, `check`)).resolves.toMatchSnapshot();
       }),
     );
 
@@ -30,38 +29,17 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const mockPluginPath = await createMockPlugin(path);
         const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
-        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+
+        await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
           httpsCaFilePath,
           plugins: [{
             path: mockPluginPath,
             spec: pluginUrl,
             checksum: `I am wrong checksum 123456`,
           }],
-        }));
+        });
 
-        const {code, stdout} = await run(`plugin`, `check`);
-        expect(code).toEqual(0);
-        expect(stdout.match(/is different/g)).not.toBeNull();
-      }),
-    );
-
-    test(
-      `it should throw an error when it finds some plugins in the CI environment that have a different checksum`,
-      makeTemporaryEnv({}, async ({path, run, source}) => {
-        const mockPluginPath = await createMockPlugin(path);
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
-        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-            checksum: `I am wrong checksum 123456`,
-          }],
-        }));
-
-        await expect(
-          run(`plugin`, `check`, {env: {CI: `1`}}),
-        ).rejects.toThrow();
+        await expect(run(`plugin`, `check`)).rejects.toThrow(/is different/);
       }),
     );
   });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -32,28 +32,30 @@ describe(`Commands`, () => {
     test(
       `it should update plugin's checksum, if it's different`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        const mockPluginPath = await createMockPlugin(path);
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await mockPluginServer(async mockServer => {
+          const mockPluginPath = await createMockPlugin(path);
+          const {pluginUrl, httpsCaFilePath} = await mockServer;
 
-        await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-            checksum: `I am wrong checksum 123456`,
-          }],
-        }));
+          await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
+            httpsCaFilePath,
+            plugins: [{
+              path: mockPluginPath,
+              spec: pluginUrl,
+              checksum: `I am wrong checksum 123456`,
+            }],
+          }));
 
-        await run(`plugin`, `import`, pluginUrl);
+          await run(`plugin`, `import`, pluginUrl);
 
-        await expect(xfs.existsPromise(ppath.join(path, mockPluginPath))).resolves.toEqual(true);
-        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-            checksum: await hashUtils.checksumFile(ppath.join(path, mockPluginPath)),
-          }],
+          await expect(xfs.existsPromise(ppath.join(path, mockPluginPath))).resolves.toEqual(true);
+          await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+            httpsCaFilePath,
+            plugins: [{
+              path: mockPluginPath,
+              spec: pluginUrl,
+              checksum: await hashUtils.checksumFile(ppath.join(path, mockPluginPath)),
+            }],
+          });
         });
       }),
     );
@@ -61,27 +63,29 @@ describe(`Commands`, () => {
     test(
       `it should clear the plugin's checksum, if it using \`--no-checksum\` option`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
-        const mockPluginPath = await createMockPlugin(path);
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await mockPluginServer(async mockServer => {
+          const mockPluginPath = await createMockPlugin(path);
+          const {pluginUrl, httpsCaFilePath} = await mockServer;
 
-        await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-            checksum: `I am checksum 123456`,
-          }],
-        }));
+          await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
+            httpsCaFilePath,
+            plugins: [{
+              path: mockPluginPath,
+              spec: pluginUrl,
+              checksum: `I am checksum 123456`,
+            }],
+          }));
 
-        await run(`plugin`, `import`, `--no-checksum`, pluginUrl);
+          await run(`plugin`, `import`, `--no-checksum`, pluginUrl);
 
-        await expect(xfs.existsPromise(`${path}/${mockPluginPath}` as PortablePath)).resolves.toEqual(true);
-        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
-          httpsCaFilePath,
-          plugins: [{
-            path: mockPluginPath,
-            spec: pluginUrl,
-          }],
+          await expect(xfs.existsPromise(`${path}/${mockPluginPath}` as PortablePath)).resolves.toEqual(true);
+          await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+            httpsCaFilePath,
+            plugins: [{
+              path: mockPluginPath,
+              spec: pluginUrl,
+            }],
+          });
         });
       }),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -1,6 +1,9 @@
-import {hashUtils}                   from '@yarnpkg/core';
-import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
-import {fs, yarn}                    from 'pkg-tests-core';
+import {hashUtils}                                 from '@yarnpkg/core';
+import {xfs, ppath, Filename, npath, PortablePath} from '@yarnpkg/fslib';
+import {stringifySyml}                             from '@yarnpkg/parsers';
+import {fs, yarn}                                  from 'pkg-tests-core';
+
+import {createMockPlugin, mockPluginServer}        from '../../features/plugins.utility';
 
 describe(`Commands`, () => {
   describe(`plugin import`, () => {
@@ -23,6 +26,61 @@ describe(`Commands`, () => {
         });
 
         await run(`hello`, `--email`, `postmaster@example.org`);
+      }),
+    );
+
+    test(
+      `it should update plugin's checksum, if it's different`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const mockPluginPath = await createMockPlugin(path);
+        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+            checksum: `I am wrong checksum 123456`,
+          }],
+        }));
+
+        await run(`plugin`, `import`, pluginUrl);
+
+        await expect(xfs.existsPromise(ppath.join(path, mockPluginPath))).resolves.toEqual(true);
+        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+            checksum: await hashUtils.checksumFile(ppath.join(path, mockPluginPath)),
+          }],
+        });
+      }),
+    );
+
+    test(
+      `it should clear the plugin's checksum, if it using \`--no-checksum\` option`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const mockPluginPath = await createMockPlugin(path);
+        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+            checksum: `I am checksum 123456`,
+          }],
+        }));
+
+        await run(`plugin`, `import`, `--no-checksum`, pluginUrl);
+
+        await expect(xfs.existsPromise(`${path}/${mockPluginPath}` as PortablePath)).resolves.toEqual(true);
+        await expect(fs.readSyml(ppath.join(path, Filename.rc))).resolves.toEqual({
+          httpsCaFilePath,
+          plugins: [{
+            path: mockPluginPath,
+            spec: pluginUrl,
+          }],
+        });
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -34,6 +34,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const mockPluginPath = await createMockPlugin(path);
         const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+
         await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
           httpsCaFilePath,
           plugins: [{
@@ -62,6 +63,7 @@ describe(`Commands`, () => {
       makeTemporaryEnv({}, async ({path, run, source}) => {
         const mockPluginPath = await createMockPlugin(path);
         const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+
         await xfs.writeFilePromise(ppath.join(path, Filename.rc), stringifySyml({
           httpsCaFilePath,
           plugins: [{

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -1,3 +1,4 @@
+import {hashUtils}                   from '@yarnpkg/core';
 import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
 import {fs, yarn}                    from 'pkg-tests-core';
 
@@ -17,6 +18,7 @@ describe(`Commands`, () => {
           plugins: [{
             path: ppath.relative(path, helloWorldPlugin),
             spec: ppath.relative(path, npath.toPortablePath(helloWorldSource)),
+            checksum: await hashUtils.checksumFile(helloWorldPlugin),
           }],
         });
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/remove.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/remove.test.ts
@@ -1,3 +1,4 @@
+import {hashUtils}                   from '@yarnpkg/core';
 import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
 import {fs, yarn}                    from 'pkg-tests-core';
 
@@ -21,9 +22,11 @@ describe(`Commands`, () => {
           plugins: [{
             path: ppath.relative(path, helloWorldPlugin),
             spec: ppath.relative(path, npath.toPortablePath(helloWorldSource)),
+            checksum: await hashUtils.checksumFile(helloWorldPlugin),
           }, {
             path: ppath.relative(path, helloUniversePlugin),
             spec: ppath.relative(path, npath.toPortablePath(helloUniverseSource)),
+            checksum: await hashUtils.checksumFile(helloUniversePlugin),
           }],
         });
 
@@ -34,6 +37,7 @@ describe(`Commands`, () => {
           plugins: [{
             path: ppath.relative(path, helloUniversePlugin),
             spec: ppath.relative(path, npath.toPortablePath(helloUniverseSource)),
+            checksum: await hashUtils.checksumFile(helloUniversePlugin),
           }],
         });
       }),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -173,9 +173,25 @@ describe(`Features`, () => {
           plugins: [{
             path: pluginPath,
             spec: pluginUrl,
-            checksum: await hashUtils.checksumFile(`${path}/${pluginPath}` as PortablePath),
           }],
         });
+      },
+    ));
+
+    test(`it should throw an error when fetching the plugin but the checksum does not match`, makeTemporaryEnv(
+      {},
+      async ({path, run}) => {
+        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
+        const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
+        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+          httpsCaFilePath,
+          plugins: [{
+            path: pluginPath,
+            spec: pluginUrl,
+            checksum: `I am wrong checksum 123456`,
+          }],
+        }));
+        await expect(run(`install`)).rejects.toThrow();
       },
     ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -1,7 +1,7 @@
-import {xfs}           from '@yarnpkg/fslib';
-import {stringifySyml} from '@yarnpkg/parsers';
+import {PortablePath, xfs} from '@yarnpkg/fslib';
+import {stringifySyml}     from '@yarnpkg/parsers';
 
-const PLUGIN = (name, {async = false, printOnBoot = false} = {}) => `
+const PLUGIN = (name: string, {async = false, printOnBoot = false} = {}) => `
 const factory = ${async ? `async` : ``} r => {
   const {Command} = r('clipanion');
 
@@ -31,9 +31,9 @@ describe(`Features`, () => {
   describe(`Plugins`, () => {
     test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`a`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`a`, {printOnBoot: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
@@ -46,9 +46,9 @@ describe(`Features`, () => {
 
     test(`it should accept asynchronous plugins`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`a`, {async: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`a`, {async: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
@@ -61,9 +61,9 @@ describe(`Features`, () => {
 
     test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`A`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`A`, {printOnBoot: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`],
       }));
 
@@ -76,10 +76,10 @@ describe(`Features`, () => {
 
     test(`it should properly load multiple plugins via the local rc file, in the right order`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js`, PLUGIN(`A`, {printOnBoot: true}));
-      await xfs.writeFilePromise(`${path}/plugin-b.js`, PLUGIN(`B`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`A`, {printOnBoot: true}));
+      await xfs.writeFilePromise(`${path}/plugin-b.js` as PortablePath, PLUGIN(`B`, {printOnBoot: true}));
 
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml`, stringifySyml({
+      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
         plugins: [`./plugin-a.js`, `./plugin-b.js`],
       }));
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -90,21 +90,6 @@ describe(`Features`, () => {
       });
     }));
 
-    test(`it should properly load a plugin via the local rc file`, makeTemporaryEnv({
-    }, async ({path, run, source}) => {
-      await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`A`, {printOnBoot: true}));
-
-      await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
-        plugins: [`./plugin-a.js`],
-      }));
-
-      await run(`install`);
-
-      await expect(run(`node`, `-e`, ``)).resolves.toMatchObject({
-        stdout: `Booting A\nBooting A\n`,
-      });
-    }));
-
     test(`it should properly load multiple plugins via the local rc file, in the right order`, makeTemporaryEnv({
     }, async ({path, run, source}) => {
       await xfs.writeFilePromise(`${path}/plugin-a.js` as PortablePath, PLUGIN(`A`, {printOnBoot: true}));

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -1,8 +1,9 @@
+import {hashUtils}         from '@yarnpkg/core';
 import {PortablePath, xfs} from '@yarnpkg/fslib';
 import {stringifySyml}     from '@yarnpkg/parsers';
 import https               from 'https';
 import {AddressInfo}       from 'net';
-import {tests}             from 'pkg-tests-core';
+import {tests, fs}         from 'pkg-tests-core';
 
 const mockPluginServer: (path: PortablePath) => Promise<{pluginUrl: string, httpsCaFilePath: PortablePath}> = async path => {
   return new Promise((resolve, reject) => {
@@ -134,6 +135,14 @@ describe(`Features`, () => {
         }));
         await run(`install`);
         await expect(await xfs.existsPromise(`${path}/${pluginPath}` as PortablePath)).toEqual(true);
+        await expect(fs.readSyml(`${path}/.yarnrc.yml` as PortablePath)).resolves.toEqual({
+          httpsCaFilePath,
+          plugins: [{
+            path: pluginPath,
+            spec: pluginUrl,
+            checksum: await hashUtils.checksumFile(`${path}/${pluginPath}` as PortablePath),
+          }],
+        });
       },
     ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -159,26 +159,28 @@ describe(`Features`, () => {
     test(`it should fetch missing plugins`, makeTemporaryEnv(
       {},
       async ({path, run, source}) => {
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
-        const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
+        await mockPluginServer(async mockServer => {
+          const {pluginUrl, httpsCaFilePath} = await mockServer;
+          const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
 
-        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
-          httpsCaFilePath,
-          plugins: [{
-            path: pluginPath,
-            spec: pluginUrl,
-          }],
-        }));
+          await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+            httpsCaFilePath,
+            plugins: [{
+              path: pluginPath,
+              spec: pluginUrl,
+            }],
+          }));
 
-        await run(`install`);
+          await run(`install`);
 
-        await expect(await xfs.existsPromise(`${path}/${pluginPath}` as PortablePath)).toEqual(true);
-        await expect(fs.readSyml(`${path}/.yarnrc.yml` as PortablePath)).resolves.toEqual({
-          httpsCaFilePath,
-          plugins: [{
-            path: pluginPath,
-            spec: pluginUrl,
-          }],
+          await expect(await xfs.existsPromise(`${path}/${pluginPath}` as PortablePath)).toEqual(true);
+          await expect(fs.readSyml(`${path}/.yarnrc.yml` as PortablePath)).resolves.toEqual({
+            httpsCaFilePath,
+            plugins: [{
+              path: pluginPath,
+              spec: pluginUrl,
+            }],
+          });
         });
       },
     ));
@@ -186,19 +188,21 @@ describe(`Features`, () => {
     test(`it should throw an error when fetching the plugin but the checksum does not match`, makeTemporaryEnv(
       {},
       async ({path, run}) => {
-        const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
-        const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
+        await mockPluginServer(async mockServer => {
+          const {pluginUrl, httpsCaFilePath} = await mockServer;
+          const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
 
-        await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
-          httpsCaFilePath,
-          plugins: [{
-            path: pluginPath,
-            spec: pluginUrl,
-            checksum: `I am wrong checksum 123456`,
-          }],
-        }));
+          await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
+            httpsCaFilePath,
+            plugins: [{
+              path: pluginPath,
+              spec: pluginUrl,
+              checksum: `I am wrong checksum 123456`,
+            }],
+          }));
 
-        await expect(run(`install`)).rejects.toThrow();
+          await expect(run(`install`)).rejects.toThrow();
+        });
       },
     ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -126,6 +126,7 @@ describe(`Features`, () => {
         modules: new Map([[pluginA.name, pluginA]]),
         plugins: new Set([pluginA.name]),
       });
+
       expect(configuration.get(`foo`)).toBe(`string`);
       expect(configuration.get(`bar`)).toBe(123);
       expect(configuration.get(`baz`)).toBe(true);
@@ -149,6 +150,7 @@ describe(`Features`, () => {
         modules: new Map([[pluginA.name, pluginA]]),
         plugins: new Set([pluginA.name]),
       });
+
       expect(configuration.get(`foo`)).toBe(`string`);
       expect(configuration.get(`bar`)).toBe(123);
       expect(configuration.get(`baz`)).toBe(true);
@@ -159,6 +161,7 @@ describe(`Features`, () => {
       async ({path, run, source}) => {
         const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
         const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
+
         await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
           httpsCaFilePath,
           plugins: [{
@@ -166,7 +169,9 @@ describe(`Features`, () => {
             spec: pluginUrl,
           }],
         }));
+
         await run(`install`);
+
         await expect(await xfs.existsPromise(`${path}/${pluginPath}` as PortablePath)).toEqual(true);
         await expect(fs.readSyml(`${path}/.yarnrc.yml` as PortablePath)).resolves.toEqual({
           httpsCaFilePath,
@@ -183,6 +188,7 @@ describe(`Features`, () => {
       async ({path, run}) => {
         const {pluginUrl, httpsCaFilePath} = await mockPluginServer(path);
         const pluginPath = `.yarn/plugins/@yarnpkg/plugin-mock.cjs`;
+
         await xfs.writeFilePromise(`${path}/.yarnrc.yml` as PortablePath, stringifySyml({
           httpsCaFilePath,
           plugins: [{
@@ -191,6 +197,7 @@ describe(`Features`, () => {
             checksum: `I am wrong checksum 123456`,
           }],
         }));
+
         await expect(run(`install`)).rejects.toThrow();
       },
     ),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
@@ -1,0 +1,40 @@
+import {PortablePath, xfs} from '@yarnpkg/fslib';
+import https               from 'https';
+import {AddressInfo}       from 'net';
+import {tests}             from 'pkg-tests-core';
+
+export const createMockPlugin = async (path: string): Promise<PortablePath> => {
+  const helloWorldPluginPath = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`) as PortablePath;
+  const helloWorldPlugin = await xfs.readFilePromise(helloWorldPluginPath);
+  const mockPluginPath = `.yarn/plugins/@yarnpkg/plugin-hello-world.cjs`;
+  await xfs.mkdirPromise(`${path}/.yarn/plugins/@yarnpkg` as PortablePath, {recursive: true});
+  await xfs.writeFilePromise(`${path}/${mockPluginPath}` as PortablePath, helloWorldPlugin);
+  return mockPluginPath as PortablePath;
+};
+
+export const mockPluginServer: (path: PortablePath) => Promise<{pluginUrl: string, httpsCaFilePath: PortablePath}> = async path => {
+  return new Promise((resolve, reject) => {
+    (async () => {
+      const certs = await tests.getHttpsCertificates();
+      const httpsCaFilePath = `${path}/rootCA.crt` as PortablePath;
+      await xfs.writeFilePromise(httpsCaFilePath, certs.ca.certificate);
+
+      const helloWorldPluginPath = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`) as PortablePath;
+      const helloWorldPlugin = await xfs.readFilePromise(helloWorldPluginPath);
+      const server = https.createServer({
+        cert: certs.server.certificate,
+        key: certs.server.clientKey,
+        ca: certs.ca.certificate,
+      }, (req, res) => {
+        res.writeHead(200);
+        res.end(helloWorldPlugin);
+      });
+
+      server.unref();
+      server.listen(() => {
+        const {port} = server.address() as AddressInfo;
+        resolve({pluginUrl: `https://localhost:${port}`, httpsCaFilePath});
+      });
+    })();
+  });
+};

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
@@ -3,38 +3,47 @@ import https               from 'https';
 import {AddressInfo}       from 'net';
 import {tests}             from 'pkg-tests-core';
 
-export const createMockPlugin = async (path: string): Promise<PortablePath> => {
+export async function createMockPlugin(path: string) {
   const helloWorldPluginPath = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`) as PortablePath;
   const helloWorldPlugin = await xfs.readFilePromise(helloWorldPluginPath);
   const mockPluginPath = `.yarn/plugins/@yarnpkg/plugin-hello-world.cjs`;
+
   await xfs.mkdirPromise(`${path}/.yarn/plugins/@yarnpkg` as PortablePath, {recursive: true});
   await xfs.writeFilePromise(`${path}/${mockPluginPath}` as PortablePath, helloWorldPlugin);
+
   return mockPluginPath as PortablePath;
-};
+}
 
-export const mockPluginServer: (path: PortablePath) => Promise<{pluginUrl: string, httpsCaFilePath: PortablePath}> = async path => {
-  return new Promise((resolve, reject) => {
-    (async () => {
-      const certs = await tests.getHttpsCertificates();
-      const httpsCaFilePath = `${path}/rootCA.crt` as PortablePath;
-      await xfs.writeFilePromise(httpsCaFilePath, certs.ca.certificate);
+export async function mockPluginServer(path: PortablePath) {
+  const certs = await tests.getHttpsCertificates();
+  const httpsCaFilePath = `${path}/rootCA.crt` as PortablePath;
+  await xfs.writeFilePromise(httpsCaFilePath, certs.ca.certificate);
 
-      const helloWorldPluginPath = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`) as PortablePath;
-      const helloWorldPlugin = await xfs.readFilePromise(helloWorldPluginPath);
-      const server = https.createServer({
-        cert: certs.server.certificate,
-        key: certs.server.clientKey,
-        ca: certs.ca.certificate,
-      }, (req, res) => {
-        res.writeHead(200);
-        res.end(helloWorldPlugin);
-      });
+  const helloWorldPluginPath = require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`) as PortablePath;
+  const helloWorldPlugin = await xfs.readFilePromise(helloWorldPluginPath);
 
-      server.unref();
-      server.listen(() => {
-        const {port} = server.address() as AddressInfo;
-        resolve({pluginUrl: `https://localhost:${port}`, httpsCaFilePath});
-      });
-    })();
+  const server = https.createServer({
+    cert: certs.server.certificate,
+    key: certs.server.clientKey,
+    ca: certs.ca.certificate,
+  }, (req, res) => {
+    res.writeHead(200);
+    res.end(helloWorldPlugin);
   });
-};
+
+  server.unref();
+
+  return new Promise<{
+    pluginUrl: string;
+    httpsCaFilePath: string;
+  }>((resolve, reject) => {
+    server.listen(() => {
+      const {port} = server.address() as AddressInfo;
+
+      resolve({
+        pluginUrl: `https://localhost:${port}`,
+        httpsCaFilePath,
+      });
+    });
+  });
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
@@ -32,9 +32,7 @@ export async function mockPluginServer(asyncFn: (mockServer: {pluginUrl: string,
     res.end(helloWorldPlugin);
   });
 
-  server.unref();
-
-  return new Promise<{
+  const mockServer = await new Promise<{
     pluginUrl: string;
     httpsCaFilePath: PortablePath;
   }>((resolve, reject) => {
@@ -46,5 +44,11 @@ export async function mockPluginServer(asyncFn: (mockServer: {pluginUrl: string,
         httpsCaFilePath,
       });
     });
-  }).then(asyncFn).finally(() => server.close());
+  });
+  
+  try {
+    await asyncFn(mockServer);
+  } finally {
+    server.close();
+  }
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.utility.ts
@@ -45,7 +45,7 @@ export async function mockPluginServer(asyncFn: (mockServer: {pluginUrl: string,
       });
     });
   });
-  
+
   try {
     await asyncFn(mockServer);
   } finally {

--- a/packages/plugin-essentials/sources/commands/plugin/check.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/check.ts
@@ -40,25 +40,26 @@ export default class PluginCheckCommand extends BaseCommand {
         if (!rcFile.data?.plugins) continue;
 
         for (const plugin of rcFile.data.plugins) {
-          if (!plugin.checksum) continue;
-          if (!plugin.spec.match(/^https?:/)) continue;
+          if (!plugin.checksum)
+            continue;
+          if (!plugin.spec.match(/^https?:/))
+            continue;
 
           const newBuffer = await httpUtils.get(plugin.spec, {configuration});
           const newChecksum = hashUtils.makeHash(newBuffer);
-          if (plugin.checksum === newChecksum) continue;
+          if (plugin.checksum === newChecksum)
+            continue;
 
           const prettyPath = formatUtils.pretty(configuration, plugin.path, formatUtils.Type.PATH) ;
           const prettySpec = formatUtils.pretty(configuration, plugin.spec, formatUtils.Type.URL) ;
           const prettyMessage =  `${prettyPath} is different from the file provided by ${prettySpec}`;
+
           report.reportJson({...plugin, newChecksum});
-          if (isCI) {
-            report.reportError(MessageName.UNNAMED, prettyMessage);
-          } else {
-            report.reportInfo(MessageName.UNNAMED, prettyMessage);
-          }
+          report.reportError(MessageName.UNNAMED, prettyMessage);
         }
       }
     });
+
     return report.exitCode();
   }
 }

--- a/packages/plugin-essentials/sources/commands/plugin/check.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/check.ts
@@ -1,0 +1,64 @@
+import {BaseCommand}                                                                 from '@yarnpkg/cli';
+import {Configuration, formatUtils, hashUtils, httpUtils, MessageName, StreamReport} from '@yarnpkg/core';
+import {isCI}                                                                        from 'ci-info';
+import {Command, Option, Usage}                                                      from 'clipanion';
+
+// eslint-disable-next-line arca/no-default-export
+export default class PluginCheckCommand extends BaseCommand {
+  static paths = [
+    [`plugin`, `check`],
+  ];
+
+  static usage: Usage = Command.Usage({
+    category: `Plugin-related commands`,
+    description: `find all third-party plugins that differ from their own spec`,
+    details: `
+      Check only the plugins from https.
+
+      If this command detects any plugin differences in the CI environment, it will throw an error.
+    `,
+    examples: [[
+      `find all third-party plugins that differ from their own spec`,
+      `$0 plugin check`,
+    ]],
+  });
+
+  json = Option.Boolean(`--json`, false, {
+    description: `Format the output as an NDJSON stream`,
+  });
+
+  async execute() {
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const rcFiles = await Configuration.findRcFiles(this.context.cwd);
+
+    const report = await StreamReport.start({
+      configuration,
+      json: this.json,
+      stdout: this.context.stdout,
+    }, async report => {
+      for (const rcFile of rcFiles) {
+        if (!rcFile.data?.plugins) continue;
+
+        for (const plugin of rcFile.data.plugins) {
+          if (!plugin.checksum) continue;
+          if (!plugin.spec.match(/^https?:/)) continue;
+
+          const newBuffer = await httpUtils.get(plugin.spec, {configuration});
+          const newChecksum = hashUtils.makeHash(newBuffer);
+          if (plugin.checksum === newChecksum) continue;
+
+          const prettyPath = formatUtils.pretty(configuration, plugin.path, formatUtils.Type.PATH) ;
+          const prettySpec = formatUtils.pretty(configuration, plugin.spec, formatUtils.Type.URL) ;
+          const prettyMessage =  `${prettyPath} is different from the file provided by ${prettySpec}`;
+          report.reportJson({...plugin, newChecksum});
+          if (isCI) {
+            report.reportError(MessageName.UNNAMED, prettyMessage);
+          } else {
+            report.reportInfo(MessageName.UNNAMED, prettyMessage);
+          }
+        }
+      }
+    });
+    return report.exitCode();
+  }
+}

--- a/packages/plugin-essentials/sources/commands/plugin/check.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/check.ts
@@ -1,6 +1,5 @@
 import {BaseCommand}                                                                 from '@yarnpkg/cli';
 import {Configuration, formatUtils, hashUtils, httpUtils, MessageName, StreamReport} from '@yarnpkg/core';
-import {isCI}                                                                        from 'ci-info';
 import {Command, Option, Usage}                                                      from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -1,4 +1,5 @@
 import {BaseCommand}                                                            from '@yarnpkg/cli';
+import {PluginMeta}                                                             from '@yarnpkg/core/sources/Plugin';
 import {Configuration, MessageName, Project, ReportError, StreamReport, Report} from '@yarnpkg/core';
 import {YarnVersion, formatUtils, httpUtils, structUtils, hashUtils}            from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs}                                        from '@yarnpkg/fslib';
@@ -27,6 +28,8 @@ export default class PluginImportCommand extends BaseCommand {
       - Third-party plugins can be referenced directly through their public urls.
       - Local plugins can be referenced by their path on the disk.
 
+      If the \`--no-checksum\` option is set, Yarn will no longer care if the plugin is modified.
+
       Plugins cannot be downloaded from the npm registry, and aren't allowed to have dependencies (they need to be bundled into a single file, possibly thanks to the \`@yarnpkg/builder\` package).
     `,
     examples: [[
@@ -45,6 +48,10 @@ export default class PluginImportCommand extends BaseCommand {
   });
 
   name = Option.String();
+
+  checksum = Option.Boolean(`--checksum`, true, {
+    description: `Whether to care if this plugin is modified`,
+  });
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
@@ -107,14 +114,14 @@ export default class PluginImportCommand extends BaseCommand {
         pluginBuffer = await httpUtils.get(pluginUrl, {configuration});
       }
 
-      await savePlugin(pluginSpec, pluginBuffer, {project, report});
+      await savePlugin(pluginSpec, pluginBuffer, {checksum: this.checksum, project, report});
     });
 
     return report.exitCode();
   }
 }
 
-export async function savePlugin(pluginSpec: string, pluginBuffer: Buffer, {project, report}: {project: Project, report: Report}) {
+export async function savePlugin(pluginSpec: string, pluginBuffer: Buffer, {checksum = true, project, report}: {checksum?: boolean, project: Project, report: Report}) {
   const {configuration} = project;
 
   const vmExports = {} as any;
@@ -134,11 +141,11 @@ export async function savePlugin(pluginSpec: string, pluginBuffer: Buffer, {proj
   await xfs.mkdirPromise(ppath.dirname(absolutePath), {recursive: true});
   await xfs.writeFilePromise(absolutePath, pluginBuffer);
 
-  const pluginMeta = {
+  const pluginMeta: PluginMeta = {
     path: relativePath,
     spec: pluginSpec,
-    checksum: await hashUtils.checksumFile(absolutePath),
   };
+  if (checksum) pluginMeta.checksum =  hashUtils.makeHash(pluginBuffer);
 
   await Configuration.addPlugin(project.cwd, [pluginMeta]);
 }

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -145,7 +145,9 @@ export async function savePlugin(pluginSpec: string, pluginBuffer: Buffer, {chec
     path: relativePath,
     spec: pluginSpec,
   };
-  if (checksum) pluginMeta.checksum =  hashUtils.makeHash(pluginBuffer);
+
+  if (checksum)
+    pluginMeta.checksum = hashUtils.makeHash(pluginBuffer);
 
   await Configuration.addPlugin(project.cwd, [pluginMeta]);
 }

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -1,6 +1,6 @@
 import {BaseCommand}                                                                       from '@yarnpkg/cli';
 import {Configuration, MessageName, Project, ReportError, StreamReport, miscUtils, Report} from '@yarnpkg/core';
-import {YarnVersion, formatUtils, httpUtils, structUtils}                                  from '@yarnpkg/core';
+import {YarnVersion, formatUtils, httpUtils, structUtils, hashUtils}                       from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs}                                                   from '@yarnpkg/fslib';
 import {Command, Option, Usage}                                                            from 'clipanion';
 import semver                                                                              from 'semver';
@@ -137,6 +137,7 @@ export async function savePlugin(pluginSpec: string, pluginBuffer: Buffer, {proj
   const pluginMeta = {
     path: relativePath,
     spec: pluginSpec,
+    checksum: await hashUtils.checksumFile(absolutePath),
   };
 
   await Configuration.updateConfiguration(project.cwd, (current: any) => {

--- a/packages/plugin-essentials/sources/commands/plugin/import.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/import.ts
@@ -1,13 +1,13 @@
-import {BaseCommand}                                                                       from '@yarnpkg/cli';
-import {Configuration, MessageName, Project, ReportError, StreamReport, miscUtils, Report} from '@yarnpkg/core';
-import {YarnVersion, formatUtils, httpUtils, structUtils, hashUtils}                       from '@yarnpkg/core';
-import {PortablePath, npath, ppath, xfs}                                                   from '@yarnpkg/fslib';
-import {Command, Option, Usage}                                                            from 'clipanion';
-import semver                                                                              from 'semver';
-import {URL}                                                                               from 'url';
-import {runInNewContext}                                                                   from 'vm';
+import {BaseCommand}                                                            from '@yarnpkg/cli';
+import {Configuration, MessageName, Project, ReportError, StreamReport, Report} from '@yarnpkg/core';
+import {YarnVersion, formatUtils, httpUtils, structUtils, hashUtils}            from '@yarnpkg/core';
+import {PortablePath, npath, ppath, xfs}                                        from '@yarnpkg/fslib';
+import {Command, Option, Usage}                                                 from 'clipanion';
+import semver                                                                   from 'semver';
+import {URL}                                                                    from 'url';
+import {runInNewContext}                                                        from 'vm';
 
-import {getAvailablePlugins}                                                               from './list';
+import {getAvailablePlugins}                                                    from './list';
 
 // eslint-disable-next-line arca/no-default-export
 export default class PluginImportCommand extends BaseCommand {
@@ -140,29 +140,5 @@ export async function savePlugin(pluginSpec: string, pluginBuffer: Buffer, {proj
     checksum: await hashUtils.checksumFile(absolutePath),
   };
 
-  await Configuration.updateConfiguration(project.cwd, (current: any) => {
-    const plugins = [];
-    let hasBeenReplaced = false;
-
-    for (const entry of current.plugins || []) {
-      const userProvidedPath = typeof entry !== `string`
-        ? entry.path
-        : entry;
-
-      const pluginPath = ppath.resolve(project.cwd, npath.toPortablePath(userProvidedPath));
-      const {name} = miscUtils.dynamicRequire(pluginPath);
-
-      if (name !== pluginName) {
-        plugins.push(entry);
-      } else {
-        plugins.push(pluginMeta);
-        hasBeenReplaced = true;
-      }
-    }
-
-    if (!hasBeenReplaced)
-      plugins.push(pluginMeta);
-
-    return {...current, plugins};
-  });
+  await Configuration.addPlugin(project.cwd, [pluginMeta]);
 }

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -21,6 +21,7 @@ import InfoCommand                                              from './commands
 import YarnCommand                                              from './commands/install';
 import LinkCommand                                              from './commands/link';
 import NodeCommand                                              from './commands/node';
+import PluginCheckCommand                                       from './commands/plugin/check';
 import PluginImportSourcesCommand                               from './commands/plugin/import/sources';
 import PluginImportCommand                                      from './commands/plugin/import';
 import PluginListCommand                                        from './commands/plugin/list';
@@ -61,6 +62,7 @@ export {YarnCommand};
 export {LinkCommand};
 export {NodeCommand};
 export {PluginImportSourcesCommand};
+export {PluginCheckCommand};
 export {PluginImportCommand};
 export {PluginListCommand};
 export {PluginRemoveCommand};
@@ -192,6 +194,7 @@ const plugin: Plugin = {
     LinkCommand,
     UnlinkCommand,
     NodeCommand,
+    PluginCheckCommand,
     PluginImportSourcesCommand,
     PluginImportCommand,
     PluginRemoveCommand,

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -11,7 +11,7 @@ import {CorePlugin}                                                             
 import {Manifest, PeerDependencyMeta}                                                                   from './Manifest';
 import {MultiFetcher}                                                                                   from './MultiFetcher';
 import {MultiResolver}                                                                                  from './MultiResolver';
-import {Plugin, Hooks}                                                                                  from './Plugin';
+import {Plugin, Hooks, PluginMeta}                                                                      from './Plugin';
 import {Report}                                                                                         from './Report';
 import {TelemetryManager}                                                                               from './TelemetryManager';
 import {VirtualFetcher}                                                                                 from './VirtualFetcher';
@@ -1170,7 +1170,8 @@ export class Configuration {
             const pluginBuffer = await httpUtils.get(userProvidedSpec, {configuration});
             const pluginChecksum = hashUtils.makeHash(pluginBuffer);
 
-            if (userProvidedChecksum !== pluginChecksum) {
+            // if there is no checksum, this means that the user used --no-checksum and does not need to check this plugin
+            if (userProvidedChecksum && userProvidedChecksum !== pluginChecksum) {
               const prettyPluginName = formatUtils.pretty(configuration, ppath.basename(pluginPath, `.cjs`), formatUtils.Type.NAME);
               const prettyYarnrc = formatUtils.pretty(configuration, configuration.values.get(`rcFilename`), formatUtils.Type.NAME) ;
               const prettyPluginImportCommand = formatUtils.pretty(configuration, `yarn plugin import ${userProvidedSpec}`, formatUtils.Type.CODE) ;
@@ -1348,11 +1349,7 @@ export class Configuration {
     });
   }
 
-  static async addPlugin(cwd: PortablePath, pluginMetaList: Array<{
-    path: PortablePath;
-    spec: string;
-    checksum: string;
-  }>) {
+  static async addPlugin(cwd: PortablePath, pluginMetaList: Array<PluginMeta>) {
     if (pluginMetaList.length === 0) return;
 
     await Configuration.updateConfiguration(cwd, (current: any) => {

--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -185,7 +185,7 @@ export type Plugin<PluginHooks = any> = {
 };
 
 // for RC file
-export interface PluginMeta{
+export interface PluginMeta {
   path: PortablePath;
   spec: string;
   checksum?: string;

--- a/packages/yarnpkg-core/sources/Plugin.ts
+++ b/packages/yarnpkg-core/sources/Plugin.ts
@@ -183,3 +183,10 @@ export type Plugin<PluginHooks = any> = {
   resolvers?: Array<ResolverPlugin>;
   hooks?: PluginHooks;
 };
+
+// for RC file
+export interface PluginMeta{
+  path: PortablePath;
+  spec: string;
+  checksum?: string;
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Closes https://github.com/yarnpkg/berry/issues/4464

When the user loses the `.yarn/plugins` directory, all yarn commands will fail. 

...

**How did you fix it?**

#### 1. I changed the loading order of the `Configuration` 0c3221df1131152404aa1fd0b8868f8e9a037349 

[reason](https://github.com/yarnpkg/berry/pull/4912#issuecomment-1262357332)
```    
before:
1. load RC file core fields
2. load core and third-party plugins
3. load RC file remaining fields

after:
1. load RC file core fields
2. load core plugins
3. load RC file remaining fields
4. load third-party plugins
```
#### 2. when initializing the Configuration, check if the plugin exists and try to fetch the missing plugins 1c5c3a0d470d3b1e5155da205d33876226d6c1d9

#### 3. test 90a8e977269f4c310f347d79b446cc298376bd23 ead886af2925500dddcc602d0cb5b504dbdd9ec4

...

**Additional attempts**

https://github.com/jj811208/berry/pull/4

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
