### PR TITLE
fix(plugin-interactive-tools): don’t list folder aliases as outdated dependencies

### DIFF
--- a/.yarn/versions/6595326e.yml
+++ b/.yarn/versions/6595326e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -327,7 +327,7 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         for (const dependencyType of [`dependencies`, `devDependencies`] as Array<HardDependencies>)
           for (const descriptor of workspace.manifest[dependencyType].values())
             if (project.tryWorkspaceByDescriptor(descriptor) === null)
-              if (!descriptor.range.startsWith('link:'))
+              if (!descriptor.range.startsWith(`link:`))
                 allDependencies.set(descriptor.descriptorHash, descriptor);
 
       const sortedDependencies = miscUtils.sortMap(allDependencies.values(), descriptor => {

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -327,7 +327,8 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
         for (const dependencyType of [`dependencies`, `devDependencies`] as Array<HardDependencies>)
           for (const descriptor of workspace.manifest[dependencyType].values())
             if (project.tryWorkspaceByDescriptor(descriptor) === null)
-              allDependencies.set(descriptor.descriptorHash, descriptor);
+              if (!descriptor.range.startsWith('link:'))
+                allDependencies.set(descriptor.descriptorHash, descriptor);
 
       const sortedDependencies = miscUtils.sortMap(allDependencies.values(), descriptor => {
         return structUtils.stringifyDescriptor(descriptor);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Folder aliases defined using `link:` were incorrectly listed as outdated dependencies

See https://github.com/yarnpkg/berry/issues/5393

**How did you fix it?**
Include a check that the dependency range must not start with `link:` to be listed by `yarn upgrade-interactive`

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective. (thanks @arcanis)
<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
