### PR TITLE
Fixes settings interpolation with dotenv variables

### DIFF
--- a/.yarn/versions/a1769d6c.yml
+++ b/.yarn/versions/a1769d6c.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/core"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,8 +13,6 @@ enableGlobalCache: false
 immutablePatterns:
   - .pnp.*
 
-initScope: yarnpkg
-
 npmPublishAccess: public
 
 packageExtensions:

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/dotEnvFiles.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/dotEnvFiles.test.ts
@@ -110,4 +110,20 @@ describe(`DotEnv files`, () => {
 
     await run(`install`);
   }));
+
+  it(`should allow values from environment files to be reused in other configuration settings`, makeTemporaryEnv({}, async ({path, run, source}) => {
+    await run(`install`);
+
+    await xfs.writeFilePromise(ppath.join(path, `.env`), [
+      `INJECTED_FROM_ENV_FILE=hello\n`,
+    ].join(``));
+
+    await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+      initScope: `\${INJECTED_FROM_ENV_FILE}`,
+    });
+
+    await expect(run(`config`, `get`, `initScope`)).resolves.toMatchObject({
+      stdout: `hello\n`,
+    });
+  }));
 });

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -749,7 +749,7 @@ function parseSingleValue(configuration: Configuration, path: string, valueBase:
       throw new Error(`Expected configuration setting "${path}" to be a string, got ${typeof value}`);
 
     const valueWithReplacedVariables = miscUtils.replaceEnvVariables(value, {
-      env: process.env,
+      env: configuration.env,
     });
 
     switch (definition.type) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I forgot in #4718 to add a test making sure that the yarnrc settings could use the variable set in the dotenv files (the existing tests were mainly around the values set during script execution), and of course I forgot a change 🥲

**How did you fix it?**

We now pass the updated environment when interpolating values.

**Checklist**

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
