### PR TITLE
perf(pack): remove duplicated assignment of `browser` in `publishConfig`

### DIFF
--- a/.yarn/versions/6e4fa8ee.yml
+++ b/.yarn/versions/6e4fa8ee.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-pack": patch

--- a/.yarn/versions/6e4fa8ee.yml
+++ b/.yarn/versions/6e4fa8ee.yml
@@ -1,2 +1,24 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -35,10 +35,7 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
 
     if (rawManifest.publishConfig.module)
       rawManifest.module = rawManifest.publishConfig.module;
-
-    if (rawManifest.publishConfig.browser)
-      rawManifest.browser = rawManifest.publishConfig.browser;
-
+    
     if (rawManifest.publishConfig.exports)
       rawManifest.exports = rawManifest.publishConfig.exports;
 

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -35,7 +35,7 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
 
     if (rawManifest.publishConfig.module)
       rawManifest.module = rawManifest.publishConfig.module;
-    
+
     if (rawManifest.publishConfig.exports)
       rawManifest.exports = rawManifest.publishConfig.exports;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
The `browser` field is assigned twice while packing ([first assignment](https://github.com/yarnpkg/berry/blob/master/packages/plugin-pack/sources/index.ts#L33), [second assignment](https://github.com/yarnpkg/berry/blob/master/packages/plugin-pack/sources/index.ts#L39)). I removed the unnecessary second assignment.

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
