### PR TITLE
Use ubuntu-20.04 to run the integration tests

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -202,21 +202,21 @@ jobs:
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
         node: [18, 19, 20]
-        platform: [ubuntu-20.04]
+        platform: [[ubuntu, 20.04]]
         shard: ['1/2', '2/2']
         # We run the rest of the tests on the minimum Node version we support with 3 shards.
         include:
           # Windows tests
-          - {node: 18, platform: windows-latest, shard: 1/3}
-          - {node: 18, platform: windows-latest, shard: 2/3}
-          - {node: 18, platform: windows-latest, shard: 3/3}
+          - {node: 18, platform: [windows, latest], shard: 1/3}
+          - {node: 18, platform: [windows, latest], shard: 2/3}
+          - {node: 18, platform: [windows, latest], shard: 3/3}
           # macOS tests
-          - {node: 18, platform: macos-latest, shard: 1/3}
-          - {node: 18, platform: macos-latest, shard: 2/3}
-          - {node: 18, platform: macos-latest, shard: 3/3}
+          - {node: 18, platform: [macos, latest], shard: 1/3}
+          - {node: 18, platform: [macos, latest], shard: 2/3}
+          - {node: 18, platform: [macos, latest], shard: 3/3}
 
-    name: '${{matrix.platform}} w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'
-    runs-on: ${{matrix.platform}}
+    name: '${{matrix.platform[0]}}-latest w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'
+    runs-on: ${{matrix.platform[0]}}-${{matrix.platform[1]}}
     needs: build
 
     steps:

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -202,7 +202,7 @@ jobs:
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
         node: [18, 19, 20]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-20.04]
         shard: ['1/2', '2/2']
         # We run the rest of the tests on the minimum Node version we support with 3 shards.
         include:
@@ -251,7 +251,7 @@ jobs:
         shard: ['1/4', '2/4', '3/4', '4/4']
 
     name: 'Big-endian debian w/ Node.js latest (${{matrix.shard}})'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: |
       github.ref == 'refs/heads/master'
     needs: build


### PR DESCRIPTION
**What's the problem this PR addresses?**

It seems Ubuntu 22.04 has some issues with Node.js: a lot of ETXTBUSY errors are thrown.

**How did you fix it?**

Pins the version of Ubuntu to 20.04 for the integration tests. I didn't pin it for every single test since things seemed to work for other jobs and making it a variable seemed unnecessary.
