### PR TITLE
Fixes `@yarnpkg/types`

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -13950,6 +13950,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -13974,6 +13975,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -13998,6 +14000,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14022,6 +14025,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14046,6 +14050,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:5fe64685a823dfbb7fb4a2b3276cfc4aa0db65837fed2fdadbcc54cab047059324a7d9490b3913073dcf62fc9a7db324f81bcd6b03e1175843cddeba54bfcd85#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14070,6 +14075,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14094,6 +14100,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14118,6 +14125,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:35104c47575f2fe378d8d20383ae667f19d4dd801df8cc4c76848603aa6b4a2234a00142ff12fd557f6f48bd2810880e31c40c767010ea61a31fca302c2cc5e0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14142,6 +14150,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14166,6 +14175,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14190,6 +14200,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14214,6 +14225,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14238,6 +14250,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14262,6 +14275,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14286,6 +14300,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14310,6 +14325,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:e3ce0ce4b7f0796ca44011528cb9cdc133fc62a76363fea6de68497bae04bdbe5a6dd47e6b9f23c282eb8e4533d75e96cf378c943d07a4e78aae0b715f06a450#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14334,6 +14350,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:86c95fabbcd56c56f5f2d2e080e64a1095e3fe233877aa9f7958f317f88a95627e0be2765e89c0cff02c9f08f27b64b7cbc9d5c3960c1df509d5e6ea98cca4f4#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14358,6 +14375,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14382,6 +14400,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\
@@ -14404,6 +14423,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/types", "workspace:packages/yarnpkg-types"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.0-rc.10"],\
           ["lodash", "npm:4.17.21"],\
           ["tau-prolog", "npm:0.2.66"],\

--- a/.yarn/versions/92646a08.yml
+++ b/.yarn/versions/92646a08.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/plugin-constraints": patch
+  "@yarnpkg/types": patch
+
+declined:
+  - "@yarnpkg/cli"

--- a/packages/plugin-constraints/package.json
+++ b/packages/plugin-constraints/package.json
@@ -28,7 +28,8 @@
     "@types/lodash": "^4.14.136",
     "@yarnpkg/builder": "workspace:^",
     "@yarnpkg/cli": "workspace:^",
-    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/types": "workspace:^"
   },
   "scripts": {
     "postpack": "rm -rf lib",

--- a/packages/plugin-constraints/sources/ModernEngine.ts
+++ b/packages/plugin-constraints/sources/ModernEngine.ts
@@ -1,4 +1,5 @@
 import {Manifest, miscUtils, nodeUtils, Project, structUtils} from '@yarnpkg/core';
+import {Yarn}                                                 from '@yarnpkg/types';
 
 import * as constraintUtils                                   from './constraintUtils';
 
@@ -86,9 +87,9 @@ export class ModernEngine implements constraintUtils.Engine {
 
     const context: Yarn.Constraints.Context = {
       Yarn: {
-        workspace: filter => {
+        workspace: ((filter?: Yarn.Constraints.WorkspaceFilter) => {
           return env.workspaces.find(filter)[0] ?? null;
-        },
+        }) as any,
         workspaces: filter => {
           return env.workspaces.find(filter);
         },

--- a/packages/yarnpkg-types/sources/constraints.ts
+++ b/packages/yarnpkg-types/sources/constraints.ts
@@ -1,153 +1,148 @@
 export type PartialObject = {[key: string]: PartialObject} | string | number | null;
 
-declare global {
-  namespace Yarn.Constraints {
-    export type DependencyType =
-      | `dependencies`
-      | `devDependencies`
-      | `peerDependencies`;
+export type DependencyType =
+  | `dependencies`
+  | `devDependencies`
+  | `peerDependencies`;
 
-    export type Dependency = {
-      /**
-       * Reference to the owning workspace.
-       */
-      workspace: Workspace;
+export type Dependency = {
+  /**
+   * Reference to the owning workspace.
+   */
+  workspace: Workspace;
 
-      /**
-       * Dependency name.
-       */
-      ident: string;
+  /**
+   * Dependency name.
+   */
+  ident: string;
 
-      /**
-       * Dependency range. Note that it doesn't have to be a semver value - it
-       * can also be a git repository, and http url, etc.
-       */
-      range: string;
+  /**
+   * Dependency range. Note that it doesn't have to be a semver value - it
+   * can also be a git repository, and http url, etc.
+   */
+  range: string;
 
-      /**
-       * Name of the field under which this dependency can be found.
-       */
-      type: DependencyType;
+  /**
+   * Name of the field under which this dependency can be found.
+   */
+  type: DependencyType;
 
-      /**
-       * Report an error unless the dependency has the expected range. If
-       * `--fix` is set, Yarn will silently update the package.json instead of
-       * reporting an error.
-       *
-       * @param range New range for the dependency.
-       */
-      update(range: string | undefined): void;
+  /**
+   * Report an error unless the dependency has the expected range. If
+   * `--fix` is set, Yarn will silently update the package.json instead of
+   * reporting an error.
+   *
+   * @param range New range for the dependency.
+   */
+  update(range: string | undefined): void;
 
-      /**
-       * Report an error (useful when you want to forbid a specific package
-       * from being added to the dependencies). If `--fix` is set, Yarn will
-       * silently remove the dependency from the package.json instead of
-       * reporting an error.
-       */
-      delete(): void;
+  /**
+   * Report an error (useful when you want to forbid a specific package
+   * from being added to the dependencies). If `--fix` is set, Yarn will
+   * silently remove the dependency from the package.json instead of
+   * reporting an error.
+   */
+  delete(): void;
 
-      /**
-       * Report a non-recoverable custom error.
-       *
-       * @param message Error message
-       */
-      error(message: string): void;
-    };
+  /**
+   * Report a non-recoverable custom error.
+   *
+   * @param message Error message
+   */
+  error(message: string): void;
+};
 
-    export type Workspace = {
-      /**
-       * Relative path from the project root to the workspace. The root
-       * workspace always has a `cwd` equal to `.`.
-       */
-      cwd: string;
+export type Workspace = {
+  /**
+   * Relative path from the project root to the workspace. The root
+   * workspace always has a `cwd` equal to `.`.
+   */
+  cwd: string;
 
-      /**
-       * Workspace name.
-       */
-      ident: string | null;
+  /**
+   * Workspace name.
+   */
+  ident: string | null;
 
-      /**
-       * Raw manifest object for the workspace.
-       */
-      manifest: PartialObject;
+  /**
+   * Raw manifest object for the workspace.
+   */
+  manifest: PartialObject;
 
-      /**
-       * Report an error unless the workspace lists the specified property
-       * with the specified value. If `--fix` is set, Yarn will silently update
-       * the package.json instead of reporting an error.
-       *
-       * @param path Property path
-       * @param value Expected value
-       */
-      set(path: Array<string> | string, value: any): void;
+  /**
+   * Report an error unless the workspace lists the specified property
+   * with the specified value. If `--fix` is set, Yarn will silently update
+   * the package.json instead of reporting an error.
+   *
+   * @param path Property path
+   * @param value Expected value
+   */
+  set(path: Array<string> | string, value: any): void;
 
-      /**
-       * Report an error if the workspace lists the specified property. If
-       * `--fix` is set, Yarn will silently remove the field from the
-       * package.json instead of reporting an error.
-       *
-       * @param path Property path
-       */
-      unset(path: Array<string> | string): void;
+  /**
+   * Report an error if the workspace lists the specified property. If
+   * `--fix` is set, Yarn will silently remove the field from the
+   * package.json instead of reporting an error.
+   *
+   * @param path Property path
+   */
+  unset(path: Array<string> | string): void;
 
-      /**
-       * Report a non-recoverable custom error.
-       *
-       * @param message Error message
-       */
-      error(message: string): void;
-    };
+  /**
+   * Report a non-recoverable custom error.
+   *
+   * @param message Error message
+   */
+  error(message: string): void;
+};
 
-    export type WorkspaceFilter = {
-      /**
-       * Only return the workspace with the given relative path.
-       *
-       * Note: This doesn't currently support glob patterns. Help welcome!
-       */
-      cwd?: string;
+export type WorkspaceFilter = {
+  /**
+   * Only return the workspace with the given relative path.
+   *
+   * Note: This doesn't currently support glob patterns. Help welcome!
+   */
+  cwd?: string;
 
-      /**
-       * Only return the workspace with the given package name.
-       *
-       * Note: This doesn't currently support glob patterns. Help welcome!
-       */
-      ident?: string;
-    };
+  /**
+   * Only return the workspace with the given package name.
+   *
+   * Note: This doesn't currently support glob patterns. Help welcome!
+   */
+  ident?: string;
+};
 
-    export type DependencyFilter = {
-      /**
-       * Only return dependencies with the given name.
-       */
-      ident?: string;
-    };
+export type DependencyFilter = {
+  /**
+   * Only return dependencies with the given name.
+   */
+  ident?: string;
+};
 
-    export type Yarn = {
-      /**
-       * Select a unique workspace according to the provided filter.
-       *
-       * @param filter
-       */
-      workspace(filter?: WorkspaceFilter): Workspace | null;
+export type Yarn = {
+  /**
+   * Select a unique workspace according to the provided filter.
+   *
+   * @param filter
+   */
+  workspace(): Workspace;
+  workspace(filter?: WorkspaceFilter): Workspace | null;
 
-      /**
-       * Select all matching workspaces according to the provided filter.
-       *
-       * @param filter
-       */
-      workspaces(filter?: WorkspaceFilter): Array<Workspace>;
+  /**
+   * Select all matching workspaces according to the provided filter.
+   *
+   * @param filter
+   */
+  workspaces(filter?: WorkspaceFilter): Array<Workspace>;
 
-      /**
-       * Select all dependencies according to the provided filter.
-       *
-       * @param filter
-       */
-      dependencies(filter?: DependencyFilter): Array<Dependency>;
-    };
+  /**
+   * Select all dependencies according to the provided filter.
+   *
+   * @param filter
+   */
+  dependencies(filter?: DependencyFilter): Array<Dependency>;
+};
 
-    export type Context = {
-      Yarn: Yarn;
-    };
-  }
-}
-
-export {};
+export type Context = {
+  Yarn: Yarn;
+};

--- a/packages/yarnpkg-types/sources/index.ts
+++ b/packages/yarnpkg-types/sources/index.ts
@@ -1,4 +1,10 @@
+import {Config} from './yarn';
+
 // Strangely, the tslib error sometimes disappear in the IDE ... so we use ts-ignore rather than ts-expect-error
 // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
 // @ts-ignore: TS incorrectly thinks it needs tslib for this type export
 export type * as Yarn from './yarn';
+
+export function defineConfig(config: Config) {
+  return config;
+}

--- a/packages/yarnpkg-types/sources/index.ts
+++ b/packages/yarnpkg-types/sources/index.ts
@@ -1,39 +1,4 @@
-declare global {
-  namespace Yarn {
-    export type Config = {
-      /**
-       * Called each time the constraints engine runs. You can then use the
-       * methods from the provided context to assert values on any of your
-       * workspaces' definitions.
-       *
-       * The constraints engine is declarative, and you don't need to compare
-       * values yourself except in some specific situations. For instance, if
-       * you wish to ensure that all workspaces define a specific license, you
-       * would write something like this:
-       *
-       * ```ts
-       * // Yes: declarative
-       * for (const w of Yarn.workspaces()) {
-       *   w.set(`license`, `MIT`);
-       * }
-       *
-       * // No: imperative
-       * for (const w of Yarn.workspaces()) {
-       *   if (w.manifest.license !== `MIT`) {
-       *     w.set(`license`, `MIT`);
-       *   }
-       * }
-       * ```
-       *
-       * Note that the presence of this field will disable any evaluation of
-       * the `constraints.pro` file, although no warning is currently emitted.
-       *
-       * @param ctx Context
-       * @returns
-       */
-      constraints: (ctx: Yarn.Constraints.Context) => Promise<void>;
-    };
-  }
-}
-
-export {};
+// Strangely, the tslib error sometimes disappear in the IDE ... so we use ts-ignore rather than ts-expect-error
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore: TS incorrectly thinks it needs tslib for this type export
+export type * as Yarn from './yarn';

--- a/packages/yarnpkg-types/sources/yarn.ts
+++ b/packages/yarnpkg-types/sources/yarn.ts
@@ -1,0 +1,40 @@
+// Strangely, the tslib error sometimes disappear in the IDE ... so we use ts-ignore rather than ts-expect-error
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore: TS incorrectly thinks it needs tslib for this type export
+import type * as Constraints from './constraints';
+
+export type * as Constraints from './constraints';
+
+export type Config = {
+  /**
+   * Called each time the constraints engine runs. You can then use the
+   * methods from the provided context to assert values on any of your
+   * workspaces' definitions.
+   *
+   * The constraints engine is declarative, and you don't need to compare
+  * values yourself except in some specific situations. For instance, if
+   * you wish to ensure that all workspaces define a specific license, you
+   * would write something like this:
+   *
+   * ```ts
+   * // Yes: declarative
+   * for (const w of Yarn.workspaces()) {
+   *   w.set(`license`, `MIT`);
+   * }
+   *
+   * // No: imperative
+   * for (const w of Yarn.workspaces()) {
+   *   if (w.manifest.license !== `MIT`) {
+   *     w.set(`license`, `MIT`);
+   *   }
+   * }
+   * ```
+   *
+   * Note that the presence of this field will disable any evaluation of
+   * the `constraints.pro` file, although no warning is currently emitted.
+   *
+   * @param ctx Context
+   * @returns
+   */
+  constraints: (ctx: Constraints.Context) => Promise<void>;
+};

--- a/packages/yarnpkg-types/sources/yarn.ts
+++ b/packages/yarnpkg-types/sources/yarn.ts
@@ -12,7 +12,7 @@ export type Config = {
    * workspaces' definitions.
    *
    * The constraints engine is declarative, and you don't need to compare
-  * values yourself except in some specific situations. For instance, if
+   * values yourself except in some specific situations. For instance, if
    * you wish to ensure that all workspaces define a specific license, you
    * would write something like this:
    *

--- a/yarn.lock
+++ b/yarn.lock
@@ -7432,6 +7432,7 @@ __metadata:
     "@yarnpkg/cli": "workspace:^"
     "@yarnpkg/core": "workspace:^"
     "@yarnpkg/fslib": "workspace:^"
+    "@yarnpkg/types": "workspace:^"
     clipanion: "npm:^3.2.0-rc.10"
     lodash: "npm:^4.17.15"
     tau-prolog: "npm:^0.2.66"
@@ -7911,7 +7912,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@yarnpkg/types@workspace:packages/yarnpkg-types":
+"@yarnpkg/types@workspace:^, @yarnpkg/types@workspace:packages/yarnpkg-types":
   version: 0.0.0-use.local
   resolution: "@yarnpkg/types@workspace:packages/yarnpkg-types"
   languageName: unknown


### PR DESCRIPTION
**What's the problem this PR addresses?**
The `@yarnpkg/types` package was using global declaration to work. It's not ideal since in case we need incompatible types we'll hit walls. It also wasn't working well due to missing imports.

**How did you fix it?**
I looked for a way to refactor the exported types so the following is possible (using JSDoc, since `yarn.config.js` can only be written in JS, so good compatibility with JSDoc is important):

```js
// @ts-check

const {Yarn} = require(`@yarnpkg/types`);

/** @type {Yarn.Config} */
module.exports = {
  constraints({Yarn}) {
    for (const w of Yarn.workspaces()) {
      w.set(`license`, `MIT`);
    }
  },
};
```

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
