### PR TITLE
perf: remove obsolete forced unplug entries

### DIFF
--- a/.yarn/versions/c236874b.yml
+++ b/.yarn/versions/c236874b.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -10,13 +10,6 @@ import * as jsInstallUtils                                                      
 import * as pnpUtils                                                                                            from './pnpUtils';
 
 const FORCED_UNPLUG_PACKAGES = new Set([
-  // Some packages do weird stuff and MUST be unplugged. I don't like them.
-  structUtils.makeIdent(null, `nan`).identHash,
-  structUtils.makeIdent(null, `node-gyp`).identHash,
-  structUtils.makeIdent(null, `node-pre-gyp`).identHash,
-  structUtils.makeIdent(null, `node-addon-api`).identHash,
-  // Those ones contain native builds (*.node), and Node loads them through dlopen
-  structUtils.makeIdent(null, `fsevents`).identHash,
   // Contains native binaries
   structUtils.makeIdent(null, `open`).identHash,
   structUtils.makeIdent(null, `opn`).identHash,

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Trigger e2e tests
+
 set -e
 
 HERE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"

--- a/scripts/e2e-setup-ci.sh
+++ b/scripts/e2e-setup-ci.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Trigger e2e tests
-
 set -e
 
 HERE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

This PR removes some entries from `FORCED_UNPLUG_PACKAGES` that are no longer needed:
- `nan` - already unplugged because of `.h` files
- `node-gyp` - already unplugged because of `.cc` files
- `node-addon-api` - already unplugged because of `.h` and `.c` files
- `fsevents` - already unplugged because of `.node` files and conditions
- `node-pre-gyp` doesn't need to be unplugged because nobody remembers the reason it was originally unplugged anymore and it doesn't currently include any code that would require it to be. The package has also been deprecated and renamed to `@mapbox/node-pre-gyp` which isn't on our list (and therefore isn't unplugged) and nobody has complained about it not working anymore. I've also done a quick check and both seem to work without unplugging.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed them.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
