### PR TITLE
Don't print `[Object object]` as a yarnrc.yml error

### DIFF
--- a/.yarn/versions/702a541c.yml
+++ b/.yarn/versions/702a541c.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -720,7 +720,7 @@ function parseSingleValue(configuration: Configuration, path: string, valueBase:
       return miscUtils.parseBoolean(value);
 
     if (typeof value !== `string`)
-      throw new Error(`Expected value (${value}) to be a string`);
+      throw new Error(`Expected configuration setting "${path}" to be a string, got ${typeof value}`);
 
     const valueWithReplacedVariables = miscUtils.replaceEnvVariables(value, {
       env: process.env,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Incorrect indentation in a `.yarnrc.yml` causes every yarn command to fail with:
```
❯ yarn config -v
Internal Error: Expected value ([object Object]) to be a string in /home/you/some_repo/.yarnrc.yml (in /home/you/some_repo/.yarnrc.yml)
    at /home/you/some_repo/.yarn/releases/yarn-3.3.0.cjs:391:17330
    at jk (/home/you/some_repo/.yarn/releases/yarn-3.3.0.cjs:391:17626)
    at Vk (/home/you/some_repo/.yarn/releases/yarn-3.3.0.cjs:391:16917)
    at dPe (/home/you/some_repo/.yarn/releases/yarn-3.3.0.cjs:391:18512)
```

This is described in #5212. I actually used this exact issue as docs :)

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Please see screenshots in #5212

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
