### PR TITLE
fix: handle unintentional floating promises

### DIFF
--- a/.yarn/versions/99c1aeb7.yml
+++ b/.yarn/versions/99c1aeb7.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -85,7 +85,7 @@ describe(`Commands`, () => {
     }));
 
     test(`test apply fix to string fields`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
-      environments[`various field types`](path);
+      await environments[`various field types`](path);
 
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
       gen_enforced_field(WorkspaceCwd, '_name', FieldValue) :- workspace_field(WorkspaceCwd, 'name', FieldValue).
@@ -99,7 +99,7 @@ describe(`Commands`, () => {
     }));
 
     test(`test apply fix to object fields`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
-      environments[`various field types`](path);
+      await environments[`various field types`](path);
 
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
       gen_enforced_field(WorkspaceCwd, '_repository', FieldValue) :- workspace_field(WorkspaceCwd, 'repository', FieldValue).
@@ -117,7 +117,7 @@ describe(`Commands`, () => {
     }));
 
     test(`test apply fix to array fields`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
-      environments[`various field types`](path);
+      await environments[`various field types`](path);
 
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
       gen_enforced_field(WorkspaceCwd, '_files', FieldValue) :- workspace_field(WorkspaceCwd, 'files', FieldValue).

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
@@ -184,7 +184,7 @@ describe(`Commands`, () => {
 
           await run(`install`);
 
-          expect(run(`workspace`, `pkg-primary`, `version`, `patch`)).resolves.toMatchObject({
+          await expect(run(`workspace`, `pkg-primary`, `version`, `patch`)).resolves.toMatchObject({
             code: 0,
             stdout: expect.stringContaining(`Couldn't auto-upgrade range * (in pkg-dependant@workspace:packages/pkg-dependant)`),
           });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -430,9 +430,9 @@ describe(`Node_Modules`, () => {
         await run(`install`);
 
         const binPath = `${path}/node_modules/.bin/dep1` as PortablePath;
-        expect(xfs.lstatPromise(binPath)).resolves.toBeDefined();
+        await expect(xfs.lstatPromise(binPath)).resolves.toBeDefined();
         await run(`remove`, `dep1`);
-        expect(xfs.lstatPromise(binPath)).rejects.toBeDefined();
+        await expect(xfs.lstatPromise(binPath)).rejects.toBeDefined();
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1096,7 +1096,7 @@ describe(`Plug'n'Play`, () => {
 
             await run2(`install`);
 
-            expect(xfs.readFilePromise(`${path2}/.pnp.cjs`, `utf8`)).resolves.toEqual(await xfs.readFilePromise(`${path}/.pnp.cjs`, `utf8`));
+            await expect(xfs.readFilePromise(`${path2}/.pnp.cjs`, `utf8`)).resolves.toEqual(await xfs.readFilePromise(`${path}/.pnp.cjs`, `utf8`));
           },
         )();
       },

--- a/packages/plugin-essentials/sources/dedupeUtils.ts
+++ b/packages/plugin-essentials/sources/dedupeUtils.ts
@@ -174,7 +174,7 @@ export async function dedupe(project: Project, {strategy, patterns, cache, repor
     const dedupePromises = await algorithm(project, patterns, {resolver, resolveOptions, fetcher, fetchOptions});
 
     const progress = Report.progressViaCounter(dedupePromises.length);
-    report.reportProgress(progress);
+    await report.reportProgress(progress);
 
     let dedupedPackageCount = 0;
 

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -963,7 +963,7 @@ export class Project {
     let firstError = false;
 
     const progress = Report.progressViaCounter(locatorHashes.length);
-    report.reportProgress(progress);
+    await report.reportProgress(progress);
 
     const limit = pLimit(FETCHER_CONCURRENCY);
 

--- a/packages/yarnpkg-fslib/tests/JailFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/JailFS.test.ts
@@ -19,7 +19,7 @@ describe(`JailFS`, () => {
     await xfs.mkdirPromise(jailedFolder);
 
     const jailFs = new JailFS(jailedFolder);
-    jailFs.writeFilePromise(ppath.join(PortablePath.root, `text.txt` as Filename), `Hello World`);
+    await jailFs.writeFilePromise(ppath.join(PortablePath.root, `text.txt` as Filename), `Hello World`);
   });
 
   it(`should throw an error when the accessed path is not inside the target folder`, async () => {

--- a/packages/yarnpkg-fslib/tests/NodeFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/NodeFS.test.ts
@@ -55,7 +55,7 @@ describe(`NodeFS`, () => {
     });
 
     it(`should support ftruncateSync`, () => {
-      xfs.mktempSync(async dir => {
+      xfs.mktempSync(dir => {
         const p = `${dir}/foo.txt` as PortablePath;
         nodeFs.writeFileSync(p, `foo`);
 

--- a/packages/yarnpkg-fslib/tests/xfs.test.ts
+++ b/packages/yarnpkg-fslib/tests/xfs.test.ts
@@ -26,7 +26,7 @@ describe(`xfs`, () => {
         return t;
       });
 
-      xfs.rmtempPromise();
+      await xfs.rmtempPromise();
 
       await expect(xfs.existsPromise(temp)).resolves.toBe(true);
       await expect(xfs.existsPromise(otherTemp)).resolves.toBe(true);

--- a/packages/yarnpkg-libzip/tests/ZipFS.test.ts
+++ b/packages/yarnpkg-libzip/tests/ZipFS.test.ts
@@ -91,7 +91,7 @@ describe(`ZipFS`, () => {
     const tmpfile = ppath.resolve(xfs.mktempSync(), `test.zip` as Filename);
     const zipFs = new ZipFS(tmpfile, {create: true});
 
-    zipFs.mkdirPromise(`/dir` as PortablePath);
+    zipFs.mkdirSync(`/dir` as PortablePath);
     zipFs.writeFileSync(`/dir/file` as PortablePath, `file content`);
 
     zipFs.symlinkSync(`dir/file` as PortablePath, `linkToFileA` as PortablePath);
@@ -825,13 +825,13 @@ describe(`ZipFS`, () => {
   it(`should support fd in writeFile and readFile`, async () => {
     const zipFs = new ZipFS();
 
-    zipFs.mkdirPromise(`/dir` as PortablePath);
+    zipFs.mkdirSync(`/dir` as PortablePath);
     zipFs.writeFileSync(`/dir/file` as PortablePath, `file content`);
 
     const fd = zipFs.openSync(`/dir/file` as PortablePath, `r`);
     zipFs.writeFileSync(fd, `new content`);
 
-    expect(zipFs.readFilePromise(fd, `utf8`)).resolves.toEqual(`new content`);
+    await expect(zipFs.readFilePromise(fd, `utf8`)).resolves.toEqual(`new content`);
 
     await zipFs.writeFilePromise(fd, `new new content`);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

There are promises in the codebase (mostly in tests) that aren't awaited when they should be.

Hopefully solves the `Jest did not exit one second after the test run has completed.` from https://github.com/nodejs/citgm/pull/905#issuecomment-1272299869.

**How did you fix it?**

`await` the promise or change to the sync version if possible.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.