### PR TITLE
Exposes packages to constraints

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8938,7 +8938,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@monaco-editor/loader", "virtual:956388b1082d91160b57d421bcac1585de699e8b08c9c76af8da19b36bbe12051a09fdfd7fdd48a1e63ae8ea79e6f91d10bd325f8c6a68380ffcebaa5742631b#npm:1.3.2"],\
           ["@types/monaco-editor", null],\
-          ["monaco-editor", null],\
+          ["monaco-editor", "npm:0.24.0"],\
           ["state-local", "npm:1.0.7"]\
         ],\
         "packagePeers": [\
@@ -8964,7 +8964,7 @@ const RAW_RUNTIME_STATE =
           ["@types/monaco-editor", null],\
           ["@types/react", "npm:16.9.2"],\
           ["@types/react-dom", null],\
-          ["monaco-editor", null],\
+          ["monaco-editor", "npm:0.24.0"],\
           ["prop-types", "npm:15.8.1"],\
           ["react", "npm:17.0.2"],\
           ["react-dom", "virtual:efae73f2e9aa11493dde5182b5b7f0894b5c101cb3c916b74523dc0bde92d8579259d43c7f83a5363dbd8939dc3d1e6c45c5965b9191878533d9a2c19b046d70#npm:17.0.2"]\
@@ -11379,11 +11379,11 @@ const RAW_RUNTIME_STATE =
           ["@types/eslint", null],\
           ["@types/typescript", null],\
           ["@types/typescript-eslint__parser", null],\
-          ["@typescript-eslint/experimental-utils", "virtual:6900ebaf5081b92e6c974168b9ed954716a444291c9fe1a173c1304197b291168df1ea3cf978bb2312fb0dbf89c3539ccdfa849d3c4eeb455264b8913835792e#npm:5.3.1"],\
+          ["@typescript-eslint/experimental-utils", "virtual:5e27cd7a319c4b7c3909eb012bf293660fa275bf4eddce08571aa0562ef7b9b8f3c02315f6dad27820a35a49c368107bf917cd6e2a8d99abe84b6a230d415fc4#npm:5.3.1"],\
           ["@typescript-eslint/parser", "virtual:7e29ef780829a7f5844bc9463a6da911a4e9f70db032355b31dd04cbadc7ff9d3a8eb4b4f77ebc94ebcbe7331a40ea818ae04778cd971a4d3699a0d352bbfe63#npm:5.3.1"],\
           ["@typescript-eslint/scope-manager", "npm:5.3.1"],\
           ["debug", "virtual:142ba651bd70dac073ff3db3802f4ea29eff00d44224dd3049edf764b3f7df3c6422788fa486ce2f45a8f2e710e5925abafab7126fee39d5d57a83f2087201ff#npm:4.3.4"],\
-          ["eslint", null],\
+          ["eslint", "npm:8.2.0"],\
           ["functional-red-black-tree", "npm:1.0.1"],\
           ["ignore", "npm:5.2.0"],\
           ["regexpp", "npm:3.2.0"],\
@@ -11448,25 +11448,6 @@ const RAW_RUNTIME_STATE =
           ["eslint", "npm:8.2.0"],\
           ["eslint-scope", "npm:5.1.1"],\
           ["eslint-utils", "virtual:6d0abafe924380b8a54934deb981250aecd1fb8124363457a374cef0557d01fb4814e3ba24dc97878e46ace75335e5f2ff24faa593260513f9428ef3fbe949ae#npm:3.0.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/eslint",\
-          "eslint"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:6900ebaf5081b92e6c974168b9ed954716a444291c9fe1a173c1304197b291168df1ea3cf978bb2312fb0dbf89c3539ccdfa849d3c4eeb455264b8913835792e#npm:5.3.1", {\
-        "packageLocation": "./.yarn/__virtual__/@typescript-eslint-experimental-utils-virtual-8e46a2fab8/0/cache/@typescript-eslint-experimental-utils-npm-5.3.1-6c74e83072-13c2e4e759.zip/node_modules/@typescript-eslint/experimental-utils/",\
-        "packageDependencies": [\
-          ["@typescript-eslint/experimental-utils", "virtual:6900ebaf5081b92e6c974168b9ed954716a444291c9fe1a173c1304197b291168df1ea3cf978bb2312fb0dbf89c3539ccdfa849d3c4eeb455264b8913835792e#npm:5.3.1"],\
-          ["@types/eslint", null],\
-          ["@types/json-schema", "npm:7.0.11"],\
-          ["@typescript-eslint/scope-manager", "npm:5.3.1"],\
-          ["@typescript-eslint/types", "npm:5.3.1"],\
-          ["@typescript-eslint/typescript-estree", "virtual:893b20127f54d6cca6f9de9b91eac8bc5d6a2f48a8cec768e046591c0fa1316878037f9fea5cd29e52c3f2ae04fe43d83fbf7ca791a69b5ed992a8b61865d25f#npm:5.3.1"],\
-          ["eslint", null],\
-          ["eslint-scope", "npm:5.1.1"],\
-          ["eslint-utils", "virtual:8e46a2fab8c7c8dfefdcc06ff3b5e26433d44ab46148b7f4ea005ceea3b9dfd3801c33d3fa99b47664a6575c17efcf43ecd4263860e99a87abce33c2edb45ba5#npm:3.0.0"]\
         ],\
         "packagePeers": [\
           "@types/eslint",\
@@ -11542,7 +11523,7 @@ const RAW_RUNTIME_STATE =
           ["@typescript-eslint/types", "npm:5.3.1"],\
           ["@typescript-eslint/typescript-estree", "virtual:893b20127f54d6cca6f9de9b91eac8bc5d6a2f48a8cec768e046591c0fa1316878037f9fea5cd29e52c3f2ae04fe43d83fbf7ca791a69b5ed992a8b61865d25f#npm:5.3.1"],\
           ["debug", "virtual:142ba651bd70dac073ff3db3802f4ea29eff00d44224dd3049edf764b3f7df3c6422788fa486ce2f45a8f2e710e5925abafab7126fee39d5d57a83f2087201ff#npm:4.3.4"],\
-          ["eslint", null],\
+          ["eslint", "npm:8.2.0"],\
           ["typescript", null]\
         ],\
         "packagePeers": [\
@@ -13138,6 +13119,7 @@ const RAW_RUNTIME_STATE =
           ["github-markdown-css", "npm:5.1.0"],\
           ["js-untar", "npm:2.0.0"],\
           ["markdown-it", "npm:13.0.1"],\
+          ["monaco-editor", "npm:0.24.0"],\
           ["pako", "npm:2.0.4"],\
           ["prism-react-renderer", "virtual:efae73f2e9aa11493dde5182b5b7f0894b5c101cb3c916b74523dc0bde92d8579259d43c7f83a5363dbd8939dc3d1e6c45c5965b9191878533d9a2c19b046d70#npm:1.3.5"],\
           ["react", "npm:17.0.2"],\
@@ -13181,8 +13163,9 @@ const RAW_RUNTIME_STATE =
           ["@rushstack/eslint-patch", "npm:1.1.0"],\
           ["@typescript-eslint/eslint-plugin", "virtual:7e29ef780829a7f5844bc9463a6da911a4e9f70db032355b31dd04cbadc7ff9d3a8eb4b4f77ebc94ebcbe7331a40ea818ae04778cd971a4d3699a0d352bbfe63#npm:5.3.1"],\
           ["@typescript-eslint/parser", "virtual:7e29ef780829a7f5844bc9463a6da911a4e9f70db032355b31dd04cbadc7ff9d3a8eb4b4f77ebc94ebcbe7331a40ea818ae04778cd971a4d3699a0d352bbfe63#npm:5.3.1"],\
+          ["eslint", "npm:8.2.0"],\
           ["eslint-plugin-arca", "npm:0.12.1"],\
-          ["eslint-plugin-react", "virtual:7e29ef780829a7f5844bc9463a6da911a4e9f70db032355b31dd04cbadc7ff9d3a8eb4b4f77ebc94ebcbe7331a40ea818ae04778cd971a4d3699a0d352bbfe63#npm:7.31.8"]\
+          ["eslint-plugin-react", "virtual:4b728ee22ccd3ae66b83e3be6d39acfb5b7a775112cc78b6b4322feb849fcfe6e39510452356cb4477dc6089bee57db31d02bbfb03b9fc8e914effa16a4145be#npm:7.31.8"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -29681,33 +29664,6 @@ const RAW_RUNTIME_STATE =
           "eslint"\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["virtual:7e29ef780829a7f5844bc9463a6da911a4e9f70db032355b31dd04cbadc7ff9d3a8eb4b4f77ebc94ebcbe7331a40ea818ae04778cd971a4d3699a0d352bbfe63#npm:7.31.8", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-plugin-react-virtual-33136f2f9f/0/cache/eslint-plugin-react-npm-7.31.8-54babab916-310d9fc70c.zip/node_modules/eslint-plugin-react/",\
-        "packageDependencies": [\
-          ["eslint-plugin-react", "virtual:7e29ef780829a7f5844bc9463a6da911a4e9f70db032355b31dd04cbadc7ff9d3a8eb4b4f77ebc94ebcbe7331a40ea818ae04778cd971a4d3699a0d352bbfe63#npm:7.31.8"],\
-          ["@types/eslint", null],\
-          ["array-includes", "npm:3.1.5"],\
-          ["array.prototype.flatmap", "npm:1.3.0"],\
-          ["doctrine", "npm:2.1.0"],\
-          ["eslint", null],\
-          ["estraverse", "npm:5.3.0"],\
-          ["jsx-ast-utils", "npm:3.2.0"],\
-          ["minimatch", "npm:3.1.2"],\
-          ["object.entries", "npm:1.1.5"],\
-          ["object.fromentries", "npm:2.0.5"],\
-          ["object.hasown", "npm:1.1.1"],\
-          ["object.values", "npm:1.1.5"],\
-          ["prop-types", "npm:15.8.1"],\
-          ["resolve", "patch:resolve@npm%3A2.0.0-next.3#optional!builtin<compat/resolve>::version=2.0.0-next.3&hash=c3c19d"],\
-          ["semver", "npm:6.3.0"],\
-          ["string.prototype.matchall", "npm:4.0.7"]\
-        ],\
-        "packagePeers": [\
-          "@types/eslint",\
-          "eslint"\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["eslint-plugin-react-hooks", [\
@@ -29797,20 +29753,6 @@ const RAW_RUNTIME_STATE =
           ["eslint-utils", "virtual:87054ba6afeb2983c270a5d27a660ead10a765c2a6a75aae8f19b85d0a11625cab0b13c2b56209a05bd888aa6cd6ffbcb5407c8d3052ba937eef576c2a8c0906#npm:3.0.0"],\
           ["@types/eslint", null],\
           ["eslint", "npm:7.32.0"],\
-          ["eslint-visitor-keys", "npm:2.1.0"]\
-        ],\
-        "packagePeers": [\
-          "@types/eslint",\
-          "eslint"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:8e46a2fab8c7c8dfefdcc06ff3b5e26433d44ab46148b7f4ea005ceea3b9dfd3801c33d3fa99b47664a6575c17efcf43ecd4263860e99a87abce33c2edb45ba5#npm:3.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-utils-virtual-c8e77ee4c8/0/cache/eslint-utils-npm-3.0.0-630b3a4013-7675260a6b.zip/node_modules/eslint-utils/",\
-        "packageDependencies": [\
-          ["eslint-utils", "virtual:8e46a2fab8c7c8dfefdcc06ff3b5e26433d44ab46148b7f4ea005ceea3b9dfd3801c33d3fa99b47664a6575c17efcf43ecd4263860e99a87abce33c2edb45ba5#npm:3.0.0"],\
-          ["@types/eslint", null],\
-          ["eslint", null],\
           ["eslint-visitor-keys", "npm:2.1.0"]\
         ],\
         "packagePeers": [\

--- a/.yarn/versions/d431919c.yml
+++ b/.yarn/versions/d431919c.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/plugin-constraints": major
+  "@yarnpkg/types": major
+
+declined:
+  - "@yarnpkg/eslint-config"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/__snapshots__/constraints.test.js.snap
@@ -22,8 +22,8 @@ exports[`Commands constraints test (empty project / gen_enforced_dependency (amb
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -126,8 +126,8 @@ exports[`Commands constraints test (empty project / gen_enforced_field (ambiguou
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -278,18 +278,18 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
   "stderr": "",
   "stdout": "├─ root-workspace-0b6124@workspace:.
 │  └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 │
 ├─ workspace-a@workspace:packages/workspace-a
 │  └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 │
 └─ workspace-b@workspace:packages/workspace-b
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -354,19 +354,19 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_dependenc
   "stderr": "",
   "stdout": "├─ workspace-a@workspace:packages/workspace-a
 │  ├─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-│  │  ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-│  │  └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+│  │  ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+│  │  └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 │  └─ Conflict detected in constraint targeting devDependencies["no-deps"]; conflicting values are:
-│     ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-│     └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+│     ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+│     └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 │
 └─ workspace-b@workspace:packages/workspace-b
    ├─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-   │  ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-   │  └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+   │  ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+   │  └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
    └─ Conflict detected in constraint targeting devDependencies["no-deps"]; conflicting values are:
-      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 ",
 }
 `;
@@ -472,18 +472,18 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (am
   "stderr": "",
   "stdout": "├─ root-workspace-0b6124@workspace:.
 │  └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 │
 ├─ workspace-a@workspace:packages/workspace-a
 │  └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+│     ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+│     └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 │
 └─ workspace-b@workspace:packages/workspace-b
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -517,10 +517,10 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (ex
   "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
 
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+│  └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 ",
 }
 `;
@@ -532,10 +532,10 @@ exports[`Commands constraints test (multiple workspaces / gen_enforced_field (ex
   "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
 
 ├─ workspace-a@workspace:packages/workspace-a
-│  └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+│  └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 │
 └─ workspace-b@workspace:packages/workspace-b
-   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 ",
 }
 `;
@@ -696,8 +696,8 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -744,8 +744,8 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_depend
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 ",
 }
 `;
@@ -812,8 +812,8 @@ exports[`Commands constraints test (one regular dependency / gen_enforced_field 
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -972,8 +972,8 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1016,8 +1016,8 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting devDependencies["no-deps"]; conflicting values are:
-      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 ",
 }
 `;
@@ -1084,8 +1084,8 @@ exports[`Commands constraints test (two development dependencies / gen_enforced_
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1236,8 +1236,8 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1284,8 +1284,8 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_depe
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 ",
 }
 `;
@@ -1352,8 +1352,8 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1377,7 +1377,7 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
   "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
 
 └─ root-workspace-0b6124@workspace:.
-   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 ",
 }
 `;
@@ -1389,7 +1389,7 @@ exports[`Commands constraints test (two regular dependencies / gen_enforced_fiel
   "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
 
 └─ root-workspace-0b6124@workspace:.
-   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 ",
 }
 `;
@@ -1512,8 +1512,8 @@ exports[`Commands constraints test (two regular dependencies, two development de
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1561,11 +1561,11 @@ exports[`Commands constraints test (two regular dependencies, two development de
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    ├─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-   │  ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-   │  └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+   │  ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+   │  └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
    └─ Conflict detected in constraint targeting devDependencies["no-deps"]; conflicting values are:
-      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ undefined at exports.constraints (/path/to/yarn.config.js:3:72)
+      └─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:4:82)
 ",
 }
 `;
@@ -1632,8 +1632,8 @@ exports[`Commands constraints test (two regular dependencies, two development de
   "stderr": "",
   "stdout": "└─ root-workspace-0b6124@workspace:.
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1657,7 +1657,7 @@ exports[`Commands constraints test (two regular dependencies, two development de
   "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
 
 └─ root-workspace-0b6124@workspace:.
-   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 ",
 }
 `;
@@ -1669,7 +1669,7 @@ exports[`Commands constraints test (two regular dependencies, two development de
   "stdout": "➤ Those errors can all be fixed by running yarn constraints --fix
 
 └─ root-workspace-0b6124@workspace:.
-   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bin': '1.0.0' }
+   └─ ⚙ Extraneous field dependencies currently set to { 'no-deps': '1.0.0', 'no-deps-bins': '1.0.0' }
 ",
 }
 `;
@@ -1792,8 +1792,8 @@ exports[`Commands constraints test (various field types / gen_enforced_dependenc
   "stderr": "",
   "stdout": "└─ foo@workspace:.
    └─ Conflict detected in constraint targeting dependencies["no-deps"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;
@@ -1896,8 +1896,8 @@ exports[`Commands constraints test (various field types / gen_enforced_field (am
   "stderr": "",
   "stdout": "└─ foo@workspace:.
    └─ Conflict detected in constraint targeting dependencies["a-new-dep"]; conflicting values are:
-      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:3)
-      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:4)
+      ├─ '1.0.0' at exports.constraints (/path/to/yarn.config.js:3:46)
+      └─ '2.0.0' at exports.constraints (/path/to/yarn.config.js:4:46)
 ",
 }
 `;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints.test.js
@@ -99,6 +99,8 @@ describe(`Commands`, () => {
           test(`test (${environmentDescription} / ${scriptDescription} / ${scriptType})`,
             makeTemporaryEnv({}, async ({path, run, source}) => {
               await environment(path);
+              await run(`install`);
+
               await writeFile(`${path}/${scriptNames[scriptType]}`, script);
 
               let code;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/query.test.js.snap
@@ -95,25 +95,25 @@ exports[`Commands constraints query test (multiple workspaces / combined predica
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = dependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = dependencies
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = dependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: Done
 ",
@@ -300,7 +300,7 @@ exports[`Commands constraints query test (two development dependencies / combine
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: Done
 ",
@@ -393,7 +393,7 @@ exports[`Commands constraints query test (two regular dependencies / combined pr
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = dependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: Done
 ",
@@ -486,13 +486,13 @@ exports[`Commands constraints query test (two regular dependencies, two developm
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = dependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
 ➤ YN0000: │ DependencIdent  = 'no-deps'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: ┌ DependencyType  = devDependencies
-➤ YN0000: │ DependencIdent  = 'no-deps-bin'
+➤ YN0000: │ DependencIdent  = 'no-deps-bins'
 ➤ YN0000: └ DependencyRange = '1.0.0'
 ➤ YN0000: Done
 ",

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/source.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/__snapshots__/source.test.js.snap
@@ -145,16 +145,16 @@ workspace('packages/workspace-a').
 workspace_ident('packages/workspace-a', 'workspace-a').
 workspace_version('packages/workspace-a', []).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', devDependencies).
 workspace('packages/workspace-b').
 workspace_ident('packages/workspace-b', 'workspace-b').
 workspace_version('packages/workspace-b', []).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -190,16 +190,16 @@ workspace('packages/workspace-a').
 workspace_ident('packages/workspace-a', 'workspace-a').
 workspace_version('packages/workspace-a', []).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', devDependencies).
 workspace('packages/workspace-b').
 workspace_ident('packages/workspace-b', 'workspace-b').
 workspace_version('packages/workspace-b', []).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -235,16 +235,16 @@ workspace('packages/workspace-a').
 workspace_ident('packages/workspace-a', 'workspace-a').
 workspace_version('packages/workspace-a', []).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', devDependencies).
 workspace('packages/workspace-b').
 workspace_ident('packages/workspace-b', 'workspace-b').
 workspace_version('packages/workspace-b', []).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -280,16 +280,16 @@ workspace('packages/workspace-a').
 workspace_ident('packages/workspace-a', 'workspace-a').
 workspace_version('packages/workspace-a', []).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-a', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-a', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-a', 'no-deps-bins', '1.0.0', devDependencies).
 workspace('packages/workspace-b').
 workspace_ident('packages/workspace-b', 'workspace-b').
 workspace_version('packages/workspace-b', []).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('packages/workspace-b', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('packages/workspace-b', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('packages/workspace-b', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -448,7 +448,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -481,7 +481,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -514,7 +514,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -547,7 +547,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -579,7 +579,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -612,7 +612,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -645,7 +645,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -678,7 +678,7 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -710,9 +710,9 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -745,9 +745,9 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -780,9 +780,9 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.
@@ -815,9 +815,9 @@ workspace('.').
 workspace_ident('.', 'root-workspace-0b6124').
 workspace_version('.', []).
 workspace_has_dependency('.', 'no-deps', '1.0.0', dependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', dependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', dependencies).
 workspace_has_dependency('.', 'no-deps', '1.0.0', devDependencies).
-workspace_has_dependency('.', 'no-deps-bin', '1.0.0', devDependencies).
+workspace_has_dependency('.', 'no-deps-bins', '1.0.0', devDependencies).
 workspace(_) :- false.
 workspace_ident(_, _) :- false.
 workspace_version(_, _) :- false.

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/environments.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/environments.js
@@ -18,7 +18,7 @@ exports.environments = {
     await writeJson(`${path}/package.json`, {
       dependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
     });
   },
@@ -26,7 +26,7 @@ exports.environments = {
     await writeJson(`${path}/package.json`, {
       devDependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
     });
   },
@@ -34,11 +34,11 @@ exports.environments = {
     await writeJson(`${path}/package.json`, {
       dependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
       devDependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
     });
   },
@@ -57,11 +57,11 @@ exports.environments = {
       name: `workspace-a`,
       dependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
       devDependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
     });
 
@@ -69,11 +69,11 @@ exports.environments = {
       name: `workspace-b`,
       dependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
       devDependencies: {
         [`no-deps`]: `1.0.0`,
-        [`no-deps-bin`]: `1.0.0`,
+        [`no-deps-bins`]: `1.0.0`,
       },
       dependenciesMeta: {
         [`no-deps`]: {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/fix.test.js
@@ -20,9 +20,10 @@ describe(`Commands`, () => {
   describe(`constraints --fix`, () => {
     test(`test apply fix to dependencies`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
+        gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -33,9 +34,10 @@ describe(`Commands`, () => {
 
     test(`test apply fix to fields`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_field('.', 'license', 'BSD-2-Clause').
+        gen_enforced_field('.', 'license', 'BSD-2-Clause').
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -46,10 +48,11 @@ describe(`Commands`, () => {
 
     test(`test apply fix to fields and manifests`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
-      gen_enforced_field('.', 'license', 'BSD-2-Clause').
+        gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
+        gen_enforced_field('.', 'license', 'BSD-2-Clause').
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -60,10 +63,11 @@ describe(`Commands`, () => {
 
     test(`test applying fix shouldn't duplicate workspaces`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
-      gen_enforced_field('.', 'license', 'BSD-2-Clause').
+        gen_enforced_dependency('.', 'is-number', '2.0.0', dependencies).
+        gen_enforced_field('.', 'license', 'BSD-2-Clause').
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -73,9 +77,10 @@ describe(`Commands`, () => {
 
     it(`should preserve the raw manifest data when applying a fix`, makeTemporaryEnv(manifest, async ({path, run, source}) => {
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_dependency('.', 'is-number', null, dependencies).
+        gen_enforced_dependency('.', 'is-number', null, dependencies).
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -88,9 +93,10 @@ describe(`Commands`, () => {
       await environments[`various field types`](path);
 
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_field(WorkspaceCwd, '_name', FieldValue) :- workspace_field(WorkspaceCwd, 'name', FieldValue).
+        gen_enforced_field(WorkspaceCwd, '_name', FieldValue) :- workspace_field(WorkspaceCwd, 'name', FieldValue).
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -102,9 +108,10 @@ describe(`Commands`, () => {
       await environments[`various field types`](path);
 
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_field(WorkspaceCwd, '_repository', FieldValue) :- workspace_field(WorkspaceCwd, 'repository', FieldValue).
+        gen_enforced_field(WorkspaceCwd, '_repository', FieldValue) :- workspace_field(WorkspaceCwd, 'repository', FieldValue).
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);
@@ -120,9 +127,10 @@ describe(`Commands`, () => {
       await environments[`various field types`](path);
 
       await xfs.writeFilePromise(`${path}/constraints.pro`, `
-      gen_enforced_field(WorkspaceCwd, '_files', FieldValue) :- workspace_field(WorkspaceCwd, 'files', FieldValue).
+        gen_enforced_field(WorkspaceCwd, '_files', FieldValue) :- workspace_field(WorkspaceCwd, 'files', FieldValue).
       `);
 
+      await run(`install`);
       await run(`constraints`, `--fix`);
 
       const fixedManifest = await xfs.readJsonPromise(`${path}/package.json`);

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -25,6 +25,7 @@
     "github-markdown-css": "^5.1.0",
     "js-untar": "^2.0.0",
     "markdown-it": "^13.0.1",
+    "monaco-editor": "^0.24.0",
     "pako": "^2.0.4",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,5 +30,8 @@
   },
   "engines": {
     "node": ">=18.12.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.2.0"
   }
 }

--- a/packages/plugin-constraints/sources/ModernEngine.ts
+++ b/packages/plugin-constraints/sources/ModernEngine.ts
@@ -1,24 +1,65 @@
-import {Manifest, miscUtils, nodeUtils, Project, structUtils} from '@yarnpkg/core';
-import {Yarn}                                                 from '@yarnpkg/types';
+import {LocatorHash, Manifest, miscUtils, nodeUtils, Project, structUtils, Workspace} from '@yarnpkg/core';
+import {Yarn}                                                                         from '@yarnpkg/types';
 
-import * as constraintUtils                                   from './constraintUtils';
+import * as constraintUtils                                                           from './constraintUtils';
 
 export class ModernEngine implements constraintUtils.Engine {
   constructor(private project: Project) {
   }
 
   private createEnvironment() {
-    const workspaces = new constraintUtils.Index<Yarn.Constraints.Workspace>([`cwd`, `ident`]);
-    const dependencies = new constraintUtils.Index<Yarn.Constraints.Dependency>([`workspace`, `type`, `ident`]);
+    const workspaceIndex = new constraintUtils.Index<Yarn.Constraints.Workspace>([`cwd`, `ident`]);
+    const dependencyIndex = new constraintUtils.Index<Yarn.Constraints.Dependency>([`workspace`, `type`, `ident`]);
+    const packageIndex = new constraintUtils.Index<Yarn.Constraints.Package>([`ident`]);
 
     const result: constraintUtils.ProcessResult = {
       manifestUpdates: new Map(),
       reportedErrors: new Map(),
     };
 
+    const packageItems = new Map<LocatorHash, Yarn.Constraints.Package>();
+    const workspaceItems = new Map<Workspace, Yarn.Constraints.Workspace>();
+
+    for (const pkg of this.project.storedPackages.values()) {
+      const peerDependencies = Array.from(pkg.peerDependencies.values(), descriptor => {
+        return [structUtils.stringifyIdent(descriptor), descriptor.range] as const;
+      });
+
+      packageItems.set(pkg.locatorHash, {
+        workspace: null,
+        ident: structUtils.stringifyIdent(pkg),
+        version: pkg.version,
+        dependencies: new Map(),
+        peerDependencies: new Map(peerDependencies.filter(([ident]) => pkg.peerDependenciesMeta.get(ident)?.optional !== true)),
+        optionalPeerDependencies: new Map(peerDependencies.filter(([ident]) => pkg.peerDependenciesMeta.get(ident)?.optional === true)),
+      });
+    }
+
+    for (const pkg of this.project.storedPackages.values()) {
+      const packageItem = packageItems.get(pkg.locatorHash)!;
+
+      packageItem.dependencies = new Map(Array.from(pkg.dependencies.values(), descriptor => {
+        const resolution = this.project.storedResolutions.get(descriptor.descriptorHash);
+        if (typeof resolution === `undefined`)
+          throw new Error(`Assertion failed: The resolution should have been registered`);
+
+        const pkg = packageItems.get(resolution);
+        if (typeof pkg === `undefined`)
+          throw new Error(`Assertion failed: The package should have been registered`);
+
+        return [structUtils.stringifyIdent(descriptor), pkg] as const;
+      }));
+
+      packageItem.dependencies.delete(packageItem.ident);
+    }
+
     for (const workspace of this.project.workspaces) {
       const ident = structUtils.stringifyIdent(workspace.anchoredLocator);
       const manifest = workspace.manifest.exportTo({});
+
+      const pkg = packageItems.get(workspace.anchoredLocator.locatorHash);
+      if (typeof pkg === `undefined`)
+        throw new Error(`Assertion failed: The package should have been registered`);
 
       const setFn = (path: Array<string> | string, value: any, {caller = nodeUtils.getCaller()}: {caller?: nodeUtils.Caller | null} = {}) => {
         const normalizedPath = constraintUtils.normalizePath(path);
@@ -41,14 +82,17 @@ export class ModernEngine implements constraintUtils.Engine {
         miscUtils.getArrayWithDefault(result.reportedErrors, workspace.cwd).push(message);
       };
 
-      const workspaceItem = workspaces.insert({
+      const workspaceItem = workspaceIndex.insert({
         cwd: workspace.relativeCwd,
         ident,
         manifest,
+        pkg,
         set: setFn,
         unset: unsetFn,
         error: errorFn,
       });
+
+      workspaceItems.set(workspace, workspaceItem);
 
       for (const dependencyType of Manifest.allDependencies) {
         for (const descriptor of workspace.manifest[dependencyType].values()) {
@@ -62,11 +106,37 @@ export class ModernEngine implements constraintUtils.Engine {
             setFn([dependencyType, ident], range, {caller: nodeUtils.getCaller()});
           };
 
-          dependencies.insert({
+          let resolutionItem: Yarn.Constraints.Package | null = null;
+          if (dependencyType !== `peerDependencies`) {
+            if (dependencyType !== `dependencies` || !workspace.manifest.devDependencies.has(descriptor.identHash)) {
+              const pkgDescriptor = workspace.anchoredPackage.dependencies.get(descriptor.identHash);
+
+              // The descriptors may be missing if the package was added to the
+              // workspace after the constraints were computed (e.g. when using
+              // the `yarn constraints --fix` command)
+              if (pkgDescriptor) {
+                if (typeof pkgDescriptor === `undefined`)
+                  throw new Error(`Assertion failed: The dependency should have been registered`);
+
+                const resolution = this.project.storedResolutions.get(pkgDescriptor.descriptorHash);
+                if (typeof resolution === `undefined`)
+                  throw new Error(`Assertion failed: The resolution should have been registered`);
+
+                const pkgItem = packageItems.get(resolution);
+                if (typeof pkgItem === `undefined`)
+                  throw new Error(`Assertion failed: The package should have been registered`);
+
+                resolutionItem = pkgItem;
+              }
+            }
+          }
+
+          dependencyIndex.insert({
             workspace: workspaceItem,
             ident,
             range: descriptor.range,
             type: dependencyType,
+            resolution: resolutionItem,
             update: updateFn,
             delete: deleteFn,
             error: errorFn,
@@ -75,9 +145,26 @@ export class ModernEngine implements constraintUtils.Engine {
       }
     }
 
+    for (const pkg of this.project.storedPackages.values()) {
+      const workspace = this.project.tryWorkspaceByLocator(pkg);
+      if (!workspace)
+        continue;
+
+      const workspaceItem = workspaceItems.get(workspace);
+      if (typeof workspaceItem === `undefined`)
+        throw new Error(`Assertion failed: The workspace should have been registered`);
+
+      const packageItem = packageItems.get(pkg.locatorHash);
+      if (typeof packageItem === `undefined`)
+        throw new Error(`Assertion failed: The package should have been registered`);
+
+      packageItem.workspace = workspaceItem;
+    }
+
     return {
-      workspaces,
-      dependencies,
+      workspaces: workspaceIndex,
+      dependencies: dependencyIndex,
+      packages: packageIndex,
       result,
     };
   }
@@ -93,11 +180,19 @@ export class ModernEngine implements constraintUtils.Engine {
         workspaces: filter => {
           return env.workspaces.find(filter);
         },
+
         dependency: ((filter?: Yarn.Constraints.DependencyFilter) => {
           return env.dependencies.find(filter)[0] ?? null;
         }) as any,
         dependencies: filter => {
           return env.dependencies.find(filter);
+        },
+
+        package: ((filter?: Yarn.Constraints.PackageFilter) => {
+          return env.packages.find(filter)[0] ?? null;
+        }) as any,
+        packages: filter => {
+          return env.packages.find(filter);
         },
       },
     };

--- a/packages/plugin-constraints/sources/commands/constraints.ts
+++ b/packages/plugin-constraints/sources/commands/constraints.ts
@@ -43,6 +43,8 @@ export default class ConstraintsCheckCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project} = await Project.find(configuration, this.context.cwd);
 
+    await project.restoreInstallState();
+
     const userConfig = await project.loadUserConfig();
 
     let engine: constraintUtils.Engine;

--- a/packages/plugin-constraints/sources/constraintUtils.ts
+++ b/packages/plugin-constraints/sources/constraintUtils.ts
@@ -14,7 +14,7 @@ export interface Engine {
   process(): Promise<ProcessResult | null>;
 }
 
-export class Index<T extends Record<keyof T, any>> {
+export class Index<T extends {[key: string]: any}> {
   private items: Array<T> = [];
 
   private indexes: {
@@ -155,7 +155,7 @@ function formatStackLine(configuration: Configuration, caller: nodeUtils.Caller)
       fileParts.push(formatUtils.pretty(configuration, caller.line, formatUtils.Type.NUMBER));
 
       if (caller.column !== null) {
-        fileParts.push(formatUtils.pretty(configuration, caller.line, formatUtils.Type.NUMBER));
+        fileParts.push(formatUtils.pretty(configuration, caller.column, formatUtils.Type.NUMBER));
       }
     }
 

--- a/packages/yarnpkg-types/sources/constraints.ts
+++ b/packages/yarnpkg-types/sources/constraints.ts
@@ -28,6 +28,21 @@ export type Dependency = {
   type: DependencyType;
 
   /**
+   * Package currently used to resolve the dependency. May be null if the
+   * dependency couldn't be resolved. This can happen in those cases:
+   *
+   * - The dependency is a peer dependency; workspaces don't have ancestors
+   *   to satisfy their peer dependencies, so they're always unresolved. This
+   *   is why we recommend to list a dev dependency for each non-optional peer
+   *   dependency you list, so that Yarn can fallback to it.
+   *
+   * - The dependency is a prod dependency, and there's a dev dependency of the
+   *   same name (in which case there will be a separate dependency entry for
+   *   the dev dependency, which will have the resolution).
+   */
+  resolution: Package | null;
+
+  /**
    * Report an error unless the dependency has the expected range. If
    * `--fix` is set, Yarn will silently update the package.json instead of
    * reporting an error.
@@ -70,6 +85,11 @@ export type Workspace = {
   manifest: any;
 
   /**
+   * The resolved information for the workspace.
+   */
+  pkg: Package;
+
+  /**
    * Report an error unless the workspace lists the specified property
    * with the specified value. If `--fix` is set, Yarn will silently update
    * the package.json instead of reporting an error.
@@ -94,6 +114,39 @@ export type Workspace = {
    * @param message Error message
    */
   error(message: string): void;
+};
+
+export type Package = {
+  /**
+   * If the package is a workspace, return the corresponding workspace
+   */
+  workspace: Workspace | null;
+
+  /**
+   * Package name.
+   */
+  ident: string;
+
+  /**
+   * Package version.
+   */
+  version: string | null;
+
+  /**
+   * A map of the dependencies the package is allowed to access. There's no
+   * distinction between prod dependencies and dev dependencies.
+   */
+  dependencies: Map<string, Package>;
+
+  /**
+   * A map of the required peer dependencies declared in the package.
+   */
+  peerDependencies: Map<string, string>;
+
+  /**
+   * A map of the optional peer dependencies declared in the package.
+   */
+  optionalPeerDependencies: Map<string, string>;
 };
 
 export type WorkspaceFilter = {
@@ -122,6 +175,28 @@ export type DependencyFilter = {
    * Only return dependencies with the given name.
    */
   ident?: string;
+
+  /**
+   * Only return dependencies listed in the following set.
+   */
+  type?: DependencyType;
+};
+
+export type PackageFilter = {
+  /**
+   * Only return packages from the given workspace.
+   */
+  workspace?: Workspace;
+
+  /**
+   * Only return packages with the given name.
+   */
+  ident?: string;
+
+  /**
+   * Only return packages with the given reference.
+   */
+  reference?: string;
 };
 
 export type Yarn = {
@@ -145,8 +220,7 @@ export type Yarn = {
    *
    * @param filter
    */
-  dependency(): Dependency;
-  dependency(filter?: DependencyFilter): Dependency | null;
+  dependency(filter: DependencyFilter): Dependency | null;
 
   /**
    * Select all dependencies according to the provided filter.
@@ -154,6 +228,20 @@ export type Yarn = {
    * @param filter
    */
   dependencies(filter?: DependencyFilter): Array<Dependency>;
+
+  /**
+   * Select a unique workspace according to the provided filter.
+   *
+   * @param filter
+   */
+  package(filter: DependencyFilter): Package | null;
+
+  /**
+   * Select all dependencies according to the provided filter.
+   *
+   * @param filter
+   */
+  packages(filter: DependencyFilter): Array<Package>;
 };
 
 export type Context = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7149,6 +7149,7 @@ __metadata:
     github-markdown-css: "npm:^5.1.0"
     js-untar: "npm:^2.0.0"
     markdown-it: "npm:^13.0.1"
+    monaco-editor: "npm:^0.24.0"
     pako: "npm:^2.0.4"
     prism-react-renderer: "npm:^1.3.5"
     react: "npm:^17.0.2"
@@ -7168,6 +7169,7 @@ __metadata:
     "@rushstack/eslint-patch": "npm:^1.1.0"
     "@typescript-eslint/eslint-plugin": "npm:^5.3.1"
     "@typescript-eslint/parser": "npm:^5.3.1"
+    eslint: "npm:^8.2.0"
     eslint-plugin-arca: "npm:^0.12.1"
     eslint-plugin-react: "npm:^7.31.8"
   peerDependencies:


### PR DESCRIPTION
**What's the problem this PR addresses?**

Constraints can only operate on the workspaces' listed dependencies, but have no idea about the shape of the global dependency tree. In general it's enough, but I wanted to write a constraint autofixing missing peer dependencies, and this wasn't possible without knowing the dependencies of our dependencies.

**How did you fix it?**

I added a concept of "package" to the constraint API. Some of their characteristics:

- They are based on the resolved dependency tree; as a result, there is no direct concept of devDependency / dependency (just like in the core `Package` type).

- They somewhat look like the `Package` type, but with fewer information (just the dependencies & peer dependencies, at the moment), and with a slightly different format (no need for serialization, so it directly references other data structure rather than go through string hashes).

- They don't provide any autofix (or even reporting) capability at the moment. Perhaps later I'll add an `error` API, like regular dependencies, but that'll probably require to enhance them so they are able to access the packages' filesystems, so it'll have to be a follow-up.

Testing is currently lacking ... like the rest of the JS constraints engine 😶‍🌫️

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
