### PR TITLE
ci: use latest Node.js v20 version

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -202,7 +202,7 @@ jobs:
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
         # https://github.com/nodejs/node/issues/48444
-        node: [18, 19, 20.2]
+        node: [18, 19, 20]
         platform: [ubuntu-latest]
         shard: ['1/2', '2/2']
         # We run the rest of the tests on the minimum Node version we support with 3 shards.


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node.js v20.4 has been released which fixes https://github.com/yarnpkg/berry/pull/5445#issuecomment-1603377915

**How did you fix it?**

Use the latest Node.js v20 version.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.