### PR TITLE
Improves init

### DIFF
--- a/.yarn/versions/52d0ce79.yml
+++ b/.yarn/versions/52d0ce79.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-init": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -52,6 +52,10 @@ export default class InitCommand extends BaseCommand {
     description: `Initialize a package with a specific bundle that will be locked in the project`,
   });
 
+  name = Option.String(`-n,--name`, {
+    description: `Initialize a package with the given name`,
+  });
+
   // Options that only mattered on v1
   usev2 = Option.Boolean(`-2`, false, {hidden: true});
   yes = Option.Boolean(`-y,--yes`, {hidden: true});
@@ -92,6 +96,8 @@ export default class InitCommand extends BaseCommand {
       args.push(`-p`);
     if (this.workspace)
       args.push(`-w`);
+    if (this.name)
+      args.push(`-n=${this.name}`);
     if (this.yes)
       args.push(`-y`);
 
@@ -119,19 +125,20 @@ export default class InitCommand extends BaseCommand {
     if (!xfs.existsSync(this.context.cwd))
       await xfs.mkdirPromise(this.context.cwd, {recursive: true});
 
-    const manifest = (await Manifest.tryFind(this.context.cwd)) || new Manifest();
+    const original = await Manifest.tryFind(this.context.cwd);
+    const manifest = original ?? new Manifest();
 
     const fields = Object.fromEntries(configuration.get(`initFields`).entries());
     manifest.load(fields);
 
     manifest.name = manifest.name
-      ?? structUtils.makeIdent(configuration.get(`initScope`), ppath.basename(this.context.cwd));
+      ?? structUtils.makeIdent(configuration.get(`initScope`), this.name ?? ppath.basename(this.context.cwd));
 
     manifest.packageManager = YarnVersion && miscUtils.isTaggedYarnVersion(YarnVersion)
       ? `yarn@${YarnVersion}`
       : null;
 
-    if (typeof manifest.raw.private === `undefined` && (this.private || (this.workspace && manifest.workspaceDefinitions.length === 0)))
+    if ((!original && this.workspace) || this.private)
       manifest.private = true;
 
     if (this.workspace && manifest.workspaceDefinitions.length === 0) {
@@ -144,28 +151,27 @@ export default class InitCommand extends BaseCommand {
     const serialized: any = {};
     manifest.exportTo(serialized);
 
-    // @ts-expect-error: The Node typings forgot one field
-    inspect.styles.name = `cyan`;
-
-    this.context.stdout.write(`${inspect(serialized, {
-      depth: Infinity,
-      colors: true,
-      compact: false,
-    })}\n`);
-
     const manifestPath = ppath.join(this.context.cwd, Manifest.fileName);
     await xfs.changeFilePromise(manifestPath, `${JSON.stringify(serialized, null, 2)}\n`, {
       automaticNewlines: true,
     });
 
+    const changedPaths = [
+      manifestPath,
+    ];
+
     const readmePath = ppath.join(this.context.cwd, `README.md` as Filename);
-    if (!xfs.existsSync(readmePath))
+    if (!xfs.existsSync(readmePath)) {
       await xfs.writeFilePromise(readmePath, `# ${structUtils.stringifyIdent(manifest.name)}\n`);
+      changedPaths.push(readmePath);
+    }
 
     if (!existingProject || existingProject.cwd === this.context.cwd) {
       const lockfilePath = ppath.join(this.context.cwd, Filename.lockfile);
-      if (!xfs.existsSync(lockfilePath))
+      if (!xfs.existsSync(lockfilePath)) {
         await xfs.writeFilePromise(lockfilePath, ``);
+        changedPaths.push(lockfilePath);
+      }
 
       const gitignoreLines = [
         `.yarn/*`,
@@ -176,7 +182,7 @@ export default class InitCommand extends BaseCommand {
         `!.yarn/versions`,
         ``,
         `# Swap the comments on the following lines if you wish to use zero-installs`,
-        `# Also don't forget to run \`yarn config set enableGlobalCache false\`!`,
+        `# In that case, don't forget to run \`yarn config set enableGlobalCache false\`!`,
         `# Documentation here: https://yarnpkg.com/features/zero-installs`,
         ``,
         `#!.yarn/cache`,
@@ -188,8 +194,10 @@ export default class InitCommand extends BaseCommand {
       }).join(``);
 
       const gitignorePath = ppath.join(this.context.cwd, `.gitignore` as Filename);
-      if (!xfs.existsSync(gitignorePath))
+      if (!xfs.existsSync(gitignorePath)) {
         await xfs.writeFilePromise(gitignorePath, gitignoreBody);
+        changedPaths.push(gitignorePath);
+      }
 
       const editorConfigProperties = {
         [`*`]: {
@@ -215,11 +223,25 @@ export default class InitCommand extends BaseCommand {
       }
 
       const editorConfigPath = ppath.join(this.context.cwd, `.editorconfig` as Filename);
-      if (!xfs.existsSync(editorConfigPath))
+      if (!xfs.existsSync(editorConfigPath)) {
         await xfs.writeFilePromise(editorConfigPath, editorConfigBody);
+        changedPaths.push(editorConfigPath);
+      }
+
+      await this.cli.run([`install`], {
+        quiet: true,
+      });
 
       if (!xfs.existsSync(ppath.join(this.context.cwd, `.git` as Filename))) {
         await execUtils.execvp(`git`, [`init`], {
+          cwd: this.context.cwd,
+        });
+
+        await execUtils.execvp(`git`, [`add`, `--`, ...changedPaths], {
+          cwd: this.context.cwd,
+        });
+
+        await execUtils.execvp(`git`, [`commit`, `--allow-empty`, `-m`, `First commit`], {
           cwd: this.context.cwd,
         });
       }

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -3,7 +3,6 @@ import {Configuration, Manifest, miscUtils, Project, YarnVersion} from '@yarnpkg
 import {execUtils, scriptUtils, structUtils}                      from '@yarnpkg/core';
 import {xfs, ppath, Filename}                                     from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                       from 'clipanion';
-import {inspect}                                                  from 'util';
 
 // eslint-disable-next-line arca/no-default-export
 export default class InitCommand extends BaseCommand {


### PR DESCRIPTION
**What's the problem this PR addresses?**

There are still a couple of annoying steps one must follow after running `yarn init` (in particular `git add . && git commit`). 

Since we don't have to worry about supporting non-git VCS, these steps can be simplified.

**How did you fix it?**

- Automatically commit the new files
- Runs an immediate install after init

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
