### PR TITLE
test: remove unnecessary node version checks

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -41477,7 +41477,6 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnp", "workspace:packages/yarnpkg-pnp"],\
           ["lodash", "npm:4.17.21"],\
           ["pkg-tests-core", "workspace:packages/acceptance-tests/pkg-tests-core"],\
-          ["semver", "npm:7.5.4"],\
           ["tar", "npm:6.1.11"],\
           ["tslib", "npm:2.4.0"]\
         ],\

--- a/packages/acceptance-tests/pkg-tests-specs/package.json
+++ b/packages/acceptance-tests/pkg-tests-specs/package.json
@@ -23,7 +23,6 @@
     "@yarnpkg/pnp": "workspace:^",
     "lodash": "^4.17.15",
     "pkg-tests-core": "workspace:^",
-    "semver": "^7.1.2",
     "tar": "^6.0.5",
     "tslib": "^2.4.0"
   },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp.test.js
@@ -1,6 +1,5 @@
 const {npath, ppath, xfs, Filename} = require(`@yarnpkg/fslib`);
 const cp = require(`child_process`);
-const {satisfies} = require(`semver`);
 
 const {
   fs: {writeFile, writeJson},
@@ -565,8 +564,7 @@ describe(`Plug'n'Play`, () => {
     ),
   );
 
-  testIf(
-    () => satisfies(process.versions.node, `>=8.9.0`),
+  test(
     `it should support the 'paths' option from require.resolve (same dependency tree)`,
     makeTemporaryEnv(
       {
@@ -603,8 +601,7 @@ describe(`Plug'n'Play`, () => {
     ),
   );
 
-  testIf(
-    () => satisfies(process.versions.node, `>=8.9.0`),
+  test(
     `it should terminate when the 'paths' option from require.resolve includes empty string and there is no .pnp.cjs in the working dir`,
     makeTemporaryEnv(
       {
@@ -716,8 +713,7 @@ describe(`Plug'n'Play`, () => {
     }),
   );
 
-  testIf(
-    () => satisfies(process.versions.node, `>=8.9.0`),
+  test(
     `it should throw when using require.resolve with unsupported options`,
     makeTemporaryEnv(
       {
@@ -2182,8 +2178,7 @@ describe(`Plug'n'Play`, () => {
     ),
   );
 
-  testIf(
-    () => satisfies(process.versions.node, `>=14`),
+  test(
     `it should emit a warning for circular dependency exports access`,
     makeTemporaryEnv({}, async ({path, run, source}) => {
       await expect(run(`install`)).resolves.toMatchObject({code: 0});

--- a/packages/acceptance-tests/pkg-tests-specs/sources/require.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/require.test.js
@@ -1,9 +1,7 @@
 const {npath, xfs} = require(`@yarnpkg/fslib`);
-const {satisfies} = require(`semver`);
 
 const {
   fs: {writeFile, writeJson},
-  tests: {testIf},
 } = require(`pkg-tests-core`);
 
 describe(`Require tests`, () => {
@@ -190,8 +188,7 @@ describe(`Require tests`, () => {
     ),
   );
 
-  testIf(
-    () => satisfies(process.versions.node, `>=8.9.0`),
+  test(
     `it should support require.resolve(..., {paths})`,
     makeTemporaryEnv(
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23690,7 +23690,6 @@ pem@dexus/pem:
     "@yarnpkg/pnp": "workspace:^"
     lodash: "npm:^4.17.15"
     pkg-tests-core: "workspace:^"
-    semver: "npm:^7.1.2"
     tar: "npm:^6.0.5"
     tslib: "npm:^2.4.0"
   languageName: unknown


### PR DESCRIPTION
**What's the problem this PR addresses?**

We have some tests that are disabled on old versions of Node.js but we've dropped support for those versions now so we can run the tests unconditionally.

**How did you fix it?**

Remove the Node.js version checks.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.