### PR TITLE
refactor: rename `motd` to `tips`

### DIFF
--- a/.yarn/versions/ff5cdcd5.yml
+++ b/.yarn/versions/ff5cdcd5.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/gatsby/content/advanced/error-codes.md
+++ b/packages/gatsby/content/advanced/error-codes.md
@@ -437,6 +437,6 @@ On local machines, Yarn will periodically check whether new versions are availab
 
 You don't have to upgrade if you don't wish to - but keeping Yarn up-to-date is generally a good idea, as they tend to often come with a significant amount of performance improvements, bugfixes, and new features.
 
-## YN0089 - `MOTD_NOTICE`
+## YN0089 - `TIPS_NOTICE`
 
 Our research showed that even our power users aren't always aware of some of the less obvious features in Yarn. To improve discoverability, on local machines, Yarn will display every day a tip about some of the nuggets it contains. Perhaps one of them will help you improve your infrastructure someday?

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -291,15 +291,15 @@ export default class YarnCommand extends BaseCommand {
         includeFooter: false,
       }, async report => {
         if (Configuration.telemetry?.isNew) {
-          Configuration.telemetry.commitMotd();
+          Configuration.telemetry.commitTips();
 
           report.reportInfo(MessageName.TELEMETRY_NOTICE, `Yarn will periodically gather anonymous telemetry: https://yarnpkg.com/advanced/telemetry`);
           report.reportInfo(MessageName.TELEMETRY_NOTICE, `Run ${formatUtils.pretty(configuration, `yarn config set --home enableTelemetry 0`, formatUtils.Type.CODE)} to disable`);
           report.reportSeparator();
-        } else if (Configuration.telemetry?.isMotd) {
+        } else if (Configuration.telemetry?.shouldShowTips) {
           const data = await fetch(`https://repo.yarnpkg.com/tags`).then(res => res.json()).catch(() => null) as {
             latest: {stable: string, canary: string};
-            motd: Array<{message: string, url?: string}>;
+            tips: Array<{message: string, url?: string}>;
           } | null;
 
           if (data !== null) {
@@ -315,19 +315,19 @@ export default class YarnCommand extends BaseCommand {
             }
 
             if (newVersion) {
-              Configuration.telemetry.commitMotd();
+              Configuration.telemetry.commitTips();
 
               report.reportInfo(MessageName.VERSION_NOTICE, `${formatUtils.applyStyle(configuration, `A new ${newVersion[0]} version of Yarn is available:`, formatUtils.Style.BOLD)} ${structUtils.prettyReference(configuration, newVersion[1])}!`);
               report.reportInfo(MessageName.VERSION_NOTICE, `Upgrade now by running ${formatUtils.pretty(configuration, `yarn set version ${newVersion[1]}`, formatUtils.Type.CODE)}`);
               report.reportSeparator();
             } else {
-              const motd = Configuration.telemetry.selectMotd(data.motd);
+              const tip = Configuration.telemetry.selectTip(data.tips);
 
-              if (motd) {
-                report.reportInfo(MessageName.MOTD_NOTICE, formatUtils.pretty(configuration, motd.message, formatUtils.Type.MARKDOWN_INLINE));
+              if (tip) {
+                report.reportInfo(MessageName.TIPS_NOTICE, formatUtils.pretty(configuration, tip.message, formatUtils.Type.MARKDOWN_INLINE));
 
-                if (motd.url)
-                  report.reportInfo(MessageName.MOTD_NOTICE, `Learn more at ${motd.url}`);
+                if (tip.url)
+                  report.reportInfo(MessageName.TIPS_NOTICE, `Learn more at ${tip.url}`);
 
                 report.reportSeparator();
               }

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -279,12 +279,6 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.BOOLEAN,
     default: true,
   },
-  enableMotd: {
-    description: `If true, installs will print an helpful message every day of the week`,
-    type: SettingsType.BOOLEAN,
-    default: !isCI,
-    defaultText: `<dynamic>`,
-  },
   enableProgressBars: {
     description: `If true, the CLI is allowed to show a progress bar for long-running events`,
     type: SettingsType.BOOLEAN,
@@ -295,6 +289,12 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     description: `If true, the CLI is allowed to print the time spent executing commands`,
     type: SettingsType.BOOLEAN,
     default: true,
+  },
+  enableTips: {
+    description: `If true, installs will print a helpful message every day of the week`,
+    type: SettingsType.BOOLEAN,
+    default: !isCI,
+    defaultText: `<dynamic>`,
   },
   preferInteractive: {
     description: `If true, the CLI will automatically use the interactive mode when called from a TTY`,
@@ -610,9 +610,9 @@ export interface ConfigurationValueMap {
   enableHyperlinks: boolean;
   enableInlineBuilds: boolean;
   enableMessageNames: boolean;
-  enableMotd: boolean;
   enableProgressBars: boolean;
   enableTimers: boolean;
+  enableTips: boolean;
   preferInteractive: boolean;
   preferTruncatedLines: boolean;
   progressBarStyle: string | undefined;

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -100,7 +100,7 @@ export enum MessageName {
   EXPLAIN_PEER_DEPENDENCIES_CTA = 86,
   MIGRATION_SUCCESS = 87,
   VERSION_NOTICE = 88,
-  MOTD_NOTICE = 89,
+  TIPS_NOTICE = 89,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {

--- a/packages/yarnpkg-core/tests/TelemetryManager.test.ts
+++ b/packages/yarnpkg-core/tests/TelemetryManager.test.ts
@@ -17,19 +17,19 @@ describe(`TelemetryManager`, () => {
       randomInitialInterval: 0,
       updateInterval: 7,
     })).toEqual({
-      nextState: {lastUpdate: TEST_TIME + 12 * hour + 7 * day, lastMotd: TEST_TIME},
+      nextState: {lastUpdate: TEST_TIME + 12 * hour + 7 * day, lastTips: TEST_TIME},
 
       triggerUpdate: false,
-      triggerMotd: false,
+      triggerTips: false,
 
-      nextMotd: TEST_TIME,
+      nextTips: TEST_TIME,
     });
   });
 
-  it(`shouldn't detect a MOTD display until 8am`, () => {
+  it(`shouldn't detect a tips display until 8am`, () => {
     expect(derive({
       state: {
-        lastMotd: TEST_TIME,
+        lastTips: TEST_TIME,
       },
 
       timeNow: TEST_TIME + (24 + 7) * hour,
@@ -39,20 +39,20 @@ describe(`TelemetryManager`, () => {
       updateInterval: 7,
     })).toEqual({
       nextState: expect.objectContaining({
-        lastMotd: TEST_TIME,
+        lastTips: TEST_TIME,
       }),
 
       triggerUpdate: false,
-      triggerMotd: false,
+      triggerTips: false,
 
-      nextMotd: TEST_TIME,
+      nextTips: TEST_TIME,
     });
   });
 
-  it(`should detect a MOTD display after 8am`, () => {
+  it(`should detect a tips display after 8am`, () => {
     expect(derive({
       state: {
-        lastMotd: TEST_TIME,
+        lastTips: TEST_TIME,
       },
 
       timeNow: TEST_TIME + (24 + 9) * hour,
@@ -62,20 +62,20 @@ describe(`TelemetryManager`, () => {
       updateInterval: 7,
     })).toEqual({
       nextState: expect.objectContaining({
-        lastMotd: TEST_TIME,
+        lastTips: TEST_TIME,
       }),
 
       triggerUpdate: false,
-      triggerMotd: true,
+      triggerTips: true,
 
-      nextMotd: TEST_TIME + 24 * hour,
+      nextTips: TEST_TIME + 24 * hour,
     });
   });
 
-  it(`should use the local timezone when checking the MOTD display`, () => {
+  it(`should use the local timezone when checking the tips display`, () => {
     expect(derive({
       state: {
-        lastMotd: TEST_TIME,
+        lastTips: TEST_TIME,
       },
 
       timeNow: TEST_TIME + (24 + 7) * hour,
@@ -85,13 +85,13 @@ describe(`TelemetryManager`, () => {
       updateInterval: 7,
     })).toEqual({
       nextState: expect.objectContaining({
-        lastMotd: TEST_TIME,
+        lastTips: TEST_TIME,
       }),
 
       triggerUpdate: false,
-      triggerMotd: true,
+      triggerTips: true,
 
-      nextMotd: TEST_TIME + 24 * hour,
+      nextTips: TEST_TIME + 24 * hour,
     });
   });
 });

--- a/tips.json
+++ b/tips.json
@@ -1,5 +1,5 @@
 [{
-  "message": "**Did you know?** Yarn will display a useful tip each day, but they can be disabled via `enableMotd: false`."
+  "message": "**Did you know?** Yarn will display a useful tip each day, but they can be disabled via `enableTips: false`."
 }, {
   "message": "**Did you know?** All `scripts` entries are run by a Posix-like JS interpreter. Even on Windows!"
 }, {


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

After some discussions, we've agreed on changing `motd` to `tips`, as the `motd` acronym (`message of the day`) might not be widespread enough.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

This PR changes:
- `enableMotd` to `enableTips`
- the `MOTD_NOTICE` message name to `TIPS_NOTICE`
- `motd.json` to `tips.json` (CC @arcanis since you need to change the cloudflare worker)
- `TelemetryManager#isMotd` to `TelemetryManager#shouldShowTips` as it's more descriptive and also more consistent with the existing `shouldCommitTips`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
