### PR TITLE
Fixes registry used to check for deprecation settings

### DIFF
--- a/.yarn/versions/3da18857.yml
+++ b/.yarn/versions/3da18857.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/3da18857.yml
+++ b/.yarn/versions/3da18857.yml
@@ -1,5 +1,6 @@
 releases:
   "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
   "@yarnpkg/plugin-npm-cli": patch
 
 declined:

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -166,6 +166,12 @@ export const validLogins = {
 let whitelist = new Map();
 let recording: Array<Request> | null = null;
 
+export function sortJson<T>(data: Iterable<T>): Array<T> {
+  return miscUtils.sortMap(data, request => {
+    return JSON.stringify(request);
+  });
+}
+
 export const startRegistryRecording = async (
   fn: () => Promise<void>,
 ) => {
@@ -174,11 +180,7 @@ export const startRegistryRecording = async (
 
   try {
     await fn();
-    return Object.assign(currentRecording, {
-      toSorted: () => miscUtils.sortMap(currentRecording, request => {
-        return JSON.stringify(request);
-      }),
-    });
+    return currentRecording;
   } finally {
     recording = null;
   }

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -584,37 +584,37 @@ export const startPackageServer = ({type}: { type: keyof typeof packageServerUrl
         type: RequestType.Repository,
       };
     } else {
-      let registry: string | undefined;
+      let registry: {registry: string} | undefined;
       if ((match = url.match(/^\/registry\/([a-z]+)\//))) {
         url = url.slice(match[0].length - 1);
-        registry = match[1];
+        registry = {registry: match[1]};
       }
 
       if ((match = url.match(/^\/-\/user\/org\.couchdb\.user:(.+)/))) {
         const [, username] = match;
 
         return {
-          registry,
+          ...registry,
           type: RequestType.Login,
           username,
         };
       } else if (url === `/-/whoami`) {
         return {
-          registry,
+          ...registry,
           type: RequestType.Whoami,
           // Set later when login is parsed
           login: null as any,
         };
       } else if (url === `/-/npm/v1/security/advisories/bulk`) {
         return {
-          registry,
+          ...registry,
           type: RequestType.BulkAdvisories,
         };
       } else if ((match = url.match(/^\/(?:(@[^/]+)\/)?([^@/][^/]*)$/)) && method == `PUT`) {
         const [, scope, localName] = match;
 
         return {
-          registry,
+          ...registry,
           type: RequestType.Publish,
           scope,
           localName,
@@ -623,7 +623,7 @@ export const startPackageServer = ({type}: { type: keyof typeof packageServerUrl
         const [, scope, localName] = match;
 
         return {
-          registry,
+          ...registry,
           type: RequestType.PackageInfo,
           scope,
           localName,
@@ -635,7 +635,7 @@ export const startPackageServer = ({type}: { type: keyof typeof packageServerUrl
           return null;
 
         return {
-          registry,
+          ...registry,
           type: RequestType.PackageTarball,
           scope,
           localName,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
@@ -198,7 +198,7 @@ describe(`Commands`, () => {
           await expect(run(`npm`, `audit`)).rejects.toThrow(/no-deps-deprecated \(deprecation\)/);
         });
 
-        expect(requests.toSorted()).toEqual([{
+        expect(tests.sortJson(requests)).toEqual([{
           registry: `audit`,
           type: `bulkAdvisories`,
         }, {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
@@ -1,4 +1,5 @@
 import {Filename, ppath, xfs} from '@yarnpkg/fslib';
+import {tests}                from 'pkg-tests-core';
 
 describe(`Commands`, () => {
   describe(`npm audit`, () => {
@@ -181,15 +182,31 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should report deprecations as audit issues`,
+      `it should perform the deprecation checks against the package registry, not the audit registry`,
       makeTemporaryEnv({
         dependencies: {
           [`no-deps-deprecated`]: `1.0.0`,
         },
       }, async ({path, run, source}) => {
+        await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+          npmAuditRegistry: `${await tests.startPackageServer()}/registry/audit`,
+        });
+
         await run(`install`);
 
-        await expect(run(`npm`, `audit`)).rejects.toThrow(/no-deps-deprecated \(deprecation\)/);
+        const requests = await tests.startRegistryRecording(async () => {
+          await expect(run(`npm`, `audit`)).rejects.toThrow(/no-deps-deprecated \(deprecation\)/);
+        });
+
+        expect(requests.toSorted()).toEqual([{
+          registry: `audit`,
+          type: `bulkAdvisories`,
+        }, {
+          registry: undefined,
+          scope: undefined,
+          localName: `no-deps-deprecated`,
+          type: `packageInfo`,
+        }]);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/stage.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/stage.test.js
@@ -48,7 +48,7 @@ describe(`Commands`, () => {
         await expect(run(`stage`, `-n`, {cwd: path})).resolves.toMatchObject({
           stdout: [
             `${npath.fromPortablePath(`${path}/.pnp.cjs`)}\n`,
-            `${npath.fromPortablePath(`${path}/.yarn/global/metadata/npm/b98544/localhost/no-deps.json`)}\n`,
+            `${npath.fromPortablePath(`${path}/.yarn/global/metadata/npm/3fb1ad/localhost/no-deps.json`)}\n`,
             `${npath.fromPortablePath(`${path}/.yarn/global/cache/no-deps-npm-1.0.0-cf533b267a-0.zip`)}\n`,
             `${npath.fromPortablePath(`${path}/.yarn/cache/.gitignore`)}\n`,
             `${npath.fromPortablePath(`${path}/.yarn/cache/no-deps-npm-1.0.0-cf533b267a-af041f19ff.zip`)}\n`,

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -170,11 +170,6 @@ type CachedMetadata = {
   lastModified?: string;
 };
 
-export type PackageMetadata = {
-  'dist-tags': Record<string, string>;
-  versions: Record<string, any>;
-};
-
 const CACHED_FIELDS = [
   `name`,
 
@@ -193,14 +188,27 @@ const CACHED_FIELDS = [
 
   `peerDependencies`,
   `peerDependenciesMeta`,
-];
+
+  `deprecated`,
+] as const;
+
+export type PackageMetadata = {
+  'dist-tags': Record<string, string>;
+  versions: Record<string, {
+    [key in typeof CACHED_FIELDS[number]]: any;
+  } & {
+    dist: {
+      tarball: string;
+    };
+  }>;
+};
 
 function pickPackageMetadata(metadata: PackageMetadata): PackageMetadata {
   return {
     'dist-tags': metadata[`dist-tags`],
     versions: Object.fromEntries(Object.entries(metadata.versions).map(([key, value]) => [
       key,
-      pick(value, CACHED_FIELDS),
+      pick(value, CACHED_FIELDS) as any,
     ])),
   };
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**

The new `yarn npm audit` implementation checks the packages' metadata on the audit server rather than the server configured to serve their metadata.

Closes #5533 

**How did you fix it?**

Updated the code to use the new `getPackageMetadata` function, which should use the proper server while also leveraging the cache if possible.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
