### PR TITLE
Implements PACK_MANIFEST

### DIFF
--- a/.yarn/versions/520bb7af.yml
+++ b/.yarn/versions/520bb7af.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-pack": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -733,5 +733,57 @@ describe(`Commands`, () => {
         expect(originalManifest.devDependencies[dependency]).toBe(`workspace:*`);
       }),
     );
+
+
+    test(
+      `it should allow to make temporary changes to the package.json during prepack, through PACK_MANIFEST`,
+      makeTemporaryEnv({
+        workspaces: [`./dependency`, `./dependant`],
+      }, async({path, run, source}) => {
+        const dependency = `@test/dependency`;
+        const dependant = `@test/dependant`;
+
+        await fsUtils.writeJson(`${path}/dependency/package.json`, {
+          name: dependency,
+          version: `1.0.0`,
+        });
+
+        const packageJson = {
+          name: dependant,
+          version: `1.0.0`,
+          scripts: {
+            prepack: `cp package.json.tmp $PACK_MANIFEST`,
+          },
+          devDependencies: {
+            [dependency]: `workspace:*`,
+          },
+        };
+
+        await fsUtils.writeJson(`${path}/dependant/package.json`, packageJson);
+        await fsUtils.writeJson(`${path}/dependant/package.json.tmp`, {
+          ...packageJson,
+          dependencies: {
+            [dependency]: `workspace:^1.0.0`,
+          },
+        });
+
+        await run(`install`);
+        await run(`pack`, {
+          cwd: `${path}/dependant`,
+        });
+
+        await fsUtils.unpackToDirectory(path, `${path}/dependant/package.tgz`);
+
+        const packedManifest = await xfs.readJsonPromise(`${path}/package/package.json`);
+
+        expect(packedManifest.dependencies[dependency]).toBe(`^1.0.0`);
+        expect(packedManifest.devDependencies[dependency]).toBe(`1.0.0`);
+
+        const originalManifest = await xfs.readJsonPromise(`${path}/dependant/package.json`);
+
+        expect(originalManifest.dependencies).toBe(undefined);
+        expect(originalManifest.devDependencies[dependency]).toBe(`workspace:*`);
+      }),
+    );
   });
 });

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -449,13 +449,14 @@ export async function hasPackageScript(locator: Locator, scriptName: string, {pr
 
 type ExecutePackageScriptOptions = {
   cwd?: PortablePath | undefined;
+  env?: Record<string, string>;
   project: Project;
   stdin: Readable | null;
   stdout: Writable;
   stderr: Writable;
 };
 
-export async function executePackageScript(locator: Locator, scriptName: string, args: Array<string>, {cwd, project, stdin, stdout, stderr}: ExecutePackageScriptOptions): Promise<number> {
+export async function executePackageScript(locator: Locator, scriptName: string, args: Array<string>, {cwd, project, env: userEnv, stdin, stdout, stderr}: ExecutePackageScriptOptions): Promise<number> {
   return await xfs.mktempPromise(async binFolder => {
     const {manifest, env, cwd: realCwd} = await initializePackageEnvironment(locator, {project, binFolder, cwd, lifecycleScript: scriptName});
 
@@ -464,7 +465,7 @@ export async function executePackageScript(locator: Locator, scriptName: string,
       return 1;
 
     const realExecutor = async () => {
-      return await execute(script, args, {cwd: realCwd, env, stdin, stdout, stderr});
+      return await execute(script, args, {cwd: realCwd, env: {...env, ...userEnv}, stdin, stdout, stderr});
     };
 
     const executor = await project.configuration.reduceHook(hooks => {
@@ -560,13 +561,14 @@ async function initializePackageEnvironment(locator: Locator, {project, binFolde
 
 type ExecuteWorkspaceScriptOptions = {
   cwd?: PortablePath | undefined;
+  env?: Record<string, string>;
   stdin: Readable | null;
   stdout: Writable;
   stderr: Writable;
 };
 
-export async function executeWorkspaceScript(workspace: Workspace, scriptName: string, args: Array<string>, {cwd, stdin, stdout, stderr}: ExecuteWorkspaceScriptOptions) {
-  return await executePackageScript(workspace.anchoredLocator, scriptName, args, {cwd, project: workspace.project, stdin, stdout, stderr});
+export async function executeWorkspaceScript(workspace: Workspace, scriptName: string, args: Array<string>, {cwd, env, stdin, stdout, stderr}: ExecuteWorkspaceScriptOptions) {
+  return await executePackageScript(workspace.anchoredLocator, scriptName, args, {cwd, project: workspace.project, env, stdin, stdout, stderr});
 }
 
 export function hasWorkspaceScript(workspace: Workspace, scriptName: string) {
@@ -575,10 +577,11 @@ export function hasWorkspaceScript(workspace: Workspace, scriptName: string) {
 
 type ExecuteWorkspaceLifecycleScriptOptions = {
   cwd?: PortablePath | undefined;
+  env?: Record<string, string>;
   report: Report;
 };
 
-export async function executeWorkspaceLifecycleScript(workspace: Workspace, lifecycleScriptName: string, {cwd, report}: ExecuteWorkspaceLifecycleScriptOptions) {
+export async function executeWorkspaceLifecycleScript(workspace: Workspace, lifecycleScriptName: string, {cwd, env, report}: ExecuteWorkspaceLifecycleScriptOptions) {
   const {configuration} = workspace.project;
   const stdin = null;
 
@@ -595,7 +598,7 @@ export async function executeWorkspaceLifecycleScript(workspace: Workspace, life
 
     report.reportInfo(MessageName.LIFECYCLE_SCRIPT, `Calling the "${lifecycleScriptName}" lifecycle script`);
 
-    const exitCode = await executeWorkspaceScript(workspace, lifecycleScriptName, [], {cwd, stdin, stdout, stderr});
+    const exitCode = await executeWorkspaceScript(workspace, lifecycleScriptName, [], {cwd, env, stdin, stdout, stderr});
 
     stdout.end();
     stderr.end();


### PR DESCRIPTION
**What's the problem this PR addresses?**

Making changes to the `package.json` during prepack is annoying, because whatever changes are made also need to be reverted (or committed, but if they are applied during build it's likely that the users don't want them).

**How did you fix it?**

This diff implements a new environment variable when the `prepack` lifecycle script is called: `PACK_MANIFEST`. If this file exists after `prepack` returns, Yarn will read it and merge it to the final manifest used to pack the package. This way, prepack scripts have the ability to modify:

- `publishConfig` (although they can now also directly modify the `main`, `exports`, etc fields)
- `version` (can be handy to handle the versioning outside of Yarn itself)
- `authors` (for example to automatically generate the authors list from the git commit)

As well as all the other fields from `package.json`. They can even add new ones, for example to attach a commit link to the package.json during builds.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
