### PR TITLE
Adds legacy plugin removal behavior

### DIFF
--- a/.yarn/versions/35f2cce0.yml
+++ b/.yarn/versions/35f2cce0.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/legacyPluginRemoval.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/legacyPluginRemoval.test.ts
@@ -1,4 +1,3 @@
-import {hashUtils}                   from '@yarnpkg/core';
 import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
 import {fs, yarn}                    from 'pkg-tests-core';
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/legacyPluginRemoval.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/legacyPluginRemoval.test.ts
@@ -1,0 +1,72 @@
+import {hashUtils}                   from '@yarnpkg/core';
+import {xfs, ppath, Filename, npath} from '@yarnpkg/fslib';
+import {fs, yarn}                    from 'pkg-tests-core';
+
+
+describe(`Features`, () => {
+  describe(`Legacy Plugin Removal`, () => {
+    test(
+      `it should remove the legacy plugins when running an install`,
+      makeTemporaryEnv(
+        {},
+        async ({path, run, source}) => {
+          const helloWorldSource = npath.toPortablePath(require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`));
+          const fakeTypeScriptPlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-typescript`);
+
+          await xfs.copyPromise(fakeTypeScriptPlugin, helloWorldSource);
+
+          await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+            plugins: [{
+              path: ppath.relative(path, fakeTypeScriptPlugin),
+              spec: `@yarnpkg/plugin-typescript`,
+            }],
+          });
+
+          await run(`install`);
+
+          await expect(xfs.existsPromise(fakeTypeScriptPlugin)).resolves.toEqual(false);
+
+          const data = await fs.readSyml(ppath.join(path, Filename.rc));
+          expect(data).toEqual({});
+        },
+      ),
+    );
+
+    test(
+      `it shouldn't remove other plugins`,
+      makeTemporaryEnv(
+        {},
+        async ({path, run, source}) => {
+          const helloWorldSource = npath.toPortablePath(require.resolve(`@yarnpkg/monorepo/scripts/plugin-hello-world.js`));
+          const fakeTypeScriptPlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-typescript`);
+          const helloWorldPlugin = yarn.getPluginPath(path, `@yarnpkg/plugin-typescript`);
+
+          await xfs.copyPromise(fakeTypeScriptPlugin, helloWorldSource);
+          await xfs.copyPromise(helloWorldPlugin, helloWorldSource);
+
+          await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+            plugins: [{
+              path: ppath.relative(path, fakeTypeScriptPlugin),
+              spec: `@yarnpkg/plugin-typescript`,
+            }, {
+              path: ppath.relative(path, helloWorldPlugin),
+              spec: `@yarnpkg/plugin-hello-world`,
+            }],
+          });
+
+          await run(`install`);
+
+          await expect(xfs.existsPromise(helloWorldPlugin)).resolves.toEqual(false);
+
+          const data = await fs.readSyml(ppath.join(path, Filename.rc));
+          expect(data).toEqual({
+            plugins: [{
+              path: ppath.relative(path, fakeTypeScriptPlugin),
+              spec: `@yarnpkg/plugin-hello-world`,
+            }],
+          });
+        },
+      ),
+    );
+  });
+});

--- a/packages/plugin-essentials/sources/commands/config/set.ts
+++ b/packages/plugin-essentials/sources/commands/config/set.ts
@@ -77,7 +77,7 @@ export default class ConfigSetCommand extends BaseCommand {
       ? JSON.parse(this.value)
       : this.value;
 
-    const updateConfiguration: (patch: ((current: any) => any)) => Promise<void> =
+    const updateConfiguration: (patch: ((current: any) => any)) => Promise<boolean> =
       this.home
         ? patch => Configuration.updateHomeConfiguration(patch)
         : patch => Configuration.updateConfiguration(assertProjectCwd(), patch);

--- a/packages/plugin-essentials/sources/commands/config/unset.ts
+++ b/packages/plugin-essentials/sources/commands/config/unset.ts
@@ -51,7 +51,7 @@ export default class ConfigUnsetCommand extends BaseCommand {
     if (typeof setting === `undefined`)
       throw new UsageError(`Couldn't find a configuration settings named "${name}"`);
 
-    const updateConfiguration: (patch: ((current: any) => any)) => Promise<void> =
+    const updateConfiguration: (patch: ((current: any) => any)) => Promise<boolean> =
       this.home
         ? patch => Configuration.updateHomeConfiguration(patch)
         : patch => Configuration.updateConfiguration(assertProjectCwd(), patch);

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -244,7 +244,7 @@ export default class YarnCommand extends BaseCommand {
       }, async report => {
         let changed = false;
 
-        if (await autofixLegacyPlugins(configuration)) {
+        if (await autofixLegacyPlugins(configuration, immutable)) {
           report.reportInfo(MessageName.AUTOMERGE_SUCCESS, `Automatically removed core plugins that are now builtins 👍`);
           changed = true;
         }
@@ -456,7 +456,7 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
   return true;
 }
 
-async function autofixLegacyPlugins(configuration: Configuration) {
+async function autofixLegacyPlugins(configuration: Configuration, immutable: boolean) {
   if (!configuration.projectCwd)
     return false;
 
@@ -468,6 +468,9 @@ async function autofixLegacyPlugins(configuration: Configuration) {
       return current;
 
     const plugins = current.plugins.filter((plugin: {spec: string, path: PortablePath}) => {
+      if (!plugin.path)
+        return true;
+
       const resolvedPath = ppath.resolve(configuration.projectCwd!, plugin.path);
       const isLegacy = LEGACY_PLUGINS.has(plugin.spec) && ppath.contains(yarnPluginDir, resolvedPath);
 
@@ -484,6 +487,8 @@ async function autofixLegacyPlugins(configuration: Configuration) {
       ...current,
       plugins,
     };
+  }, {
+    immutable,
   });
 
   if (!changed)

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -1,10 +1,10 @@
-import {BaseCommand, WorkspaceRequiredError}                                                                                     from '@yarnpkg/cli';
-import {Configuration, Cache, MessageName, Project, ReportError, StreamReport, formatUtils, InstallMode, execUtils, structUtils} from '@yarnpkg/core';
-import {xfs, ppath, Filename}                                                                                                    from '@yarnpkg/fslib';
-import {parseSyml, stringifySyml}                                                                                                from '@yarnpkg/parsers';
-import CI                                                                                                                        from 'ci-info';
-import {Command, Option, Usage, UsageError}                                                                                      from 'clipanion';
-import * as t                                                                                                                    from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                                                                                                     from '@yarnpkg/cli';
+import {Configuration, Cache, MessageName, Project, ReportError, StreamReport, formatUtils, InstallMode, execUtils, structUtils, LEGACY_PLUGINS} from '@yarnpkg/core';
+import {xfs, ppath, Filename, PortablePath}                                                                                                      from '@yarnpkg/fslib';
+import {parseSyml, stringifySyml}                                                                                                                from '@yarnpkg/parsers';
+import CI                                                                                                                                        from 'ci-info';
+import {Command, Option, Usage, UsageError}                                                                                                      from 'clipanion';
+import * as t                                                                                                                                    from 'typanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class YarnCommand extends BaseCommand {
@@ -242,8 +242,19 @@ export default class YarnCommand extends BaseCommand {
         stdout: this.context.stdout,
         includeFooter: false,
       }, async report => {
+        let changed = false;
+
+        if (await autofixLegacyPlugins(configuration)) {
+          report.reportInfo(MessageName.AUTOMERGE_SUCCESS, `Automatically removed core plugins that are now builtins 👍`);
+          changed = true;
+        }
+
         if (await autofixMergeConflicts(configuration, immutable)) {
           report.reportInfo(MessageName.AUTOMERGE_SUCCESS, `Automatically fixed merge conflicts 👍`);
+          changed = true;
+        }
+
+        if (changed) {
           report.reportSeparator();
         }
       });
@@ -441,6 +452,46 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
   await xfs.changeFilePromise(lockfilePath, stringifySyml(merged), {
     automaticNewlines: true,
   });
+
+  return true;
+}
+
+async function autofixLegacyPlugins(configuration: Configuration) {
+  if (!configuration.projectCwd)
+    return false;
+
+  const legacyPlugins: Array<PortablePath> = [];
+  const yarnPluginDir = ppath.join(configuration.projectCwd, `.yarn/plugins/@yarnpkg`);
+
+  const changed = await Configuration.updateConfiguration(configuration.projectCwd, current => {
+    if (!Array.isArray(current.plugins))
+      return current;
+
+    const plugins = current.plugins.filter((plugin: {spec: string, path: PortablePath}) => {
+      const resolvedPath = ppath.resolve(configuration.projectCwd!, plugin.path);
+      const isLegacy = LEGACY_PLUGINS.has(plugin.spec) && ppath.contains(yarnPluginDir, resolvedPath);
+
+      if (isLegacy)
+        legacyPlugins.push(resolvedPath);
+
+      return !isLegacy;
+    });
+
+    if (current.plugins.length === plugins.length)
+      return current;
+
+    return {
+      ...current,
+      plugins,
+    };
+  });
+
+  if (!changed)
+    return false;
+
+  await Promise.all(legacyPlugins.map(async pluginPath => {
+    await xfs.removePromise(pluginPath);
+  }));
 
   return true;
 }

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1219,7 +1219,7 @@ export class Configuration {
           const userProvidedChecksum = userPluginEntry?.checksum ?? ``;
 
           const pluginPath = ppath.resolve(cwd, npath.toPortablePath(userProvidedPath));
-          if (!ppath.relative(ppath.join(projectCwd!, `.yarn/plugins/@yarnpkg`), pluginPath).startsWith(`../`))
+          if (projectCwd && ppath.contains(ppath.join(projectCwd!, `.yarn/plugins/@yarnpkg`), pluginPath))
             continue;
 
           if (!await xfs.existsPromise(pluginPath)) {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -9,11 +9,10 @@ import {PassThrough, Writable}                                                  
 
 import {CorePlugin}                                                                                              from './CorePlugin';
 import {Manifest, PeerDependencyMeta}                                                                            from './Manifest';
-import {MessageName}                                                                                             from './MessageName';
 import {MultiFetcher}                                                                                            from './MultiFetcher';
 import {MultiResolver}                                                                                           from './MultiResolver';
 import {Plugin, Hooks, PluginMeta}                                                                               from './Plugin';
-import {Report, ReportError}                                                                                     from './Report';
+import {Report}                                                                                                  from './Report';
 import {TelemetryManager}                                                                                        from './TelemetryManager';
 import {VirtualFetcher}                                                                                          from './VirtualFetcher';
 import {VirtualResolver}                                                                                         from './VirtualResolver';

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1419,16 +1419,8 @@ export class Configuration {
       }
     }
 
-    let writeFile: (() => Promise<void>) | undefined;
-    if (opts?.immutable) {
-      writeFile = async () => {
-        throw new ReportError(MessageName.AUTOMERGE_IMMUTABLE, `Cannot autofix a lockfile when running an immutable install`);
-      };
-    }
-
     await xfs.changeFilePromise(configurationPath, stringifySyml(replacement), {
       automaticNewlines: true,
-      writeFile,
     });
 
     return true;

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -33,6 +33,16 @@ const isPublicRepository = GITHUB_ACTIONS && process.env.GITHUB_EVENT_PATH
   ? !(xfs.readJsonSync(npath.toPortablePath(process.env.GITHUB_EVENT_PATH)).repository?.private ?? true)
   : false;
 
+export const LEGACY_PLUGINS = new Set([
+  `@yarnpkg/plugin-constraints`,
+  `@yarnpkg/plugin-exec`,
+  `@yarnpkg/plugin-interactive-tools`,
+  `@yarnpkg/plugin-stage`,
+  `@yarnpkg/plugin-typescript`,
+  `@yarnpkg/plugin-version`,
+  `@yarnpkg/plugin-workspace-tools`,
+]);
+
 const IGNORED_ENV_VARIABLES = new Set([
   // Used by our test environment
   `isTestEnv`,
@@ -1209,6 +1219,9 @@ export class Configuration {
           const userProvidedChecksum = userPluginEntry?.checksum ?? ``;
 
           const pluginPath = ppath.resolve(cwd, npath.toPortablePath(userProvidedPath));
+          if (!ppath.relative(ppath.join(projectCwd!, `.yarn/plugins/@yarnpkg`), pluginPath).startsWith(`../`))
+            continue;
+
           if (!await xfs.existsPromise(pluginPath)) {
             if (!userProvidedSpec) {
               const prettyPluginName = formatUtils.pretty(configuration, ppath.basename(pluginPath, `.cjs`), formatUtils.Type.NAME);
@@ -1369,7 +1382,7 @@ export class Configuration {
       }
 
       if (replacement === current) {
-        return;
+        return false;
       }
     } else {
       replacement = current;
@@ -1401,13 +1414,15 @@ export class Configuration {
       }
 
       if (!patched) {
-        return;
+        return false;
       }
     }
 
     await xfs.changeFilePromise(configurationPath, stringifySyml(replacement), {
       automaticNewlines: true,
     });
+
+    return true;
   }
 
   static async addPlugin(cwd: PortablePath, pluginMetaList: Array<PluginMeta>) {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1218,10 +1218,10 @@ export class Configuration {
           const userProvidedSpec = userPluginEntry?.spec ?? ``;
           const userProvidedChecksum = userPluginEntry?.checksum ?? ``;
 
-          const pluginPath = ppath.resolve(cwd, npath.toPortablePath(userProvidedPath));
-          if (projectCwd && ppath.contains(ppath.join(projectCwd!, `.yarn/plugins/@yarnpkg`), pluginPath))
+          if (LEGACY_PLUGINS.has(userProvidedSpec))
             continue;
 
+          const pluginPath = ppath.resolve(cwd, npath.toPortablePath(userProvidedPath));
           if (!await xfs.existsPromise(pluginPath)) {
             if (!userProvidedSpec) {
               const prettyPluginName = formatUtils.pretty(configuration, ppath.basename(pluginPath, `.cjs`), formatUtils.Type.NAME);

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -12,7 +12,7 @@ import * as tgzUtils    from './tgzUtils';
 import * as treeUtils   from './treeUtils';
 
 export {Cache}                                                                                            from './Cache';
-export {DEFAULT_RC_FILENAME, DEFAULT_LOCK_FILENAME, TAG_REGEXP}                                           from './Configuration';
+export {DEFAULT_RC_FILENAME, DEFAULT_LOCK_FILENAME, LEGACY_PLUGINS, TAG_REGEXP}                           from './Configuration';
 export {Configuration, FormatType, ProjectLookup, SettingsType, WindowsLinkType}                          from './Configuration';
 export type {PluginConfiguration, SettingsDefinition, PackageExtensionData}                               from './Configuration';
 export type {ConfigurationValueMap, ConfigurationDefinitionMap}                                           from './Configuration';


### PR DESCRIPTION
**What's the problem this PR addresses?**

When using `yarn set version` with Yarn 4, the core plugins that were previously externals now conflict with the builtin ones, causing surprising errors.

Fixes #4952

**How did you fix it?**

Yarn will now ignore the specified list of plugins when booting. It'll then automatically remove them during the next install.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
