### PR TITLE
docs: remove link to `actions/checkout` partial clone PR

### DIFF
--- a/packages/gatsby/content/features/zero-installs.md
+++ b/packages/gatsby/content/features/zero-installs.md
@@ -57,7 +57,7 @@ Every time you update a dependency and commit it, the repository will grow, the 
 
     - Git will lazily download the missing files as needed. For example, if you run `git checkout` on an old commit, Git will fetch whatever files are needed before the command returns, so you won't see any difference.
 
-    - **This feature is supported by both GitHub and Gitlab, and is probably the best option at your disposal** if you can modify the way `git clone` is performed. Note however that the `actions/checkout` GitHub Action doesn't allow it yet (a PR is open [here](https://github.com/actions/checkout/pull/680)).
+    - **This feature is supported by both GitHub and Gitlab, and is probably the best option at your disposal** if you can modify the way `git clone` is performed.
 
 - [Sparse checkouts](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/) are the older cousin of partial clones. Instead of retrieving the whole Git history but putting aside the binary data, sparse checkouts instead define a cutoff commit which Git will treat as having no parents.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

`actions/checkout` now supports modifying the way `git clone` is performed so the link to the upstream PR should be removed.

Closes https://github.com/yarnpkg/berry/pull/5607
Closes https://github.com/yarnpkg/berry/pull/5598
Closes https://github.com/yarnpkg/berry/pull/5592

**How did you fix it?**

Removed the link from the v3 docs.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.