### PR TITLE
feat(plugin-nm): support configuring link mode

### DIFF
--- a/.yarn/versions/40c30377.yml
+++ b/.yarn/versions/40c30377.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-nm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1853,6 +1853,7 @@ describe(`Node_Modules`, () => {
 
         expect(reparsePoints).toMatch(`ws1`);
         expect(reparsePoints).toMatch(`<SYMLINKD>`);
+        expect(ppath.isAbsolute(await xfs.readlinkPromise(npath.toPortablePath(`${path}/node_modules/ws1`)))).toBeFalsy();
       },
     ),
   );
@@ -1878,6 +1879,7 @@ describe(`Node_Modules`, () => {
 
         expect(reparsePoints).toMatch(`ws1`);
         expect(reparsePoints).toMatch(`<JUNCTION>`);
+        expect(ppath.isAbsolute(await xfs.readlinkPromise(npath.toPortablePath(`${path}/node_modules/ws1`)))).toBeTruthy();
       },
     ),
   );
@@ -1898,10 +1900,11 @@ describe(`Node_Modules`, () => {
         });
 
         await run(`install`);
+        const ws1Path = npath.toPortablePath(`${path}/node_modules/ws1`);
+        const ws1Stats = await xfs.lstatPromise(ws1Path);
 
-        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/ws1`));
-
-        expect(ws1.isSymbolicLink()).toBeTruthy();
+        expect(path.isAbsolute(await xfs.readlinkPromise(ws1Path))).toBeFalsy();
+        expect(ws1Stats.isSymbolicLink()).toBeTruthy();
       },
     ),
   );
@@ -1923,9 +1926,11 @@ describe(`Node_Modules`, () => {
 
         await run(`install`);
 
-        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/ws1`));
+        const ws1Path = npath.toPortablePath(`${path}/node_modules/ws1`);
+        const ws1Stats = await xfs.lstatPromise(wsPath);
 
-        expect(ws1.isSymbolicLink()).toBeTruthy();
+        expect(path.isAbsolute(await xfs.readlinkPromise(ws1Path))).toBeFalsy();
+        expect(ws1Stats.isSymbolicLink()).toBeTruthy();
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1903,7 +1903,7 @@ describe(`Node_Modules`, () => {
         const ws1Path = npath.toPortablePath(`${path}/node_modules/ws1`);
         const ws1Stats = await xfs.lstatPromise(ws1Path);
 
-        expect(path.isAbsolute(await xfs.readlinkPromise(ws1Path))).toBeFalsy();
+        expect(ppath.isAbsolute(await xfs.readlinkPromise(ws1Path))).toBeFalsy();
         expect(ws1Stats.isSymbolicLink()).toBeTruthy();
       },
     ),
@@ -1927,9 +1927,9 @@ describe(`Node_Modules`, () => {
         await run(`install`);
 
         const ws1Path = npath.toPortablePath(`${path}/node_modules/ws1`);
-        const ws1Stats = await xfs.lstatPromise(wsPath);
+        const ws1Stats = await xfs.lstatPromise(ws1Path);
 
-        expect(path.isAbsolute(await xfs.readlinkPromise(ws1Path))).toBeFalsy();
+        expect(ppath.isAbsolute(await xfs.readlinkPromise(ws1Path))).toBeFalsy();
         expect(ws1Stats.isSymbolicLink()).toBeTruthy();
       },
     ),

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1883,7 +1883,7 @@ describe(`Node_Modules`, () => {
   );
 
   testIf(() => process.platform !== `win32`,
-    `'nmFolderLinkMode: classic' not-on WIndows should use symlinks in node_modules directories`,
+    `'nmFolderLinkMode: classic' not-on Windows should use symlinks in node_modules directories`,
     makeTemporaryEnv(
       {
         workspaces: [`ws1`],
@@ -1899,7 +1899,7 @@ describe(`Node_Modules`, () => {
 
         await run(`install`);
 
-        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules`));
+        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/ws1`));
 
         expect(ws1.isSymbolicLink()).toBeTruthy();
       },
@@ -1907,7 +1907,7 @@ describe(`Node_Modules`, () => {
   );
 
   testIf(() => process.platform !== `win32`,
-    `'nmFolderLinkMode: symlinks' not-on WIndows should use symlinks in node_modules directories`,
+    `'nmFolderLinkMode: symlinks' not-on Windows should use symlinks in node_modules directories`,
     makeTemporaryEnv(
       {
         workspaces: [`ws1`],
@@ -1923,7 +1923,7 @@ describe(`Node_Modules`, () => {
 
         await run(`install`);
 
-        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules`));
+        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules/ws1`));
 
         expect(ws1.isSymbolicLink()).toBeTruthy();
       },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1,4 +1,8 @@
 import {xfs, npath, PortablePath, ppath, Filename} from '@yarnpkg/fslib';
+import {exec}                                      from 'node:child_process';
+import {promisify}                                 from 'node:util';
+
+const execPromise = promisify(exec);
 
 const {
   fs: {writeFile, writeJson},
@@ -1826,5 +1830,103 @@ describe(`Node_Modules`, () => {
           `native-foo-x86`,
         ]);
       }),
+  );
+
+  testIf(() => process.platform === `win32`,
+    `'nmFolderLinkMode: symlinks' on Windows should use symlinks in node_modules directories`,
+    makeTemporaryEnv(
+      {
+        workspaces: [`ws1`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmFolderLinkMode: `symlinks`,
+      },
+      async ({path, run}) => {
+        await writeJson(npath.toPortablePath(`${path}/ws1/package.json`), {
+          name: `ws1`,
+        });
+
+        await run(`install`);
+
+        const {stdout: reparsePoints} = await execPromise(`dir ${npath.fromPortablePath(`${path}/node_modules`)} /al /l | findstr "<SYMLINKD>"`, {shell: `cmd.exe`});
+
+        expect(reparsePoints).toMatch(`ws1`);
+        expect(reparsePoints).toMatch(`<SYMLINKD>`);
+      },
+    ),
+  );
+
+  testIf(() => process.platform === `win32`,
+    `'nmFolderLinkMode: classic' on Windows should use junctions in node_modules directories`,
+    makeTemporaryEnv(
+      {
+        workspaces: [`ws1`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmFolderLinkMode: `classic`,
+      },
+      async ({path, run}) => {
+        await writeJson(npath.toPortablePath(`${path}/ws1/package.json`), {
+          name: `ws1`,
+        });
+
+        await run(`install`);
+
+        const {stdout: reparsePoints} = await execPromise(`dir ${npath.fromPortablePath(`${path}/node_modules`)} /al /l | findstr "<JUNCTION>"`, {shell: `cmd.exe`});
+
+        expect(reparsePoints).toMatch(`ws1`);
+        expect(reparsePoints).toMatch(`<JUNCTION>`);
+      },
+    ),
+  );
+
+  testIf(() => process.platform !== `win32`,
+    `'nmFolderLinkMode: classic' not-on WIndows should use symlinks in node_modules directories`,
+    makeTemporaryEnv(
+      {
+        workspaces: [`ws1`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmFolderLinkMode: `classic`,
+      },
+      async ({path, run}) => {
+        await writeJson(npath.toPortablePath(`${path}/ws1/package.json`), {
+          name: `ws1`,
+        });
+
+        await run(`install`);
+
+        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules`));
+
+        expect(ws1.isSymbolicLink()).toBeTruthy();
+      },
+    ),
+  );
+
+  testIf(() => process.platform !== `win32`,
+    `'nmFolderLinkMode: symlinks' not-on WIndows should use symlinks in node_modules directories`,
+    makeTemporaryEnv(
+      {
+        workspaces: [`ws1`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmFolderLinkMode: `symlinks`,
+      },
+      async ({path, run}) => {
+        await writeJson(npath.toPortablePath(`${path}/ws1/package.json`), {
+          name: `ws1`,
+        });
+
+        await run(`install`);
+
+        const ws1 = await xfs.lstatPromise(npath.toPortablePath(`${path}/node_modules`));
+
+        expect(ws1.isSymbolicLink()).toBeTruthy();
+      },
+    ),
   );
 });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/__snapshots__/git.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/__snapshots__/git.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Protocols git: it should resolve a git dependency (git+ssh://git@github.com/yarnpkg/util-deprecate.git#v1.0.1) 1`] = `"util-deprecate@git+ssh://git@github.com/yarnpkg/util-deprecate.git#commit=6e923f7d98a0afbe5b9c7db9d0f0029c1936746c"`;
+
 exports[`Protocols git: it should resolve a git dependency (https://github.com/yarnpkg/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d) 1`] = `"util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=b3562c2798507869edb767da869cd7b85487726d"`;
 
 exports[`Protocols git: it should resolve a git dependency (https://github.com/yarnpkg/util-deprecate.git#master) 1`] = `"util-deprecate@https://github.com/yarnpkg/util-deprecate.git#commit=4bcc600d20e3a53ea27fa52c4d1fc49cc2d0eabb"`;

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -404,7 +404,7 @@
     },
     "nmFolderLinkMode": {
       "_package": "@yarnpkg/plugin-nm",
-      "description": "If set to `classic` (the default), when linking workspaces into `node_modules` directories, Yarn will use symlinks on Linux and MacOS, and Windows Junctions on Windows leading to potentional differences in behavior as Windows Junctions are always absolute. With `symlinks`, Yarn will utilize symlinks on all platforms, allowing for relative links on Windows.",
+      "description": "If set to `classic` Yarn will use symlinks on Linux and MacOS and Windows `junctions` on Windows when linking workspaces into `node_modules` directories. This can result in inconsistent behavior on Windows because `junctions` are always absolute paths while `symlinks` may be relative. Set to `symlinks`, Yarn will utilize symlinks on all platforms which enables links with relative paths paths on Windows.",
       "type": "string",
       "enum": ["classic", "symlinks"],
       "default": "classic"

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -402,6 +402,13 @@
       "enum": ["workspaces", "dependencies", "none"],
       "default": "none"
     },
+    "nmFolderLinkMode": {
+      "_package": "@yarnpkg/plugin-nm",
+      "description": "If set to `classic` (the default), when linking workspaces into `node_modules` directories, Yarn will use symlinks on Linux and MacOS, and Windows Junctions on Windows leading to potentional differences in behavior as Windows Junctions are always absolute. With `symlinks`, Yarn will utilize symlinks on all platforms, allowing for relative links on Windows.",
+      "type": "string",
+      "enum": ["classic", "symlinks"],
+      "default": "classic"
+    },
     "nmSelfReferences": {
       "_package": "@yarnpkg/plugin-nm",
       "description": "Defines whether workspaces are allowed to require themselves - results in creation of self-referencing symlinks. This setting can be overriden per-workspace through the [`installConfig.selfReferences` field](/configuration/manifest#installConfig.selfReferences).",

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -1282,8 +1282,6 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
   const nmFolderLinkModeSetting = project.configuration.get(`nmFolderLinkMode`);
   const nmFolderLinkMode = {value: nmFolderLinkModeSetting};
 
-  console.log(`FOLDER MODE: ${nmFolderLinkModeSetting}`);
-
   try {
     // For the first pass we'll only want to install a single copy for each
     // source directory. We'll later use the resulting install directories for

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -32,6 +32,12 @@ export enum NodeModulesMode {
   HARDLINKS_GLOBAL = `hardlinks-global`,
 }
 
+export enum NodeModulesFolderLinkMode {
+  CLASSIC = `classic`,
+  SYMLINKS = `symlinks`,
+}
+
+
 export class NodeModulesLinker implements Linker {
   private installStateCache: Map<string, Promise<InstallState | null>> = new Map();
 
@@ -664,21 +670,24 @@ const buildLocationTree = (locatorMap: NodeModulesLocatorMap | null, {skipPrefix
   return locationTree;
 };
 
-const symlinkPromise = async (srcPath: PortablePath, dstPath: PortablePath) => {
-  let stats;
-
-  try {
-    if (process.platform === `win32`) {
+const symlinkPromise = async (srcPath: PortablePath, dstPath: PortablePath, nmFolderLinkMode: NodeModulesFolderLinkMode) => {
+  // use junctions on windows if in classic mode
+  if (process.platform === `win32` && nmFolderLinkMode === NodeModulesFolderLinkMode.CLASSIC) {
+    let stats;
+    try {
       stats = await xfs.lstatPromise(srcPath);
+    } catch (e) {
     }
-  } catch (e) {
+
+    if (process.platform == `win32` && (!stats || stats.isDirectory())) {
+      await xfs.symlinkPromise(srcPath, dstPath, `junction`);
+      return;
+    }
+    // fall through to symlink
   }
 
-  if (process.platform == `win32` && (!stats || stats.isDirectory())) {
-    await xfs.symlinkPromise(srcPath, dstPath, `junction`);
-  } else {
-    await xfs.symlinkPromise(ppath.relative(ppath.dirname(dstPath), srcPath), dstPath);
-  }
+  // use symlink if tests for junction case fail
+  await xfs.symlinkPromise(ppath.relative(ppath.dirname(dstPath), srcPath), dstPath);
 };
 
 async function atomicFileWrite(tmpDir: PortablePath, dstPath: PortablePath, content: Buffer) {
@@ -774,7 +783,7 @@ type DirEntry = {
   symlinkTo: PortablePath;
 };
 
-const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs, globalHardlinksStore, nmMode, packageChecksum}: {baseFs: FakeFS<PortablePath>, globalHardlinksStore: PortablePath | null, nmMode: {value: NodeModulesMode}, packageChecksum: string | null}) => {
+const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs, globalHardlinksStore, nmMode, nmFolderLinkMode, packageChecksum}: {baseFs: FakeFS<PortablePath>, globalHardlinksStore: PortablePath | null, nmMode: {value: NodeModulesMode}, nmFolderLinkMode: {value: NodeModulesFolderLinkMode}, packageChecksum: string | null}) => {
   await xfs.mkdirPromise(dstDir, {recursive: true});
 
   const getEntriesRecursive = async (relativePath: PortablePath = PortablePath.dot): Promise<Map<PortablePath, DirEntry>> => {
@@ -837,7 +846,7 @@ const copyPromise = async (dstDir: PortablePath, srcDir: PortablePath, {baseFs, 
         mtimesChanged = true;
       }
     } else if (entry.kind === DirEntryKind.SYMLINK) {
-      await symlinkPromise(ppath.resolve(ppath.dirname(dstPath), entry.symlinkTo), dstPath);
+      await symlinkPromise(ppath.resolve(ppath.dirname(dstPath), entry.symlinkTo), dstPath, nmFolderLinkMode.value);
     }
   }
 
@@ -1052,14 +1061,14 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
   const locationTree = buildLocationTree(installState, {skipPrefix: project.cwd});
 
   const addQueue: Array<Promise<void>> = [];
-  const addModule = async ({srcDir, dstDir, linkType, globalHardlinksStore, nmMode, packageChecksum}: {srcDir: PortablePath, dstDir: PortablePath, linkType: LinkType, globalHardlinksStore: PortablePath | null, nmMode: {value: NodeModulesMode}, packageChecksum: string | null}) => {
+  const addModule = async ({srcDir, dstDir, linkType, globalHardlinksStore, nmMode, nmFolderLinkMode, packageChecksum}: {srcDir: PortablePath, dstDir: PortablePath, linkType: LinkType, globalHardlinksStore: PortablePath | null, nmMode: {value: NodeModulesMode},  nmFolderLinkMode: {value: NodeModulesFolderLinkMode}, packageChecksum: string | null}) => {
     const promise: Promise<any> = (async () => {
       try {
         if (linkType === LinkType.SOFT) {
           await xfs.mkdirPromise(ppath.dirname(dstDir), {recursive: true});
-          await symlinkPromise(ppath.resolve(srcDir), dstDir);
+          await symlinkPromise(ppath.resolve(srcDir), dstDir, nmFolderLinkMode.value);
         } else {
-          await copyPromise(dstDir, srcDir, {baseFs, globalHardlinksStore, nmMode, packageChecksum});
+          await copyPromise(dstDir, srcDir, {baseFs, globalHardlinksStore, nmMode, nmFolderLinkMode, packageChecksum});
         }
       } catch (e) {
         e.message = `While persisting ${srcDir} -> ${dstDir} ${e.message}`;
@@ -1270,6 +1279,10 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
   const reportedProgress = report.reportProgress(progress);
   const nmModeSetting = project.configuration.get(`nmMode`);
   const nmMode = {value: nmModeSetting};
+  const nmFolderLinkModeSetting = project.configuration.get(`nmFolderLinkMode`);
+  const nmFolderLinkMode = {value: nmFolderLinkModeSetting};
+
+  console.log(`FOLDER MODE: ${nmFolderLinkModeSetting}`);
 
   try {
     // For the first pass we'll only want to install a single copy for each
@@ -1288,7 +1301,7 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
     for (const entry of addList) {
       if (entry.linkType === LinkType.SOFT || !persistedLocations.has(entry.srcDir)) {
         persistedLocations.set(entry.srcDir, entry.dstDir);
-        await addModule({...entry, globalHardlinksStore, nmMode, packageChecksum: realLocatorChecksums.get(entry.realLocatorHash) || null});
+        await addModule({...entry, globalHardlinksStore, nmMode, nmFolderLinkMode, packageChecksum: realLocatorChecksums.get(entry.realLocatorHash) || null});
       }
     }
 
@@ -1308,7 +1321,7 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
     await xfs.mkdirPromise(rootNmDirPath, {recursive: true});
 
     const binSymlinks = await createBinSymlinkMap(installState, locationTree, project.cwd, {loadManifest});
-    await persistBinSymlinks(prevBinSymlinks, binSymlinks, project.cwd);
+    await persistBinSymlinks(prevBinSymlinks, binSymlinks, project.cwd, nmFolderLinkModeSetting);
 
     await writeInstallState(project, installState, binSymlinks, nmMode, {installChangedByUser});
 
@@ -1320,7 +1333,7 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
   }
 }
 
-async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlinks: BinSymlinkMap, projectCwd: PortablePath) {
+async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlinks: BinSymlinkMap, projectCwd: PortablePath, nmFolderLinkMode: NodeModulesFolderLinkMode) {
   // Delete outdated .bin folders
   for (const location of previousBinSymlinks.keys()) {
     if (ppath.contains(projectCwd, location) === null)
@@ -1358,7 +1371,7 @@ async function persistBinSymlinks(previousBinSymlinks: BinSymlinkMap, binSymlink
         await cmdShim(npath.fromPortablePath(target), npath.fromPortablePath(symlinkPath), {createPwshFile: false});
       } else {
         await xfs.removePromise(symlinkPath);
-        await symlinkPromise(target, symlinkPath);
+        await symlinkPromise(target, symlinkPath, nmFolderLinkMode);
         if (ppath.contains(projectCwd, await xfs.realpathPromise(target)) !== null) {
           await xfs.chmodPromise(target, 0o755);
         }

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -679,7 +679,7 @@ const symlinkPromise = async (srcPath: PortablePath, dstPath: PortablePath, nmFo
     } catch (e) {
     }
 
-    if (process.platform == `win32` && (!stats || stats.isDirectory())) {
+    if (!stats || stats.isDirectory()) {
       await xfs.symlinkPromise(srcPath, dstPath, `junction`);
       return;
     }

--- a/packages/plugin-nm/sources/index.ts
+++ b/packages/plugin-nm/sources/index.ts
@@ -49,7 +49,8 @@ const plugin: Plugin<Hooks> = {
       default: NodeModulesMode.HARDLINKS_LOCAL,
     },
     nmFolderLinkMode: {
-      description: `If set to "classic" (the default), when linking workspaces into "node_modules" directories, Yarn will use symlinks on Linux and MacOS, and Windows Junctions on Windows leading to potentional differences in behavior as Windows Junctions are always absolute. With "symlinks" Yarn will utilize symlinks on all platforms, allowing for relative links on Windows.`,
+      description: `If set to "classic" Yarn will use symlinks on Linux and MacOS and Windows "junctions" on Windows when linking workspaces into "node_modules" directories. This can result in inconsistent behavior on Windows because "junctions" are always absolute paths while "symlinks" may be relative. Set to "symlinks", Yarn will utilize symlinks on all platforms which enables links with relative paths paths on Windows.`,
+
       type: SettingsType.STRING,
       values: [
         NodeModulesFolderLinkMode.CLASSIC,

--- a/packages/plugin-nm/sources/index.ts
+++ b/packages/plugin-nm/sources/index.ts
@@ -1,19 +1,21 @@
-import {Hooks, Plugin, SettingsType}        from '@yarnpkg/core';
-import {xfs}                                from '@yarnpkg/fslib';
-import {NodeModulesHoistingLimits}          from '@yarnpkg/nm';
+import {Hooks, Plugin, SettingsType}                                   from '@yarnpkg/core';
+import {xfs}                                                           from '@yarnpkg/fslib';
+import {NodeModulesHoistingLimits}                                     from '@yarnpkg/nm';
 
-import {NodeModulesLinker, NodeModulesMode} from './NodeModulesLinker';
-import {getGlobalHardlinksStore}            from './NodeModulesLinker';
-import {PnpLooseLinker}                     from './PnpLooseLinker';
+import {NodeModulesLinker, NodeModulesMode, NodeModulesFolderLinkMode} from './NodeModulesLinker';
+import {getGlobalHardlinksStore}                                       from './NodeModulesLinker';
+import {PnpLooseLinker}                                                from './PnpLooseLinker';
 
 export {NodeModulesLinker};
 export {NodeModulesMode};
+export {NodeModulesFolderLinkMode};
 export {PnpLooseLinker};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     nmHoistingLimits: NodeModulesHoistingLimits;
     nmMode: NodeModulesMode;
+    nmFolderLinkMode: NodeModulesFolderLinkMode;
     nmSelfReferences: boolean;
   }
 }
@@ -45,6 +47,15 @@ const plugin: Plugin<Hooks> = {
         NodeModulesMode.HARDLINKS_GLOBAL,
       ],
       default: NodeModulesMode.HARDLINKS_LOCAL,
+    },
+    nmFolderLinkMode: {
+      description: `If set to "classic" (the default), when linking workspaces into "node_modules" directories, Yarn will use symlinks on Linux and MacOS, and Windows Junctions on Windows leading to potentional differences in behavior as Windows Junctions are always absolute. With "symlinks" Yarn will utilize symlinks on all platforms, allowing for relative links on Windows.`,
+      type: SettingsType.STRING,
+      values: [
+        NodeModulesFolderLinkMode.CLASSIC,
+        NodeModulesFolderLinkMode.SYMLINKS,
+      ],
+      default: NodeModulesFolderLinkMode.CLASSIC,
     },
     nmSelfReferences: {
       description: `If set to 'false' the workspace will not be allowed to require itself and corresponding self-referencing symlink will not be created`,

--- a/packages/plugin-nm/sources/index.ts
+++ b/packages/plugin-nm/sources/index.ts
@@ -50,7 +50,6 @@ const plugin: Plugin<Hooks> = {
     },
     nmFolderLinkMode: {
       description: `If set to "classic" Yarn will use symlinks on Linux and MacOS and Windows "junctions" on Windows when linking workspaces into "node_modules" directories. This can result in inconsistent behavior on Windows because "junctions" are always absolute paths while "symlinks" may be relative. Set to "symlinks", Yarn will utilize symlinks on all platforms which enables links with relative paths paths on Windows.`,
-
       type: SettingsType.STRING,
       values: [
         NodeModulesFolderLinkMode.CLASSIC,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Closes yarnpkg/berry#4979

Currently on Windows `yarn` uses `junctions` to link workspaces into `node_modules` directories. On other platforms `yarn` uses symlinks.

As a result, workspace links in `node_modules` on Windows are _always_ absolute paths. On other platforms links may be relative paths, leading to _inconsistent behavior_ when using `nodeLinker: node-modules` and running `yarn install` from Windows vs. Linux.

A particularly bad side-effect of absolute paths on Windows is that it breaks Docker builds--when a monorepo is mounted into a container, the absolute paths are invalid.

The PR adds an additional configuration option for the `nm-linker` to use symbolic links on Windows as well, thereby supporting relative links, and fixing container builds.
...

**How did you fix it?**
added the option `nmFolderLinkMode` with two settiings:
- `classic` (the default) -- `nm-linker` behaves exactly as today, using junctions on Windows and symlinks on other platforms.
- `symlinks` -- `nm-linker` uses symlinks on _all_ platforms

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective. 
       **[PLEASE CHECK MY WORK HERE!]**

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed. 
       **[A handful of unit and integration tests are failing when I run against `master`. This same set fails on my branch]**
