### PR TITLE
test: fix constraints test to handle paths containing spaces

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
@@ -1,3 +1,4 @@
+const {npath} = require(`@yarnpkg/fslib`);
 const {
   fs: {writeFile},
 } = require(`pkg-tests-core`);
@@ -110,7 +111,7 @@ describe(`Commands`, () => {
                 ({code, stdout, stderr} = error);
               }
 
-              stdout = stdout.replace(/[^( ]+[\\/](yarn\.config)/g, `/path/to/$1`);
+              stdout = stdout.replace(new RegExp(npath.join(npath.fromPortablePath(path), `yarn.config.js`).replace(/\\/g, `\\\\`), `g`), `/path/to/yarn.config.js`);
               stdout = stdout.replace(/(Module|Object)\.(exports\.)/g, `$2`);
 
               expect({code, stdout, stderr}).toMatchSnapshot();


### PR DESCRIPTION
**What's the problem this PR addresses?**

The constraints tests added in https://github.com/yarnpkg/berry/pull/5026 doesn't work when the path to the config contains a space.

Fixes point three in https://github.com/nodejs/citgm/pull/905#issuecomment-1318883988

**How did you fix it?**

Updated the test to remove the absolute path to the config.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.