### PR TITLE
fix(shell): fix alternative value not working as expected

### DIFF
--- a/.yarn/versions/dfa11c68.yml
+++ b/.yarn/versions/dfa11c68.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -703,15 +703,21 @@ describe(`Shell`, () => {
         await expect(bufferResult(
           `echo "\${FOOBAR:+hello world}"`,
         )).resolves.toMatchObject({
-          stdout: ``,
+          stdout: `\n`,
         });
       });
 
       it(`should support alternative arguments via \${N:+...}`, async () => {
         await expect(bufferResult(
-          `echo "\${1:+hello world}"`,
+          `echo "\${0:+hello world}"`, [`goodbye world`],
         )).resolves.toMatchObject({
           stdout: `hello world\n`,
+        });
+
+        await expect(bufferResult(
+          `echo "\${0:+hello world}"`,
+        )).resolves.toMatchObject({
+          stdout: `\n`,
         });
       });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

close https://github.com/yarnpkg/berry/issues/4892
 
close https://github.com/yarnpkg/berry/issues/4893

after this PR is merged, https://github.com/yarnpkg/berry/pull/4900 all tests should pass

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I modified the default case of `evaluateVariable`.

steps:
1. parse the argument and variable first
2. parse default value and alternative value according to the result of the previous step
3. If neither value is found, throw an error

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
