### PR TITLE
docs: add `yarn-plugin-scripts` to Contrib plugins

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -103,4 +103,6 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**yarn-plugin-pin-deps**](https://github.com/splitgraph/yarn-plugin-pin-deps) by [**Splitgraph**](https://github.com/splitgraph) - Pin dependencies to their currently resolved exact version. This plugin will find any dependencies referenced with a semver identifier, and will update `package.json` to replace that identifier with the exact version of the package currently resolved in the lockfile for that reference.
 
+- [**yarn-scripts**](https://github.com/jgttech/yarn-plugin-scripts) by [**jgttech**](https://github.com/jgttech) - Add capability to define customized scripts within the `.yarnrc.yml` file, similar to `package.json`, but more robost and similar to something like GitHub Actions. Each script can be invoked by its name, such as `yarn scripts <name_of_script>`. Each script is an array of one or more commands to execute.
+
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!

--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -103,6 +103,6 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**yarn-plugin-pin-deps**](https://github.com/splitgraph/yarn-plugin-pin-deps) by [**Splitgraph**](https://github.com/splitgraph) - Pin dependencies to their currently resolved exact version. This plugin will find any dependencies referenced with a semver identifier, and will update `package.json` to replace that identifier with the exact version of the package currently resolved in the lockfile for that reference.
 
-- [**yarn-scripts**](https://github.com/jgttech/yarn-plugin-scripts) by [**jgttech**](https://github.com/jgttech) - Add capability to define customized scripts within the `.yarnrc.yml` file, similar to `package.json`, but more robost and similar to something like GitHub Actions. Each script can be invoked by its name, such as `yarn scripts <name_of_script>`. Each script is an array of one or more commands to execute.
+- [**yarn-plugin-scripts**](https://github.com/jgttech/yarn-plugin-scripts) by [**jgttech**](https://github.com/jgttech) - Add capability to define customized scripts within the `.yarnrc.yml` file, similar to `package.json`, but more robost and similar to something like GitHub Actions. Each script can be invoked by its name, such as `yarn scripts <name_of_script>`. Each script is an array of one or more commands to execute.
 
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!


### PR DESCRIPTION
Add `scripts` capability to `.yarnrc.yml` file.

**What's the problem this PR addresses?**
This is just to add more plugins to the Yarn 3 ecosystem. Specifically, a plugin that allows a `scripts` configuration within the `.yarnrc.yml` file that can be invoked under a `scripts` namespace (i.e `yarn scripts my-script`).

...

**How did you fix it?**
It is already built and linked in the README.md for others to use. Tests are run with `yarn test` and builds are run with `yarn build`. Idk if I am missing anything but everything is there to be tested and run.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
