### PR TITLE
docs: update the install section of all plugin's readme

### DIFF
--- a/.yarn/versions/95c5c99a.yml
+++ b/.yarn/versions/95c5c99a.yml
@@ -1,0 +1,8 @@
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"

--- a/packages/plugin-constraints/README.md
+++ b/packages/plugin-constraints/README.md
@@ -4,6 +4,4 @@ This plugin adds support for [constraints](https://yarnpkg.com/features/constrai
 
 ## Install
 
-```
-yarn plugin import constraints
-```
+This plugin is included by default starting from Yarn 4.

--- a/packages/plugin-exec/README.md
+++ b/packages/plugin-exec/README.md
@@ -8,9 +8,7 @@ This plugin will add support to Yarn for the `exec:` protocol. This protocol is 
 
 ## Install
 
-```
-yarn plugin import exec
-```
+This plugin is included by default starting from Yarn 4.
 
 ## Usage
 

--- a/packages/plugin-interactive-tools/README.md
+++ b/packages/plugin-interactive-tools/README.md
@@ -4,9 +4,7 @@ This plugin adds support for various interactive commands.
 
 ## Install
 
-```
-yarn plugin import interactive-tools
-```
+This plugin is included by default starting from Yarn 4.
 
 ## Commands
 

--- a/packages/plugin-stage/README.md
+++ b/packages/plugin-stage/README.md
@@ -4,6 +4,4 @@ This plugin adds support for the [`yarn stage`](https://yarnpkg.com/cli/stage) c
 
 ## Install
 
-```
-yarn plugin import stage
-```
+This plugin is included by default starting from Yarn 4.

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -7,9 +7,7 @@
 
 ## Install
 
-```bash
-yarn plugin import typescript
-```
+This plugin is included by default starting from Yarn 4.
 
 ## Example
 

--- a/packages/plugin-version/README.md
+++ b/packages/plugin-version/README.md
@@ -4,6 +4,4 @@ This plugin adds support for the new [release workflow](https://yarnpkg.com/feat
 
 ## Install
 
-```
-yarn plugin import version
-```
+This plugin is included by default starting from Yarn 4.

--- a/packages/plugin-workspace-tools/README.md
+++ b/packages/plugin-workspace-tools/README.md
@@ -4,9 +4,7 @@ This plugin adds support for various workspace-related commands.
 
 ## Install
 
-```
-yarn plugin import workspace-tools
-```
+This plugin is included by default starting from Yarn 4.
 
 ## Commands
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Since https://github.com/yarnpkg/berry/pull/4253, users no longer need to manually install the official plugins, so the readme installation section is outdated
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Change the install section of all plugin's readme to `This plugin is included by default in Yarn 4.`
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
