### PR TITLE
feat(sdks): support eslint flat config

### DIFF
--- a/.yarn/versions/deb5e1c6.yml
+++ b/.yarn/versions/deb5e1c6.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -216,14 +216,16 @@ export class Wrapper {
       throw new Error(`Assertion failed: Package ${this.name} isn't a dependency of the top-level`);
 
     const manifest = dynamicRequire(npath.join(pkgInformation.packageLocation, `package.json`));
-
-    await xfs.mkdirPromise(ppath.dirname(absWrapperPath), {recursive: true});
-    await xfs.writeJsonPromise(absWrapperPath, {
+    const data = {
       name: this.name,
       version: `${manifest.version}-sdk`,
       main: manifest.main,
       type: `commonjs`,
-    });
+      exports: manifest.exports,
+    };
+    await xfs.mkdirPromise(ppath.dirname(absWrapperPath), {recursive: true});
+    await xfs.writeJsonPromise(absWrapperPath, data);
+    return data;
   }
 
   async writeBinary(relPackagePath: PortablePath, options: TemplateOptions = {}) {

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -1,3 +1,4 @@
+import {semverUtils}                            from '@yarnpkg/core';
 import {PortablePath}                           from '@yarnpkg/fslib';
 import {PnpApi}                                 from '@yarnpkg/pnp';
 
@@ -16,10 +17,13 @@ export const generateAstroLanguageServerBaseWrapper: GenerateBaseWrapper = async
 export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
+  const pkg = await wrapper.writeManifest();
 
   await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
   await wrapper.writeFile(`lib/api.js` as PortablePath, {requirePath: `` as PortablePath});
+
+  if (semverUtils.satisfiesWithPrereleases(pkg.version, `>=8`))
+    await wrapper.writeFile(`lib/unsupported-api.js` as PortablePath, {requirePath: `/use-at-your-own-risk` as PortablePath});
 
   return wrapper;
 };


### PR DESCRIPTION
**What's the problem this PR addresses?**

`yarn dlx @yarnpkg/sdks vscode` does not work with https://eslint.org/blog/2022/08/new-config-system-part-2/

**How did you fix it?**

Add a missing file for `eslint` and copies the exports map from manifests.

The newly generated files:

```js
#!/usr/bin/env node

const {existsSync} = require(`fs`);
const {createRequire} = require(`module`);
const {resolve} = require(`path`);

const relPnpApiPath = "../../../../.pnp.cjs";

const absPnpApiPath = resolve(__dirname, relPnpApiPath);
const absRequire = createRequire(absPnpApiPath);

if (existsSync(absPnpApiPath)) {
  if (!process.versions.pnp) {
    // Setup the environment to be able to require eslint/use-at-your-own-risk
    require(absPnpApiPath).setup();
  }
}

// Defer to the real eslint/use-at-your-own-risk your application uses
module.exports = absRequire(`eslint/use-at-your-own-risk`);
```

```json
{
  "name": "eslint",
  "version": "8.40.0-sdk",
  "main": "./lib/api.js",
  "type": "commonjs",
  "exports": {
    "./package.json": "./package.json",
    ".": "./lib/api.js",
    "./use-at-your-own-risk": "./lib/unsupported-api.js"
  }
}
```

I ran this via `yarn pack` and installed it into my local project and then tested it against an `eslint` that is using flat config. Everything works as expected.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
