### PR TITLE
perf(plugin-pnp): remove redundant node check

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -19677,7 +19677,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],\
@@ -19687,7 +19686,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19703,7 +19701,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/yarnpkg-cli"],\
@@ -19713,7 +19710,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19729,7 +19725,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],\
@@ -19739,7 +19734,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19755,7 +19749,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],\
@@ -19765,7 +19758,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19781,7 +19773,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],\
@@ -19791,7 +19782,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19807,7 +19797,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:35104c47575f2fe378d8d20383ae667f19d4dd801df8cc4c76848603aa6b4a2234a00142ff12fd557f6f48bd2810880e31c40c767010ea61a31fca302c2cc5e0#workspace:packages/yarnpkg-cli"],\
@@ -19817,7 +19806,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19833,7 +19821,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],\
@@ -19843,7 +19830,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19859,7 +19845,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/yarnpkg-cli"],\
@@ -19869,7 +19854,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19885,7 +19869,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:7b82ac5a3734606065dc76f117982c681b5b5076260acfcac869c687f06db0b8c08eae0998f419d64b9e59f6c816bcc70e067c87fa32ffe9cb979faf85cd80b4#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:8bb72793b532d34e63bbc26264dcbcfc4dc4faa0a42627635e997081722bf229d67b7a677d86a568dad949d756630e45b9d4da97ee14b1b4c506494f8a58ea91#workspace:packages/yarnpkg-cli"],\
@@ -19895,7 +19878,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19911,7 +19893,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],\
@@ -19921,7 +19902,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19937,7 +19917,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],\
@@ -19947,7 +19926,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19963,7 +19941,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],\
@@ -19973,7 +19950,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -19989,7 +19965,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],\
@@ -19999,7 +19974,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20015,7 +19989,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/yarnpkg-cli"],\
@@ -20025,7 +19998,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20041,7 +20013,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:e3ce0ce4b7f0796ca44011528cb9cdc133fc62a76363fea6de68497bae04bdbe5a6dd47e6b9f23c282eb8e4533d75e96cf378c943d07a4e78aae0b715f06a450#workspace:packages/yarnpkg-cli"],\
@@ -20051,7 +20022,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20067,7 +20037,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:86c95fabbcd56c56f5f2d2e080e64a1095e3fe233877aa9f7958f317f88a95627e0be2765e89c0cff02c9f08f27b64b7cbc9d5c3960c1df509d5e6ea98cca4f4#workspace:packages/yarnpkg-cli"],\
@@ -20077,7 +20046,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20093,7 +20061,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],\
@@ -20103,7 +20070,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20119,7 +20085,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/yarnpkg-cli"],\
@@ -20129,7 +20094,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20145,7 +20109,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],\
@@ -20155,7 +20118,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "packagePeers": [\
@@ -20171,7 +20133,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@yarnpkg/plugin-pnp", "workspace:packages/plugin-pnp"],\
           ["@types/micromatch", "npm:4.0.1"],\
-          ["@types/semver", "npm:7.5.0"],\
           ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
@@ -20179,7 +20140,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:3.2.1"],\
           ["micromatch", "npm:4.0.5"],\
-          ["semver", "npm:7.5.4"],\
           ["tslib", "npm:2.4.0"]\
         ],\
         "linkType": "SOFT"\

--- a/.yarn/versions/7232adf9.yml
+++ b/.yarn/versions/7232adf9.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/package.json
+++ b/packages/plugin-pnp/package.json
@@ -9,13 +9,11 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@types/semver": "^7.1.0",
     "@yarnpkg/fslib": "workspace:^",
     "@yarnpkg/plugin-stage": "workspace:^",
     "@yarnpkg/pnp": "workspace:^",
     "clipanion": "^3.2.1",
     "micromatch": "^4.0.2",
-    "semver": "^7.1.2",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -1,7 +1,6 @@
 import {Hooks as CoreHooks, Plugin, Project, SettingsType, WindowsLinkType} from '@yarnpkg/core';
 import {Filename, PortablePath, npath, ppath, xfs}                          from '@yarnpkg/fslib';
 import {Hooks as StageHooks}                                                from '@yarnpkg/plugin-stage';
-import semver                                                               from 'semver';
 import {pathToFileURL}                                                      from 'url';
 
 import {PnpLinker}                                                          from './PnpLinker';
@@ -31,9 +30,6 @@ async function setupScriptEnvironment(project: Project, env: {[key: string]: str
 
   if (xfs.existsSync(pnpPath.esmLoader))
     pnpRequire = `${pnpRequire} --experimental-loader ${pathToFileURL(npath.fromPortablePath(pnpPath.esmLoader)).href}`;
-
-  if (pnpPath.cjs.includes(` `) && semver.lt(process.versions.node, `12.0.0`))
-    throw new Error(`Expected the build location to not include spaces when using Node < 12.0.0 (${process.versions.node})`);
 
   if (xfs.existsSync(pnpPath.cjs)) {
     let nodeOptions = env.NODE_OPTIONS || ``;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7783,7 +7783,6 @@ __metadata:
   resolution: "@yarnpkg/plugin-pnp@workspace:packages/plugin-pnp"
   dependencies:
     "@types/micromatch": "npm:^4.0.1"
-    "@types/semver": "npm:^7.1.0"
     "@yarnpkg/cli": "workspace:^"
     "@yarnpkg/core": "workspace:^"
     "@yarnpkg/fslib": "workspace:^"
@@ -7791,7 +7790,6 @@ __metadata:
     "@yarnpkg/pnp": "workspace:^"
     clipanion: "npm:^3.2.1"
     micromatch: "npm:^4.0.2"
-    semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@yarnpkg/cli": "workspace:^"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

https://github.com/yarnpkg/berry/pull/824 added a check that throws an error on Node < 12 if the `.pnp.cjs` path contains spaces, due to an old bug in Node.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Removed the check since the bug has been fixed since Node 12.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
