### PR TITLE
ci(release): push release to master `master` and allow retrying releases

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -72,3 +72,4 @@ jobs:
         git checkout $RELEASE_COMMIT -- packages/*/bin/**
         git add .
         git commit -m 'Sync master with the changes from ${{github.event.inputs.branch}}'
+        git push

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -57,6 +57,10 @@ jobs:
 
     - name: 'Updates the stableVersion field'
       run: |
+        # Revert the change from "Build a binary for convenience"
+        git update-index --no-skip-worktree -- .yarnrc.yml
+        git checkout HEAD -- .yarnrc.yml
+
         RELEASE_COMMIT=$(git rev-parse HEAD)
         node ./scripts/stable-versions-store.js
         git fetch origin master

--- a/scripts/release/01-release-tags.sh
+++ b/scripts/release/01-release-tags.sh
@@ -33,9 +33,9 @@ done
 RELEASE_DETAILS=$(yarn version apply --all --json ${APPLY_OPTIONS})
 RELEASE_SIZE=$(wc -l <<< "$RELEASE_DETAILS")
 
-if [[ $RELEASE_SIZE -eq 0 ]]; then
+if [[ -z $RELEASE_DETAILS ]]; then
   echo "No package to release"
-  exit 1
+  exit 0
 elif [[ $RELEASE_SIZE -eq 1 ]]; then
   COMMIT_MESSAGE="Releasing one new package"
 else

--- a/scripts/release/02-release-builds.sh
+++ b/scripts/release/02-release-builds.sh
@@ -12,8 +12,11 @@ fi
 
 RELEASE_ARGUMENTS=()
 
+CLOSEST_TAG=$(git describe --tags --abbrev=0)
+RELEASE_COMMIT=$(git rev-list -n 1 "$CLOSEST_TAG")
+
 maybe_release_package() {
-  if git describe --match "$1/*" HEAD >& /dev/null; then
+  if git describe --match "$1/*" $RELEASE_COMMIT >&/dev/null; then
     RELEASE_ARGUMENTS+=(--include "$1")
   fi
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

- Release is stopped when `scripts/release/01-release-tags.sh` has no work to do.
- `scripts/release/02-release-builds.sh` assumes `HEAD` is the release commit but it might not be, for example after committing fixes to the release workflow and creating a new release.
- The release commit isn't getting pushed to `master`.

Follow-up to https://github.com/yarnpkg/berry/pull/5476 and https://github.com/yarnpkg/berry/pull/5478.

**How did you fix it?**

- Handle no new packages to release and change the exit code to 0.
- Find the last release commit and check that instead of `HEAD`.
- Reset the changes done to `.yarnrc.yml` and push the changes.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.