### PR TITLE
ci: clear warning messages about `GitHub Action will no longer support node12`

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -13,7 +13,7 @@ runs:
         check-latest: true
 
     #region Build the standard bundle
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache-build
       with:
         path: packages/yarnpkg-cli/bundles/yarn.js
@@ -32,7 +32,7 @@ runs:
       run: echo "::set-output name=globalFolder::$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js config get globalFolder)"
       shell: bash
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ${{ steps.global-path.outputs.globalFolder }}/cache
         key: dependencies-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

GitHub announced on September 22, 2022 that GitHub Action will no longer support node12 in the summer of 2023
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

So most of Yarn's GitHub Actions have warnings

I looked at all the Action we use, here are the actions that use node 12

- actions/cache@v2
- actions/checkout@v2
- actions/upload-artifact@v2
- actions/download-artifact@v2

but I don't know why only `actions/cache@v2` has a warning 🧐.

![image](https://user-images.githubusercontent.com/25342059/195079922-b74defd7-100d-4011-bde4-8f3fbca47177.png)

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I only updated `action/cache` from v2 to v3

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
