### PR TITLE
Include missing needed to setup yarn when using asdf-vm

### DIFF
--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -42,6 +42,14 @@ Take a look at the [latest Yarn release](https://github.com/yarnpkg/berry/releas
 corepack prepare yarn@<version> --activate
 ```
 
+## Asdf-vm additional instructions
+
+Run the addtional command to make yarn recognized:
+
+```bash
+asdf reshim nodejs
+```
+
 ## Initializing your project
 
 Just run the following command. It will generate some files inside your current directory; add them all to your next commit, and you'll be done!

--- a/packages/gatsby/content/getting-started/install.md
+++ b/packages/gatsby/content/getting-started/install.md
@@ -44,7 +44,7 @@ corepack prepare yarn@<version> --activate
 
 ## Asdf-vm additional instructions
 
-Run the addtional command to make yarn recognized:
+If you use asdf-vm, run the following additional command. It will reshim Node.js and enable yarn on the command prompt.
 
 ```bash
 asdf reshim nodejs


### PR DESCRIPTION
**What's the problem this PR addresses?**

If you install nodejs using asdf-vm and use the corepack to enable yarn, the yarn is not found on the command prompt. You need to reshim nodejs to allow the use of yarn.

**How did you fix it?**

Just included the missing instruction on the documentation.

**Checklist**

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
