### PR TITLE
fix(suggestUtils): use `workspace.anchoredLocator`

### DIFF
--- a/.yarn/versions/5fa2fe14.yml
+++ b/.yarn/versions/5fa2fe14.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -140,7 +140,7 @@ export async function findProjectDescriptors(ident: Ident, {project, target}: {p
       const peerDescriptor = workspace.manifest.peerDependencies.get(ident.identHash);
 
       if (peerDescriptor !== undefined) {
-        getDescriptorEntry(peerDescriptor).locators.push(workspace.locator);
+        getDescriptorEntry(peerDescriptor).locators.push(workspace.anchoredLocator);
       }
     } else {
       const regularDescriptor = workspace.manifest.dependencies.get(ident.identHash);
@@ -148,15 +148,15 @@ export async function findProjectDescriptors(ident: Ident, {project, target}: {p
 
       if (target === Target.DEVELOPMENT) {
         if (developmentDescriptor !== undefined) {
-          getDescriptorEntry(developmentDescriptor).locators.push(workspace.locator);
+          getDescriptorEntry(developmentDescriptor).locators.push(workspace.anchoredLocator);
         } else if (regularDescriptor !== undefined) {
-          getDescriptorEntry(regularDescriptor).locators.push(workspace.locator);
+          getDescriptorEntry(regularDescriptor).locators.push(workspace.anchoredLocator);
         }
       } else {
         if (regularDescriptor !== undefined) {
-          getDescriptorEntry(regularDescriptor).locators.push(workspace.locator);
+          getDescriptorEntry(regularDescriptor).locators.push(workspace.anchoredLocator);
         } else if (developmentDescriptor !== undefined) {
-          getDescriptorEntry(developmentDescriptor).locators.push(workspace.locator);
+          getDescriptorEntry(developmentDescriptor).locators.push(workspace.anchoredLocator);
         }
       }
     }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`findProjectDescriptors` returns a list of `workspace.locator`s, which is then compared against `workspace.anchoredLocator`, when they can never be equal.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it return a list of `workspace.anchoredLocator`s since in the future I'd prefer to just completely get rid of `workspace.locator` anyways and it also makes more sense to display the `anchoredLocator` in the interactive prompt since it matters more that the package is a workspace, not that it has a specific version.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
