### PR TITLE
fixed #5156 - <package> isn't supported by any available resolver

### DIFF
--- a/.yarn/versions/cca73614.yml
+++ b/.yarn/versions/cca73614.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
+++ b/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
@@ -19,7 +19,7 @@ export const IMPORTED_PATTERNS: Array<[RegExp, (version: string, ...args: Array<
 
   // These ones come from the npm registry
   // Note: /download/ is used by custom registries like Taobao
-  [/^https?:\/\/[^/]+\/(?:[^/]+\/)*(?:@.+(?:\/|(?:%2f)))?([^/]+)\/(?:-|download)\/\1-[^/]+\.tgz(?:#|$)/, version => `npm:${version}`],
+  [/^https?:\/\/[^/]+\/(?:[^/]+\/)*(@.+(?:\/|(?:%2f)))?([^/]+)\/(?:-|download)\/(\1\2|\2)-[^/]+\.tgz(?:#|$)/, version => `npm:${version}`],
   // The GitHub package registry uses a different style of URLs
   [/^https:\/\/npm\.pkg\.github\.com\/download\/(?:@[^/]+)\/(?:[^/]+)\/(?:[^/]+)\/(?:[0-9a-f]+)(?:#|$)/, version => `npm:${version}`],
   // FontAwesome too; what is it with these registries that made them think using a different url pattern was a good idea?

--- a/packages/yarnpkg-core/tests/LegacyMigrationResolver.test.ts
+++ b/packages/yarnpkg-core/tests/LegacyMigrationResolver.test.ts
@@ -18,13 +18,13 @@ describe(`LegacyMigrationResolver`, () => {
     {
       version: `1.0.0`,
       resolved: `https://company.jfrog.io/company/api/npm/registry-name/@scope/package-name/-/@scope/package-name-1.0.0.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34`,
-      expected: `npm:1.0.0::__archiveUrl=https%3A%2F%2Fcompany.jfrog.io%2Fcompany%2Fapi%2Fnpm%2Fregistry-name%2F%40scope%2Fpackage-name%2F-%2F%40scope%2Fpackage-name-1.0.0.tgz%23`,
+      expected: `npm:1.0.0`,
     },
     // https://github.com/yarnpkg/berry/pull/4702
     {
       version: `1.0.0`,
       resolved: `https://packages.example.com/artifactory/api/npm/registry-name/@scope/package-name/-/@scope/package-name-1.0.0.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34`,
-      expected: `npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.example.com%2Fartifactory%2Fapi%2Fnpm%2Fregistry-name%2F%40scope%2Fpackage-name%2F-%2F%40scope%2Fpackage-name-1.0.0.tgz%23`,
+      expected: `npm:1.0.0`,
     },
     // https://github.com/yarnpkg/berry/issues/902#issuecomment-732360991
     {


### PR DESCRIPTION
**What's the problem this PR addresses?**
When migrating from yarn@1 to yarn@3 some of scoped packages hosted in private repository weren't migrated properly.

Fixes #5156

...

**How did you fix it?**
This PR removes `__archiveUrl` for them which solves problem.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
