### PR TITLE
test: reference functions directly

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/fs.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/fs.ts
@@ -100,7 +100,7 @@ export const packToStream = (
 export const packToFile = (target: PortablePath, source: PortablePath, options: {virtualPath?: PortablePath | null}): Promise<void> => {
   const tarballStream = xfs.createWriteStream(target);
 
-  const packStream = exports.packToStream(source, options);
+  const packStream = packToStream(source, options);
   packStream.pipe(tarballStream);
 
   return new Promise((resolve, reject) => {
@@ -150,7 +150,7 @@ export const writeFile = async (target: PortablePath, body: string | Buffer): Pr
 };
 
 export const writeJson = (target: PortablePath, object: any): Promise<void> => {
-  return exports.writeFile(target, JSON.stringify(object));
+  return writeFile(target, JSON.stringify(object));
 };
 
 export const readSyml = async (source: PortablePath): Promise<any> => {
@@ -170,7 +170,7 @@ export const makeFakeBinary = async (
   const realTarget = IS_WIN32 ? `${target}.cmd` as PortablePath : target;
   const header = IS_WIN32 ? `@echo off\n` : `#!/bin/sh\n`;
 
-  await exports.writeFile(realTarget, `${header}printf "%s" "${output}"\nexit ${exitCode}\n`);
+  await writeFile(realTarget, `${header}printf "%s" "${output}"\nexit ${exitCode}\n`);
   await xfs.chmodPromise(realTarget, 0o755);
 };
 

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/misc.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/misc.ts
@@ -36,7 +36,7 @@ export const filePatternMatch = (
   patterns: Array<string>,
   {matchBase = true, dot = true}: {matchBase?: boolean, dot?: boolean} = {},
 ): boolean => {
-  return exports.stringPatternMatch(posix.resolve(`/`, filePath), patterns, {matchBase, dot});
+  return stringPatternMatch(posix.resolve(`/`, filePath), patterns, {matchBase, dot});
 };
 
 export const parseJsonStream = (


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some of our test code is referencing methods in the same file through `exports` which works due to how Babel transpiles the files, however when transpiled by esbuild it throws.

TypeScript doesn't complain because `@types/node` contains `declare var exports: any`.

**How did you fix it?**

Reference the functions directly.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.