### PR TITLE
ci: cache metadata

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -38,6 +38,8 @@ runs:
 
     - uses: actions/cache@v3
       with:
-        path: ${{ steps.global-path.outputs.globalFolder }}/cache
+        path: |
+          ${{ steps.global-path.outputs.globalFolder }}/cache
+          ${{ steps.global-path.outputs.globalFolder }}/metadata
         key: dependencies-${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
     #endregion


### PR DESCRIPTION
**What's the problem this PR addresses?**

Now that https://github.com/yarnpkg/berry/pull/5491 has landed we can cache the metadata for our e2e tests to potentially speed them up.

**How did you fix it?**

Cache metadata.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.