### PR TITLE
fix(essentials): set `yarnPath` in project `.yarnrc.yml` regardless if it's set in a parent directory

### DIFF
--- a/.yarn/versions/187a6871.yml
+++ b/.yarn/versions/187a6871.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
@@ -100,6 +100,39 @@ describe(`Commands`, () => {
         await check(projectDir, {corepackVersion: /[0-9]+\./, usePath: true});
       }),
     );
+
+    test(
+      `it shouldn't set the version when using '--only-if-needed' and a yarnPath is already set`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `self`);
+
+        const before = await xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`);
+        await run(`set`, `version`, `3.0.0`, `--only-if-needed`);
+        const after = await xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`);
+
+        expect(before).toEqual(after);
+      }),
+    );
+
+    test(
+      `it should set yarnPath when using '--only-if-needed' even if yarnPath is set outside of the project`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `self`);
+        await check(path, {corepackVersion: /[0-9]+\./, usePath: true});
+
+        const projectDir = ppath.join(path, `project` as Filename);
+        await xfs.mkdirPromise(projectDir);
+        await xfs.writeJsonPromise(ppath.join(projectDir, Filename.manifest), {});
+        await xfs.writeFilePromise(ppath.join(projectDir, Filename.lockfile), ``);
+
+        await run(`set`, `version`, `self`, `--only-if-needed`, {cwd: projectDir});
+        await check(projectDir, {corepackVersion: /[0-9]+\./, usePath: true});
+      }),
+    );
   });
 });
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
@@ -82,6 +82,24 @@ describe(`Commands`, () => {
         await check(path, {corepackVersion: /[0-9]+\./, usePath: true});
       }),
     );
+
+    test(
+      `it should set yarnPath even if yarnPath is set outside of the project`,
+      makeTemporaryEnv({}, {
+        env: {COREPACK_ROOT: undefined},
+      }, async ({path, run, source}) => {
+        await run(`set`, `version`, `self`);
+        await check(path, {corepackVersion: /[0-9]+\./, usePath: true});
+
+        const projectDir = ppath.join(path, `project` as Filename);
+        await xfs.mkdirPromise(projectDir);
+        await xfs.writeJsonPromise(ppath.join(projectDir, Filename.manifest), {});
+        await xfs.writeFilePromise(ppath.join(projectDir, Filename.lockfile), ``);
+
+        await run(`set`, `version`, `self`, {cwd: projectDir});
+        await check(projectDir, {corepackVersion: /[0-9]+\./, usePath: true});
+      }),
+    );
   });
 });
 

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -226,11 +226,9 @@ export async function setVersion(configuration: Configuration, bundleVersion: st
 
     await xfs.writeFilePromise(absolutePath, bundleBuffer, {mode: 0o755});
 
-    if (!yarnPath || ppath.contains(releaseFolder, yarnPath)) {
-      await Configuration.updateConfiguration(projectCwd, {
-        yarnPath: ppath.relative(projectCwd, absolutePath),
-      });
-    }
+    await Configuration.updateConfiguration(projectCwd, {
+      yarnPath: ppath.relative(projectCwd, absolutePath),
+    });
   } else {
     await xfs.removePromise(ppath.dirname(absolutePath));
 

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -82,8 +82,16 @@ export default class SetVersionCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
-    if (configuration.get(`yarnPath`) && this.onlyIfNeeded)
-      return 0;
+    if (this.onlyIfNeeded && configuration.get(`yarnPath`)) {
+      const yarnPathSource = configuration.sources.get(`yarnPath`) as PortablePath | undefined;
+      if (!yarnPathSource)
+        throw new Error(`Assertion failed: Expected 'yarnPath' to have a source`);
+
+      const projectCwd = configuration.projectCwd ?? configuration.startingCwd;
+      if (ppath.contains(projectCwd, yarnPathSource)) {
+        return 0;
+      }
+    }
 
     const getBundlePath = () => {
       if (typeof YarnVersion === `undefined`)


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn set version` doesn't set the `yarnPath` in the project `.yarnrc.yml` if it's set in a parent directory of the project.

Fixes https://github.com/yarnpkg/berry/issues/4366 (Issue doesn't have a reproduction so I can only guess)
Fixes https://github.com/yarnpkg/berry/issues/4426

**How did you fix it?**

Update the `.yarnrc.yml` file in the project when required.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.