### PR TITLE
Fixes a bug in `yarn unplug --all`

### DIFF
--- a/.yarn/versions/0e2286cc.yml
+++ b/.yarn/versions/0e2286cc.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -122,10 +122,10 @@ export default class UnplugCommand extends BaseCommand {
           return;
 
         const isWorkspace = !!project.tryWorkspaceByLocator(pkg);
+        if (depth > 0 && !this.recursive && isWorkspace)
+          return;
 
-        const mustRecurse = depth === 0 || this.recursive;
-        if (!mustRecurse && isWorkspace)
-          seen.add(pkg.locatorHash);
+        seen.add(pkg.locatorHash);
 
         // Note: We shouldn't skip virtual packages, as
         // we don't iterate over the devirtualized copies.
@@ -133,7 +133,7 @@ export default class UnplugCommand extends BaseCommand {
           selection.push(pkg);
 
         // Don't recurse unless requested
-        if (!mustRecurse)
+        if (depth > 0 && !this.recursive)
           return;
 
         for (const dependency of pkg.dependencies.values()) {

--- a/packages/plugin-pnp/sources/commands/unplug.ts
+++ b/packages/plugin-pnp/sources/commands/unplug.ts
@@ -121,7 +121,11 @@ export default class UnplugCommand extends BaseCommand {
         if (seen.has(pkg.locatorHash))
           return;
 
-        seen.add(pkg.locatorHash);
+        const isWorkspace = !!project.tryWorkspaceByLocator(pkg);
+
+        const mustRecurse = depth === 0 || this.recursive;
+        if (!mustRecurse && isWorkspace)
+          seen.add(pkg.locatorHash);
 
         // Note: We shouldn't skip virtual packages, as
         // we don't iterate over the devirtualized copies.
@@ -129,7 +133,7 @@ export default class UnplugCommand extends BaseCommand {
           selection.push(pkg);
 
         // Don't recurse unless requested
-        if (depth > 0 && !this.recursive)
+        if (!mustRecurse)
           return;
 
         for (const dependency of pkg.dependencies.values()) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

I noticed that running `yarn unplug --all got` didn't work in our repository. After digging, I found out its traversal logic was mistakenly marking the workspaces as being visited as soon as they were seen as dependency - even if they weren't actually traversed due to the `--recursive` flag being missing.

**How did you fix it?**

Fixed the traversal logic.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
