### PR TITLE
Tweaks the .env implementation

### DIFF
--- a/.yarn/versions/523ca228.yml
+++ b/.yarn/versions/523ca228.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/parsers": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The following changes only affect people writing Yarn plugins:
 
 ### Features
 
+- `yarn run` now injects the environment variables defined in `.env.yarn` when spawning a process. The list of files thus injected can be controlled using the `injectEnvironmentFiles` variable.
 - `yarn workspaces foreach` now automatically enables the `-v,--verbose` flag in interactive terminal environments.
 
 ### Bugfixes

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
@@ -1,5 +1,5 @@
 import {Filename, ppath, xfs} from '@yarnpkg/fslib';
-import { parseSyml } from '@yarnpkg/parsers';
+import {parseSyml}            from '@yarnpkg/parsers';
 import {EOL}                  from 'os';
 
 describe(`Commands`, () => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/config/set.test.ts
@@ -1,8 +1,24 @@
-import {PortablePath, xfs} from '@yarnpkg/fslib';
-import {EOL}               from 'os';
+import {Filename, ppath, xfs} from '@yarnpkg/fslib';
+import { parseSyml } from '@yarnpkg/parsers';
+import {EOL}                  from 'os';
 
 describe(`Commands`, () => {
   describe(`config set`, () => {
+    test(
+      `it shouldn't remove empty arrays from the files`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
+          injectEnvironmentFiles: [],
+        });
+
+        await run(`config`, `set`, `pnpShebang`, `#!/usr/bin/env iojs\n`);
+
+        expect(parseSyml(await xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`))).toMatchObject({
+          injectEnvironmentFiles: [],
+        });
+      }),
+    );
+
     test(
       `it should print the configured value for the current directory`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
@@ -10,7 +26,7 @@ describe(`Commands`, () => {
           stdout: expect.stringContaining(`#!/usr/bin/env iojs\\n`),
         });
 
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml` as PortablePath, `utf8`)).resolves.toContain(`pnpShebang`);
+        await expect(xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`)).resolves.toContain(`pnpShebang`);
       }),
     );
 
@@ -22,7 +38,7 @@ describe(`Commands`, () => {
         expect(stdout).not.toContain(`foobar`);
         expect(stdout).toContain(`********`);
 
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml` as PortablePath, `utf8`)).resolves.toContain(`npmAuthToken: foobar`);
+        await expect(xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`)).resolves.toContain(`npmAuthToken: foobar`);
       }),
     );
 
@@ -36,7 +52,7 @@ describe(`Commands`, () => {
         expect(stdout).toContain(`npmScopes.yarnpkg`);
         expect(stdout).toContain(`npmAlwaysAuth: false`);
 
-        await expect(xfs.readFilePromise(`${path}/.yarnrc.yml` as PortablePath, `utf8`)).resolves.toContain(
+        await expect(xfs.readFilePromise(ppath.join(path, Filename.rc), `utf8`)).resolves.toContain(
           `npmScopes:${EOL}` +
           `  yarnpkg:${EOL}` +
           `    npmAlwaysAuth: false`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/dotEnvFiles.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/dotEnvFiles.test.ts
@@ -1,10 +1,10 @@
 import {Filename, ppath, xfs} from '@yarnpkg/fslib';
 
 describe(`DotEnv files`, () => {
-  it(`should automatically inject a .env file in the environment`, makeTemporaryEnv({}, async ({path, run, source}) => {
+  it(`should automatically inject a .env.yarn file in the environment`, makeTemporaryEnv({}, async ({path, run, source}) => {
     await run(`install`);
 
-    await xfs.writeFilePromise(ppath.join(path, `.env`), [
+    await xfs.writeFilePromise(ppath.join(path, `.env.yarn`), [
       `INJECTED_FROM_ENV_FILE=hello\n`,
     ].join(``));
 
@@ -16,7 +16,7 @@ describe(`DotEnv files`, () => {
   it(`should allow .env variables to be interpolated`, makeTemporaryEnv({}, async ({path, run, source}) => {
     await run(`install`);
 
-    await xfs.writeFilePromise(ppath.join(path, `.env`), [
+    await xfs.writeFilePromise(ppath.join(path, `.env.yarn`), [
       `INJECTED_FROM_ENV_FILE=\${FOO}\n`,
     ].join(``));
 
@@ -28,7 +28,7 @@ describe(`DotEnv files`, () => {
   it(`should allow .env variables to be used in the next ones`, makeTemporaryEnv({}, async ({path, run, source}) => {
     await run(`install`);
 
-    await xfs.writeFilePromise(ppath.join(path, `.env`), [
+    await xfs.writeFilePromise(ppath.join(path, `.env.yarn`), [
       `INJECTED_FROM_ENV_FILE_1=hello\n`,
       `INJECTED_FROM_ENV_FILE_2=\${INJECTED_FROM_ENV_FILE_1} world\n`,
     ].join(``));
@@ -38,7 +38,7 @@ describe(`DotEnv files`, () => {
     });
   }));
 
-  it(`shouldn't read the .env if the injectEnvironmentFiles setting is defined`, makeTemporaryEnv({}, async ({path, run, source}) => {
+  it(`shouldn't read the .env.yarn file if the injectEnvironmentFiles setting is defined`, makeTemporaryEnv({}, async ({path, run, source}) => {
     await xfs.writeJsonPromise(ppath.join(path, Filename.rc), {
       injectEnvironmentFiles: [],
     });
@@ -114,7 +114,7 @@ describe(`DotEnv files`, () => {
   it(`should allow values from environment files to be reused in other configuration settings`, makeTemporaryEnv({}, async ({path, run, source}) => {
     await run(`install`);
 
-    await xfs.writeFilePromise(ppath.join(path, `.env`), [
+    await xfs.writeFilePromise(ppath.join(path, `.env.yarn`), [
       `INJECTED_FROM_ENV_FILE=hello\n`,
     ].join(``));
 

--- a/packages/plugin-essentials/sources/commands/plugin/remove.ts
+++ b/packages/plugin-essentials/sources/commands/plugin/remove.ts
@@ -51,21 +51,23 @@ export default class PluginRemoveCommand extends BaseCommand {
       }
 
       report.reportInfo(MessageName.UNNAMED, `Updating the configuration...`);
-      await Configuration.updateConfiguration(project.cwd, (current: {[key: string]: unknown}) => {
-        if (!Array.isArray(current.plugins))
-          return current;
+      await Configuration.updateConfiguration(project.cwd, {
+        plugins: plugins => {
+          if (!Array.isArray(plugins))
+            return plugins;
 
-        const plugins = current.plugins.filter((plugin: {path: string}) => {
-          return plugin.path !== relativePath;
-        });
+          const filteredPlugins = plugins.filter((plugin: {path: string}) => {
+            return plugin.path !== relativePath;
+          });
 
-        if (current.plugins.length === plugins.length)
-          return current;
+          if (filteredPlugins.length === 0)
+            return Configuration.deleteProperty;
 
-        return {
-          ...current,
-          plugins,
-        };
+          if (filteredPlugins.length === plugins.length)
+            return plugins;
+
+          return filteredPlugins;
+        },
       });
     });
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -540,7 +540,7 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
   injectEnvironmentFiles: {
     description: `List of all the environment files that Yarn should inject inside the process when it starts`,
     type: SettingsType.ABSOLUTE_PATH,
-    default: [`.env?`],
+    default: [`.env.yarn?`],
     isArray: true,
   },
 

--- a/packages/yarnpkg-parsers/sources/syml.ts
+++ b/packages/yarnpkg-parsers/sources/syml.ts
@@ -25,7 +25,7 @@ function isRemovableField(value: any): boolean {
   if (typeof value === `undefined`)
     return true;
 
-  if (typeof value === `object` && value !== null)
+  if (typeof value === `object` && value !== null && !Array.isArray(value))
     return Object.keys(value).every(key => isRemovableField(value[key]));
 
   return false;


### PR DESCRIPTION
**What's the problem this PR addresses?**

It was raised in https://github.com/yarnpkg/berry/pull/5544#issuecomment-1613691793 that automatically injecting the `.env` file in the environment could break compatibility with some software that already do this in their own way. It makes sense, and I prefer to avoid doing that if there's a reasonable compromise.

Also closes https://github.com/yarnpkg/berry/issues/5545.

**How did you fix it?**

Yarn will now default into loading the `.env.yarn` file, rather than `.env`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
