### PR TITLE
Update alpine version for sherlock workflow

### DIFF
--- a/scripts/actions/local-yarn-command/Dockerfile
+++ b/scripts/actions/local-yarn-command/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 
 LABEL "com.github.actions.name"="local-yarn-command"
 LABEL "com.github.actions.description"="Run a Yarn command using the checked-in build"


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The Sherlock GitHub Action has been failing because the Alpine version specified for the Docker container only has packages for node 16.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Updated the Alpine version

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
