### PR TITLE
Refactors context passing

### DIFF
--- a/.yarn/versions/bfe31a8a.yml
+++ b/.yarn/versions/bfe31a8a.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": major
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/cli.ts
+++ b/packages/yarnpkg-cli/sources/cli.ts
@@ -1,10 +1,11 @@
 import '@yarnpkg/cli/polyfills';
-import {npath}                  from '@yarnpkg/fslib';
+import {npath, ppath}           from '@yarnpkg/fslib';
 
 import {runExit}                from './lib';
 import {getPluginConfiguration} from './tools/getPluginConfiguration';
 
 runExit(process.argv.slice(2), {
+  cwd: ppath.cwd(),
   selfPath: npath.toPortablePath(npath.resolve(process.argv[1])),
   pluginConfiguration: getPluginConfiguration(),
 });

--- a/packages/yarnpkg-cli/sources/index.ts
+++ b/packages/yarnpkg-cli/sources/index.ts
@@ -1,7 +1,9 @@
-export {BaseCommand}            from './tools/BaseCommand';
-export {WorkspaceRequiredError} from './tools/WorkspaceRequiredError';
-export {getDynamicLibs}         from './tools/getDynamicLibs';
-export {getPluginConfiguration} from './tools/getPluginConfiguration';
-export {openWorkspace}          from './tools/openWorkspace';
-export {getCli, runExit}        from './lib';
-export {pluginCommands}         from './pluginCommands';
+export {type CommandContext}           from '@yarnpkg/core';
+
+export {BaseCommand}                   from './tools/BaseCommand';
+export {WorkspaceRequiredError}        from './tools/WorkspaceRequiredError';
+export {getDynamicLibs}                from './tools/getDynamicLibs';
+export {getPluginConfiguration}        from './tools/getPluginConfiguration';
+export {openWorkspace}                 from './tools/openWorkspace';
+export {type YarnCli, getCli, runExit} from './lib';
+export {pluginCommands}                from './pluginCommands';


### PR DESCRIPTION
**What's the problem this PR addresses?**

Passing the context to the CLI instance was impractical, as it required to know exactly what was the context that the commands expect. I think there's something to improve here in Clipanion itself (perhaps so that the context can be defined when instantiating the CLI, not running the first command), but that's for a separate time.

**How did you fix it?**

I made `getCliBase` add a `defaultContext` field to the CLI instance. I considered returning them as separate fields, but wasn't sure it'd be worth the hassle of conveying two different values. Might revisit in a follow-up PR.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
