### PR TITLE
chore: update benchmark dependencies

### DIFF
--- a/scripts/benchmarks/gatsby.json
+++ b/scripts/benchmarks/gatsby.json
@@ -1,18 +1,7 @@
 {
   "dependencies": {
-    "gatsby": "^4",
-    "gatsby-plugin-gatsby-cloud": "^4",
-    "gatsby-plugin-image": "^2",
-    "gatsby-plugin-manifest": "^4",
-    "gatsby-plugin-offline": "^5",
-    "gatsby-plugin-react-helmet": "^5",
-    "gatsby-plugin-sharp": "^4",
-    "gatsby-source-filesystem": "^4",
-    "gatsby-transformer-sharp": "^4",
-    "prettier": "^2",
-    "prop-types": "^15",
+    "gatsby": "^5",
     "react": "^18",
-    "react-dom": "^18",
-    "react-helmet": "^6"
+    "react-dom": "^18"
   }
 }

--- a/scripts/benchmarks/next.json
+++ b/scripts/benchmarks/next.json
@@ -1,12 +1,7 @@
 {
-  "private": true,
   "dependencies": {
-      "next": "^12",
-      "react": "^18",
-      "react-dom": "^18"
-  },
-  "devDependencies": {
-      "@types/react": "^18",
-      "@types/react-dom": "^18"
+    "next": "^13",
+    "react": "^18",
+    "react-dom": "^18"
   }
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

- The benchmark dependencies are almost a year old and therefore doesn't reflect newly created Next.js and Gatsby projects anymore.
- pnpm has been unable to install the Gatsby dependencies since 2023-03-28 based on https://yarnpkg.org/benchmarks (cc @zkochan).

**How did you fix it?**

Updated the dependencies to match newly created Next.js and Gatsby projects, which pnpm is also able to install.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.