### PR TITLE
feat(workspace-tools): add --include-paths and --exclude-paths flags to foreach

### DIFF
--- a/.yarn/versions/b21115a6.yml
+++ b/.yarn/versions/b21115a6.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": minor

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -254,6 +254,34 @@ Done
 }
 `;
 
+exports[`Commands workspace foreach should only run the scripts on workspaces that match the --include-paths list with globs 1`] = `
+{
+  "code": 0,
+  "stderr": "",
+  "stdout": "[workspace-c]: Process started
+[workspace-c]: Test Workspace C
+[workspace-c]: Process exited (exit code 0)
+
+[workspace-d]: Process started
+[workspace-d]: Test Workspace D
+[workspace-d]: Process exited (exit code 0)
+
+[workspace-e]: Process started
+[workspace-e]: Test Workspace E
+[workspace-e]: Process exited (exit code 0)
+
+[workspace-f]: Process started
+[workspace-f]: Test Workspace F
+[workspace-f]: Process exited (exit code 0)
+
+[workspace-g]: Process started
+[workspace-g]: Test Workspace G
+[workspace-g]: Process exited (exit code 0)
+Done
+",
+}
+`;
+
 exports[`Commands workspace foreach should prefix the output with run with --verbose 1`] = `
 {
   "code": 0,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -162,6 +162,34 @@ Done
 }
 `;
 
+exports[`Commands workspace foreach should never run the scripts on workspaces that match the --exclude-paths list 1`] = `
+{
+  "code": 0,
+  "stderr": "",
+  "stdout": "[workspace-c]: Process started
+[workspace-c]: Test Workspace C
+[workspace-c]: Process exited (exit code 0)
+
+[workspace-d]: Process started
+[workspace-d]: Test Workspace D
+[workspace-d]: Process exited (exit code 0)
+
+[workspace-e]: Process started
+[workspace-e]: Test Workspace E
+[workspace-e]: Process exited (exit code 0)
+
+[workspace-f]: Process started
+[workspace-f]: Test Workspace F
+[workspace-f]: Process exited (exit code 0)
+
+[workspace-g]: Process started
+[workspace-g]: Test Workspace G
+[workspace-g]: Process exited (exit code 0)
+Done
+",
+}
+`;
+
 exports[`Commands workspace foreach should not fall into endless loop if foreach cmd is the same as lifecycle script name 1`] = `
 {
   "code": 0,
@@ -195,6 +223,22 @@ Done
 `;
 
 exports[`Commands workspace foreach should only run the scripts on workspaces that match the --include list 1`] = `
+{
+  "code": 0,
+  "stderr": "",
+  "stdout": "[workspace-a]: Process started
+[workspace-a]: Test Workspace A
+[workspace-a]: Process exited (exit code 0)
+
+[workspace-b]: Process started
+[workspace-b]: Test Workspace B
+[workspace-b]: Process exited (exit code 0)
+Done
+",
+}
+`;
+
+exports[`Commands workspace foreach should only run the scripts on workspaces that match the --include-paths list 1`] = `
 {
   "code": 0,
   "stderr": "",
@@ -305,5 +349,49 @@ exports[`Commands workspace foreach should start all the processes at once when 
 [workspace-f]: Process started
 [workspace-g]: Process started",
   "stderr": "",
+}
+`;
+
+exports[`Commands workspace foreach should support a mix of --exclude and --exclude-paths for selecting workspaces 1`] = `
+{
+  "code": 0,
+  "stderr": "",
+  "stdout": "[workspace-c]: Process started
+[workspace-c]: Test Workspace C
+[workspace-c]: Process exited (exit code 0)
+
+[workspace-d]: Process started
+[workspace-d]: Test Workspace D
+[workspace-d]: Process exited (exit code 0)
+
+[workspace-e]: Process started
+[workspace-e]: Test Workspace E
+[workspace-e]: Process exited (exit code 0)
+
+[workspace-f]: Process started
+[workspace-f]: Test Workspace F
+[workspace-f]: Process exited (exit code 0)
+
+[workspace-g]: Process started
+[workspace-g]: Test Workspace G
+[workspace-g]: Process exited (exit code 0)
+Done
+",
+}
+`;
+
+exports[`Commands workspace foreach should support a mix of --include and --include-paths for selecting workspaces 1`] = `
+{
+  "code": 0,
+  "stderr": "",
+  "stdout": "[workspace-a]: Process started
+[workspace-a]: Test Workspace A
+[workspace-a]: Process exited (exit code 0)
+
+[workspace-b]: Process started
+[workspace-b]: Test Workspace B
+[workspace-b]: Process exited (exit code 0)
+Done
+",
 }
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -244,6 +244,22 @@ describe(`Commands`, () => {
     );
 
     test(
+      `should only run the scripts on workspaces that match the --include-paths list`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--include-paths`, `packages/workspace-a`, `--include-paths`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
+        },
+      ),
+    );
+
+    test(
       `should never run the scripts on workspaces that match the --exclude list`,
       makeTemporaryEnv(
         {
@@ -255,6 +271,54 @@ describe(`Commands`, () => {
           await run(`install`);
 
           await expect(run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
+        },
+      ),
+    );
+
+    test(
+      `should never run the scripts on workspaces that match the --exclude-paths list`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--exclude-paths`, `packages/workspace-a`, `--exclude-paths`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
+        },
+      ),
+    );
+
+    test(
+      `should support a mix of --include and --include-paths for selecting workspaces`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--include`, `workspace-a`, `--include-paths`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
+        },
+      ),
+    );
+
+    test(
+      `should support a mix of --exclude and --exclude-paths for selecting workspaces`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--exclude`, `workspace-a`, `--exclude-paths`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -260,6 +260,22 @@ describe(`Commands`, () => {
     );
 
     test(
+      `should only run the scripts on workspaces that match the --include-paths list with globs`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--verbose`, `--include-paths`, `packages/workspace-c/**`, `run`, `print`)).resolves.toMatchSnapshot();
+        },
+      ),
+    );
+
+    test(
       `should never run the scripts on workspaces that match the --exclude list`,
       makeTemporaryEnv(
         {

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -196,7 +196,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
       if (this.include.length > 0 && micromatch.isMatch(structUtils.stringifyIdent(workspace.locator), this.include))
         shouldInclude = true;
 
-      if (this.includePaths.length > 0 && !shouldInclude && this.includePaths.some(testPath => micromatch.contains(path.resolve(project.cwd, workspace.relativeCwd), path.resolve(project.cwd, testPath))))
+      if (this.includePaths.length > 0 && !shouldInclude && micromatch.isMatch(workspace.relativeCwd, this.includePaths))
         shouldInclude = true;
 
       if (!shouldInclude)
@@ -205,7 +205,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
       if (this.exclude.length > 0 && micromatch.isMatch(structUtils.stringifyIdent(workspace.locator), this.exclude))
         continue;
 
-      if (this.excludePaths.length > 0 && this.excludePaths.some(testPath => micromatch.contains(path.resolve(project.cwd, workspace.relativeCwd), path.resolve(project.cwd, testPath))))
+      if (this.excludePaths.length > 0 && micromatch.isMatch(workspace.relativeCwd,  this.excludePaths))
         continue;
 
       if (this.publicOnly && workspace.manifest.private === true)


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Quite often, repos are laid out where workspaces are grouped by directories, but the workspace identifier is kept as the package name. This makes it hard to run a command on all workspaces that are within a `libs` directory for example, using the existing `yarn workspaces foreach` command.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

This PR adds an `--include-paths` and `--exclude-paths` flag to the foreach command in the workspace-tools plugin, allowing filtering of workspaces by path. These new flags work in-tandem with the existing filter flags, and can be utilised at the same time. They both accept path globs.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
