### PR TITLE
fix(cli): `--cwd` does not work with relative paths

### DIFF
--- a/.yarn/versions/c7cd192b.yml
+++ b/.yarn/versions/c7cd192b.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/script.test.js
@@ -16,6 +16,15 @@ const configs = [{
 }];
 
 describe(`Scripts tests`, () => {
+  test.only(
+    `it should run scripts by correct directory`,
+    makeTemporaryEnv({scripts: {myScript: `mkdir foo && yarn --cwd ./foo -v`}}, async ({path, run, source}) => {
+      await run(`install`);
+
+      await expect(run(`run`, `myScript`)).resolves.not.toThrow();
+    }),
+  );
+
   test(
     `it should run scripts using the same Node than the one used by Yarn`,
     makeTemporaryEnv({scripts: {myScript: `node --version`}}, async ({path, run, source}) => {

--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -151,6 +151,11 @@ export async function main({binaryVersion, pluginConfiguration}: {binaryVersion:
 
         if (iAmHere !== iShouldBeHere) {
           process.chdir(cwd);
+
+          const cwdIndex = process.argv.findIndex(arg => arg === `--cwd`);
+          if (cwdIndex !== -1)
+            process.argv.splice(cwdIndex, 2);
+
           await run();
           return;
         }


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Closes https://github.com/yarnpkg/berry/issues/4908

I Found:
1. this can only be reproduced if yarn berry is installed globally (cannot be reproduced in the yarn berry project directory), 
2. this seems to be reproducible on any yarn command
3. it will infinite loops to find the relative path until the error

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

after running `process.chdir(cwd)`, remove the `-cwd` option from `process.argv`

3a17d5b3753a860d5f83e25f020a527ee38f19c4

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
