### PR TITLE
fix(pnp): fix infinite recursion when .pnp.cjs is a symlink and pnp inlining is disabled

### DIFF
--- a/.yarn/versions/12c46079.yml
+++ b/.yarn/versions/12c46079.yml
@@ -1,0 +1,27 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-pnp/sources/generatePnpScript.ts
+++ b/packages/yarnpkg-pnp/sources/generatePnpScript.ts
@@ -44,7 +44,10 @@ function generateInlinedSetup(data: SerializedState) {
 function generateSplitSetup() {
   return [
     `function $$SETUP_STATE(hydrateRuntimeState, basePath) {\n`,
-    `  return hydrateRuntimeState(require(${JSON.stringify(`./${Filename.pnpData}`)}), {basePath: basePath || __dirname});\n`,
+    `  const fs = require('fs');\n`,
+    `  const path = require('path');\n`,
+    `  const pnpDataFilepath = path.resolve(__dirname, ${JSON.stringify(Filename.pnpData)});\n`,
+    `  return hydrateRuntimeState(JSON.parse(fs.readFileSync(pnpDataFilepath, 'utf8')), {basePath: basePath || __dirname});\n`,
     `}\n`,
   ].join(``);
 }


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fix an infinite recursion in Yarn PnP that occurs when working tree is made of symlinks (e.g., inside bazel sandbox), and workspace's disabled the `pnpEnableInlining` option. In this type of scenario the `.pnp.cjs` ends up calling into itself when requiring the data file
```
    /private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test-sandbox-out/.pnp.cjs:44
    const fs__default = /*#__PURE__*/_interopDefaultLegacy(fs);
                                     ^·
    RangeError: Maximum call stack size exceeded
        at Object.<anonymous> (/private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test-sandbox-out/.pnp.cjs:44:34)
        at Module._compile (node:internal/modules/cjs/loader:1254:14)
        at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
        at require$$0.Module._extensions..js (/private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test/.pnp.cjs:5499:33)
        at Module.load (node:internal/modules/cjs/loader:1117:32)
        at loadApiInstance (/private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test/.pnp.cjs:7137:12)
        at Object.getApiEntry (/private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test/.pnp.cjs:7160:19)
        at require$$0.Module._resolveFilename (/private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test/.pnp.cjs:5426:57)
        at Module._load (node:internal/modules/cjs/loader:920:27)
        at require$$0.Module._load (/private/var/folders/s8/_fsw_h153fvdqr2vdzkwlm_00000gn/T/xfs-5ff6cf33/test/.pnp.cjs:5347:31)·
    Node.js v18.15.0
```

**How did you fix it?**
Replace `require('./.pnp.data.json')` call w/ a direct fs read to avoid calling into node.js module APIs which are monkey-patched by Yarn PnP

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
