### PR TITLE
ci: e2e - fix installing @types/testing-library__jest-dom v6 instead of v5 in CRA tests

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -42,7 +42,7 @@ jobs:
         yarn add -D eslint-config-react-app eslint
 
         # TODO: Remove when https://github.com/facebook/create-react-app/pull/11751 is released
-        yarn add -D @types/testing-library__jest-dom
+        yarn add -D @types/testing-library__jest-dom@5
 
         yarn build
         yarn test


### PR DESCRIPTION
**What's the problem this PR addresses?**

CRA installs @testing-library/jest-dom@5.17.0, and @types/testing-library__jest-dom is already at v6. This caused incompatible definitions to be installed, eventually leading to tests crashing.

**How did you fix it?**

Recreated environment created by E2E tests, figured out what the error is, fixed type definitions version, made sure TypeScript no longer complains.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
