### PR TITLE
[v1 migration] create/modify gitignore file

### DIFF
--- a/.yarn/versions/e209f708.yml
+++ b/.yarn/versions/e209f708.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/legacy.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/legacy.test.ts
@@ -119,4 +119,53 @@ describe(`Legacy tests`, () => {
       },
     ),
   );
+
+  test(
+    `it should generate a .gitignore file`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`no-deps`]: `*`},
+      },
+      async ({path, run, source}) => {
+        await xfs.writeFilePromise(`${path}/yarn.lock` as PortablePath, lockfile100);
+        await run(`install`);
+
+        await expect(xfs.readFilePromise(`${path}/.gitignore` as PortablePath, `utf-8`)).resolves.toBe(`
+# yarn berry config, more information in https://yarnpkg.com/getting-started/qa/#which-files-should-be-gitignored
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+`);
+      },
+    ));
+
+  test(
+    `it should modify the .gitignore file if it already exists`,
+    makeTemporaryEnv(
+      {
+        dependencies: {[`no-deps`]: `*`},
+      },
+      async ({path, run, source}) => {
+        await xfs.writeFilePromise(`${path}/.gitignore` as PortablePath, `foo\nbar`);
+
+        await xfs.writeFilePromise(`${path}/yarn.lock` as PortablePath, lockfile100);
+        await run(`install`);
+
+        await expect(xfs.readFilePromise(`${path}/.gitignore` as PortablePath, `utf-8`)).resolves.toBe(`foo
+bar
+# yarn berry config, more information in https://yarnpkg.com/getting-started/qa/#which-files-should-be-gitignored
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+`);
+      },
+    ));
 });


### PR DESCRIPTION
**What's the problem this PR addresses?**

Resolves https://github.com/yarnpkg/berry/issues/5237

**How did you fix it?**

In `install.ts` next to the logic for displaying the error message for the v1 migration, I added a logic to generate the `.gitignore` file.
I also added tests

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
