### PR TITLE
Support Buffers in `toPortablePath`

### DIFF
--- a/.yarn/versions/50a4561e.yml
+++ b/.yarn/versions/50a4561e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/fslib": patch

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -140,10 +140,15 @@ function fromPortablePath(p: Path): NativePath {
 
 // Path should look like "N:/berry/scripts/plugin-pack.js"
 // And transform to "/N:/berry/scripts/plugin-pack.js"
-function toPortablePath(p: Path): PortablePath {
+function toPortablePath(p: Path | Buffer): PortablePath {
   if (process.platform !== `win32`)
     return p as PortablePath;
 
+  // Convert buffers to string paths.
+  if (typeof p !== 'string') {
+    return toPortablePath(p.toString());
+  }
+  
   p = p.replace(/\\/g, `/`);
 
   let windowsPathMatch, uncWindowsPathMatch;

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -141,14 +141,14 @@ function fromPortablePath(p: Path): NativePath {
 // Path should look like "N:/berry/scripts/plugin-pack.js"
 // And transform to "/N:/berry/scripts/plugin-pack.js"
 function toPortablePath(p: Path | Buffer): PortablePath {
+  // Convert buffers to string paths.
+  if (typeof p !== `string`)
+    return toPortablePath(p.toString());
+
+
   if (process.platform !== `win32`)
     return p as PortablePath;
 
-  // Convert buffers to string paths.
-  if (typeof p !== 'string') {
-    return toPortablePath(p.toString());
-  }
-  
   p = p.replace(/\\/g, `/`);
 
   let windowsPathMatch, uncWindowsPathMatch;


### PR DESCRIPTION
**What's the problem this PR addresses?**

resolves #1818

In some instances, `toPortablePath` is provided a `Buffer` on Windows. This results in a crash, since `toPortablePath` only expects to receive strings.

**How did you fix it?**

When `toPortablePath` is provided a `Buffer`, I first convert it to a `string` before continuing.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

I left all other packages as `undecided` for release. I suppose let me know if they need patch bumps too.