### PR TITLE
Improves string escaping during serialization

### DIFF
--- a/.yarn/versions/d3925be6.yml
+++ b/.yarn/versions/d3925be6.yml
@@ -1,0 +1,11 @@
+releases:
+  "@yarnpkg/parsers": patch
+
+declined:
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/shell"

--- a/packages/yarnpkg-parsers/tests/shell.test.ts
+++ b/packages/yarnpkg-parsers/tests/shell.test.ts
@@ -172,6 +172,9 @@ describe(`Shell parser`, () => {
 
 const STRINGIFIER_TESTS: Array<[string, string]> = [
   [`echo foo`, `echo foo`],
+  [`echo parapapa`, `echo parapapa`],
+  [`echo 'foo bar'`, `echo 'foo bar'`],
+  [`echo "foo' bar'"`, `echo "foo' bar'"`],
   [`echo foo; echo bar`, `echo foo; echo bar`],
   [`echo foo; echo bar;`, `echo foo; echo bar`],
   [`echo foo &`, `echo foo &`],
@@ -190,7 +193,7 @@ const STRINGIFIER_TESTS: Array<[string, string]> = [
   [`FOO=bar echo foo`, `FOO=bar echo foo`],
   [`FOO=bar BAZ=qux`, `FOO=bar BAZ=qux`],
   [`FOO=$'\\x09'`, `FOO=$'\\t'`],
-  [`FOO=$'\\u0027'`, `FOO=$'\\''`],
+  [`FOO=$'\\u0027'`, `FOO="'"`],
   [`FOO=$'\\U0001F601'`, `FOO=😁`],
 ];
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Positional arguments were over-complexified during serialization. For example, `"foo bar"` was serialized as `$'foo bar'`. It works, but it's a surprising syntax for users.

**How did you fix it?**

Since I needed to use the serialization to generate part of the new website, I fixed it to make it look more natural, and added tests to avoid regressions.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
