### PR TITLE
Disables emoji in our Windows tests until Node is fixed

### DIFF
--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -1455,7 +1455,11 @@ describe(`Shell`, () => {
             await xfs.writeFilePromise(ppath.join(tmpDir, `BAR.txt`), ``);
             await xfs.writeFilePromise(ppath.join(tmpDir, `hello_world123.txt`), ``);
             await xfs.writeFilePromise(ppath.join(tmpDir, `&434)hello.txt`), ``);
-            await xfs.writeFilePromise(ppath.join(tmpDir, `😀.txt`), ``);
+
+            // TODO: Remove the condition once Node is fixed:
+            // https://github.com/nodejs/node/issues/48673
+            if (process.platform !== `win32`)
+              await xfs.writeFilePromise(ppath.join(tmpDir, `😀.txt`), ``);
 
             await expectResult(bufferResult(
               `echo +([[:alnum:]]).txt`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node.js 20.4 broke using emojis in file names: https://github.com/nodejs/node/issues/48673

**How did you fix it?**

Disabling the code that relies on it (it's just a sanity check anyway).

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
