### PR TITLE
fix(builder): restore resolution of `.mjs` files

### DIFF
--- a/.yarn/versions/768bd0b5.yml
+++ b/.yarn/versions/768bd0b5.yml
@@ -1,0 +1,12 @@
+releases:
+  "@yarnpkg/builder": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -133,6 +133,8 @@ export default class BuildBundleCommand extends Command {
             }),
           },
           outfile: output,
+          // Default extensions + .mjs
+          resolveExtensions: [`.tsx`, `.ts`, `.jsx`, `.mjs`, `.js`, `.css`, `.json`],
           logLevel: `silent`,
           format: `iife`,
           platform: `node`,

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -113,6 +113,8 @@ export default class BuildPluginCommand extends Command {
           entryPoints: [path.resolve(basedir, main ?? `sources/index`)],
           bundle: true,
           outfile: output,
+          // Default extensions + .mjs
+          resolveExtensions: [`.tsx`, `.ts`, `.jsx`, `.mjs`, `.js`, `.css`, `.json`],
           logLevel: `silent`,
           format: `iife`,
           platform: `node`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/yarnpkg/berry/pull/4732 stopped resolving `.mjs` files by default which probably wasn't on purpose.

**How did you fix it?**

Added `resolveExtensions` with the default extensions and `.mjs`.

**Results**

The performance doesn't change but the bundle size is slightly improved

```console
$ du -s yarn*
2736    yarn-after.js
2744    yarn-before.js

$ YARN_IGNORE_PATH=1 hyperfine -w 1 \
  --prepare 'node ./before.cjs remove dummy-pkg || true' \
  'node ./before.cjs add dummy-pkg@link:./dummy-pkg' \
  --prepare 'node ./after.cjs remove dummy-pkg || true' \
  'node ./after.cjs add dummy-pkg@link:./dummy-pkg'
Benchmark 1: node ./before.cjs add dummy-pkg@link:./dummy-pkg
  Time (mean ± σ):      1.280 s ±  0.017 s    [User: 1.724 s, System: 0.306 s]
  Range (min … max):    1.263 s …  1.316 s    10 runs

Benchmark 2: node ./after.cjs add dummy-pkg@link:./dummy-pkg
  Time (mean ± σ):      1.278 s ±  0.007 s    [User: 1.699 s, System: 0.320 s]
  Range (min … max):    1.271 s …  1.289 s    10 runs

Summary
  'node ./after.cjs add dummy-pkg@link:./dummy-pkg' ran
    1.00 ± 0.01 times faster than 'node ./before.cjs add dummy-pkg@link:./dummy-pkg'
```

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.