### PR TITLE
Implements enableOfflineMode

### DIFF
--- a/.yarn/versions/03e1fe2a.yml
+++ b/.yarn/versions/03e1fe2a.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+  "@yarnpkg/plugin-npm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ The following changes only affect people writing Yarn plugins:
 
 ### Features
 
+- `enableOfflineMode` is a new setting that, when set, will instruct Yarn to only use the metadata and archives already stored on the local machine rather than download them from the registry. This can be useful when performing local development under network-constrained environments (trains, planes, ...).
 - `yarn run bin` now injects the environment variables defined in `.env.yarn` when spawning a process. This can be configured using the `injectEnvironmentFiles` variable.
 - `yarn workspaces foreach` now automatically enables the `yarn workspaces foreach ! --verbose` flag in interactive terminals.
 - Constraints can now be written in JavaScript. See the [revamped documentation](/features/constraints) for more information.

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -28,7 +28,10 @@ const mte = generatePkgDriver({
       ? [projectFolder]
       : [];
 
-    const yarnBinary = require.resolve(`${__dirname}/../../../../yarnpkg-cli/bundles/yarn.js`);
+    const yarnBinary = process.env.TEST_FROM_SOURCES
+      ? require.resolve(`${__dirname}/../../../../../scripts/run-yarn.js`)
+      : require.resolve(`${__dirname}/../../../../yarnpkg-cli/bundles/yarn.js`);
+
     const res = await execFile(process.execPath, [yarnBinary, ...cwdArgs, command, ...args], {
       cwd: cwd || path,
       env: {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/enableOfflineMode.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/enableOfflineMode.test.ts
@@ -1,0 +1,43 @@
+describe(`Features`, () => {
+  describe(`enableNetwork`, () => {
+    test(
+      `it should let Yarn reuse the package metadata from its cache`,
+      makeTemporaryEnv({}, {
+        enableGlobalCache: false,
+      }, async ({path, run, source}) => {
+        await run(`add`, `no-deps`);
+        await run(`remove`, `no-deps`);
+
+        await run(`add`, `no-deps`, {
+          enableNetwork: false,
+          enableOfflineMode: true,
+        });
+
+        await expect(source(`require('no-deps/package.json')`)).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `2.0.0`,
+        });
+      }),
+    );
+
+    test(
+      `it should fix the 'latest' tag to reference the highest version found in the cache`,
+      makeTemporaryEnv({}, {
+        enableGlobalCache: false,
+      }, async ({path, run, source}) => {
+        await run(`add`, `no-deps@1.0.0`);
+        await run(`remove`, `no-deps`);
+
+        await run(`add`, `no-deps`, {
+          enableNetwork: false,
+          enableOfflineMode: true,
+        });
+
+        await expect(source(`require('no-deps/package.json')`)).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+      }),
+    );
+  });
+});

--- a/packages/docusaurus/docs/advanced/01-general-reference/error-codes.md
+++ b/packages/docusaurus/docs/advanced/01-general-reference/error-codes.md
@@ -438,3 +438,9 @@ You don't have to upgrade if you don't wish to - but keeping Yarn up-to-date is 
 ## YN0089 - `TIPS_NOTICE`
 
 Our research showed that even our power users aren't always aware of some of the less obvious features in Yarn. To improve discoverability, on local machines, Yarn will display every day a tip about some of the nuggets it contains. Perhaps one of them will help you improve your infrastructure someday?
+
+## YN0090 - `OFFLINE_MODE_ENABLED`
+
+When enabled, the `enableOfflineMode` flag tells Yarn to ignore remote registries and only pull data from its internal caches. This is a handy mode when working from within network-constrained environments such as planes or trains.
+
+To leave the offline work mode, check how it got enabled by running `yarn config --why`. If `<environment>`, run `unset YARN_ENABLE_OFFLINE_MODE` in your terminal. Otherwise, remove the `enableOfflineMode` flag from the relevant `.yarnrc.yml` files.

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -193,6 +193,13 @@
       "type": "boolean",
       "default": true
     },
+    "enableOfflineMode": {
+      "_package": "@yarnpkg/core",
+      "title": "Define whether Yarn should exclusively read package metadata from its cache",
+      "description": "If true, Yarn will replace any network requests by reads from its local caches - even if they contain old information. This can be useful when performing local work on environments without network access (trains, planes, ...), as you can at least leverage the packages you installed on the same machine in the past.\n\nSince this setting will lead to stale data being used, it's recommended to set it for the current session as an environment variable (by running `export YARN_ENABLE_OFFLINE_MODE=1` in your terminal) rather than by adding it to your `.yarnrc.yml` file.",
+      "type": "boolean",
+      "default": false
+    },
     "enableProgressBars": {
       "_package": "@yarnpkg/core",
       "title": "Define whether animated progress bars should be shown or not.",

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -315,6 +315,9 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
       } break;
 
       case Strategy.LATEST: {
+        const hasNetwork = project.configuration.get(`enableNetwork`);
+        const isOfflineMode = project.configuration.get(`enableOfflineMode`);
+
         await trySuggest(async () => {
           if (target === Target.PEER) {
             suggested.push({
@@ -322,7 +325,7 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
               name: `Use *`,
               reason: `(catch-all peer dependency pattern)`,
             });
-          } else if (!project.configuration.get(`enableNetwork`)) {
+          } else if (!hasNetwork && !isOfflineMode) {
             suggested.push({
               descriptor: null,
               name: `Resolve from latest`,
@@ -334,7 +337,7 @@ export async function getSuggestedDescriptors(request: Descriptor, {project, wor
               suggested.push({
                 descriptor: latest,
                 name: `Use ${structUtils.prettyDescriptor(project.configuration, latest)}`,
-                reason: `(resolved from latest)`,
+                reason: `(resolved from ${isOfflineMode ? `the cache` : `latest`})`,
               });
             }
           }

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -48,6 +48,7 @@ export class NpmSemverResolver implements Resolver {
       throw new Error(`Expected a valid range, got ${descriptor.range.slice(PROTOCOL.length)}`);
 
     const registryData = await npmHttpUtils.getPackageMetadata(descriptor, {
+      cache: opts.fetchOptions?.cache,
       project: opts.project,
       version: semver.valid(range.raw) ? range.raw : undefined,
     });
@@ -126,6 +127,7 @@ export class NpmSemverResolver implements Resolver {
       throw new ReportError(MessageName.RESOLVER_NOT_FOUND, `The npm semver resolver got selected, but the version isn't semver`);
 
     const registryData = await npmHttpUtils.getPackageMetadata(locator, {
+      cache: opts.fetchOptions?.cache,
       project: opts.project,
       version,
     });

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -40,6 +40,7 @@ export class NpmTagResolver implements Resolver {
     const tag = descriptor.range.slice(PROTOCOL.length);
 
     const registryData = await npmHttpUtils.getPackageMetadata(descriptor, {
+      cache: opts.fetchOptions?.cache,
       project: opts.project,
     });
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -360,9 +360,14 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     default: true,
   },
   enableNetwork: {
-    description: `If false, the package manager will refuse to use the network if required to`,
+    description: `If false, Yarn will refuse to use the network if required to`,
     type: SettingsType.BOOLEAN,
     default: true,
+  },
+  enableOfflineMode: {
+    description: `If true, Yarn will attempt to retrieve files and metadata from the global cache rather than the network`,
+    type: SettingsType.BOOLEAN,
+    default: false,
   },
   httpProxy: {
     description: `URL of the http proxy that must be used for outgoing http requests`,
@@ -618,6 +623,7 @@ export interface ConfigurationValueMap {
 
   enableMirror: boolean;
   enableNetwork: boolean;
+  enableOfflineMode: boolean;
   httpProxy: string | null;
   httpsProxy: string | null;
   unsafeHttpWhitelist: Array<string>;

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -101,6 +101,7 @@ export enum MessageName {
   MIGRATION_SUCCESS = 87,
   VERSION_NOTICE = 88,
   TIPS_NOTICE = 89,
+  OFFLINE_MODE_ENABLED = 90,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -1727,6 +1727,9 @@ export class Project {
     await opts.report.startTimerPromise(`Project validation`, {
       skipIfEmpty: true,
     }, async () => {
+      if (this.configuration.get(`enableOfflineMode`))
+        opts.report.reportWarning(MessageName.OFFLINE_MODE_ENABLED, `Offline work is enabled; Yarn won't fetch packages from the remote registry if it can avoid it`);
+
       await this.configuration.triggerHook(hooks => {
         return hooks.validateProject;
       }, this, {


### PR DESCRIPTION
**What's the problem this PR addresses?**

We didn't have a good story for people performing local development on their projects while under network-constrained environments. I'm myself working from trains from time to time, and each time it always come a point where I want to do a quick repro with one package or another, but since I don't have network it's a pain.

**How did you fix it?**

A new `enableOfflineMode` setting tells Yarn to reuse the metadata stored in the cache, even if they may be stale (a good feature reuse of the logic @paul-soporan's originally made for perf reasons!).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
