### PR TITLE
test: fix range for parent URL test

### DIFF
--- a/.yarn/versions/c594112e.yml
+++ b/.yarn/versions/c594112e.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/pnp"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
@@ -972,7 +972,7 @@ describe(`Plug'n'Play - ESM`, () => {
       ),
     );
 
-    (loaderFlags.HAS_CONSOLIDATED_HOOKS ? test : test.skip)(
+    (loaderFlags.ALLOWS_NON_FILE_PARENT ? test : test.skip)(
       `it should allow importing files regardless of parent URL`,
       makeTemporaryEnv(
         {

--- a/packages/yarnpkg-pnp/sources/esm-loader/loaderFlags.ts
+++ b/packages/yarnpkg-pnp/sources/esm-loader/loaderFlags.ts
@@ -15,3 +15,6 @@ export const WATCH_MODE_MESSAGE_USES_ARRAYS = major > 19 || (major === 19 && min
 // https://github.com/nodejs/node/pull/45659 changed the internal translators to be lazy loaded
 // TODO: Update the version range if https://github.com/nodejs/node/pull/46425 lands.
 export const HAS_LAZY_LOADED_TRANSLATORS = major > 19 || (major === 19 && minor >= 3);
+
+// https://github.com/nodejs/node/pull/42881
+export const ALLOWS_NON_FILE_PARENT = major > 18 || (major === 18 && minor >= 1) || (major === 16 && minor >= 17);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The test added in https://github.com/yarnpkg/berry/pull/5362 doesn't run on Node.js v17.

Fixes https://github.com/yarnpkg/berry/actions/runs/5060283241/jobs/9083017466

**How did you fix it?**

Updated the range to match Node.js versions containing https://github.com/nodejs/node/pull/42881

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.