### PR TITLE
ci(release): create GitHub release

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -9,7 +9,7 @@ on:
 name: 'Release Branch'
 jobs:
   release:
-    name: 'Releasing a Patch Version'
+    name: 'Release a new stable version'
     runs-on: ubuntu-latest
 
     env:
@@ -45,8 +45,16 @@ jobs:
       run: |
         git config user.name "Yarn Bot"
         git config user.email nison.mael+yarnbot@gmail.com
+
+        OLD_VERSION=$(YARN_IGNORE_PATH=1 node ./packages/yarnpkg-cli/bin/yarn.js --version)
         ./scripts/release/01-release-tags.sh
+        NEW_VERSION=$(YARN_IGNORE_PATH=1 node ./packages/yarnpkg-cli/bin/yarn.js --version)
+
         git push --follow-tags
+
+        if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+          gh release create "@yarnpkg/cli/$NEW_VERSION" --title "v$NEW_VERSION" --verify-tag --generate-notes --notes-start-tag "@yarnpkg/cli/$OLD_VERSION"
+        fi
 
     - name: 'Upload the releases'
       run: |


### PR DESCRIPTION
**What's the problem this PR addresses?**

[GitHub releases](https://github.com/yarnpkg/berry/releases) are created manually.

**How did you fix it?**

Automated it with the `gh release create` command.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.