### PR TITLE
refactor(pack): use const for nextIgnoreLists

### DIFF
--- a/.yarn/versions/7d750b71.yml
+++ b/.yarn/versions/7d750b71.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/packages/plugin-pack/sources/packUtils.ts
+++ b/packages/plugin-pack/sources/packUtils.ts
@@ -278,12 +278,11 @@ async function walk(initialCwd: PortablePath, {hasExplicitFileList, globalList, 
           ? await loadIgnoreList(cwdFs, cwd, `.gitignore` as Filename)
           : null;
 
-      let nextIgnoreLists = localIgnoreList !== null
-        ? [localIgnoreList].concat(ignoreLists)
-        : ignoreLists;
-
-      if (isIgnored(cwd, {globalList, ignoreLists}))
-        nextIgnoreLists = [...ignoreLists, {accept: [], reject: [`**/*`]}];
+      const nextIgnoreLists = isIgnored(cwd, {globalList, ignoreLists})
+        ? [...ignoreLists, {accept: [], reject: [`**/*`]}]
+        : localIgnoreList !== null
+          ? [localIgnoreList].concat(ignoreLists)
+          : ignoreLists;
 
       for (const entry of entries) {
         cwdList.push([ppath.resolve(cwd, entry), nextIgnoreLists]);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The variable `nextIgnoreLists` can be declared as const, and assigned values in a conditional operator

**How did you fix it?**

Use const for variable `nextIgnoreLists`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
