### PR TITLE
test: use `stream.promises.pipeline`

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/fs.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/fs.ts
@@ -2,13 +2,9 @@ import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
 import {parseSyml}                       from '@yarnpkg/parsers';
 import stream                            from 'stream';
 import tarFs                             from 'tar-fs';
-import {promisify}                       from 'util';
 import zlib, {Gzip}                      from 'zlib';
 
 import {execPromise}                     from './exec';
-
-// TODO: Use stream.promises.pipeline when dropping support for Node.js < 15.0.0
-const pipelinePromise = promisify(stream.pipeline);
 
 const IS_WIN32 = process.platform === `win32`;
 
@@ -48,14 +44,14 @@ export const packToStream = (
 };
 
 export const packToFile = async (target: PortablePath, source: PortablePath, options: {virtualPath?: PortablePath | null}): Promise<void> => {
-  await pipelinePromise(
+  await stream.promises.pipeline(
     packToStream(source, options),
     xfs.createWriteStream(target),
   );
 };
 
 export const unpackToDirectory = async (target: PortablePath, source: PortablePath): Promise<void> => {
-  await pipelinePromise(
+  await stream.promises.pipeline(
     xfs.createReadStream(source),
     zlib.createUnzip(),
     tarFs.extract(npath.fromPortablePath(target)),

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -25,9 +25,6 @@ import * as fsUtils                                            from './fs';
 const deepResolve = require(`super-resolve`);
 const staticServer = serveStatic(npath.fromPortablePath(require(`pkg-tests-fixtures`)));
 
-// TODO: Use stream.promises.pipeline when dropping support for Node.js < 15.0.0
-const pipelinePromise = promisify(stream.pipeline);
-
 // Testing things inside a big-endian container takes forever
 export const TEST_TIMEOUT = os.endianness() === `BE`
   ? 150000
@@ -273,10 +270,10 @@ export const getPackageArchiveHash = async (
   name: string,
   version: string,
 ): Promise<string | Buffer> => {
-  const stream = await getPackageArchiveStream(name, version);
+  const archiveStream = await getPackageArchiveStream(name, version);
   const hash = crypto.createHash(`sha1`);
 
-  await pipelinePromise(stream, hash);
+  await stream.promises.pipeline(archiveStream, hash);
 
   return hash.digest(`hex`);
 };
@@ -435,7 +432,7 @@ export const startPackageServer = ({type}: { type: keyof typeof packageServerUrl
         [`Transfer-Encoding`]: `chunked`,
       });
 
-      await pipelinePromise(
+      await stream.promises.pipeline(
         fsUtils.packToStream(npath.toPortablePath(packageVersionEntry.path), {virtualPath: npath.toPortablePath(`/package`)}),
         response,
       );


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Our tests still use `promisify(stream.pipeline)`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made them use `stream.promises.pipeline`, which has been available since Node `15.0.0`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
