### PR TITLE
perf: avoid unnecessary `structUtils.convertToIdent`

### DIFF
--- a/.yarn/versions/656f837d.yml
+++ b/.yarn/versions/656f837d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/workspace.ts
+++ b/packages/plugin-essentials/sources/commands/workspace.ts
@@ -1,5 +1,5 @@
 import {WorkspaceRequiredError, BaseCommand} from '@yarnpkg/cli';
-import {Configuration, Project, Workspace}   from '@yarnpkg/core';
+import {Configuration, Project}              from '@yarnpkg/core';
 import {structUtils}                         from '@yarnpkg/core';
 import {Command, Option, Usage, UsageError}  from 'clipanion';
 
@@ -39,10 +39,7 @@ export default class WorkspaceCommand extends BaseCommand {
     const candidates = project.workspaces;
     const candidatesByName = new Map(
       candidates.map(
-        (workspace): [string, Workspace] => {
-          const ident = structUtils.convertToIdent(workspace.locator);
-          return [structUtils.stringifyIdent(ident), workspace];
-        },
+        workspace => [structUtils.stringifyIdent(workspace.locator), workspace],
       ),
     );
 

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -400,8 +400,7 @@ function getPrefix(workspace: Workspace, {configuration, commandIndex, verbose}:
   if (!verbose)
     return null;
 
-  const ident = structUtils.convertToIdent(workspace.locator);
-  const name = structUtils.stringifyIdent(ident);
+  const name = structUtils.stringifyIdent(workspace.locator);
 
   const prefix = `[${name}]:`;
 

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -46,7 +46,7 @@ export function makeDescriptor(ident: Ident, range: string): Descriptor {
  * Creates a package locator.
  *
  * @param ident The base ident (see `makeIdent`)
- * @param range The reference to attach (eg. `1.0.0`)
+ * @param reference The reference to attach (eg. `1.0.0`)
  */
 export function makeLocator(ident: Ident, reference: string): Locator {
   return {identHash: ident.identHash, scope: ident.scope, name: ident.name, locatorHash: hashUtils.makeHash<LocatorHash>(ident.identHash, reference), reference};


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

There are 2 unnecessary `structUtils.convertToIdent` calls that don't have to exist since there's no problem if the ident has extra fields. 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed them.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
