### PR TITLE
docs: add theme colour

### DIFF
--- a/packages/gatsby/src/components/seo.tsx
+++ b/packages/gatsby/src/components/seo.tsx
@@ -52,6 +52,10 @@ export function SEO({description, lang = `en`, meta = [], keywords = [], title}:
           content: metaDescription,
         },
         {
+          name: `theme-color`,
+          content: `#25799f`,
+        },
+        {
           property: `og:title`,
           content: title,
         },


### PR DESCRIPTION
Hi, By adding `<meta name="theme-color " />` we can customise the colour of the app bar. For more info please [click here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)

I have added `#25799f` as a theme-colour  :)

_Extremely sorry if I made any mistakes :(_