### PR TITLE
chore: fix creation of `@yarnpkg/cli-dist` and artifact updating

### DIFF
--- a/scripts/release/01-release-tags.sh
+++ b/scripts/release/01-release-tags.sh
@@ -73,7 +73,7 @@ cp "$REPO_DIR"/packages/yarnpkg-cli/bin/yarn.js \
    "$REPO_DIR"/packages/berry-cli/bin/berry.js
 
 # In case the PnP hook got updated run an install to update the `.pnp.cjs` file
-YARN_ENABLE_IMMUTABLE_INSTALLS=0 yarn
+YARN_IGNORE_PATH=1 YARN_ENABLE_IMMUTABLE_INSTALLS=0 node "$REPO_DIR/packages/yarnpkg-cli/bin/yarn.js"
 
 git add "$REPO_DIR"
 git commit -m "$COMMIT_MESSAGE"

--- a/scripts/release/03-release-npm.sh
+++ b/scripts/release/03-release-npm.sh
@@ -10,7 +10,7 @@ if ! [[ -z $(git status --porcelain) ]]; then
   exit 1
 fi
 
-VERSION=$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bin/yarn.js --version)
+VERSION=$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js --version)
 
 TEMP_DIR="$(mktemp -d)"
 mkdir "$TEMP_DIR"/bin
@@ -19,7 +19,7 @@ jq > "$TEMP_DIR"/package.json \
   '{name: "@yarnpkg/cli-dist", version: "'"$VERSION"'", "bin": {"yarn": "bin/yarn.js", "yarnpkg": "bin/yarn.js"}} + (. | {license,repository,engines})' \
   "$REPO_DIR"/packages/yarnpkg-cli/package.json
 
-cp "$REPO_DIR"/packages/yarnpkg-cli/bin/yarn.js "$TEMP_DIR"/bin/yarn.js
+cp "$REPO_DIR"/packages/yarnpkg-cli/bundles/yarn.js "$TEMP_DIR"/bin/yarn.js
 cp "$REPO_DIR"/scripts/dist-scripts/* "$TEMP_DIR"/bin
 chmod +x "$TEMP_DIR"/bin/*
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

- The fix in https://github.com/yarnpkg/berry/pull/3499 didn't work since the `yarn` binary it uses is created before the PnP hook is potentially updated
https://github.com/yarnpkg/berry/blob/86183c70a76a5556d290951b5c1385d304155023/.github/workflows/release-candidate.yml#L31-L41
- The CI creates `@yarnpkg/cli-dist` using the stable bundle instead of the RC since
https://github.com/yarnpkg/berry/blob/0926e2474e0d7431366988c4bbb1f2a407b1bcb8/scripts/release/01-release-tags.sh#L111-L116 runs before it does.

**How did you fix it?**

- Run the built bundle directly.
- Copy the correct bundle.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.