### PR TITLE
Infer which files should SDKs include using manifest data

### DIFF
--- a/.yarn/sdks/eslint/lib/unsupported-api.js
+++ b/.yarn/sdks/eslint/lib/unsupported-api.js
@@ -11,10 +11,10 @@ const absRequire = createRequire(absPnpApiPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require typescript
+    // Setup the environment to be able to require eslint/use-at-your-own-risk
     require(absPnpApiPath).setup();
   }
 }
 
-// Defer to the real typescript your application uses
-module.exports = absRequire(`typescript`);
+// Defer to the real eslint/use-at-your-own-risk your application uses
+module.exports = absRequire(`eslint/use-at-your-own-risk`);

--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -2,5 +2,13 @@
   "name": "eslint",
   "version": "8.45.0-sdk",
   "main": "./lib/api.js",
-  "type": "commonjs"
+  "type": "commonjs",
+  "bin": {
+    "eslint": "./bin/eslint.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./lib/api.js",
+    "./use-at-your-own-risk": "./lib/unsupported-api.js"
+  }
 }

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -2,5 +2,9 @@
   "name": "typescript",
   "version": "5.2.1-rc-sdk",
   "main": "./lib/typescript.js",
-  "type": "commonjs"
+  "type": "commonjs",
+  "bin": {
+    "tsc": "./bin/tsc",
+    "tsserver": "./bin/tsserver"
+  }
 }

--- a/.yarn/versions/4d2d8afa.yml
+++ b/.yarn/versions/4d2d8afa.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -6,9 +6,7 @@ import {Wrapper, GenerateBaseWrapper, BaseSdks} from '../generateSdk';
 export const generateAstroLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`@astrojs/language-server` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`bin/nodeServer.js` as PortablePath);
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
@@ -16,28 +14,15 @@ export const generateAstroLanguageServerBaseWrapper: GenerateBaseWrapper = async
 export const generateEslintBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`eslint` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`bin/eslint.js` as PortablePath);
-  await wrapper.writeFile(`lib/api.js` as PortablePath, {
-    // Empty path to use the entrypoint and let Node.js resolve the correct path itself
-    requirePath: `` as PortablePath,
-  });
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
 
 export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
-  const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target});
+  const wrapper = new Wrapper(`prettier` as PortablePath, {pnpApi, target, manifestOverrides: {exports: undefined}});
 
-  await wrapper.writeManifest({
-    main: `./index.js`,
-  });
-
-  await wrapper.writeBinary(`index.js` as PortablePath, {
-    // Empty path to use the entrypoint and let Node.js resolve the correct path itself
-    requirePath: `` as PortablePath,
-  });
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
@@ -45,9 +30,7 @@ export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: P
 export const generateRelayCompilerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`relay-compiler` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`cli.js` as PortablePath);
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
@@ -55,9 +38,7 @@ export const generateRelayCompilerBaseWrapper: GenerateBaseWrapper = async (pnpA
 export const generateTypescriptLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`typescript-language-server` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`lib/cli.js` as PortablePath);
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
@@ -272,15 +253,10 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 
   const wrapper = new Wrapper(`typescript` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`bin/tsc` as PortablePath);
-  await wrapper.writeBinary(`bin/tsserver` as PortablePath);
-
   await wrapper.writeFile(`lib/tsc.js` as PortablePath);
   await wrapper.writeFile(`lib/tsserver.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
-  await wrapper.writeFile(`lib/typescript.js` as PortablePath);
   await wrapper.writeFile(`lib/tsserverlibrary.js` as PortablePath, {wrapModule: tsServerMonkeyPatch});
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
@@ -288,9 +264,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
 export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`svelte-language-server` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`bin/server.js` as PortablePath);
+  await wrapper.writeDefaults();
 
   return wrapper;
 };
@@ -298,9 +272,7 @@ export const generateSvelteLanguageServerBaseWrapper: GenerateBaseWrapper = asyn
 export const generateFlowBinBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`flow-bin` as PortablePath, {pnpApi, target});
 
-  await wrapper.writeManifest();
-
-  await wrapper.writeBinary(`cli.js` as PortablePath);
+  await wrapper.writeDefaults();
 
   return wrapper;
 };

--- a/packages/yarnpkg-sdks/sources/sdks/cocvim.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/cocvim.ts
@@ -17,11 +17,11 @@ export const generateEslintWrapper: GenerateIntegrationWrapper = async (pnpApi: 
   await addCocVimWorkspaceConfiguration(pnpApi, CocVimConfiguration.settings, {
     [`eslint.packageManager`]: `yarn`,
     [`eslint.nodePath`]: npath.fromPortablePath(
-      ppath.dirname(ppath.dirname(ppath.dirname(
+      ppath.dirname(ppath.dirname(
         wrapper.getProjectPathTo(
-          `lib/api.js` as PortablePath,
+          `package.json` as PortablePath,
         ),
-      ))),
+      )),
     ),
   });
 };

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -48,11 +48,11 @@ export const generateAstroLanguageServerWrapper: GenerateIntegrationWrapper = as
 export const generateEslintWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`eslint.nodePath`]: npath.fromPortablePath(
-      ppath.dirname(ppath.dirname(ppath.dirname(
+      ppath.dirname(ppath.dirname(
         wrapper.getProjectPathTo(
-          `lib/api.js` as PortablePath,
+          `package.json` as PortablePath,
         ),
-      ))),
+      )),
     ),
   });
 
@@ -67,7 +67,7 @@ export const generatePrettierWrapper: GenerateIntegrationWrapper = async (pnpApi
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`prettier.prettierPath`]: npath.fromPortablePath(
       wrapper.getProjectPathTo(
-        `index.js` as PortablePath,
+        ppath.normalize(wrapper.manifest.main),
       ),
     ),
   });


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Some SDKs do not include all exposed files, making some features inaccessible to some editor integration. In particular, the ESLint SDK does not include `lib/unsupported-api.js` needed for its experimental flat config feature.

Closes #5231
Closes #5471

**How did you fix it?**
<!-- A detailed description of your implementation. -->

As outlined in #5231, the list of exposed files can be inferred by reading the `main`, `bin`, and `exports` fields of the manifest. This PR switches all existing SDK generators to doing so. Some SDKs (e.g. Typescript) still requires some special treatment so the PR keeps some escape hatches.

**Questions**

1. I don't know if this is considered a breaking change, I have marked `@yarnpkg/sdks` for a minor release for now.
2. `typescript-language-server` has not exposed a CJS entrypoint since 1.0.0, and as far as I know the SDK mechanism cannot support ESM files since loaders cannot be dynamically once userland code starts execution. Should we just remove that SDK?
3. In the same vein, should we just ignore any conditional exports that require the `import` condition? `.mjs` files?

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
