### PR TITLE
Followups on the release branch workflow

### DIFF
--- a/scripts/release/03-release-npm.sh
+++ b/scripts/release/03-release-npm.sh
@@ -28,4 +28,4 @@ cd "$TEMP_DIR"
 export YARN_ENABLE_IMMUTABLE_INSTALLS=0
 
 node "$TEMP_DIR"/bin/yarn.js
-node "$TEMP_DIR"/bin/yarn.js npm publish --access=public
+node "$TEMP_DIR"/bin/yarn.js npm publish --tolerate-republish --access=public


### PR DESCRIPTION
- The GH action doesn't fetch the `master` branch, so it was missing
- The job wasn't retry-able, the npm package publishing would have failed.