### PR TITLE
fix(sdks): support Prettier v3

### DIFF
--- a/.yarn/versions/5a966911.yml
+++ b/.yarn/versions/5a966911.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -206,7 +206,7 @@ export class Wrapper {
     this.target = target;
   }
 
-  async writeManifest() {
+  async writeManifest(rawManifest: Record<string, any> = {}) {
     const absWrapperPath = ppath.join(this.target, this.name, `package.json`);
 
     const topLevelInformation = this.pnpApi.getPackageInformation(this.pnpApi.topLevel)!;
@@ -224,10 +224,11 @@ export class Wrapper {
       version: `${manifest.version}-sdk`,
       main: manifest.main,
       type: `commonjs`,
+      ...rawManifest,
     });
   }
 
-  async writeBinary(relPackagePath: PortablePath, options: TemplateOptions = {}) {
+  async writeBinary(relPackagePath: PortablePath, options: TemplateOptions & {requirePath?: PortablePath} = {}) {
     await this.writeFile(relPackagePath, {...options, mode: 0o755});
   }
 

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -27,9 +27,11 @@ export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: Pnp
 export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
+  await wrapper.writeManifest({
+    main: `./index.js`,
+  });
 
-  await wrapper.writeBinary(`index.js` as PortablePath);
+  await wrapper.writeBinary(`index.js` as PortablePath, {requirePath: `` as PortablePath});
 
   return wrapper;
 };

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -19,7 +19,10 @@ export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: Pnp
   await wrapper.writeManifest();
 
   await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
-  await wrapper.writeFile(`lib/api.js` as PortablePath, {requirePath: `` as PortablePath});
+  await wrapper.writeFile(`lib/api.js` as PortablePath, {
+    // Empty path to use the entrypoint and let Node.js resolve the correct path itself
+    requirePath: `` as PortablePath,
+  });
 
   return wrapper;
 };
@@ -31,7 +34,10 @@ export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: P
     main: `./index.js`,
   });
 
-  await wrapper.writeBinary(`index.js` as PortablePath, {requirePath: `` as PortablePath});
+  await wrapper.writeBinary(`index.js` as PortablePath, {
+    // Empty path to use the entrypoint and let Node.js resolve the correct path itself
+    requirePath: `` as PortablePath,
+  });
 
   return wrapper;
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**

Prettier v3 changes the path to the entry point so we need to update the path used.

**How did you fix it?**

Updated the SDK to require `prettier` and let Node.js find the entry point.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.