### PR TITLE
Add files listed by `package.json::directories.bin` to `Manifest.bin`

### DIFF
--- a/.yarn/versions/342c8e4a.yml
+++ b/.yarn/versions/342c8e4a.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/packages/yarnpkg-core/sources/Manifest.ts
+++ b/packages/yarnpkg-core/sources/Manifest.ts
@@ -155,11 +155,11 @@ export class Manifest {
       throw error;
     }
 
-    this.load(data);
+    this.load(data, {packageDir: {baseFs, dir: ppath.dirname(path)}});
     this.indent = getIndent(content);
   }
 
-  load(data: any, {yamlCompatibilityMode = false}: {yamlCompatibilityMode?: boolean} = {}) {
+  load(data: any, {yamlCompatibilityMode = false, packageDir = null}: {yamlCompatibilityMode?: boolean, packageDir?: null | {baseFs: FakeFS<PortablePath>, dir: PortablePath}} = {}) {
     if (typeof data !== `object` || data === null)
       throw new Error(`Utterly invalid manifest data (${data})`);
 
@@ -306,6 +306,12 @@ export class Manifest {
         // }
         const binaryIdent = structUtils.parseIdent(key);
         this.bin.set(binaryIdent.name, normalizeSlashes(value));
+      }
+    } else if (packageDir !== null && typeof data.directories?.bin === `string`) {
+      for (const file of packageDir.baseFs.readdirSync(ppath.join(packageDir.dir, data.directories.bin), {withFileTypes: true})) {
+        if (file.isFile()) {
+          this.bin.set(file.name, normalizeSlashes(ppath.join(data.directories.bin, file.name)));
+        }
       }
     }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
When running `yarn pack`, files listed by the [`directories.bin`](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#directoriesbin) field in package.json do not have the executable bits set on them. Yarn classic and npm both set these bits correctly.  
Closes #5155

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
I added a new optional key/value to the second parameter of the `Manifest.load` method that optionally takes in the directory of the `package.json` being loaded. `Manifest.loadFromFile` then passes in the `FakeFS` and `PortablePath` through this parameter, and the `Manifest.load` function then reads the files in the `package.json::directories.bin` if it exists and has a reference directory.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
