### PR TITLE
Autocorrects git:// into https:// for GitHub

### DIFF
--- a/.yarn/versions/8ca5de64.yml
+++ b/.yarn/versions/8ca5de64.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-git": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -121,7 +121,7 @@ export function normalizeRepoUrl(url: string, {git = false}: {git?: boolean} = {
   url = url.replace(/^git\+https:/, `https:`);
 
   // We support this as an alias to GitHub repositories
-  url = url.replace(/^(?:github:|https:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
+  url = url.replace(/^(?:github:|https:\/\/github\.com\/|git:\/\/github\.com\/)?(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)(?:\.git)?(#.*)?$/, `https://github.com/$1/$2.git$3`);
 
   // We support GitHub `/tarball/` URLs
   url = url.replace(/^https:\/\/github\.com\/(?!\.{1,2}\/)([a-zA-Z0-9._-]+)\/(?!\.{1,2}(?:#|$))([a-zA-Z0-9._-]+?)\/tarball\/(.+)?$/, `https://github.com/$1/$2.git#$3`);

--- a/packages/plugin-git/tests/__snapshots__/gitUtils.test.ts.snap
+++ b/packages/plugin-git/tests/__snapshots__/gitUtils.test.ts.snap
@@ -48,9 +48,9 @@ exports[`gitUtils should properly normalize git+ssh://git@github.com:yarnpkg/ber
 
 exports[`gitUtils should properly normalize git+ssh://git@github.com:yarnpkg/berry.git#v2.1.1 ({ git: true }) 1`] = `"ssh://git@github.com/yarnpkg/berry.git#v2.1.1"`;
 
-exports[`gitUtils should properly normalize git://github.com/yarnpkg/util-deprecate.git#v1.0.1 ({ git: false }) 1`] = `"git://github.com/yarnpkg/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize git://github.com/yarnpkg/util-deprecate.git#v1.0.1 ({ git: false }) 1`] = `"https://github.com/yarnpkg/util-deprecate.git#v1.0.1"`;
 
-exports[`gitUtils should properly normalize git://github.com/yarnpkg/util-deprecate.git#v1.0.1 ({ git: true }) 1`] = `"git://github.com/yarnpkg/util-deprecate.git#v1.0.1"`;
+exports[`gitUtils should properly normalize git://github.com/yarnpkg/util-deprecate.git#v1.0.1 ({ git: true }) 1`] = `"https://github.com/yarnpkg/util-deprecate.git#v1.0.1"`;
 
 exports[`gitUtils should properly normalize github:GitHubOrg/foo-bar.js ({ git: false }) 1`] = `"https://github.com/GitHubOrg/foo-bar.js.git"`;
 
@@ -227,7 +227,7 @@ exports[`gitUtils should properly split git+ssh://git@github.com:yarnpkg/berry.g
 exports[`gitUtils should properly split git://github.com/yarnpkg/util-deprecate.git#v1.0.1 1`] = `
 {
   "extra": {},
-  "repo": "git://github.com/yarnpkg/util-deprecate.git",
+  "repo": "https://github.com/yarnpkg/util-deprecate.git",
   "treeish": {
     "protocol": null,
     "request": "v1.0.1",


### PR DESCRIPTION
**What's the problem this PR addresses?**

GitHub doesn't support `git://` anymore (and hasn't been for some time now):
https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/

A couple of old dependencies (including internal ones) still reference `git://` urls, which prevents them from being used.

**How did you fix it?**

Just autofix the `git://github.com` url into `https://github.com`. I don't think this has any negative impact.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
