### PR TITLE
docs: fix `:::warning` aside

### DIFF
--- a/packages/docusaurus/docs/features/plugnplay.md
+++ b/packages/docusaurus/docs/features/plugnplay.md
@@ -75,7 +75,7 @@ Semantic erroring goes a long way into letting you understand and address proble
 
 If you're creating a project from scratch, your project itself should work almost "out of the box". You may have to use `packageExtensions` from time to time to fix an occasional ghost dependency, but that remains uncommon, and this process is otherwise straightforward. Most tools in the ecosystem are designed and tested to work well in Yarn PnP environments, so problems are infrequent.
 
-:::warn
+:::warning
 A notable exception is React Native / Expo, which require using typical `node_modules` installs.
 :::
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The intended aside wasn't being rendered because of a typo.

Pls tag for hacktoberfest, if y'all participating.

**Before**
![Screenshot 2023-10-09 at 15 25 44](https://github.com/yarnpkg/berry/assets/59713582/8d0b931b-9772-4271-a90d-5fd32e28be5c)

**After**

![Screenshot 2023-10-09 at 15 42 57](https://github.com/yarnpkg/berry/assets/59713582/7573a0e4-1640-4334-be7a-424db3371eb8)

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Corrected the typo
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
