### PR TITLE
refactor!: simplify `Configuration.findProjectCwd`

### DIFF
--- a/.yarn/versions/1d7f6642.yml
+++ b/.yarn/versions/1d7f6642.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": major
+  "@yarnpkg/core": major
+  "@yarnpkg/doctor": patch
+  "@yarnpkg/plugin-dlx": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ The following changes only affect people writing Yarn plugins:
   - `workspace.anchoredLocator` to get the locator that's used throughout the dependency tree.
   - `workspace.manifest.version` to get the workspace version.
 
+- `ProjectLookup` has been removed. Both `Configuration.find` and `Configuration.findProjectCwd` now always do a lockfile lookup.
+
 ### Installs
 
 - Yarn now caches npm version metadata, leading to faster resolution steps and decreased network data usage.

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}                                  from '@yarnpkg/cli';
 import {Configuration, MessageName, miscUtils, Project, stringifyMessageName} from '@yarnpkg/core';
 import {scriptUtils, structUtils, formatUtils}                                from '@yarnpkg/core';
-import {NativePath, Filename, ppath, xfs, npath}                              from '@yarnpkg/fslib';
+import {NativePath, ppath, xfs, npath}                                        from '@yarnpkg/fslib';
 import {Command, Option, Usage}                                               from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
@@ -51,7 +51,7 @@ export default class DlxCommand extends BaseCommand {
       await xfs.writeFilePromise(ppath.join(tmpDir, `yarn.lock`), ``);
 
       const targetYarnrc = ppath.join(tmpDir, `.yarnrc.yml`);
-      const projectCwd = await Configuration.findProjectCwd(this.context.cwd, Filename.lockfile);
+      const projectCwd = await Configuration.findProjectCwd(this.context.cwd);
 
       // We set enableGlobalCache to true for dlx calls to speed it up but only if the
       // project it's run in has enableGlobalCache set to false, otherwise we risk running into

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -977,14 +977,7 @@ async function checkYarnPath({configuration, selfPath}: {configuration: Configur
   }
 }
 
-export enum ProjectLookup {
-  LOCKFILE,
-  MANIFEST,
-  NONE,
-}
-
 export type FindProjectOptions = {
-  lookup?: ProjectLookup;
   strict?: boolean;
   usePathCheck?: PortablePath | null;
   useRc?: boolean;
@@ -1068,7 +1061,7 @@ export class Configuration {
    * way around).
    */
 
-  static async find(startingCwd: PortablePath, pluginConfiguration: PluginConfiguration | null, {lookup = ProjectLookup.LOCKFILE, strict = true, usePathCheck = null, useRc = true}: FindProjectOptions = {}) {
+  static async find(startingCwd: PortablePath, pluginConfiguration: PluginConfiguration | null, {strict = true, usePathCheck = null, useRc = true}: FindProjectOptions = {}) {
     const environmentSettings = getEnvironmentSettings();
     delete environmentSettings.rcFilename;
 
@@ -1140,24 +1133,7 @@ export class Configuration {
     // We need to know the project root before being able to truly instantiate
     // our configuration.
 
-    let projectCwd: PortablePath | null;
-    switch (lookup) {
-      case ProjectLookup.LOCKFILE: {
-        projectCwd = await Configuration.findProjectCwd(startingCwd, Filename.lockfile);
-      } break;
-
-      case ProjectLookup.MANIFEST: {
-        projectCwd = await Configuration.findProjectCwd(startingCwd, null);
-      } break;
-
-      case ProjectLookup.NONE: {
-        if (xfs.existsSync(ppath.join(startingCwd, `package.json`))) {
-          projectCwd = ppath.resolve(startingCwd);
-        } else {
-          projectCwd = null;
-        }
-      } break;
-    }
+    const projectCwd = await Configuration.findProjectCwd(startingCwd);
 
     // Great! We now have enough information to really start to setup the
     // core configuration object.
@@ -1388,7 +1364,7 @@ export class Configuration {
     return null;
   }
 
-  static async findProjectCwd(startingCwd: PortablePath, lockfileFilename: Filename | null) {
+  static async findProjectCwd(startingCwd: PortablePath) {
     let projectCwd = null;
 
     let nextCwd = startingCwd;
@@ -1397,19 +1373,11 @@ export class Configuration {
     while (nextCwd !== currentCwd) {
       currentCwd = nextCwd;
 
-      if (xfs.existsSync(ppath.join(currentCwd, `package.json`)))
-        projectCwd = currentCwd;
+      if (xfs.existsSync(ppath.join(currentCwd, Filename.lockfile)))
+        return currentCwd;
 
-      if (lockfileFilename !== null) {
-        if (xfs.existsSync(ppath.join(currentCwd, lockfileFilename))) {
-          projectCwd = currentCwd;
-          break;
-        }
-      } else {
-        if (projectCwd !== null) {
-          break;
-        }
-      }
+      if (xfs.existsSync(ppath.join(currentCwd, Filename.manifest)))
+        projectCwd = currentCwd;
 
       nextCwd = ppath.dirname(currentCwd);
     }

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -13,7 +13,7 @@ import * as treeUtils   from './treeUtils';
 
 export {CACHE_VERSION, CACHE_CHECKPOINT, Cache}                                                                     from './Cache';
 export {DEFAULT_RC_FILENAME, LEGACY_PLUGINS, TAG_REGEXP}                                                            from './Configuration';
-export {Configuration, FormatType, ProjectLookup, SettingsType, WindowsLinkType}                                    from './Configuration';
+export {Configuration, FormatType, SettingsType, WindowsLinkType}                                                   from './Configuration';
 export type {PluginConfiguration, SettingsDefinition, PackageExtensionData}                                         from './Configuration';
 export type {ConfigurationValueMap, ConfigurationDefinitionMap}                                                     from './Configuration';
 export type {Fetcher, FetchOptions, FetchResult, MinimalFetchOptions}                                               from './Fetcher';

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-import {getPluginConfiguration}                                                                                                                                                                            from '@yarnpkg/cli';
-import {Cache, Configuration, Project, Report, Workspace, structUtils, ProjectLookup, Manifest, Descriptor, HardDependencies, ThrowReport, StreamReport, MessageName, Ident, ResolveOptions, FetchOptions} from '@yarnpkg/core';
-import {PortablePath, npath, ppath, xfs}                                                                                                                                                                   from '@yarnpkg/fslib';
-import {Cli, Command, Builtins, Option}                                                                                                                                                                    from 'clipanion';
-import globby                                                                                                                                                                                              from 'globby';
-import micromatch                                                                                                                                                                                          from 'micromatch';
-import {Module}                                                                                                                                                                                            from 'module';
-import * as ts                                                                                                                                                                                             from 'typescript';
+import {getPluginConfiguration}                                                                                                                                                             from '@yarnpkg/cli';
+import {Cache, Configuration, Project, Report, Workspace, structUtils, Manifest, Descriptor, HardDependencies, ThrowReport, StreamReport, MessageName, Ident, ResolveOptions, FetchOptions} from '@yarnpkg/core';
+import {PortablePath, npath, ppath, xfs}                                                                                                                                                    from '@yarnpkg/fslib';
+import {Cli, Command, Builtins, Option}                                                                                                                                                     from 'clipanion';
+import globby                                                                                                                                                                               from 'globby';
+import micromatch                                                                                                                                                                           from 'micromatch';
+import {Module}                                                                                                                                                                             from 'module';
+import * as ts                                                                                                                                                                              from 'typescript';
 
-import * as ast                                                                                                                                                                                            from './ast';
+import * as ast                                                                                                                                                                             from './ast';
 
 const BUILTINS = new Set([
   ...(Module.builtinModules || []),
@@ -333,14 +333,7 @@ class EntryCommand extends Command {
 
     const pluginConfiguration = getPluginConfiguration();
 
-    const findStandaloneWorkspace = async (manifestCwd: PortablePath) => {
-      const configuration = await Configuration.find(manifestCwd, pluginConfiguration, {strict: false, lookup: ProjectLookup.NONE});
-      const {workspace} = await Project.find(configuration, manifestCwd);
-
-      return workspace;
-    };
-
-    const findLockfileWorkspace = async (manifestCwd: PortablePath) => {
+    const findWorkspace = async (manifestCwd: PortablePath) => {
       const configuration = await Configuration.find(manifestCwd, pluginConfiguration, {strict: false});
       if (!configuration.projectCwd)
         return null;
@@ -351,18 +344,6 @@ class EntryCommand extends Command {
         return null;
 
       return workspace;
-    };
-
-    const findWorkspace = async (manifestCwd: PortablePath) => {
-      const lockfileWorkspace = await findLockfileWorkspace(manifestCwd);
-      if (lockfileWorkspace)
-        return lockfileWorkspace;
-
-      const standaloneWorkspace = await findStandaloneWorkspace(manifestCwd);
-      if (standaloneWorkspace)
-        return standaloneWorkspace;
-
-      return null;
     };
 
     const report = await StreamReport.start({


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`Configuration.findProjectCwd` is written to support both a `lockfile` lookup (which is kind of a mixed lookup anyways) and a `manifest` lookup. `Configuration.find` supports both these lookups and also `ProjectLookup.NONE`, which only looks inside the current folder.

`ProjectLookup.MANIFEST` isn't used anywhere, and `ProjectLookup.NONE` is only used inside `@yarnpkg/doctor`, but it should never get to run because `findLockfileWorkspace` runs first and it does a regular mixed lookup which already succeeds even if there's no lockfile but there's a manifest.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I simplified all of this and got rid of the lookups. Now everything does a mixed ("lockfile") lookup by default.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
