### PR TITLE
Prints the constraints errors on CI

### DIFF
--- a/.yarn/versions/a0820a77.yml
+++ b/.yarn/versions/a0820a77.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-constraints": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-constraints/sources/index.ts
+++ b/packages/plugin-constraints/sources/index.ts
@@ -57,7 +57,15 @@ const plugin: Plugin<Hooks> = {
 
       const {remainingErrors} = constraintUtils.applyEngineReport(project, result);
       if (remainingErrors.size !== 0) {
-        reportError(MessageName.CONSTRAINTS_CHECK_FAILED, `Constraint check failed; run ${formatUtils.pretty(project.configuration, `yarn constraints`, formatUtils.Type.CODE)} for more details`);
+        if (project.configuration.isCI) {
+          for (const [workspace, workspaceErrors] of remainingErrors) {
+            for (const error of workspaceErrors) {
+              reportError(MessageName.CONSTRAINTS_CHECK_FAILED, `${formatUtils.pretty(project.configuration, workspace.locator, formatUtils.Type.IDENT)}: ${error.text}`);
+            }
+          }
+        } else {
+          reportError(MessageName.CONSTRAINTS_CHECK_FAILED, `Constraint check failed; run ${formatUtils.pretty(project.configuration, `yarn constraints`, formatUtils.Type.CODE)} for more details`);
+        }
       }
     },
   },

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -950,6 +950,8 @@ export class Configuration {
 
   public static telemetry: TelemetryManager | null = null;
 
+  public isCI = isCI;
+
   public startingCwd: PortablePath;
   public projectCwd: PortablePath | null = null;
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

When a constraints fail, we currently print a message suggesting to run `yarn constraints` to get the full details. However, this doesn't make sense on CI, where the command can't be run.

**How did you fix it?**

On CI, we now print the error list.

I'm however kinda reconsidering this approach of "run `yarn constraints` for more details" - if this message is displayed, the user will have to run the command 100% of the time. By this point, why not display the output by default? 🤔

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
