### PR TITLE
fix(plugin-pnp): unset `NODE_OPTIONS` when preparing the environment after switching linkers

### DIFF
--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -4,13 +4,6 @@ on:
   push:
     branches:
     - master
-    paths:
-    - .github/actions/prepare/action.yml
-    - .github/workflows/e2e-nm-berry-workflow.yml
-    - scripts/e2e-setup-ci.sh
-    - packages/yarnpkg-nm/sources/hoist.ts
-    - packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
-    - packages/plugin-nm/sources/NodeModulesLinker.ts
   pull_request:
     paths:
     - .github/actions/prepare/action.yml

--- a/.yarn/versions/89a69c6d.yml
+++ b/.yarn/versions/89a69c6d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -27,6 +27,7 @@ export const quotePathIfNeeded = (path: string) => {
 async function setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>) {
   // We still support .pnp.js files to improve multi-project compatibility.
   // TODO: Drop the question mark in the RegExp after .pnp.js files stop being used.
+  // TODO: Support `-r` as an alias for `--require` (in all packages)
   const pnpRegularExpression = /\s*--require\s+\S*\.pnp\.c?js\s*/g;
   const esmLoaderExpression = /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/;
 

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -25,6 +25,23 @@ export const quotePathIfNeeded = (path: string) => {
 };
 
 async function setupScriptEnvironment(project: Project, env: {[key: string]: string}, makePathWrapper: (name: string, argv0: string, args: Array<string>) => Promise<void>) {
+  // We still support .pnp.js files to improve multi-project compatibility.
+  // TODO: Drop the question mark in the RegExp after .pnp.js files stop being used.
+  const pnpRegularExpression = /\s*--require\s+\S*\.pnp\.c?js\s*/g;
+  const esmLoaderExpression = /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/;
+
+  const nodeOptions = (env.NODE_OPTIONS ?? ``)
+    .replace(pnpRegularExpression, ` `)
+    .replace(esmLoaderExpression, ` `)
+    .trim();
+
+  // We remove the PnP hook from NODE_OPTIONS because the process can have
+  // NODE_OPTIONS set while changing linkers, which affects build scripts.
+  if (project.configuration.get(`nodeLinker`) !== `pnp`) {
+    env.NODE_OPTIONS = nodeOptions;
+    return;
+  }
+
   const pnpPath = getPnpPath(project);
   let pnpRequire = `--require ${quotePathIfNeeded(npath.fromPortablePath(pnpPath.cjs))}`;
 
@@ -32,17 +49,7 @@ async function setupScriptEnvironment(project: Project, env: {[key: string]: str
     pnpRequire = `${pnpRequire} --experimental-loader ${pathToFileURL(npath.fromPortablePath(pnpPath.esmLoader)).href}`;
 
   if (xfs.existsSync(pnpPath.cjs)) {
-    let nodeOptions = env.NODE_OPTIONS || ``;
-
-    // We still support .pnp.js files to improve multi-project compatibility.
-    // TODO: Drop the question mark in the RegExp after .pnp.js files stop being used.
-    const pnpRegularExpression = /\s*--require\s+\S*\.pnp\.c?js\s*/g;
-    const esmLoaderExpression = /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/;
-    nodeOptions = nodeOptions.replace(pnpRegularExpression, ` `).replace(esmLoaderExpression, ` `).trim();
-
-    nodeOptions = nodeOptions ? `${pnpRequire} ${nodeOptions}` : pnpRequire;
-
-    env.NODE_OPTIONS = nodeOptions;
+    env.NODE_OPTIONS = nodeOptions ? `${pnpRequire} ${nodeOptions}` : pnpRequire;
   }
 }
 

--- a/scripts/setup-ts-execution.js
+++ b/scripts/setup-ts-execution.js
@@ -8,7 +8,7 @@ const zlib = require(`zlib`);
 
 // Needed by the worker spawned by esbuild
 if (process.versions.pnp)
-  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ``} -r ${JSON.stringify(require.resolve(`pnpapi`))}`;
+  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ``} --require ${JSON.stringify(require.resolve(`pnpapi`))}`;
 
 const resolveVirtual = process.versions.pnp
   ? require(`pnpapi`).resolveVirtual

--- a/scripts/setup-ts-execution.js
+++ b/scripts/setup-ts-execution.js
@@ -8,7 +8,9 @@ const zlib = require(`zlib`);
 
 // Needed by the worker spawned by esbuild
 if (process.versions.pnp)
-  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ``} --require ${JSON.stringify(require.resolve(`pnpapi`))}`;
+  // Unquoted because Yarn doesn't support it quoted yet
+  // TODO: make Yarn support quoted PnP requires in NODE_OPTIONS
+  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ``} --require ${require.resolve(`pnpapi`)}`;
 
 const resolveVirtual = process.versions.pnp
   ? require(`pnpapi`).resolveVirtual


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

We [set `NODE_OPTIONS` for PnP](https://github.com/yarnpkg/berry/blob/f5f2f6ef97be320eb625adb69ad8cd6c54b75745/scripts/setup-ts-execution.js#L11) in `setup-ts-execution`, which causes `yarn config set nodeLinker && yarn install` to fail due to `NODE_OPTIONS` still referencing the removed PnP files during build scripts.

I consider this a Yarn issue and not a `setup-ts-execution` issue because Yarn, like any other package, is supposed to work under PnP, even if `NODE_OPTIONS` happens to be set.

Fixes https://github.com/yarnpkg/berry/actions/runs/5669921008/job/15363692897#step:4:229.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

This PR makes `setupScriptEnvironment` from `@yarnpkg/plugin-pnp` remove the PnP flags from `NODE_OPTIONS` if the linker isn't `pnp`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
