### PR TITLE
docs (migration): `yarn list` --> `yarn info --recursive`

### DIFF
--- a/packages/gatsby/content/getting-started/migration.md
+++ b/packages/gatsby/content/getting-started/migration.md
@@ -279,6 +279,7 @@ nmHoistingLimits: workspaces
 | `yarn create`   | `yarn dlx create-<name>`   | `yarn create` still works, but prefer using `yarn dlx` |
 | `yarn global`   | `yarn dlx`                 | [Dedicated section](#use-yarn-dlx-instead-of-yarn-global) |
 | `yarn info`     | `yarn npm info`            ||
+| `yarn list`     | `yarn info --recursive`    ||
 | `yarn login`    | `yarn npm login`           ||
 | `yarn logout`   | `yarn npm logout`          ||
 | `yarn outdated` | `yarn upgrade-interactive` | [Read more on GitHub](https://github.com/yarnpkg/berry/issues/749) |
@@ -303,7 +304,6 @@ Those features simply haven't been implemented yet. Help welcome!
 
 | <div style="width:150px">Yarn Classic (1.x)</div> | Notes |
 | ------------------ | ----------------------------- |
-| `yarn list`     | `yarn why` may provide some information in the meantime |
 | `yarn owner`    | Will eventually be available as `yarn npm owner` |
 | `yarn team`     | Will eventually be available as `yarn npm team` |
 


### PR DESCRIPTION
https://yarnpkg.com/getting-started/migration suggests `yarn why` as a band-aid for `yarn list` "not being implemented yet", but `yarn info` is a better replacement, and I think fits better in the ["Renamed" table](https://yarnpkg.com/getting-started/migration#renamed) than in the ["Not implemented yet" table](https://yarnpkg.com/getting-started/migration#not-implemented-yet).

_References:_
_https://classic.yarnpkg.com/lang/en/docs/cli/list/_
_https://yarnpkg.com/cli/info_

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
