### PR TITLE
ci: update to Node.js v18

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
         check-latest: true
 
     #region Build the standard bundle

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,13 +3,17 @@ inputs:
     description: 'Whether to minify the bundle'
     required: false
     default: 'false'
+  node-version:
+    description: 'The version of Node.js to use'
+    required: false
+    default: '18.x'
 
 runs:
   using: composite
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: ${{ inputs.node-version }}
         check-latest: true
 
     #region Build the standard bundle

--- a/.github/workflows/e2e-preact-cli-workflow.yml
+++ b/.github/workflows/e2e-preact-cli-workflow.yml
@@ -20,6 +20,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: ./.github/actions/prepare
+      with:
+        # Remove when Preact CLI supports Node.js 18
+        node-version: 16.x
 
     - name: 'Running the integration test'
       run: |

--- a/.github/workflows/e2e-preact-cli-workflow.yml
+++ b/.github/workflows/e2e-preact-cli-workflow.yml
@@ -24,25 +24,17 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        git clone https://github.com/preactjs-templates/default.git default
-        cd default/template
-        touch yarn.lock
-        echo $(cat package.json | jq '.name = "pnp-test"') > package.json
-        yarn
+
+        yarn dlx preact-cli create default default-app --yarn
+        cd default-app
         yarn build
 
     - name: 'Running the TypeScript integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        git clone https://github.com/preactjs-templates/typescript.git default
-        cd default/template
 
-        # TODO: Remove once https://github.com/preactjs-templates/typescript/issues/71 is fixed
-        rm -rf tests
-
-        touch yarn.lock
-        echo $(cat package.json | jq '.name = "pnp-test"') > package.json
-        yarn
+        yarn dlx preact-cli create typescript ts-app --yarn
+        cd ts-app
         yarn build
       if: |
         success() || failure()

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -23,10 +23,9 @@ jobs:
     - run: |
         git fetch --no-tags --unshallow origin HEAD master
 
-    - name: 'Use Node.js 16.x'
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
 
     - name: 'Check that the Yarn files don''t change on new installs (fix w/ "yarn install")'
       run: |
@@ -151,10 +150,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: 'Use Node.js 16.x'
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
 
     - name: 'Build bundle & plugins'
       run: |

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -24,10 +24,9 @@ jobs:
     - name: 'Retrieve all the relevant tags'
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - name: 'Use Node.js 16.x'
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
 
     - name: 'Build a binary for convenience'
       run: |

--- a/.github/workflows/sherlock-workflow.yml
+++ b/.github/workflows/sherlock-workflow.yml
@@ -9,10 +9,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: 'Install Node'
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 18.x
 
     - name: 'Always use the latest sherlock'
       run: |


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node.js v18 is LTS now so we should run our e2e tests against it.
https://nodejs.org/en/blog/release/v18.12.0/

Also fixes:
> error Gatsby requires Node.js 18.0.0 or higher (you have v16.18.0).
https://github.com/yarnpkg/berry/actions/runs/3447208507/jobs/5752979253#step:4:72


**How did you fix it?**

Updated the CI to Node.js v18.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.