### PR TITLE
docs: additional coc vim sdk configuration step

### DIFF
--- a/packages/gatsby/content/getting-started/editor-sdks.md
+++ b/packages/gatsby/content/getting-started/editor-sdks.md
@@ -70,6 +70,8 @@ Run the following command, which will generate a new directory called `.yarn/sdk
 yarn dlx @yarnpkg/sdks vim
 ```
 
+If you are using `coc-tsserver` then you might want to check what version it uses by running `:CocCommand tsserver.chooseVersion` — make sure, that `Local version` is selected, instead of `Bunlded with coc-tsserver` one.
+
 #### Neovim Native LSP
 
 > **Note:** Requires Neovim version >=0.6


### PR DESCRIPTION
**What's the problem this PR addresses?**
Describe additional SDK configuration step for Vim and Nvim with CoC plugin, which might be required.
Specifically addresses this issue: https://stackoverflow.com/questions/75986441/cannot-find-module-with-coc-tsserver-ts2307

...

**How did you fix it?**
By trying out all available CoC commands

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
