### PR TITLE
Adds support for Windows when opening urls

### DIFF
--- a/.yarn/versions/96582795.yml
+++ b/.yarn/versions/96582795.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,12 +1,11 @@
-import {Configuration, Ident, formatUtils, httpUtils, nodeUtils, StreamReport, execUtils} from '@yarnpkg/core';
-import {MessageName, ReportError}                                                         from '@yarnpkg/core';
-import {ppath}                                                                            from '@yarnpkg/fslib';
-import {prompt}                                                                           from 'enquirer';
-import {URL}                                                                              from 'url';
+import {Configuration, Ident, formatUtils, httpUtils, nodeUtils, StreamReport} from '@yarnpkg/core';
+import {MessageName, ReportError}                                              from '@yarnpkg/core';
+import {prompt}                                                                from 'enquirer';
+import {URL}                                                                   from 'url';
 
-import {Hooks}                                                                            from './index';
-import * as npmConfigUtils                                                                from './npmConfigUtils';
-import {MapLike}                                                                          from './npmConfigUtils';
+import {Hooks}                                                                 from './index';
+import * as npmConfigUtils                                                     from './npmConfigUtils';
+import {MapLike}                                                               from './npmConfigUtils';
 
 export enum AuthType {
   NO_AUTH,

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -1,12 +1,12 @@
-import {Configuration, Ident, formatUtils, httpUtils, StreamReport, execUtils} from '@yarnpkg/core';
-import {MessageName, ReportError}                                              from '@yarnpkg/core';
-import {ppath}                                                                 from '@yarnpkg/fslib';
-import {prompt}                                                                from 'enquirer';
-import {URL}                                                                   from 'url';
+import {Configuration, Ident, formatUtils, httpUtils, nodeUtils, StreamReport, execUtils} from '@yarnpkg/core';
+import {MessageName, ReportError}                                                         from '@yarnpkg/core';
+import {ppath}                                                                            from '@yarnpkg/fslib';
+import {prompt}                                                                           from 'enquirer';
+import {URL}                                                                              from 'url';
 
-import {Hooks}                                                                 from './index';
-import * as npmConfigUtils                                                     from './npmConfigUtils';
-import {MapLike}                                                               from './npmConfigUtils';
+import {Hooks}                                                                            from './index';
+import * as npmConfigUtils                                                                from './npmConfigUtils';
+import {MapLike}                                                                          from './npmConfigUtils';
 
 export enum AuthType {
   NO_AUTH,
@@ -273,7 +273,7 @@ async function askForOtp(error: any, {configuration}: {configuration: Configurat
 
       if (!process.env.YARN_IS_TEST_ENV) {
         const autoOpen = notice.match(/open (https?:\/\/\S+)/i);
-        if (autoOpen) {
+        if (autoOpen && nodeUtils.openUrl) {
           const {openNow} = await prompt<{openNow: boolean}>({
             type: `confirm`,
             name: `openNow`,
@@ -284,12 +284,8 @@ async function askForOtp(error: any, {configuration}: {configuration: Configurat
           });
 
           if (openNow) {
-            try {
-              await execUtils.execvp(`open`, [autoOpen[1]], {cwd: ppath.cwd()});
-            } catch {
-              try {
-                await execUtils.execvp(`xdg-open`, [autoOpen[1]], {cwd: ppath.cwd()});
-              } catch {}
+            if (!await nodeUtils.openUrl(autoOpen[1])) {
+              report.reportWarning(MessageName.UNNAMED, `We failed to automatically open the url; you'll have to open it yourself in your browser of choice.`);
             }
           }
         }

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -284,6 +284,7 @@ async function askForOtp(error: any, {configuration}: {configuration: Configurat
 
           if (openNow) {
             if (!await nodeUtils.openUrl(autoOpen[1])) {
+              report.reportSeparator();
               report.reportWarning(MessageName.UNNAMED, `We failed to automatically open the url; you'll have to open it yourself in your browser of choice.`);
             }
           }

--- a/packages/yarnpkg-core/sources/nodeUtils.ts
+++ b/packages/yarnpkg-core/sources/nodeUtils.ts
@@ -13,7 +13,7 @@ const openUrlBinary = new Map([
 export const openUrl = typeof openUrlBinary !== `undefined`
   ? async (url: string) => {
     try {
-      await execUtils.execvp(`open`, [url], {cwd: ppath.cwd()});
+      await execUtils.execvp(openUrlBinary, [url], {cwd: ppath.cwd()});
       return true;
     } catch {
       return false;

--- a/packages/yarnpkg-core/sources/nodeUtils.ts
+++ b/packages/yarnpkg-core/sources/nodeUtils.ts
@@ -1,6 +1,25 @@
+import {ppath}        from '@yarnpkg/fslib';
 import Module         from 'module';
 
+import * as execUtils from './execUtils';
 import * as miscUtils from './miscUtils';
+
+const openUrlBinary = new Map([
+  [`darwin`, `open`],
+  [`linux`, `xdg-open`],
+  [`win32`, `explorer.exe`],
+]).get(process.platform);
+
+export const openUrl = typeof openUrlBinary !== `undefined`
+  ? async (url: string) => {
+    try {
+      await execUtils.execvp(`open`, [url], {cwd: ppath.cwd()});
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  : undefined;
 
 export function builtinModules(): Set<string> {
   // @ts-expect-error


### PR DESCRIPTION
**What's the problem this PR addresses?**

TOTP requests from the npm registry (#4308) aren't automatically opened on Windows.

**How did you fix it?**

We now make a call to `explorer.exe` to open them. Will double-check it works well on my Windows machine.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
