### PR TITLE
feat(pnp): enable ESM support by default

### DIFF
--- a/.yarn/versions/380139a7.yml
+++ b/.yarn/versions/380139a7.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-pnp": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -69,8 +69,6 @@ packageExtensions:
       typedoc-plugin-yarn:
         optional: true
 
-pnpEnableEsmLoader: true
-
 preferInteractive: true
 
 supportedArchitectures:

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/installArtifactCleanup.test.ts
@@ -37,9 +37,7 @@ describe(`Install Artifact Cleanup`, () => {
             await expect(xfs.existsPromise(`${path}/.pnp.data.json` as PortablePath)).resolves.toStrictEqual(false);
           }));
 
-          it(`should remove the .pnp.loader.mjs file after switching to the ${linker} linker`, makeTemporaryEnv({}, {
-            pnpEnableEsmLoader: true,
-          }, async ({path, run, source}) => {
+          it(`should remove the .pnp.loader.mjs file after switching to the ${linker} linker`, makeTemporaryEnv({}, async ({path, run, source}) => {
             await run(`install`);
 
             // Sanity check

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
@@ -120,9 +120,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should allow relative imports with search params`,
     makeTemporaryEnv(
       {},
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});
 
@@ -142,9 +139,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should preserve search params in the resolve result (cache busting)`,
     makeTemporaryEnv(
       {},
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});
 
@@ -173,9 +167,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should allow absolute imports with search params`,
     makeTemporaryEnv(
       {},
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});
 
@@ -361,9 +352,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should load extensionless commonjs files as an entrypoint`,
     makeTemporaryEnv(
       { },
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await xfs.writeFilePromise(ppath.join(path, `index`), `console.log(typeof require === 'undefined')`);
 
@@ -381,9 +369,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should load symlinked extensionless commonjs files as an entrypoint`,
     makeTemporaryEnv(
       { },
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await xfs.mkdirPromise(ppath.join(path, `lib`));
         await xfs.writeFilePromise(ppath.join(path, `lib/index`), `console.log(typeof require === 'undefined')`);
@@ -403,9 +388,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should not allow extensionless commonjs imports`,
     makeTemporaryEnv(
       { },
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await xfs.writeFilePromise(ppath.join(path, `index.mjs`), `import bin from './cjs-bin';\nconsole.log(bin)`);
         await xfs.writeFilePromise(ppath.join(path, `cjs-bin`), `module.exports = {foo: 'bar'}`);
@@ -425,9 +407,6 @@ describe(`Plug'n'Play - ESM`, () => {
     makeTemporaryEnv(
       {
         type: `module`,
-      },
-      {
-        pnpEnableEsmLoader: true,
       },
       async ({path, run, source}) => {
         await xfs.writeFilePromise(ppath.join(path, `index`), ``);
@@ -505,9 +484,6 @@ describe(`Plug'n'Play - ESM`, () => {
           "is-number": `1.0.0`,
         },
       },
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await xfs.writeFilePromise(ppath.join(path, `index.js`), `require('no-deps');\nimport('is-number').then(() => console.log(42))`);
 
@@ -525,9 +501,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should set the main module`,
     makeTemporaryEnv(
       {},
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});
 
@@ -554,9 +527,6 @@ describe(`Plug'n'Play - ESM`, () => {
     `it should suppress the experimental ESM loader warning`,
     makeTemporaryEnv(
       {},
-      {
-        pnpEnableEsmLoader: true,
-      },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});
 
@@ -578,9 +548,6 @@ describe(`Plug'n'Play - ESM`, () => {
         dependencies: {
           'no-deps-esm': `1.0.0`,
         },
-      },
-      {
-        pnpEnableEsmLoader: true,
       },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});
@@ -608,9 +575,6 @@ describe(`Plug'n'Play - ESM`, () => {
         dependencies: {
           'no-deps-mjs': `1.0.0`,
         },
-      },
-      {
-        pnpEnableEsmLoader: true,
       },
       async ({path, run, source}) => {
         await expect(run(`install`)).resolves.toMatchObject({code: 0});

--- a/packages/gatsby/content/features/plugnplay.md
+++ b/packages/gatsby/content/features/plugnplay.md
@@ -74,11 +74,22 @@ yarn node ./server.js
 require('./.pnp.cjs').setup();
 ```
 
-As a quick tip, all `yarn node` typically does is set the `NODE_OPTIONS` environment variable to use the [`--require`](https://nodejs.org/api/cli.html#cli_r_require_module) option from Node, associated with the path of the `.pnp.cjs` file. You can easily apply this operation yourself if you prefer:
+As a quick tip, all `yarn node` typically does is set the `NODE_OPTIONS` environment variable to use the [`--require`](https://nodejs.org/api/cli.html#cli_r_require_module) and [`--experimental-loader`](https://nodejs.org/api/cli.html#--experimental-loadermodule) option to setup PnP support. You can apply this operation yourself if you prefer.
 
-```
+If you don't need ESM support you can use the following:
+
+```sh
 node -r ./.pnp.cjs ./server.js
-NODE_OPTIONS="--require $(pwd)/.pnp.cjs" node ./server.js
+# or
+NODE_OPTIONS="--require \"$(pwd)/.pnp.cjs\"" node ./server.js
+```
+
+If you need ESM support you can use the following:
+
+```sh
+node -r ./.pnp.cjs --experimental-loader ./.pnp.loader.mjs ./server.js
+# or
+NODE_OPTIONS="--require \"$(pwd)/.pnp.cjs\" --experimental-loader \"$(pwd)/.pnp.loader.mjs\"" node ./server.js
 ```
 
 ## PnP `loose` mode

--- a/packages/gatsby/static/configuration/yarnrc.json
+++ b/packages/gatsby/static/configuration/yarnrc.json
@@ -633,9 +633,9 @@
     },
     "pnpEnableEsmLoader": {
       "_package": "@yarnpkg/plugin-pnp",
-      "description": "If true, Yarn will generate an experimental ESM loader (`.pnp.loader.mjs`). Yarn tries to automatically detect whether ESM support is required.",
+      "description": "If true, Yarn will generate an experimental ESM loader (`.pnp.loader.mjs`).",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "pnpEnableInlining": {
       "_package": "@yarnpkg/plugin-pnp",

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -110,9 +110,9 @@ const plugin: Plugin<CoreHooks & StageHooks> = {
       isArray: true,
     },
     pnpEnableEsmLoader: {
-      description: `If true, Yarn will generate an ESM loader (\`.pnp.loader.mjs\`). If this is not explicitly set Yarn tries to automatically detect whether ESM support is required.`,
+      description: `If true, Yarn will generate an ESM loader (\`.pnp.loader.mjs\`).`,
       type: SettingsType.BOOLEAN,
-      default: false,
+      default: true,
     },
     pnpEnableInlining: {
       description: `If true, the PnP data will be inlined along with the generated loader`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Some projects and their dependencies require ESM support but Yarn is unable to detect it.

Fixes https://github.com/yarnpkg/berry/actions/runs/5505562368/jobs/10033080416#step:4:56
```
Error: ENOTDIR: not a directory, stat '/home/runner/.yarn/berry/cache/prettier-npm-3.0.0-7ffbcce680-10c0.zip/node_modules/prettier/internal/cli.mjs'
    at statSync (node:fs:1615:3)
    at tryStatSync (node:internal/modules/esm/resolve:176:13)
    at finalizeResolution (node:internal/modules/esm/resolve:316:17)
    at moduleResolve (node:internal/modules/esm/resolve:945:10)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:[52](https://github.com/yarnpkg/berry/actions/runs/5505562368/jobs/10033080416#step:4:59)5:22)
    at importModuleDynamically (node:internal/modules/cjs/loader:1188:29) {
  errno: -20,
  syscall: 'stat',
  code: 'ENOTDIR',
  path: '/home/runner/.yarn/berry/cache/prettier-npm-3.0.0-7ffbcce680-10c0.zip/node_modules/prettier/internal/cli.mjs'
}
```

**How did you fix it?**

Removed the auto-detection and enabled ESM support by default.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.