### PR TITLE
ci(release): set `GH_TOKEN` when creating GitHub release

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -53,7 +53,7 @@ jobs:
         git push --follow-tags
 
         if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-          gh release create "@yarnpkg/cli/$NEW_VERSION" --title "v$NEW_VERSION" --verify-tag --generate-notes --notes-start-tag "@yarnpkg/cli/$OLD_VERSION"
+          GH_TOKEN="${{secrets.YARNBOT_TOKEN}}" gh release create "@yarnpkg/cli/$NEW_VERSION" --title "v$NEW_VERSION" --verify-tag --generate-notes --notes-start-tag "@yarnpkg/cli/$OLD_VERSION"
         fi
 
     - name: 'Upload the releases'


### PR DESCRIPTION
**What's the problem this PR addresses?**

The GitHub CLI requires setting the `GH_TOKEN` environment variable in order to use it.

Fixes https://github.com/yarnpkg/berry/actions/runs/5427185945/jobs/9870161176#step:6:414
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

**How did you fix it?**

Set the environment variable.

Verified this works with https://github.com/yarnpkg/berry/commit/87a0d818ce646284e3bda7234a014525f51fa164 to create https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F3.6.1.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.