### PR TITLE
refactor: use `timers/promises`

### DIFF
--- a/.yarn/versions/8b252311.yml
+++ b/.yarn/versions/8b252311.yml
@@ -1,0 +1,35 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-shell/sources/index.ts
+++ b/packages/yarnpkg-shell/sources/index.ts
@@ -4,15 +4,13 @@ import {EnvSegment, ArithmeticExpression, ArithmeticPrimary}                    
 import chalk                                                                                                from 'chalk';
 import {homedir}                                                                                            from 'os';
 import {PassThrough, Readable, Writable}                                                                    from 'stream';
-import {promisify}                                                                                          from 'util';
+import {setTimeout}                                                                                         from 'timers/promises';
 
 import EntryCommand                                                                                         from './commands/entry';
 import {ShellError}                                                                                         from './errors';
 import * as globUtils                                                                                       from './globUtils';
 import {createOutputStreamsWithPrefix, makeBuiltin, makeProcess}                                            from './pipe';
 import {Handle, ProcessImplementation, ProtectedStream, Stdio, start, Pipe}                                 from './pipe';
-
-const setTimeoutPromise = promisify(setTimeout);
 
 export {EntryCommand};
 export {ShellError};
@@ -165,7 +163,7 @@ const BUILTINS = new Map<string, ShellBuiltin>([
     if (Number.isNaN(seconds))
       throw new ShellError(`sleep: invalid time interval '${time}'`);
 
-    return await setTimeoutPromise(1000 * seconds, 0);
+    return await setTimeout(1000 * seconds, 0);
   }],
 
   [`__ysh_run_procedure`, async (args: Array<string>, opts: ShellOptions, state: ShellState) => {

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -2,9 +2,7 @@ import {xfs, ppath, PortablePath} from '@yarnpkg/fslib';
 import {execute, UserOptions}     from '@yarnpkg/shell';
 import {PassThrough}              from 'stream';
 import stripAnsi                  from 'strip-ansi';
-import {promisify}                from 'util';
-
-const setTimeoutPromise = promisify(setTimeout);
+import {setTimeout}               from 'timers/promises';
 
 const isNotWin32 = process.platform !== `win32`;
 
@@ -2010,12 +2008,12 @@ describe(`Shell`, () => {
     it(`should wait for all background jobs to finish before resolving`, async () => {
       await expect(Promise.race([
         bufferResult(`sleep 0.4 && echo foo`, [], {tty: false}),
-        setTimeoutPromise(300),
+        setTimeout(300),
       ])).resolves.toBeUndefined();
 
       await expectResult(Promise.race([
         bufferResult(`sleep 0.4 && echo foo`, [], {tty: false}),
-        setTimeoutPromise(500),
+        setTimeout(500),
       ]), {
         stdout: `foo\n`,
         stderr: ``,
@@ -2024,12 +2022,12 @@ describe(`Shell`, () => {
 
       await expect(Promise.race([
         bufferResult(`sleep 0.4 & echo foo`, [], {tty: false}),
-        setTimeoutPromise(300),
+        setTimeout(300),
       ])).resolves.toBeUndefined();
 
       await expectResult(Promise.race([
         bufferResult(`sleep 0.4 & echo foo`, [], {tty: false}),
-        setTimeoutPromise(500),
+        setTimeout(500),
       ]), {
         stdout: `foo\n`,
         stderr: ``,


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`timersPromises.setTimeout` has been available since Node `15.0.0`.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Replaced `promisify(setTimeout)` with `timersPromises.setTimeout`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
