### PR TITLE
Exposes the error function through the workspace

### DIFF
--- a/.yarn/versions/20b1eacd.yml
+++ b/.yarn/versions/20b1eacd.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-constraints": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-constraints/sources/ModernEngine.ts
+++ b/packages/plugin-constraints/sources/ModernEngine.ts
@@ -37,12 +37,17 @@ export class ModernEngine implements constraintUtils.Engine {
         return setFn(path, undefined, {caller: nodeUtils.getCaller()});
       };
 
+      const errorFn = (message: string) => {
+        miscUtils.getArrayWithDefault(result.reportedErrors, workspace.cwd).push(message);
+      };
+
       const workspaceItem = workspaces.insert({
         cwd: workspace.cwd,
         ident,
         manifest,
         set: setFn,
         unset: unsetFn,
+        error: errorFn,
       });
 
       for (const dependencyType of Manifest.allDependencies) {
@@ -55,10 +60,6 @@ export class ModernEngine implements constraintUtils.Engine {
 
           const updateFn = (range: string) => {
             setFn([dependencyType, ident], range, {caller: nodeUtils.getCaller()});
-          };
-
-          const errorFn = (message: string) => {
-            miscUtils.getArrayWithDefault(result.reportedErrors, workspace.cwd).push(message);
           };
 
           dependencies.insert({

--- a/packages/plugin-constraints/sources/ModernEngineContext.d.ts
+++ b/packages/plugin-constraints/sources/ModernEngineContext.d.ts
@@ -16,6 +16,7 @@ export type Workspace = {
   manifest: PartialObject;
   set(path: Array<string> | string, value: any): void;
   unset(path: Array<string> | string): void;
+  error(message: string): void;
 };
 
 export type WorkspaceFilter = {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `error` function is exposed to constraints for each dependency, but not on individual workspaces. It should, because someone may want to report an error in the workspace definition that isn't related to its dependencies.

**How did you fix it?**

Added the missing `error` function.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
