### PR TITLE
Fix partial clone PR number

### DIFF
--- a/packages/gatsby/content/features/zero-installs.md
+++ b/packages/gatsby/content/features/zero-installs.md
@@ -57,7 +57,9 @@ Every time you update a dependency and commit it, the repository will grow, the 
 
     - Git will lazily download the missing files as needed. For example, if you run `git checkout` on an old commit, Git will fetch whatever files are needed before the command returns, so you won't see any difference.
 
-    - **This feature is supported by both GitHub and Gitlab, and is probably the best option at your disposal** if you can modify the way `git clone` is performed. Note however that the `actions/checkout` GitHub Action doesn't allow it yet (a PR is open [here](https://github.com/actions/checkout/pull/680)).
+    - **This feature is supported by both GitHub and Gitlab, and is probably the best option at your disposal** if you can modify the way `git clone` is performed.
+      Note that the `actions/checkout` GitHub Action only allows a `blob:none` filter by setting `sparse-checkout: '/*/'`.
+      (A [PR is open](https://github.com/actions/checkout/pull/1396) for custom partial clone filters).
 
 - [Sparse checkouts](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/) are the older cousin of partial clones. Instead of retrieving the whole Git history but putting aside the binary data, sparse checkouts instead define a cutoff commit which Git will treat as having no parents.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The “Zero Installs” docs link the wrong `actions/checkout` PR (closed and addressing sparse checkouts instead of shallow clones)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I linked to the correct PR and provided a workaround that is possible today.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
