### PR TITLE
chore: delete global folder in benchmarks

### DIFF
--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -79,9 +79,8 @@ case $PACKAGE_MANAGER in
     ;;
   yarn)
     setup-yarn2
-    # TODO: Use `yarn cache clean` instead of manually removing the npm metadata once the feature is implemented
     bench install-full-cold \
-      --prepare 'rm -rf .yarn .pnp.* yarn.lock "$(yarn config get globalFolder)/npm-metadata" && yarn cache clean --all' \
+      --prepare 'rm -rf .yarn .pnp.* yarn.lock .yarn-global' \
       'yarn install'
     bench install-cache-only \
       --prepare 'rm -rf .yarn .pnp.* yarn.lock' \
@@ -96,9 +95,8 @@ case $PACKAGE_MANAGER in
   yarn-nm)
     setup-yarn2
     setup-yarn2-nm
-    # TODO: Use `yarn cache clean` instead of manually removing the npm metadata once the feature is implemented
     bench install-full-cold \
-      --prepare 'rm -rf .yarn node_modules yarn.lock "$(yarn config get globalFolder)/npm-metadata" && yarn cache clean --all' \
+      --prepare 'rm -rf .yarn node_modules yarn.lock .yarn-global' \
       'yarn install'
     bench install-cache-only \
       --prepare 'rm -rf .yarn node_modules yarn.lock' \
@@ -113,9 +111,8 @@ case $PACKAGE_MANAGER in
   yarn-pnpm)
     setup-yarn2
     setup-yarn2-pnpm
-    # TODO: Use `yarn cache clean` instead of manually removing the npm metadata once the feature is implemented
     bench install-full-cold \
-      --prepare 'rm -rf .yarn node_modules yarn.lock "$(yarn config get globalFolder)/npm-metadata" && yarn cache clean --all' \
+      --prepare 'rm -rf .yarn node_modules yarn.lock .yarn-global' \
       'yarn install'
     bench install-cache-only \
       --prepare 'rm -rf .yarn node_modules yarn.lock' \


### PR DESCRIPTION
**What's the problem this PR addresses?**

- https://github.com/yarnpkg/berry/pull/5491/commits/07b4ceb3c9c7b8a35037b9307980ffa2bcd1d9c8 changed the metadata cache structure but didn't update the benchmark script to match.
- We're not removing the `$globalFolder/index` folder so `install-full-cold` is skipping some work.

Follow-up to https://github.com/yarnpkg/berry/pull/5491

**How did you fix it?**

Clear the entire global folder.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.