### PR TITLE
chore: fix tsconfig excludes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,9 @@
     "useUnknownInCatchVariables": false
   },
   "exclude": [
-    "packages/*/{lib,bin,bundles}",
+    "packages/*/lib",
+    "packages/*/bin",
+    "packages/*/bundles",
     "packages/yarnpkg-doctor/fixtures",
     "packages/gatsby",
     "packages/docusaurus",


### PR DESCRIPTION
**What's the problem this PR addresses?**

The exclude pattern `packages/*/{lib,bin,bundles}` in the `tsconfig.json` file doesn't work.

**How did you fix it?**

Split it out into separate entries.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.