### PR TITLE
test(core): avoid mocking `got`

### DIFF
--- a/packages/yarnpkg-core/tests/httpUtils.test.ts
+++ b/packages/yarnpkg-core/tests/httpUtils.test.ts
@@ -1,42 +1,8 @@
-import {Configuration, Plugin} from '@yarnpkg/core';
-import {npath}                 from '@yarnpkg/fslib';
-import got                     from 'got';
-
-import * as httpUtils          from '../sources/httpUtils';
-import {Method}                from '../sources/httpUtils';
-
-jest.mock(`got`, () => ({
-  extend: jest.fn(),
-}));
-
-const mockExtend = got.extend as jest.Mock;
-const mockClient = jest.fn();
+import {Configuration, Plugin, httpUtils} from '@yarnpkg/core';
+import {npath}                            from '@yarnpkg/fslib';
 
 describe(`httpUtils`, () => {
-  beforeEach(() => {
-    mockExtend.mockReset();
-    mockExtend.mockReturnValue(mockClient);
-  });
-
   describe(`request`, () => {
-    it(`executes a request to the given target`, async () => {
-      // Arrange
-      const target = `https://my/fake/target`;
-      const body = {fake: `body`};
-      const configuration = Configuration.create(npath.toPortablePath(`.`));
-      const expectedResponse = {};
-      mockClient.mockReturnValue(expectedResponse);
-
-      // Act
-      const response = await httpUtils.request(target, body, {configuration});
-
-      // Assert
-      expect(mockExtend.mock.calls.length).toBe(1);
-      expect(mockClient.mock.calls.length).toBe(1);
-      expect(mockClient.mock.calls[0][0].href).toBe(target);
-      expect(response).toEqual(expectedResponse);
-    });
-
     it(`executes a request to the given target using any registered wrapNetworkRequest plugins`, async () => {
       // Arrange
       const target = `https://my/fake/target`;
@@ -45,20 +11,19 @@ describe(`httpUtils`, () => {
       const {plugins, mockWrapNetworkRequest} = getPluginsWithMockWrapNetworkRequestPlugin();
 
       const configuration = Configuration.create(npath.toPortablePath(`.`), plugins);
-      const expectedResponse = {};
-      mockClient.mockReturnValue(expectedResponse);
+      mockWrapNetworkRequest.mockReturnValue(() => {});
 
       const headers = {};
       const jsonRequest = true;
       const jsonResponse = true;
-      const method = Method.PUT;
+      const method = httpUtils.Method.PUT;
 
       // Act
       await httpUtils.request(target, body, {configuration, headers, jsonRequest, jsonResponse, method});
 
       // Assert
       expect(mockWrapNetworkRequest.mock.calls.length).toBe(1);
-      // mockWrapNetworkRequest.mock.calls[0][0] is supplied implicitly by Configuration.reduceHooks, tested elsewhere presumedly
+      // mockWrapNetworkRequest.mock.calls[0][0] is supplied implicitly by Configuration.reduceHooks, tested elsewhere presumably
       const hookArgumentResult = mockWrapNetworkRequest.mock.calls[0][1];
       expect(hookArgumentResult.target).toBe(target);
       expect(hookArgumentResult.body).toBe(body);
@@ -72,7 +37,6 @@ describe(`httpUtils`, () => {
 
   function getPluginsWithMockWrapNetworkRequestPlugin() {
     const mockWrapNetworkRequest = jest.fn();
-    mockWrapNetworkRequest.mockImplementation(async () => async () => {});
     const plugins = new Map<string, Plugin<any>>();
     plugins.set(`fakeWrapNetworkRequestPlugin`, {
       hooks: {


### PR DESCRIPTION
**What's the problem this PR addresses?**

One of our tests mocks `got` to validate that it is passed the correct URL which doesn't work when transpiled by esbuild.
We have a test that checks that the URL is correct using `wrapNetworkRequest` and various integration tests that should cover it.

Extracted from https://github.com/yarnpkg/berry/pull/5581

**How did you fix it?**

Removed the test that required mocking `got`.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.