### PR TITLE
chore: remove unused `Report#buffered`

### DIFF
--- a/.yarn/versions/20d2e33b.yml
+++ b/.yarn/versions/20d2e33b.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/core"

--- a/packages/yarnpkg-core/sources/Report.ts
+++ b/packages/yarnpkg-core/sources/Report.ts
@@ -44,8 +44,6 @@ export abstract class Report {
   cacheHits = new Set<LocatorHash>();
   cacheMisses = new Set<LocatorHash>();
 
-  protected buffered: Array<() => void> = [];
-
   private reportedInfos: Set<any> = new Set();
   private reportedWarnings: Set<any> = new Set();
   private reportedErrors: Set<any> = new Set();


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

https://github.com/yarnpkg/berry/pull/5530 introduced a new `buffered` property to `Report` but it didn't end up being used.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed it, can always be introduced again if we ever need it.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
