### PR TITLE
perf(cli): avoid resolving `ppath.cwd()`

### DIFF
--- a/.yarn/versions/d9107e26.yml
+++ b/.yarn/versions/d9107e26.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-cli/sources/lib.ts
+++ b/packages/yarnpkg-cli/sources/lib.ts
@@ -101,7 +101,10 @@ function checkCwd(cli: YarnCli, argv: Array<string>) {
     postCwdArgv = argv.slice(1);
   }
 
-  cli.defaultContext.cwd = ppath.resolve(cwd ?? ppath.cwd());
+  cli.defaultContext.cwd = cwd !== null
+    ? ppath.resolve(cwd)
+    : ppath.cwd();
+
   return postCwdArgv;
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`@yarnpkg/cli` currently does a `ppath.resolve(cwd ?? ppath.cwd())`, which is unnecessary for `ppath.cwd()` as it already returns an absolute path.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Made it skip resolving it.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
