### PR TITLE
fix(fslib): resolve path with platform-specific method

### DIFF
--- a/.yarn/versions/84edc798.yml
+++ b/.yarn/versions/84edc798.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/fslib"

--- a/packages/yarnpkg-fslib/sources/path.ts
+++ b/packages/yarnpkg-fslib/sources/path.ts
@@ -61,9 +61,9 @@ ppath.cwd = () => toPortablePath(process.cwd());
 
 ppath.resolve = (...segments: Array<PortablePath | Filename>) => {
   if (segments.length > 0 && ppath.isAbsolute(segments[0])) {
-    return path.posix.resolve(...segments) as PortablePath;
+    return path.resolve(...segments) as PortablePath;
   } else {
-    return path.posix.resolve(ppath.cwd(), ...segments) as PortablePath;
+    return path.resolve(ppath.cwd(), ...segments) as PortablePath;
   }
 };
 

--- a/packages/yarnpkg-fslib/tests/ppath.test.ts
+++ b/packages/yarnpkg-fslib/tests/ppath.test.ts
@@ -1,0 +1,10 @@
+import {ppath} from '../sources/path';
+
+describe(`Portable paths`, () => {
+  describe(`resolve`, () => {
+    it(`should use platform-specific resolution`, () => {
+      const path = ppath.resolve(process.cwd(), `sub-dir`);
+      expect(path.startsWith(`/`)).toBe(process.platform !== `win32`);
+    });
+  });
+});


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

`ppath.resolve` will produce incorrect result on Windows, which fails to use `cd` command with `yarnpkg-shell` on Windows.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Use platform-specific resolution method.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
