### PR TITLE
chore: use `os.availableParallelism` when available

### DIFF
--- a/.yarn/versions/cad178bf.yml
+++ b/.yarn/versions/cad178bf.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -5,11 +5,20 @@ import {formatUtils, miscUtils, structUtils}                         from '@yarn
 import {gitUtils}                                                    from '@yarnpkg/plugin-git';
 import {Command, Option, Usage, UsageError}                          from 'clipanion';
 import micromatch                                                    from 'micromatch';
-import {cpus}                                                        from 'os';
+import os                                                            from 'os';
 import pLimit                                                        from 'p-limit';
 import {Writable}                                                    from 'stream';
 import {WriteStream}                                                 from 'tty';
 import * as t                                                        from 'typanion';
+
+function availableParallelism() {
+  // TODO: Use os.availableParallelism directly when dropping support for Node.js < 19.4.0
+  if (`availableParallelism` in os)
+    // @ts-expect-error - No types yet
+    return os.availableParallelism();
+
+  return Math.max(1, os.cpus().length);
+}
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesForeachCommand extends BaseCommand {
@@ -200,7 +209,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     const concurrency = this.parallel ?
       (this.jobs === `unlimited`
         ? Infinity
-        : Number(this.jobs) || Math.max(1, cpus().length / 2))
+        : Number(this.jobs) || Math.ceil(availableParallelism() / 2))
       : 1;
 
     // No need to parallelize if we were explicitly asked for one job

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -1,24 +1,14 @@
 import {BaseCommand, WorkspaceRequiredError}                         from '@yarnpkg/cli';
 import {Configuration, LocatorHash, Project, scriptUtils, Workspace} from '@yarnpkg/core';
 import {DescriptorHash, MessageName, Report, StreamReport}           from '@yarnpkg/core';
-import {formatUtils, miscUtils, structUtils}                         from '@yarnpkg/core';
+import {formatUtils, miscUtils, structUtils, nodeUtils}              from '@yarnpkg/core';
 import {gitUtils}                                                    from '@yarnpkg/plugin-git';
 import {Command, Option, Usage, UsageError}                          from 'clipanion';
 import micromatch                                                    from 'micromatch';
-import os                                                            from 'os';
 import pLimit                                                        from 'p-limit';
 import {Writable}                                                    from 'stream';
 import {WriteStream}                                                 from 'tty';
 import * as t                                                        from 'typanion';
-
-function availableParallelism() {
-  // TODO: Use os.availableParallelism directly when dropping support for Node.js < 19.4.0
-  if (`availableParallelism` in os)
-    // @ts-expect-error - No types yet
-    return os.availableParallelism();
-
-  return Math.max(1, os.cpus().length);
-}
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesForeachCommand extends BaseCommand {
@@ -209,7 +199,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     const concurrency = this.parallel ?
       (this.jobs === `unlimited`
         ? Infinity
-        : Number(this.jobs) || Math.ceil(availableParallelism() / 2))
+        : Number(this.jobs) || Math.ceil(nodeUtils.availableParallelism() / 2))
       : 1;
 
     // No need to parallelize if we were explicitly asked for one job

--- a/packages/yarnpkg-core/sources/WorkerPool.ts
+++ b/packages/yarnpkg-core/sources/WorkerPool.ts
@@ -1,6 +1,7 @@
-import os       from 'os';
-import PLimit   from 'p-limit';
-import {Worker} from 'worker_threads';
+import PLimit         from 'p-limit';
+import {Worker}       from 'worker_threads';
+
+import * as nodeUtils from './nodeUtils';
 
 const kTaskInfo = Symbol(`kTaskInfo`);
 
@@ -8,18 +9,9 @@ type PoolWorker<TOut> = Worker & {
   [kTaskInfo]: null | { resolve: (value: TOut) => void, reject: (reason?: any) => void };
 };
 
-function availableParallelism(): number {
-  // TODO: Use os.availableParallelism directly when dropping support for Node.js < 19.4.0
-  if (`availableParallelism` in os)
-    // @ts-expect-error - No types yet
-    return os.availableParallelism();
-
-  return Math.max(1, os.cpus().length);
-}
-
 export class WorkerPool<TIn, TOut> {
   private workers: Array<PoolWorker<TOut>> = [];
-  private limit = PLimit(availableParallelism());
+  private limit = PLimit(nodeUtils.availableParallelism());
   private cleanupInterval: ReturnType<typeof setInterval>;
 
   constructor(private source: string) {

--- a/packages/yarnpkg-core/sources/nodeUtils.ts
+++ b/packages/yarnpkg-core/sources/nodeUtils.ts
@@ -1,5 +1,6 @@
 import {ppath}        from '@yarnpkg/fslib';
 import Module         from 'module';
+import os             from 'os';
 
 import * as execUtils from './execUtils';
 import * as miscUtils from './miscUtils';
@@ -135,4 +136,13 @@ export function getCaller() {
   const line = err.stack!.split(`\n`)[3];
 
   return parseStackLine(line);
+}
+
+export function availableParallelism() {
+  // TODO: Use os.availableParallelism directly when dropping support for Node.js < 19.4.0
+  if (`availableParallelism` in os)
+    // @ts-expect-error - No types yet
+    return os.availableParallelism();
+
+  return Math.max(1, os.cpus().length);
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node.js v19.4.0 comes with a [`os.availableParallelism`](https://nodejs.org/dist/latest-v19.x/docs/api/os.html#osavailableparallelism) function and to quote the docs:
> os.cpus().length should not be used to calculate the amount of parallelism available to an application. Use [os.availableParallelism()](https://nodejs.org/dist/latest-v19.x/docs/api/os.html#osavailableparallelism) for this purpose.
https://nodejs.org/dist/latest-v19.x/docs/api/os.html#oscpus

**How did you fix it?**

Use `os.availableParallelism` when available.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.