### PR TITLE
feat(builder): make bundle executable

### DIFF
--- a/.yarn/versions/6459c603.yml
+++ b/.yarn/versions/6459c603.yml
@@ -1,0 +1,12 @@
+releases:
+  "@yarnpkg/builder": minor
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -1,8 +1,7 @@
 import {StreamReport, MessageName, Configuration, formatUtils, structUtils} from '@yarnpkg/core';
-import {npath, xfs}                                                         from '@yarnpkg/fslib';
+import {npath, ppath, xfs}                                                  from '@yarnpkg/fslib';
 import {Command, Option, Usage, UsageError}                                 from 'clipanion';
 import {build, Plugin}                                                      from 'esbuild';
-import fs                                                                   from 'fs';
 import path                                                                 from 'path';
 import semver                                                               from 'semver';
 
@@ -63,9 +62,9 @@ export default class BuildPluginCommand extends Command {
     const {name: rawName, main} = require(`${basedir}/package.json`);
     const name = getNormalizedName(rawName);
     const prettyName = structUtils.prettyIdent(configuration, structUtils.parseIdent(name));
-    const output = path.join(basedir, `bundles/${name}.js`);
+    const output = ppath.join(portableBaseDir, `bundles/${name}.js`);
 
-    await xfs.mkdirPromise(npath.toPortablePath(path.dirname(output)), {recursive: true});
+    await xfs.mkdirPromise(ppath.dirname(output), {recursive: true});
 
     const report = await StreamReport.start({
       configuration,
@@ -113,7 +112,7 @@ export default class BuildPluginCommand extends Command {
           },
           entryPoints: [path.resolve(basedir, main ?? `sources/index`)],
           bundle: true,
-          outfile: output,
+          outfile: npath.fromPortablePath(output),
           // Default extensions + .mjs
           resolveExtensions: [`.tsx`, `.ts`, `.jsx`, `.mjs`, `.js`, `.css`, `.json`],
           logLevel: `silent`,
@@ -152,7 +151,7 @@ export default class BuildPluginCommand extends Command {
     } else {
       report.reportInfo(null, `${Mark.Check} Done building ${prettyName}!`);
       report.reportInfo(null, `${Mark.Question} Bundle path: ${formatUtils.pretty(configuration, output, formatUtils.Type.PATH)}`);
-      report.reportInfo(null, `${Mark.Question} Bundle size: ${formatUtils.pretty(configuration, fs.statSync(output).size, formatUtils.Type.SIZE)}`);
+      report.reportInfo(null, `${Mark.Question} Bundle size: ${formatUtils.pretty(configuration, (await xfs.statPromise(output)).size, formatUtils.Type.SIZE)}`);
     }
 
     return report.exitCode();


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The builder doesn't make the bundle executable, which means that it can't be spawned directly without node.

I noticed this while testing the `yarn bench` script in our repo, which symlinks the bundle and then [tries to spawn it](https://github.com/yarnpkg/berry/blob/cb19bb3377b7564eced457c47db18109e1041cc1/scripts/bench-folder.ts#L111) without first `chmod`-ing it.

I decided that it makes sense for the builder to chmod it directly.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made the builder `chmod` it.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
