### PR TITLE
Clairify installation of corepack with package managers that don't include corepack with nodejs

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -18,6 +18,12 @@ Corepack is included by default with all Node.js installs, but is currently opt-
 corepack enable
 ```
 
+Some package managers do not include corepack with nodejs and the above command will fail. In this case, you may install corepack with npm:
+
+```bash
+npm i -g corepack
+```
+
 ### Node.js <16.10
 
 Corepack isn't included with Node.js in versions before the 16.10; to address that, run:


### PR DESCRIPTION
**What's the problem this PR addresses?**
I tried to install yarn on Ubuntu 22.10 with `corepack enable` per the documentation but corepack was not installed with nodejs.
White #5060 and https://github.com/yarnpkg/berry/discussions/5060 have been answered, this solidifies the answers into the documentation.

...

**How did you fix it?**
Kept the `corepack enable` command in the documentation but noted that some package managers may not include corepack with nodejs and corepack may instead be installed with `npm i -g corepack.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
