### PR TITLE
test(shell): fix failing tests

### DIFF
--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -1259,27 +1259,27 @@ describe(`Shell`, () => {
   describe(`Lists`, () => {
     it(`should execute lists with left associativity`, async () => {
       await expectResult(bufferResult(
-        `inexistent && echo yes || echo no`,
+        `false && echo yes || echo no`,
       ), {
         exitCode: 0,
         stdout: `no\n`,
-        stderr: `command not found: inexistent\n`,
+        stderr: ``,
       });
 
       await expectResult(bufferResult(
-        `inexistent || echo no && echo yes`,
+        `false || echo no && echo yes`,
       ), {
         exitCode: 0,
         stdout: `no\nyes\n`,
-        stderr: `command not found: inexistent\n`,
+        stderr: ``,
       });
 
       await expectResult(bufferResult(
-        `inexistent && echo yes || inexistent && echo yes || echo no`,
+        `false && echo yes || false && echo yes || echo no`,
       ), {
         exitCode: 0,
         stdout: `no\n`,
-        stderr: `command not found: inexistent\ncommand not found: inexistent\n`,
+        stderr: ``,
       });
     });
   });


### PR DESCRIPTION
**What's the problem this PR addresses?**

We were running some test by calling missing binaries to check for the `||` and `&&` operators. While it worked, it seems that on Windows some extra cruft is printed on stderr, tainting the expectations.

**How did you fix it?**

Instead of calling a non-existent binary, we now just call the `false` builtin (which has the same effect but doesn't output anything).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
