### PR TITLE
feat!: enable interactivity by default when possible

### DIFF
--- a/.yarn/versions/db5a0b98.yml
+++ b/.yarn/versions/db5a0b98.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/plugin-essentials": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -71,8 +71,6 @@ packageExtensions:
 
 pnpEnableEsmLoader: true
 
-preferInteractive: true
-
 supportedArchitectures:
   cpu:
     - x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Yarn now accepts sponsorships! Please give a look at our [OpenCollective](https:
   - Plugins cannot access the internal copy of Yup anymore (use [Typanion](https://github.com/arcanis/typanion) instead)
   - Yarn will no longer remove the old Yarn 2.x `.pnp.js` file when migrating.
   - The `--assume-fresh-project` flag of `yarn init` has been removed.
+- Yarn is now interactive by default whenever possible:
+  - The `--interactive` flag is no longer needed for `yarn add` and `yarn up`.
+  - Yarn will never be interactive in CI environments or outside of a TTY.
+  - You can always set `preferInteractive: false` to prevent Yarn from being implicitly interactive.
 
 ### **API Changes**
 

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -132,7 +132,10 @@ export default class AddCommand extends BaseCommand {
     });
 
     const fixed = this.fixed;
-    const interactive = this.interactive ?? configuration.get(`preferInteractive`);
+    const interactive = configuration.isInteractive({
+      interactive: this.interactive,
+      stdout: this.context.stdout,
+    });
     const reuse = interactive || configuration.get(`preferReuse`);
 
     const modifier = suggestUtils.getModifier(this, project);

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -161,7 +161,10 @@ export default class UpCommand extends BaseCommand {
     });
 
     const fixed = this.fixed;
-    const interactive = this.interactive ?? configuration.get(`preferInteractive`);
+    const interactive = configuration.isInteractive({
+      interactive: this.interactive,
+      stdout: this.context.stdout,
+    });
 
     const modifier = suggestUtils.getModifier(this, project);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Interactivity can lead to a more user-friendly experience and we have quite a lot of interactive commands, but some of them (`add` and `up`) only enable it when explicitly requested via `--interactive` or when `preferInteractive` is set to `true`, which most users forget to do since it isn't the default.

In addition, when `preferInteractive` is set to `true`, these commands are interactive even outside TTYs, which is unintended (can be checked by running `yarn add lodash` in our repository).

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made interactivity the default, by defaulting `preferInteractive` to `true`, except on CI.

Also made it so that Yarn is never interactive outside of TTY environments since that can never work.

Now there are a few questions remaining:

- should Yarn be interactive on CI when `--interactive` is passed? Is there a use case for it? Or should the CI check override everything else just like the TTY one
- how can we make the OTP prompt in `npmHttpUtils` respect all of this? Do we forward `stdout` as a parameter everywhere or is there a better option? :thinking: 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
