### PR TITLE
fix(nm): pnp should be a prod dep of nm

### DIFF
--- a/.yarn/versions/1ac92dd7.yml
+++ b/.yarn/versions/1ac92dd7.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/nm": patch
+
+declined:
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-nm/package.json
+++ b/packages/yarnpkg-nm/package.json
@@ -10,9 +10,7 @@
   "sideEffects": false,
   "dependencies": {
     "@yarnpkg/core": "workspace:^",
-    "@yarnpkg/fslib": "workspace:^"
-  },
-  "devDependencies": {
+    "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/pnp": "workspace:^"
   },
   "scripts": {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Currently when using the nm package directly, there is compilation error because pnp is not in the deps:

![image](https://user-images.githubusercontent.com/1927579/195475614-6b730045-454e-46ec-837d-07a6198acce5.png)


**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
