### PR TITLE
Add arm64 to example supported cpu values

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -764,7 +764,7 @@
             "type": "string"
           },
           "default": [],
-          "_exampleItems": ["current", "x64", "ia32"]
+          "_exampleItems": ["current", "x64", "arm64", "ia32"]
         },
         "libc": {
           "title": "The list of standard C libraries to cover.",

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -764,7 +764,7 @@
             "type": "string"
           },
           "default": [],
-          "_exampleItems": ["current", "x64", "arm64", "ia32"]
+          "_exampleItems": ["current", "x64", "ia32", "arm64"]
         },
         "libc": {
           "title": "The list of standard C libraries to cover.",


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

PR adds `arm64` to the list of example architectures for the CPU for the `.yarnrc` config file. I added this given that it's probably one of the most popular things people might add to this field given the existence of the Apple M1/M2 machines, and that I originally stumbled onto this field about just that, and the clickthrough to the node docs was unnecessary if the docs just listed this field. There is precedent in having the `arm64` field listed in the example per the `manifest.json` file:

https://github.com/yarnpkg/berry/blob/2634e6ca9c1c63a17b9c2f679ae77f9d852ff5d2/packages/docusaurus/static/configuration/manifest.json#L69-L77

**How did you fix it?**
<!-- A detailed description of your implementation. -->

By adding `arm64` to the list of supported CPU architectures.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
