### PR TITLE
Reimplements the Git merge conflict resolution

### DIFF
--- a/.yarn/versions/a1d2b6c1.yml
+++ b/.yarn/versions/a1d2b6c1.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/__snapshots__/mergeConflictResolution.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/__snapshots__/mergeConflictResolution.test.js.snap
@@ -40,7 +40,7 @@ exports[`Features Merge Conflict Resolution it should properly fix merge conflic
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Fetch step
-➤ YN0019: │ no-deps-npm-1.0.0-cf533b267a-8bd88a447c.zip appears to be unused - removing
+➤ YN0019: │ no-deps-npm-2.0.0-8c4f3f8395-9c77ddf9a6.zip appears to be unused - removing
 ➤ YN0000: └ Completed
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -393,6 +393,9 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
     // in the lockfile rather than "foo@npm:x.y.z")
     if (variant.__metadata.version < 7) {
       for (const key of Object.keys(variant)) {
+        if (key === `__metadata`)
+          continue;
+
         const descriptor = structUtils.parseDescriptor(key, true);
         const normalizedDescriptor = configuration.normalizeDependency(descriptor);
         const newKey = structUtils.stringifyDescriptor(normalizedDescriptor);

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -416,7 +416,7 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
     return variant.__metadata.version ?? Infinity;
   }));
 
-  merged.__metadata.cacheKey = Math.max(0, ...variants.map(variant => {
+  merged.__metadata.cacheKey = Math.min(0, ...variants.map(variant => {
     return variant.__metadata.cacheKey ?? 0;
   }));
 

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -94,6 +94,8 @@ export enum MessageName {
   NETWORK_DISABLED = 80,
   NETWORK_UNSAFE_HTTP = 81,
   RESOLUTION_FAILED = 82,
+  AUTOMERGE_GIT_ERROR = 83,
+  AUTOMERGE_LOCKFILE_VERSION_MISMATCH = 84,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The current merge conflict resolution algorithm is nice because it operates using only the conflict markers that Git puts into the files, but it has several drawbacks:

- Git sometimes generates bogus conflict markers, which lead to the resulting lockfile to have invalid checksums (#2583, https://github.com/yarnpkg/berry/issues/1771#issuecomment-734813568, ...)

- Git doesn't put conflict markers on the `__metadata.version` field (because it rarely change except when you upgrade Yarn, so there are no conflicts), which prevents us from knowing whether the merged lockfile has accurate metadata.

Closes #2583
Closes #5041

**How did you fix it?**

This diff reimplements the merge conflict auto-resolver to instead query the Git state. It retrieves the original variants of the lockfile, ignores the ones that don't make sense, tries to perform a couple of compatibility fixes if it knows how (useful for the lockfile v6 -> v7 migration), and merges the resulting data.

The main drawback is that the `yarn install` command must be run within the context of the conflicting `git merge` command. You cannot anymore accidentally commit the conflict, and fix it later (because then we'd lose the information telling us which commits are being merged).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
