### PR TITLE
fix(pack): Adds support for "imports" in publishConfig

### DIFF
--- a/.yarn/versions/0af71d48.yml
+++ b/.yarn/versions/0af71d48.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -324,12 +324,14 @@ describe(`Commands`, () => {
         module: `./index.mjs`,
         browser: `./index.umd.js`,
         exports: `./index.modern.js`,
+        imports: {[`#dep`]: `local`},
         publishConfig: {
           type: `module`,
           main: `./published.js`,
           module: `./published.mjs`,
           browser: `./published.umd.js`,
           exports: `./published.modern.js`,
+          imports: {[`#dep`]: `published`},
         },
       }, async ({path, run, source}) => {
         await run(`install`);
@@ -344,6 +346,7 @@ describe(`Commands`, () => {
         expect(packedManifest.module).toBe(`./published.mjs`);
         expect(packedManifest.browser).toBe(`./published.umd.js`);
         expect(packedManifest.exports).toBe(`./published.modern.js`);
+        expect(packedManifest.imports).toEqual({[`#dep`]: `published`});
 
         const originalManifest = await xfs.readJsonPromise(`${path}/package.json`);
 
@@ -352,6 +355,7 @@ describe(`Commands`, () => {
         expect(originalManifest.module).toBe(`./index.mjs`);
         expect(originalManifest.browser).toBe(`./index.umd.js`);
         expect(originalManifest.exports).toBe(`./index.modern.js`);
+        expect(originalManifest.imports).toEqual({[`#dep`]: `local`});
       }),
     );
 

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -40,7 +40,7 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
       rawManifest.exports = rawManifest.publishConfig.exports;
 
     if (rawManifest.publishConfig.imports)
-      rawManifest.exports = rawManifest.publishConfig.imports;
+      rawManifest.imports = rawManifest.publishConfig.imports;
 
     if (rawManifest.publishConfig.bin) {
       rawManifest.bin = rawManifest.publishConfig.bin;

--- a/packages/plugin-pack/sources/index.ts
+++ b/packages/plugin-pack/sources/index.ts
@@ -39,6 +39,9 @@ const beforeWorkspacePacking = (workspace: Workspace, rawManifest: any) => {
     if (rawManifest.publishConfig.exports)
       rawManifest.exports = rawManifest.publishConfig.exports;
 
+    if (rawManifest.publishConfig.imports)
+      rawManifest.exports = rawManifest.publishConfig.imports;
+
     if (rawManifest.publishConfig.bin) {
       rawManifest.bin = rawManifest.publishConfig.bin;
     }


### PR DESCRIPTION
**What's the problem this PR addresses?**

We don't currently copy `publishConfig.imports` to `imports` when packing the project, despite doing that for `exports`.

**How did you fix it?**

Adds the missing assignment.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
