### PR TITLE
Fixes hardcoded Yarn version

### DIFF
--- a/.yarn/versions/620160d3.yml
+++ b/.yarn/versions/620160d3.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-essentials"

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -1,11 +1,11 @@
-import {BaseCommand, WorkspaceRequiredError}                                                                                                                            from '@yarnpkg/cli';
-import {Configuration, Cache, MessageName, Project, ReportError, StreamReport, formatUtils, InstallMode, execUtils, structUtils, LEGACY_PLUGINS, ConfigurationValueMap} from '@yarnpkg/core';
-import {xfs, ppath, Filename, PortablePath}                                                                                                                             from '@yarnpkg/fslib';
-import {parseSyml, stringifySyml}                                                                                                                                       from '@yarnpkg/parsers';
-import CI                                                                                                                                                               from 'ci-info';
-import {Command, Option, Usage, UsageError}                                                                                                                             from 'clipanion';
-import semver                                                                                                                                                           from 'semver';
-import * as t                                                                                                                                                           from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                                                                                                                                         from '@yarnpkg/cli';
+import {Configuration, Cache, MessageName, Project, ReportError, StreamReport, formatUtils, InstallMode, execUtils, structUtils, LEGACY_PLUGINS, ConfigurationValueMap, YarnVersion} from '@yarnpkg/core';
+import {xfs, ppath, Filename, PortablePath}                                                                                                                                          from '@yarnpkg/fslib';
+import {parseSyml, stringifySyml}                                                                                                                                                    from '@yarnpkg/parsers';
+import CI                                                                                                                                                                            from 'ci-info';
+import {Command, Option, Usage, UsageError}                                                                                                                                          from 'clipanion';
+import semver                                                                                                                                                                        from 'semver';
+import * as t                                                                                                                                                                        from 'typanion';
 
 const LOCKFILE_MIGRATION_RULES: Array<{
   selector: (version: number) => boolean;
@@ -304,7 +304,6 @@ export default class YarnCommand extends BaseCommand {
 
           if (data !== null) {
             let newVersion: [string, string] | null = null;
-            const YarnVersion = `3.0.0`;
             if (YarnVersion !== null) {
               const isRcBinary = semver.prerelease(YarnVersion);
               const releaseType = isRcBinary ? `canary` : `stable`;


### PR DESCRIPTION
**What's the problem this PR addresses?**

I forgot to remove debug code from the upgrade CTA, causing Yarn to always think it should upgrade to 3.6.0.

**How did you fix it?**

Removes the hardcoded `3.0.0` version.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
