### PR TITLE
feat(sdks): add `relay-compiler` to vscode sdks

### DIFF
--- a/.yarn/versions/e6809da7.yml
+++ b/.yarn/versions/e6809da7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/docusaurus/docs/getting-started/editor-sdks.md
+++ b/packages/docusaurus/docs/getting-started/editor-sdks.md
@@ -30,6 +30,7 @@ import TOCInline from '@theme/TOCInline';
 | [prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | [prettier](https://yarnpkg.com/package/prettier) |
 | [flow-for-vscode*](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode) | [flow-bin](https://flow.org/) |
 | [astro-vscode](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode) | [astro](https://astro.build/) |
+| [relay](https://marketplace.visualstudio.com/items?itemName=meta.relay) | [relay](https://relay.dev/)
 
 > \* Flow is currently [incompatible with PnP](/features/pnp#incompatible).
 

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -178,6 +178,7 @@ export type SupportedSdk =
   | '@astrojs/language-server'
   | 'eslint'
   | 'prettier'
+  | 'relay-compiler'
   | 'typescript-language-server'
   | 'typescript'
   | 'svelte-language-server'

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -34,6 +34,16 @@ export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: P
   return wrapper;
 };
 
+export const generateRelayCompilerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`relay-compiler` as PortablePath, {pnpApi, target});
+
+  await wrapper.writeManifest();
+
+  await wrapper.writeBinary(`cli.js` as PortablePath);
+
+  return wrapper;
+};
+
 export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
@@ -291,6 +301,7 @@ export const BASE_SDKS: BaseSdks = [
   [`@astrojs/language-server`, generateAstroLanguageServerBaseWrapper],
   [`eslint`, generateEslintBaseWrapper],
   [`prettier`, generatePrettierBaseWrapper],
+  [`relay-compiler`, generateRelayCompilerBaseWrapper],
   [`typescript-language-server`, generateTypescriptLanguageServerBaseWrapper],
   [`typescript`, generateTypescriptBaseWrapper],
   [`svelte-language-server`, generateSvelteLanguageServerBaseWrapper],

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -79,6 +79,22 @@ export const generatePrettierWrapper: GenerateIntegrationWrapper = async (pnpApi
   });
 };
 
+export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
+    [`relay.pathToRelay`]: npath.fromPortablePath(
+      wrapper.getProjectPathTo(
+        `cli.js` as PortablePath,
+      ),
+    ),
+  });
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
+    [`recommendations`]: [
+      `meta.relay`,
+    ],
+  });
+};
+
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`typescript.tsdk`]: npath.fromPortablePath(
@@ -129,6 +145,7 @@ export const VSCODE_SDKS: IntegrationSdks = [
   [`@astrojs/language-server`, generateAstroLanguageServerWrapper],
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
+  [`relay-compiler`, generateRelayCompilerWrapper],
   [`typescript-language-server`, null],
   [`typescript`, generateTypescriptWrapper],
   [`svelte-language-server`, generateSvelteLanguageServerWrapper],


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`@yarnpkg/sdks` doesn't support [Relay GraphQL VSCode extension](https://marketplace.visualstudio.com/items?itemName=meta.relay).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Adds `relay-compiler` support to `@yarnpkg/sdks`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
