### PR TITLE
perf(cli): use `Module.runMain` instead of `child_process`

### DIFF
--- a/.yarn/versions/bcd19e09.yml
+++ b/.yarn/versions/bcd19e09.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When `yarnPath` points to a different binary from the current one, Yarn forwards the command to the specified binary using `child_process.execFileSync`, which adds unnecessary overhead.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it use `Module.runMain` instead, the same trick we use in corepack starting from https://github.com/nodejs/corepack/pull/97.

This speeds up every command when using Yarn from sources (or in other cases where `corepack` uses modern, and `corepack` and `yarnPath` point to different binaries).

`yarn -v` in such a situation:
- Before: `0.263s`
- After: `0.229s`
- Improvement: `13%`

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
