### PR TITLE
Add `yarn-plugin-list` to plugin list

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -115,6 +115,8 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**yarn-plugin-env**](https://github.com/MDReal32/yarn-plugin-env) by [**MDReal Aliyev**](https://github.com/MDReal32) - A Yarn Berry plugin to load environment variables from files to `process.env` on startup any script.
 
-- [**yarn-plugin-env-vars**](https://github.com/scinos/yarn-plugin-env-vars) by [**Sergio Cinos**](https://github.com/scinos) - A Yarn plugin that ensures your environment variables are set before running any npm scripts. 
+- [**yarn-plugin-env-vars**](https://github.com/scinos/yarn-plugin-env-vars) by [**Sergio Cinos**](https://github.com/scinos) - A Yarn plugin that ensures your environment variables are set before running any npm scripts.
+
+- [**yarn-plugin-list**](https://github.com/arendjr/yarn-plugin-list) by [**Arend van Beelen jr.**](https://github.com/arendjr) - A modern Yarn plugin to reimplement the `list` command from Yarn v1.
 
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!


### PR DESCRIPTION
**What's the problem this PR addresses?**

It merely adds `yarn-plugin-list` to list of contrib plugins.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
