### PR TITLE
Implements automated constraints checks

### DIFF
--- a/.yarn/versions/54ba2009.yml
+++ b/.yarn/versions/54ba2009.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-constraints": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
@@ -76,8 +76,10 @@ exports[`Commands constraints test (empty project / gen_enforced_dependency (inc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -86,8 +88,10 @@ exports[`Commands constraints test (empty project / gen_enforced_dependency (inc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -96,8 +100,10 @@ exports[`Commands constraints test (empty project / gen_enforced_dependency (mis
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -106,8 +112,10 @@ exports[`Commands constraints test (empty project / gen_enforced_dependency (mis
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -156,8 +164,10 @@ exports[`Commands constraints test (empty project / gen_enforced_field (incompat
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -166,8 +176,10 @@ exports[`Commands constraints test (empty project / gen_enforced_field (incompat
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -176,8 +188,10 @@ exports[`Commands constraints test (empty project / gen_enforced_field (missing)
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -186,8 +200,10 @@ exports[`Commands constraints test (empty project / gen_enforced_field (missing)
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -304,11 +320,13 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ workspace-a@workspace:packages/workspace-a
-│  └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ workspace-a@workspace:packages/workspace-a
+│  └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+   └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -317,13 +335,15 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ workspace-a@workspace:packages/workspace-a
-│  ├─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
-│  └─ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ workspace-a@workspace:packages/workspace-a
+│  ├─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+│  └─ ⚙ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   ├─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
-   └─ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
+   ├─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+   └─ ⚙ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -378,14 +398,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+│  └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -394,14 +416,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+│  └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -410,14 +434,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+│  └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -426,14 +452,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+│  └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -486,11 +514,13 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (ex
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ workspace-a@workspace:packages/workspace-a
-│  └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ workspace-a@workspace:packages/workspace-a
+│  └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 ",
 }
 `;
@@ -499,11 +529,13 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (ex
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ workspace-a@workspace:packages/workspace-a
-│  └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ workspace-a@workspace:packages/workspace-a
+│  └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 ",
 }
 `;
@@ -512,14 +544,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (in
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+│  └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -528,14 +562,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (in
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+│  └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -544,14 +580,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (mi
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+│  └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -560,14 +598,16 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (mi
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ root-workspace-0b6124@workspace:.
-│  └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ root-workspace-0b6124@workspace:.
+│  └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 │
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+│  └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -608,11 +648,13 @@ exports[`Commands constraints test (multiple workspaces / workspace_field w/ str
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ workspace-a@workspace:packages/workspace-a
-│  └─ Missing field _name; expected 'workspace-a'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ workspace-a@workspace:packages/workspace-a
+│  └─ ⚙ Missing field _name; expected 'workspace-a'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Missing field _name; expected 'workspace-b'
+   └─ ⚙ Missing field _name; expected 'workspace-b'
 ",
 }
 `;
@@ -621,11 +663,13 @@ exports[`Commands constraints test (multiple workspaces / workspace_field w/ str
 {
   "code": 1,
   "stderr": "",
-  "stdout": "├─ workspace-a@workspace:packages/workspace-a
-│  └─ Missing field _name; expected 'workspace-a'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+├─ workspace-a@workspace:packages/workspace-a
+│  └─ ⚙ Missing field _name; expected 'workspace-a'
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ Missing field _name; expected 'workspace-b'
+   └─ ⚙ Missing field _name; expected 'workspace-b'
 ",
 }
 `;
@@ -674,8 +718,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -684,8 +730,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -714,8 +762,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -724,8 +774,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -734,8 +786,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -744,8 +798,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -778,8 +834,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0' }
 ",
 }
 `;
@@ -788,8 +846,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0' }
 ",
 }
 `;
@@ -798,8 +858,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -808,8 +870,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -818,8 +882,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -828,8 +894,10 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -934,8 +1002,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -964,8 +1034,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -974,8 +1046,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -984,8 +1058,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -994,8 +1070,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1044,8 +1122,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -1054,8 +1134,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -1064,8 +1146,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -1074,8 +1158,10 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1172,8 +1258,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -1182,8 +1270,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -1212,8 +1302,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1222,8 +1314,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1232,8 +1326,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1242,8 +1338,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1276,8 +1374,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 ",
 }
 `;
@@ -1286,8 +1386,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 ",
 }
 `;
@@ -1296,8 +1398,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1306,8 +1410,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1316,8 +1422,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -1326,8 +1434,10 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1424,8 +1534,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -1434,9 +1546,11 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   ├─ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
-   └─ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   ├─ ⚙ Extraneous field dependencies["no-deps"] currently set to '1.0.0'
+   └─ ⚙ Extraneous field devDependencies["no-deps"] currently set to '1.0.0'
 ",
 }
 `;
@@ -1468,8 +1582,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1478,8 +1594,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1488,8 +1606,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1498,8 +1618,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1532,8 +1654,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 ",
 }
 `;
@@ -1542,8 +1666,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
 ",
 }
 `;
@@ -1552,8 +1678,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1562,8 +1690,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Invalid field dependencies["no-deps"]; expected '2.0.0', found '1.0.0'
 ",
 }
 `;
@@ -1572,8 +1702,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -1582,8 +1714,10 @@ exports[`Commands constraints test (two regular dependencies, two development de
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ root-workspace-0b6124@workspace:.
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ root-workspace-0b6124@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1712,8 +1846,10 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -1722,8 +1858,10 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -1732,8 +1870,10 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1742,8 +1882,10 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field peerDependencies["one-fixed-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1792,8 +1934,10 @@ exports[`Commands constraints test (various field types / gen_enforced_field (in
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -1802,8 +1946,10 @@ exports[`Commands constraints test (various field types / gen_enforced_field (in
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field dependencies["no-deps"]; expected '2.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field dependencies["no-deps"]; expected '2.0.0'
 ",
 }
 `;
@@ -1812,8 +1958,10 @@ exports[`Commands constraints test (various field types / gen_enforced_field (mi
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field dependencies["a-new-deps"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-deps"]; expected '1.0.0'
 ",
 }
 `;
@@ -1822,8 +1970,10 @@ exports[`Commands constraints test (various field types / gen_enforced_field (mi
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field dependencies["a-new-dep"]; expected '1.0.0'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field dependencies["a-new-dep"]; expected '1.0.0'
 ",
 }
 `;
@@ -1832,8 +1982,10 @@ exports[`Commands constraints test (various field types / workspace_field w/ arr
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field _files; expected [ '/a', '/b', '/c' ]
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field _files; expected [ '/a', '/b', '/c' ]
 ",
 }
 `;
@@ -1842,8 +1994,10 @@ exports[`Commands constraints test (various field types / workspace_field w/ arr
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field _files; expected [ '/a', '/b', '/c' ]
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field _files; expected [ '/a', '/b', '/c' ]
 ",
 }
 `;
@@ -1852,8 +2006,10 @@ exports[`Commands constraints test (various field types / workspace_field w/ obj
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field _repository; expected { type: 'git', url: 'ssh://git@github.com/yarnpkg/berry.git', directory: '.' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field _repository; expected { type: 'git', url: 'ssh://git@github.com/yarnpkg/berry.git', directory: '.' }
 ",
 }
 `;
@@ -1862,8 +2018,10 @@ exports[`Commands constraints test (various field types / workspace_field w/ obj
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field _repository; expected { type: 'git', url: 'ssh://git@github.com/yarnpkg/berry.git', directory: '.' }
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field _repository; expected { type: 'git', url: 'ssh://git@github.com/yarnpkg/berry.git', directory: '.' }
 ",
 }
 `;
@@ -1872,8 +2030,10 @@ exports[`Commands constraints test (various field types / workspace_field w/ str
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field _name; expected 'foo'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field _name; expected 'foo'
 ",
 }
 `;
@@ -1882,8 +2042,10 @@ exports[`Commands constraints test (various field types / workspace_field w/ str
 {
   "code": 1,
   "stderr": "",
-  "stdout": "└─ foo@workspace:.
-   └─ Missing field _name; expected 'foo'
+  "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
+
+└─ foo@workspace:.
+   └─ ⚙ Missing field _name; expected 'foo'
 ",
 }
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/constraintsChecks.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/constraintsChecks.test.ts
@@ -1,0 +1,22 @@
+import {Filename, ppath, xfs} from '@yarnpkg/fslib';
+
+describe(`Features`, () => {
+  describe(`Constraints Checks`, () => {
+    test(
+      `should detect constraints errors on install when enableConstraintsChecks is set to true`,
+      makeTemporaryEnv({}, {
+        enableConstraintsChecks: true,
+      }, async ({path, run}) => {
+        await xfs.writeFilePromise(ppath.join(path, `yarn.config.js` as Filename), [
+          `exports.constraints = ({ Yarn }) => {\n`,
+          `  for (const workspace of Yarn.workspaces()) {\n`,
+          `    workspace.set('foo', 'bar')\n`,
+          `  }\n`,
+          `};\n`,
+        ].join(``));
+
+        await expect(run(`install`)).rejects.toThrow(/Constraint check failed; run yarn constraints for more details/);
+      }),
+    );
+  });
+});

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -1,38 +1,10 @@
-import {BaseCommand}                                                       from '@yarnpkg/cli';
-import {Configuration, Project, Manifest, treeUtils, miscUtils, nodeUtils} from '@yarnpkg/core';
-import {formatUtils}                                                       from '@yarnpkg/core';
-import {Command, Option, Usage}                                            from 'clipanion';
-import get                                                                 from 'lodash/get';
-import set                                                                 from 'lodash/set';
-import unset                                                               from 'lodash/unset';
+import {BaseCommand}                                                                       from '@yarnpkg/cli';
+import {Configuration, Project, Manifest, treeUtils, miscUtils, StreamReport, MessageName} from '@yarnpkg/core';
+import {formatUtils}                                                                       from '@yarnpkg/core';
+import {Command, Option, Usage}                                                            from 'clipanion';
 
-import {ModernEngine}                                                      from '../ModernEngine';
-import * as constraintUtils                                                from '../constraintUtils';
-
-function formatStackLine(configuration: Configuration, caller: nodeUtils.Caller) {
-  // TODO: Should this be in formatUtils? Might not be super useful as a core feature...
-  const parts: Array<string> = [];
-
-  if (caller.methodName !== null)
-    parts.push(formatUtils.pretty(configuration, caller.methodName, formatUtils.Type.CODE));
-
-  if (caller.file !== null) {
-    const fileParts: Array<string> = [];
-    fileParts.push(formatUtils.pretty(configuration, caller.file, formatUtils.Type.PATH));
-
-    if (caller.line !== null) {
-      fileParts.push(formatUtils.pretty(configuration, caller.line, formatUtils.Type.NUMBER));
-
-      if (caller.column !== null) {
-        fileParts.push(formatUtils.pretty(configuration, caller.line, formatUtils.Type.NUMBER));
-      }
-    }
-
-    parts.push(`(${fileParts.join(formatUtils.pretty(configuration, `:`, `grey`))})`);
-  }
-
-  return parts.join(` `);
-}
+import {ModernEngine}                                                                      from '../ModernEngine';
+import * as constraintUtils                                                                from '../constraintUtils';
 
 // eslint-disable-next-line arca/no-default-export
 export default class ConstraintsCheckCommand extends BaseCommand {
@@ -81,117 +53,99 @@ export default class ConstraintsCheckCommand extends BaseCommand {
       engine = await Constraints.find(project);
     }
 
-    let root!: treeUtils.TreeRoot;
-    let hasErrors = false;
+    const root: treeUtils.TreeRoot = {children: []};
 
-    for (let t = 0, T = this.fix ? 10 : 1; t < T; ++t) {
-      root = {children: []};
+    let hasFixableErrors = false;
+    let allFixableErrors = false;
 
+    for (let t = this.fix ? 10 : 1; t > 0; --t) {
       const result = await engine.process();
       if (!result)
         break;
 
+      const {
+        changedWorkspaces,
+        remainingErrors,
+      } = constraintUtils.applyEngineReport(project, result, {
+        fix: this.fix,
+      });
+
       const updates: Array<Promise<void>> = [];
-      for (const [workspaceCwd, workspaceUpdates] of result.manifestUpdates) {
-        const workspaceErrors = result.reportedErrors.get(workspaceCwd) ?? [];
+      for (const [workspace, manifest] of changedWorkspaces) {
+        const indent = workspace.manifest.indent;
 
-        const workspace = project.getWorkspaceByCwd(workspaceCwd);
-        const manifest = workspace.manifest.exportTo({});
+        workspace.manifest = new Manifest();
+        workspace.manifest.indent = indent;
+        workspace.manifest.load(manifest);
 
-        let changedWorkspace = false;
-        for (const [fieldPath, newValues] of workspaceUpdates) {
-          if (newValues.size > 1) {
-            const conflictingValuesMessage = [...newValues].map(([value, sources]) => {
-              const prettyValue = formatUtils.pretty(configuration, value, formatUtils.Type.INSPECT);
+        updates.push(workspace.persistManifest());
+      }
 
-              const stackLine = sources.size > 0
-                ? formatStackLine(configuration, sources.values().next().value)
-                : null;
+      if (changedWorkspaces.size > 0 && t > 1)
+        continue;
 
-              return stackLine !== null
-                ? `\n${prettyValue} at ${stackLine}`
-                : `\n${prettyValue}`;
-            }).join(``);
+      hasFixableErrors = false;
+      allFixableErrors = true;
 
-            workspaceErrors.push(`Conflict detected in constraint targeting ${formatUtils.pretty(configuration, fieldPath, formatUtils.Type.CODE)}; conflicting values are:${conflictingValuesMessage}`);
+      for (const [workspace, workspaceErrors] of remainingErrors) {
+        const errorNodes: Array<treeUtils.TreeNode> = [];
+        for (const error of workspaceErrors) {
+          const lines = error.text.split(/\n/);
+
+          if (error.fixable) {
+            lines[0] = `${formatUtils.pretty(configuration, `⚙`, `gray`)} ${lines[0]}`;
+            hasFixableErrors = true;
           } else {
-            const [[newValue]] = newValues;
-
-            const currentValue = get(manifest, fieldPath);
-            if (currentValue === newValue)
-              continue;
-
-            if (!this.fix) {
-              const errorMessage = typeof currentValue === `undefined`
-                ? `Missing field ${formatUtils.pretty(configuration, fieldPath, formatUtils.Type.CODE)}; expected ${formatUtils.pretty(configuration, newValue, formatUtils.Type.INSPECT)}`
-                : typeof newValue === `undefined`
-                  ? `Extraneous field ${formatUtils.pretty(configuration, fieldPath, formatUtils.Type.CODE)} currently set to ${formatUtils.pretty(configuration, currentValue, formatUtils.Type.INSPECT)}`
-                  : `Invalid field ${formatUtils.pretty(configuration, fieldPath, formatUtils.Type.CODE)}; expected ${formatUtils.pretty(configuration, newValue, formatUtils.Type.INSPECT)}, found ${formatUtils.pretty(configuration, currentValue, formatUtils.Type.INSPECT)}`;
-
-              workspaceErrors.push(errorMessage);
-              continue;
-            }
-
-            if (typeof newValue === `undefined`)
-              unset(manifest, fieldPath);
-            else
-              set(manifest, fieldPath, newValue);
-
-            changedWorkspace = true;
-          }
-        }
-
-        if (changedWorkspace) {
-          const indent = workspace.manifest.indent;
-
-          workspace.manifest = new Manifest();
-          workspace.manifest.indent = indent;
-          workspace.manifest.load(manifest);
-
-          updates.push(workspace.persistManifest());
-        }
-
-        if (workspaceErrors.length > 0) {
-          const errorNodes: Array<treeUtils.TreeNode> = [];
-          for (const error of workspaceErrors) {
-            const lines = error.split(/\n/);
-
-            errorNodes.push({
-              value: formatUtils.tuple(formatUtils.Type.NO_HINT, lines[0]),
-              children: lines.slice(1).map(line => ({
-                value: formatUtils.tuple(formatUtils.Type.NO_HINT, line),
-              })),
-            });
+            allFixableErrors = false;
           }
 
-          const workspaceNode: treeUtils.TreeNode = {
-            value: formatUtils.tuple(formatUtils.Type.LOCATOR, workspace.anchoredLocator),
-            children: miscUtils.sortMap(errorNodes, node => node.value![1]),
-          };
-
-          root.children.push(workspaceNode);
-          hasErrors = true;
+          errorNodes.push({
+            value: formatUtils.tuple(formatUtils.Type.NO_HINT, lines[0]),
+            children: lines.slice(1).map(line => ({
+              value: formatUtils.tuple(formatUtils.Type.NO_HINT, line),
+            })),
+          });
         }
-      }
 
-      if (updates.length === 0) {
-        break;
+        const workspaceNode: treeUtils.TreeNode = {
+          value: formatUtils.tuple(formatUtils.Type.LOCATOR, workspace.anchoredLocator),
+          children: miscUtils.sortMap(errorNodes, node => node.value![1]),
+        };
+
+        root.children.push(workspaceNode);
       }
+    }
+
+    if (root.children.length === 0)
+      return 0;
+
+    if (hasFixableErrors) {
+      const message = allFixableErrors
+        ? `Those errors can all be fixed by running ${formatUtils.pretty(configuration, `yarn constraints --fix`, formatUtils.Type.CODE)}`
+        : `Errors prefixed by '⚙' can be fixed by running ${formatUtils.pretty(configuration, `yarn constraints --fix`, formatUtils.Type.CODE)}`;
+
+      await StreamReport.start({
+        configuration,
+        stdout: this.context.stdout,
+        includeNames: false,
+        includeFooter: false,
+      }, async report => {
+        report.reportInfo(MessageName.UNNAMED, message);
+        report.reportSeparator();
+      });
     }
 
     root.children = miscUtils.sortMap(root.children, node => {
       return node.value![1];
     });
 
-    if (hasErrors) {
-      treeUtils.emitTree(root, {
-        configuration,
-        stdout: this.context.stdout,
-        json: this.json,
-        separators: 1,
-      });
-    }
+    treeUtils.emitTree(root, {
+      configuration,
+      stdout: this.context.stdout,
+      json: this.json,
+      separators: 1,
+    });
 
-    return hasErrors ? 1 : 0;
+    return 1;
   }
 }

--- a/packages/plugin-constraints/sources/constraintUtils.ts
+++ b/packages/plugin-constraints/sources/constraintUtils.ts
@@ -1,6 +1,9 @@
-import {Manifest, miscUtils, nodeUtils} from '@yarnpkg/core';
-import {PortablePath}                   from '@yarnpkg/fslib';
-import toPath                           from 'lodash/toPath';
+import {Configuration, formatUtils, Manifest, miscUtils, nodeUtils, Project, Workspace} from '@yarnpkg/core';
+import {PortablePath}                                                                   from '@yarnpkg/fslib';
+import get                                                                              from 'lodash/get';
+import set                                                                              from 'lodash/set';
+import toPath                                                                           from 'lodash/toPath';
+import unset                                                                            from 'lodash/unset';
 
 export type ProcessResult = {
   manifestUpdates: Map<PortablePath, Map<string, Map<any, Set<nodeUtils.Caller>>>>;
@@ -135,4 +138,102 @@ export function normalizePath(p: Array<string> | string) {
   });
 
   return normalizedParts.join(``).replace(/^\./, ``);
+}
+
+function formatStackLine(configuration: Configuration, caller: nodeUtils.Caller) {
+  // TODO: Should this be in formatUtils? Might not be super useful as a core feature...
+  const parts: Array<string> = [];
+
+  if (caller.methodName !== null)
+    parts.push(formatUtils.pretty(configuration, caller.methodName, formatUtils.Type.CODE));
+
+  if (caller.file !== null) {
+    const fileParts: Array<string> = [];
+    fileParts.push(formatUtils.pretty(configuration, caller.file, formatUtils.Type.PATH));
+
+    if (caller.line !== null) {
+      fileParts.push(formatUtils.pretty(configuration, caller.line, formatUtils.Type.NUMBER));
+
+      if (caller.column !== null) {
+        fileParts.push(formatUtils.pretty(configuration, caller.line, formatUtils.Type.NUMBER));
+      }
+    }
+
+    parts.push(`(${fileParts.join(formatUtils.pretty(configuration, `:`, `grey`))})`);
+  }
+
+  return parts.join(` `);
+}
+
+export function applyEngineReport(project: Project, {manifestUpdates, reportedErrors}: ProcessResult, {fix}: {fix?: boolean} = {}) {
+  type AnnotatedError = {
+    text: string;
+    fixable: boolean;
+  };
+
+  const changedWorkspaces = new Map<Workspace, Record<string, any>>();
+  const remainingErrors = new Map<Workspace, Array<AnnotatedError>>();
+
+  for (const [workspaceCwd, workspaceUpdates] of manifestUpdates) {
+    const workspaceErrors = reportedErrors.get(workspaceCwd)?.map(text => ({text, fixable: false})) ?? [];
+    let changedWorkspace = false;
+
+    const workspace = project.getWorkspaceByCwd(workspaceCwd);
+    const manifest = workspace.manifest.exportTo({});
+
+    for (const [fieldPath, newValues] of workspaceUpdates) {
+      if (newValues.size > 1) {
+        const conflictingValuesMessage = [...newValues].map(([value, sources]) => {
+          const prettyValue = formatUtils.pretty(project.configuration, value, formatUtils.Type.INSPECT);
+
+          const stackLine = sources.size > 0
+            ? formatStackLine(project.configuration, sources.values().next().value)
+            : null;
+
+          return stackLine !== null
+            ? `\n${prettyValue} at ${stackLine}`
+            : `\n${prettyValue}`;
+        }).join(``);
+
+        workspaceErrors.push({text: `Conflict detected in constraint targeting ${formatUtils.pretty(project.configuration, fieldPath, formatUtils.Type.CODE)}; conflicting values are:${conflictingValuesMessage}`, fixable: false});
+      } else {
+        const [[newValue]] = newValues;
+
+        const currentValue = get(manifest, fieldPath);
+        if (currentValue === newValue)
+          continue;
+
+        if (!fix) {
+          const errorMessage = typeof currentValue === `undefined`
+            ? `Missing field ${formatUtils.pretty(project.configuration, fieldPath, formatUtils.Type.CODE)}; expected ${formatUtils.pretty(project.configuration, newValue, formatUtils.Type.INSPECT)}`
+            : typeof newValue === `undefined`
+              ? `Extraneous field ${formatUtils.pretty(project.configuration, fieldPath, formatUtils.Type.CODE)} currently set to ${formatUtils.pretty(project.configuration, currentValue, formatUtils.Type.INSPECT)}`
+              : `Invalid field ${formatUtils.pretty(project.configuration, fieldPath, formatUtils.Type.CODE)}; expected ${formatUtils.pretty(project.configuration, newValue, formatUtils.Type.INSPECT)}, found ${formatUtils.pretty(project.configuration, currentValue, formatUtils.Type.INSPECT)}`;
+
+          workspaceErrors.push({text: errorMessage, fixable: true});
+          continue;
+        }
+
+        if (typeof newValue === `undefined`)
+          unset(manifest, fieldPath);
+        else
+          set(manifest, fieldPath, newValue);
+
+        changedWorkspace = true;
+      }
+
+      if (changedWorkspace) {
+        changedWorkspaces.set(workspace, manifest);
+      }
+    }
+
+    if (workspaceErrors.length > 0) {
+      remainingErrors.set(workspace, workspaceErrors);
+    }
+  }
+
+  return {
+    changedWorkspaces,
+    remainingErrors,
+  };
 }

--- a/packages/plugin-constraints/sources/index.ts
+++ b/packages/plugin-constraints/sources/index.ts
@@ -1,9 +1,11 @@
-import {Plugin, SettingsType}   from '@yarnpkg/core';
-import {PortablePath}           from '@yarnpkg/fslib';
+import {formatUtils, Hooks, MessageName, Plugin, SettingsType} from '@yarnpkg/core';
+import {PortablePath}                                          from '@yarnpkg/fslib';
 
-import ConstraintsQueryCommand  from './commands/constraints/query';
-import ConstraintsSourceCommand from './commands/constraints/source';
-import ConstraintsCheckCommand  from './commands/constraints';
+import {ModernEngine}                                          from './ModernEngine';
+import ConstraintsQueryCommand                                 from './commands/constraints/query';
+import ConstraintsSourceCommand                                from './commands/constraints/source';
+import ConstraintsCheckCommand                                 from './commands/constraints';
+import * as constraintUtils                                    from './constraintUtils';
 
 export {ConstraintsQueryCommand};
 export {ConstraintsSourceCommand};
@@ -12,11 +14,17 @@ export {ConstraintsCheckCommand};
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     constraintsPath: PortablePath;
+    enableConstraintsChecks: boolean;
   }
 }
 
-const plugin: Plugin = {
+const plugin: Plugin<Hooks> = {
   configuration: {
+    enableConstraintsChecks: {
+      description: `If true, constraints will run during installs`,
+      type: SettingsType.BOOLEAN,
+      default: false,
+    },
     constraintsPath: {
       description: `The path of the constraints file.`,
       type: SettingsType.ABSOLUTE_PATH,
@@ -28,6 +36,31 @@ const plugin: Plugin = {
     ConstraintsSourceCommand,
     ConstraintsCheckCommand,
   ],
+  hooks: {
+    async validateProject(project, {reportError}) {
+      if (!project.configuration.get(`enableConstraintsChecks`))
+        return;
+
+      const userConfig = await project.loadUserConfig();
+
+      let engine: constraintUtils.Engine;
+      if (userConfig?.constraints) {
+        engine = new ModernEngine(project);
+      } else {
+        const {Constraints} = await import(`./Constraints`);
+        engine = await Constraints.find(project);
+      }
+
+      const result = await engine.process();
+      if (!result)
+        return;
+
+      const {remainingErrors} = constraintUtils.applyEngineReport(project, result);
+      if (remainingErrors.size !== 0) {
+        reportError(MessageName.CONSTRAINTS_CHECK_FAILED, `Constraint check failed; run ${formatUtils.pretty(project.configuration, `yarn constraints`, formatUtils.Type.CODE)} for more details`);
+      }
+    },
+  },
 };
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -95,6 +95,7 @@ export enum MessageName {
   NETWORK_UNSAFE_HTTP = 81,
   RESOLUTION_FAILED = 82,
   AUTOMERGE_GIT_ERROR = 83,
+  CONSTRAINTS_CHECK_FAILED = 84,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1513,16 +1513,25 @@ export class Project {
     const nodeLinker = this.configuration.get(`nodeLinker`);
     Configuration.telemetry?.reportInstall(nodeLinker);
 
+    let hasErrors = false;
     await opts.report.startTimerPromise(`Project validation`, {
       skipIfEmpty: true,
     }, async () => {
       await this.configuration.triggerHook(hooks => {
         return hooks.validateProject;
       }, this, {
-        reportWarning: opts.report.reportWarning.bind(opts.report),
-        reportError: opts.report.reportError.bind(opts.report),
+        reportWarning: (name, text) => {
+          opts.report.reportWarning(name, text);
+        },
+        reportError: (name, text) => {
+          opts.report.reportError(name, text);
+          hasErrors = true;
+        },
       });
     });
+
+    if (hasErrors)
+      return;
 
     for (const extensionsByIdent of this.configuration.packageExtensions.values())
       for (const [, extensionsByRange] of extensionsByIdent)

--- a/packages/yarnpkg-core/sources/StreamReport.ts
+++ b/packages/yarnpkg-core/sources/StreamReport.ts
@@ -17,6 +17,7 @@ export type StreamReportOptions = {
   includeFooter?: boolean;
   includeInfos?: boolean;
   includeLogs?: boolean;
+  includeNames?: boolean;
   includeWarnings?: boolean;
   includePrefix?: boolean;
   json?: boolean;
@@ -143,6 +144,7 @@ export class StreamReport extends Report {
   }
 
   private configuration: Configuration;
+  private includeNames: boolean;
   private includePrefix: boolean;
   private includeFooter: boolean;
   private includeInfos: boolean;
@@ -186,6 +188,7 @@ export class StreamReport extends Report {
     configuration,
     stdout,
     json = false,
+    includeNames = true,
     includePrefix = true,
     includeFooter = true,
     includeLogs = !json,
@@ -201,6 +204,7 @@ export class StreamReport extends Report {
     this.configuration = configuration;
     this.forgettableBufferSize = forgettableBufferSize;
     this.forgettableNames = new Set([...forgettableNames, ...BASE_FORGETTABLE_NAMES]);
+    this.includeNames = includeNames;
     this.includePrefix = includePrefix;
     this.includeFooter = includeFooter;
     this.includeInfos = includeInfos;
@@ -681,6 +685,9 @@ export class StreamReport extends Report {
   }
 
   private formatName(name: MessageName | null) {
+    if (!this.includeNames)
+      return ``;
+
     return formatName(name, {
       configuration: this.configuration,
       json: this.json,
@@ -692,6 +699,9 @@ export class StreamReport extends Report {
   }
 
   private formatNameWithHyperlink(name: MessageName | null) {
+    if (!this.includeNames)
+      return ``;
+
     return formatNameWithHyperlink(name, {
       configuration: this.configuration,
       json: this.json,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Running constraints must currently be a conscious thing, or run on CI. I think some users have the expectation that Yarn should just report the errors during install, as it's the main interface they'll use.

**How did you fix it?**

This PR adds a new setting, `enableConstraintsChecks`. When enabled, constraints will be checked during each install, as part of the project validation.

*note:* Prolog constraints are slower than the (new) JS ones; it's suggested to upgrade to JS constraints when using this setting.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
