### PR TITLE
fix: support fragment in tar regex

### DIFF
--- a/.yarn/versions/3717145c.yml
+++ b/.yarn/versions/3717145c.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-http": patch
+
+declined:
+  - "@yarnpkg/cli"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -627,7 +627,7 @@ export const startPackageServer = ({type}: { type: keyof typeof packageServerUrl
           scope,
           localName,
         };
-      } else if ((match = url.match(/^\/(?:(@[^/]+)\/)?([^@/][^/]*)\/(-|tralala)\/\2-(.*)\.tgz.*$/))) {
+      } else if ((match = url.match(/^\/(?:(@[^/]+)\/)?([^@/][^/]*)\/(-|tralala)\/\2-(.*)\.tgz(\?.*)?$/))) {
         const [, scope, localName, split, version] = match;
 
         if ((localName === `unconventional-tarball` || localName === `private-unconventional-tarball`) && split === `-`)

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -627,7 +627,7 @@ export const startPackageServer = ({type}: { type: keyof typeof packageServerUrl
           scope,
           localName,
         };
-      } else if ((match = url.match(/^\/(?:(@[^/]+)\/)?([^@/][^/]*)\/(-|tralala)\/\2-(.*)\.tgz$/))) {
+      } else if ((match = url.match(/^\/(?:(@[^/]+)\/)?([^@/][^/]*)\/(-|tralala)\/\2-(.*)\.tgz.*$/))) {
         const [, scope, localName, split, version] = match;
 
         if ((localName === `unconventional-tarball` || localName === `private-unconventional-tarball`) && split === `-`)
@@ -790,8 +790,19 @@ export const generatePkgDriver = ({
           return content.replace(/(https?):\/\/localhost:\d+/g, `$1://registry.example.org`);
         }
 
+        function cleanupPackageJson(packageJson: Record<string, any>) {
+          for (const key in packageJson) {
+            if (typeof packageJson[key] === `object`) {
+              packageJson[key] = cleanupPackageJson(packageJson[key]);
+            } else if (typeof packageJson[key] === `string`) {
+              packageJson[key] = packageJson[key].replace(/https?:\/\/registry.example.org/, registryUrl);
+            }
+          }
+          return packageJson;
+        }
+
         // Writes a new package.json file into our temporary directory
-        await xfs.writeJsonPromise(npath.toPortablePath(`${path}/package.json`), await deepResolve(packageJson));
+        await xfs.writeJsonPromise(npath.toPortablePath(`${path}/package.json`), await deepResolve(cleanupPackageJson(packageJson)));
 
         const run = async (...args: Array<any>) => {
           let callDefinition = {};

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
@@ -104,5 +104,45 @@ describe(`Protocols`, () => {
         });
       }),
     );
+
+    test(
+      `it should allow fetching packages that have an unconventional url (fragment)`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`unconventional-tarball`]: `https://registry.example.org/unconventional-tarball/tralala/unconventional-tarball-1.0.0.tgz#fragment`},
+        },
+        async ({path, run, source, registryUrl}) => {
+          await run(`install`);
+
+          await expect(source(`require('unconventional-tarball')`)).resolves.toMatchObject({
+            name: `unconventional-tarball`,
+            version: `1.0.0`,
+          });
+
+          await xfs.removePromise(`${path}/.yarn`);
+          await run(`install`);
+        },
+      ),
+    );
+
+    test(
+      `it should allow fetching packages that have an unconventional url (query)`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`unconventional-tarball`]: `https://registry.example.org/unconventional-tarball/tralala/unconventional-tarball-1.0.0.tgz?auth=1234`},
+        },
+        async ({path, run, source, registryUrl}) => {
+          await run(`install`);
+
+          await expect(source(`require('unconventional-tarball')`)).resolves.toMatchObject({
+            name: `unconventional-tarball`,
+            version: `1.0.0`,
+          });
+
+          await xfs.removePromise(`${path}/.yarn`);
+          await run(`install`);
+        },
+      ),
+    );
   });
 });

--- a/packages/plugin-http/sources/constants.ts
+++ b/packages/plugin-http/sources/constants.ts
@@ -1,3 +1,3 @@
-export const TARBALL_REGEXP = /^[^?]*\.(?:tar\.gz|tgz)(?:\?.*)?$/;
+export const TARBALL_REGEXP = /^[^?]*\.(?:tar\.gz|tgz)(?:\?.*)?(?:#.*)?$/;
 
 export const PROTOCOL_REGEXP = /^https?:/;


### PR DESCRIPTION
**What's the problem this PR addresses?**
fixes #5434

...

**How did you fix it?**
Add support for tar resolver URLs with fragments

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
