### PR TITLE
fix(core) Pass mutex file to yarn classic when installing classic git dependencies

### DIFF
--- a/.yarn/versions/74e53c7e.yml
+++ b/.yarn/versions/74e53c7e.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+
+declined:
+  - "@yarnpkg/builder": patch
+  - "@yarnpkg/doctor": patch
+  - "@yarnpkg/extensions": patch
+  - "@yarnpkg/nm": patch
+  - "@yarnpkg/plugin-compat": patch
+  - "@yarnpkg/plugin-constraints": patch
+  - "@yarnpkg/plugin-dlx": patch
+  - "@yarnpkg/plugin-essentials": patch
+  - "@yarnpkg/plugin-exec": patch
+  - "@yarnpkg/plugin-file": patch
+  - "@yarnpkg/plugin-git": patch
+  - "@yarnpkg/plugin-github": patch
+  - "@yarnpkg/plugin-http": patch
+  - "@yarnpkg/plugin-init": patch
+  - "@yarnpkg/plugin-interactive-tools": patch
+  - "@yarnpkg/plugin-link": patch
+  - "@yarnpkg/plugin-nm": patch
+  - "@yarnpkg/plugin-npm": patch
+  - "@yarnpkg/plugin-npm-cli": patch
+  - "@yarnpkg/plugin-pack": patch
+  - "@yarnpkg/plugin-patch": patch
+  - "@yarnpkg/plugin-pnp": patch
+  - "@yarnpkg/plugin-pnpm": patch
+  - "@yarnpkg/plugin-stage": patch
+  - "@yarnpkg/plugin-typescript": patch
+  - "@yarnpkg/plugin-version": patch
+  - "@yarnpkg/plugin-workspace-tools": patch
+  - "@yarnpkg/pnpify": patch
+  - "@yarnpkg/sdks": patch

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -774,6 +774,13 @@
       "pattern": "^.*__virtual__$",
       "default": "./.yarn/__virtual__"
     },
+    "yarn1MutexFilename": {
+      "_package": "@yarnpkg/core",
+      "description": "Path to use as a mutex file when installing yarn classic git dependencies. If a relative path is provided, it is relative to the yarn project cwd.",
+      "type": "string",
+      "format": "uri-reference",
+      "examples": ["./.yarn/.yarn-mutex"]
+    },
     "yarnPath": {
       "_package": "@yarnpkg/core",
       "description": "The path of a Yarn binary, which will be executed instead of any other (including the global one) for any command run within the directory covered by the rc file. If the file extension ends with `.js` it will be required, and will be spawned in any other case.\n\nThe `yarnPath` setting is currently the preferred way to install Yarn within a project, as it ensures that your whole team will use the exact same Yarn version, without having to individually keep it up-to-date.",

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -244,6 +244,11 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.BOOLEAN,
     default: true,
   },
+  yarn1MutexFilename: {
+    description: `When repositories that use yarn1 are included as dependencies, this file is used as a mutex to avoid concurrency issues.`,
+    type: SettingsType.ABSOLUTE_PATH,
+    default: `./.yarn/.yarn-mutex`,
+  },
 
   // Settings related to the output style
   enableColors: {
@@ -586,7 +591,7 @@ export interface ConfigurationValueMap {
   immutablePatterns: Array<string>;
   rcFilename: Filename;
   enableGlobalCache: boolean;
-
+  yarn1MutexFilename: PortablePath;
   enableColors: boolean;
   enableHyperlinks: boolean;
   enableInlineBuilds: boolean;


### PR DESCRIPTION
**What's the problem this PR addresses?**

fixes #5349

Due to yarn classic not being concurrency-safe by default, there was potential for a cache conflict if multiple yarn classic github dependencies were installed in parallel.

For example 2 github repos that both use yarn classic
```
"dependencies": {
  "some-yarn-classic-project": "git+ssh://git@github.com:org/some-yarn-classic-project.git",
  "another-yarn-classic-project": "git+ssh://git@github.com:org/another-yarn-classic-project.git"
```
if they happen to install in parallel, it could lead to a yarn classic `ENOENT` error during the `Fetching packages` stage.

...

**How did you fix it?**

* Added a new `yarnrc` config option `yarn1MutexFilename` that defaults to `./.yarn/.yarn-mutex`.
* When yarn classic is run to `install` classic deps, `--mutex file:...` option is passed, using the path from the `yarn1MutexFilename` setting.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
