### PR TITLE
Detects when file:./foo.tgz files have changed

### DIFF
--- a/.yarn/versions/c6bf69b2.yml
+++ b/.yarn/versions/c6bf69b2.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-file": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -191,7 +191,7 @@ export const getPackageArchiveStream = async (name: string, version: string): Pr
   });
 };
 
-export const getPackageArchivePath = async (name: string, version: string): Promise<string> => {
+export const getPackageArchivePath = async (name: string, version: string): Promise<PortablePath> => {
   const packageEntry = await getPackageEntry(name);
   if (!packageEntry)
     throw new Error(`Unknown package "${name}"`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/file.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/file.test.ts
@@ -1,9 +1,13 @@
-import {xfs, PortablePath} from '@yarnpkg/fslib';
+import {xfs, PortablePath, ppath, Filename} from '@yarnpkg/fslib';
+
+const {
+  tests: {getPackageArchivePath},
+} = require(`pkg-tests-core`);
 
 describe(`Protocols`, () => {
   describe(`file:`, () => {
     test(
-      `it should update the cache`,
+      `it should update the cache when a file:./folder reference gets updated`,
       makeTemporaryEnv({
         dependencies: {
           [`pkg`]: `file:./folder`,
@@ -29,6 +33,34 @@ describe(`Protocols`, () => {
         await run(`install`);
 
         await expect(source(`require('pkg')`)).resolves.toEqual(100);
+      }),
+    );
+
+    test(
+      `it should update the cache when a file:./file.tgz reference gets updated`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`pkg`]: `file:./pkg.tgz`,
+        },
+      }, async ({path, run, source}) => {
+        const noDeps1 = await getPackageArchivePath(`no-deps`, `1.0.0`);
+        const noDeps2 = await getPackageArchivePath(`no-deps`, `2.0.0`);
+
+        const destination = ppath.join(path, `pkg.tgz` as Filename);
+
+        await xfs.copyPromise(destination, noDeps1);
+        await run(`install`);
+        await expect(source(`require('pkg/package.json')`)).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+
+        await xfs.copyPromise(destination, noDeps2);
+        await run(`install`);
+        await expect(source(`require('pkg/package.json')`)).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `2.0.0`,
+        });
       }),
     );
   });

--- a/packages/plugin-file/sources/FileResolver.ts
+++ b/packages/plugin-file/sources/FileResolver.ts
@@ -49,7 +49,6 @@ export class FileResolver implements Resolver {
       throw new Error(`Assertion failed: This resolver cannot be used unless a fetcher is configured`);
 
     const {path, parentLocator} = fileUtils.parseSpec(descriptor.range);
-
     if (parentLocator === null)
       throw new Error(`Assertion failed: The descriptor should have been bound`);
 
@@ -69,7 +68,7 @@ export class FileResolver implements Resolver {
 
     const folderHash = hashUtils.makeHash(`${CACHE_VERSION}`, archiveBuffer).slice(0, 6);
 
-    return [fileUtils.makeLocator(descriptor, {parentLocator, path, folderHash, protocol: PROTOCOL})];
+    return [fileUtils.makeLocator(descriptor, {parentLocator, path, hash: folderHash, protocol: PROTOCOL})];
   }
 
   async getSatisfying(descriptor: Descriptor, dependencies: Record<string, Package>, locators: Array<Locator>, opts: ResolveOptions) {

--- a/packages/plugin-file/sources/TarballFileFetcher.ts
+++ b/packages/plugin-file/sources/TarballFileFetcher.ts
@@ -1,10 +1,9 @@
-import {Fetcher, FetchOptions, FetchResult, MinimalFetchOptions} from '@yarnpkg/core';
-import {Locator}                                                 from '@yarnpkg/core';
-import {miscUtils, structUtils, tgzUtils}                        from '@yarnpkg/core';
-import {PortablePath, ppath, CwdFS}                              from '@yarnpkg/fslib';
+import {Fetcher, FetchOptions, MinimalFetchOptions} from '@yarnpkg/core';
+import {Locator}                                    from '@yarnpkg/core';
+import {structUtils, tgzUtils}                      from '@yarnpkg/core';
 
-import {TARBALL_REGEXP, PROTOCOL}                                from './constants';
-import * as fileUtils                                            from './fileUtils';
+import {TARBALL_REGEXP, PROTOCOL}                   from './constants';
+import * as fileUtils                               from './fileUtils';
 
 export class TarballFileFetcher implements Fetcher {
   supports(locator: Locator, opts: MinimalFetchOptions) {

--- a/packages/plugin-file/sources/TarballFileFetcher.ts
+++ b/packages/plugin-file/sources/TarballFileFetcher.ts
@@ -4,6 +4,7 @@ import {miscUtils, structUtils, tgzUtils}                        from '@yarnpkg/
 import {PortablePath, ppath, CwdFS}                              from '@yarnpkg/fslib';
 
 import {TARBALL_REGEXP, PROTOCOL}                                from './constants';
+import * as fileUtils                                            from './fileUtils';
 
 export class TarballFileFetcher implements Fetcher {
   supports(locator: Locator, opts: MinimalFetchOptions) {
@@ -39,34 +40,12 @@ export class TarballFileFetcher implements Fetcher {
   }
 
   async fetchFromDisk(locator: Locator, opts: FetchOptions) {
-    const {parentLocator, path} = structUtils.parseFileStyleRange(locator.reference, {protocol: PROTOCOL});
+    const sourceBuffer = await fileUtils.fetchArchiveFromLocator(locator, opts);
 
-    // If the file target is an absolute path we can directly access it via its
-    // location on the disk. Otherwise we must go through the package fs.
-    const parentFetch: FetchResult = ppath.isAbsolute(path)
-      ? {packageFs: new CwdFS(PortablePath.root), prefixPath: PortablePath.dot, localPath: PortablePath.root}
-      : await opts.fetcher.fetch(parentLocator, opts);
-
-    // If the package fs publicized its "original location" (for example like
-    // in the case of "file:" packages), we use it to derive the real location.
-    const effectiveParentFetch: FetchResult = parentFetch.localPath
-      ? {packageFs: new CwdFS(PortablePath.root), prefixPath: ppath.relative(PortablePath.root, parentFetch.localPath)}
-      : parentFetch;
-
-    // Discard the parent fs unless we really need it to access the files
-    if (parentFetch !== effectiveParentFetch && parentFetch.releaseFs)
-      parentFetch.releaseFs();
-
-    const sourceFs = effectiveParentFetch.packageFs;
-    const sourcePath = ppath.join(effectiveParentFetch.prefixPath, path);
-    const sourceBuffer = await sourceFs.readFilePromise(sourcePath);
-
-    return await miscUtils.releaseAfterUseAsync(async () => {
-      return await tgzUtils.convertToZip(sourceBuffer, {
-        compressionLevel: opts.project.configuration.get(`compressionLevel`),
-        prefixPath: structUtils.getIdentVendorPath(locator),
-        stripComponents: 1,
-      });
-    }, effectiveParentFetch.releaseFs);
+    return await tgzUtils.convertToZip(sourceBuffer, {
+      compressionLevel: opts.project.configuration.get(`compressionLevel`),
+      prefixPath: structUtils.getIdentVendorPath(locator),
+      stripComponents: 1,
+    });
   }
 }

--- a/packages/plugin-file/sources/TarballFileResolver.ts
+++ b/packages/plugin-file/sources/TarballFileResolver.ts
@@ -2,7 +2,6 @@ import {Resolver, ResolveOptions, MinimalResolveOptions, Package, hashUtils} fro
 import {Descriptor, Locator, Manifest}                                       from '@yarnpkg/core';
 import {LinkType}                                                            from '@yarnpkg/core';
 import {miscUtils, structUtils}                                              from '@yarnpkg/core';
-import {npath}                                                               from '@yarnpkg/fslib';
 
 import {FILE_REGEXP, TARBALL_REGEXP, PROTOCOL}                               from './constants';
 import * as fileUtils                                                        from './fileUtils';


### PR DESCRIPTION
**What's the problem this PR addresses?**

While `file:./folder` references are properly updated when their content changes, the same doesn't happen for `file:./file.tgz` references.

Fixes #5186

**How did you fix it?**

The resolver will now check the tgz file hash, so that changing its content should lead to the cache entry being refetched.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
