### PR TITLE
Testing ETXTBUSY errors in the test infra

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -224,6 +224,8 @@ jobs:
 
     - name: 'Run the integration tests'
       run: |
+        # https://github.com/nodejs/node/issues/48444
+        export UV_USE_IO_URING=0
         node ./scripts/run-yarn.js test:integration --maxWorkers=100% --shard=${{matrix.shard}}
       shell: bash
 

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -201,19 +201,9 @@ jobs:
       fail-fast: false
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
-        node: [18, 19, 20]
+        node: [18, 20.6.1, 20.7]
         platform: [ubuntu-latest]
         shard: ['1/2', '2/2']
-        # We run the rest of the tests on the minimum Node version we support with 3 shards.
-        include:
-          # Windows tests
-          - {node: 18, platform: windows-latest, shard: 1/3}
-          - {node: 18, platform: windows-latest, shard: 2/3}
-          - {node: 18, platform: windows-latest, shard: 3/3}
-          # macOS tests
-          - {node: 18, platform: macos-latest, shard: 1/3}
-          - {node: 18, platform: macos-latest, shard: 2/3}
-          - {node: 18, platform: macos-latest, shard: 3/3}
 
     name: '${{matrix.platform}} w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'
     runs-on: ${{matrix.platform}}

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -201,8 +201,8 @@ jobs:
       fail-fast: false
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
-        node: [18, 20.6.1, 20.7]
-        platform: [ubuntu-latest]
+        node: [18, 20.6, 20.7]
+        platform: [ubuntu-22.04, ubuntu-20.04]
         shard: ['1/2', '2/2']
 
     name: '${{matrix.platform}} w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'


### PR DESCRIPTION
**What's the problem this PR addresses?**

I noticed some of our tests are randomly failing on Node 20. I'm trying to see if it's caused by the Node 20.7 release.
