### PR TITLE
test: fix editor SDK test

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/editorSdks.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/editorSdks.test.js
@@ -150,8 +150,7 @@ describe(`Features`, () => {
 
           // Same thing, but this file has virtual instances.
           const yarnpkgCli = npath.normalize(npath.join(__dirname, `../../../../yarnpkg-cli/sources/index.ts`))
-            .replace(/\\/g, `/`)
-            .replace(/^\/?/, `/`);
+            .replace(/\\/g, `/`);
 
           // Some sanity check to make sure everything is A-OK
           expect(lodashTypeDef).toContain(`.zip`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Due to the Windows CI often timing out I ignored the test failure in https://github.com/yarnpkg/berry/pull/5351 but the test was actually broken.

**How did you fix it?**

Updated the path to match.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.