### PR TITLE
ci: e2e - use Node.js 18 for Preact CLI tests

### DIFF
--- a/.github/workflows/e2e-preact-cli-workflow.yml
+++ b/.github/workflows/e2e-preact-cli-workflow.yml
@@ -20,9 +20,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: ./.github/actions/prepare
-      with:
-        # Remove when Preact CLI supports Node.js 18
-        node-version: 16.x
 
     - name: 'Running the integration test'
       run: |


### PR DESCRIPTION

**What's the problem this PR addresses?**

Preact CLI not only now supports Node.js 18, but _requires_ it:

> Usage Error: This tool requires a Node version compatible with >=18.12.0 (got 16.20.2).


**How did you fix it?**

> `# Remove when Preact CLI supports Node.js 18`

So I did 🤷 

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
