### PR TITLE
feat(sdks): add `@astrojs/language-server` to vscode sdks

### DIFF
--- a/.yarn/versions/2bf50a76.yml
+++ b/.yarn/versions/2bf50a76.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/docusaurus/docs/getting-started/editor-sdks.md
+++ b/packages/docusaurus/docs/getting-started/editor-sdks.md
@@ -29,6 +29,7 @@ import TOCInline from '@theme/TOCInline';
 | [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
 | [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
 | [flow-for-vscode*](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode) | [flow-bin](https://flow.org/) |
+| [astro-vscode](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) | [astro](https://astro.build/) |
 
 > \* Flow is currently [incompatible with PnP](/features/pnp#incompatible).
 

--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -29,6 +29,7 @@ Generally speaking:
 | [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) | [eslint](https://yarnpkg.com/package/eslint) |
 | [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
 | [flow-for-vscode*](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode) | [flow-bin](https://flow.org/) |
+| [astro-vscode](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) | [astro](https://astro.build/) |
 
 > \* Flow is currently [incompatible with PnP](/features/pnp#incompatible).
 

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -175,6 +175,7 @@ export type GenerateIntegrationWrapper = (pnpApi: PnpApi, target: PortablePath, 
 export type GenerateDefaultWrapper = (pnpApi: PnpApi, target: PortablePath) => Promise<void>;
 
 export type SupportedSdk =
+  | '@astrojs/language-server'
   | 'eslint'
   | 'prettier'
   | 'typescript-language-server'

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -3,6 +3,16 @@ import {PnpApi}                                 from '@yarnpkg/pnp';
 
 import {Wrapper, GenerateBaseWrapper, BaseSdks} from '../generateSdk';
 
+export const generateAstroLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`@astrojs/language-server` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`bin/nodeServer.js` as PortablePath);
+
+  return wrapper;
+};
+
 export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
@@ -276,6 +286,7 @@ export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: Pn
 };
 
 export const BASE_SDKS: BaseSdks = [
+  [`@astrojs/language-server`, generateAstroLanguageServerBaseWrapper],
   [`eslint`, generateEslintBaseWrapper],
   [`prettier`, generatePrettierBaseWrapper],
   [`typescript-language-server`, generateTypescriptLanguageServerBaseWrapper],

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -29,6 +29,22 @@ export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: Pnp
   });
 };
 
+export const generateAstroLanguageServerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
+    [`astro.language-server.ls-path`]: npath.fromPortablePath(
+      wrapper.getProjectPathTo(
+        `bin/nodeServer.js` as PortablePath,
+      ),
+    ),
+  });
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
+    [`recommendations`]: [
+      `astro-build.astro-vscode`,
+    ],
+  });
+};
+
 export const generateEslintWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`eslint.nodePath`]: npath.fromPortablePath(
@@ -110,6 +126,7 @@ export const generateFlowBinWrapper: GenerateIntegrationWrapper = async (pnpApi:
 
 export const VSCODE_SDKS: IntegrationSdks = [
   [null, generateDefaultWrapper],
+  [`@astrojs/language-server`, generateAstroLanguageServerWrapper],
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
   [`typescript-language-server`, null],


### PR DESCRIPTION
**What's the problem this PR addresses?**

`astro-vscode` has an `ls-path` setting that behaves the same as `svelte-vscode`'s. However, there is currently no SDK generation available in `@yarnpkg/sdks` to generate a compatible file.

**How did you fix it?**

Added generators for `@astrojs/language-server` to `@yarnpkg/sdks` in the same manner as `svelte-language-server` (https://github.com/yarnpkg/berry/pull/1465).

**Checklist**

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
