### PR TITLE
ci: migrate from `::set-output` to `$GITHUB_OUTPUT` environment file

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -29,7 +29,7 @@ runs:
     #region Cache workflow dependencies
     - name: Get global path
       id: global-path
-      run: echo "::set-output name=globalFolder::$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js config get globalFolder)"
+      run: echo "globalFolder=$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js config get globalFolder)" >> $GITHUB_OUTPUT
       shell: bash
 
     - uses: actions/cache@v3


### PR DESCRIPTION
**What's the problem this PR addresses?**

GitHub has deprecated the use of `::set-output`.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**How did you fix it?**

Update to write to the new `GITHUB_OUTPUT` environment file.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.