### PR TITLE
docs: Fix package "types available" check

### DIFF
--- a/packages/docusaurus/src/lib/packageChecks.tsx
+++ b/packages/docusaurus/src/lib/packageChecks.tsx
@@ -157,7 +157,7 @@ export const checks: Array<Check> = [{
       if (releaseInfo.jsdelivr.fileSet.has(`${fileNoExt}${ext}`))
         return {ok: true};
 
-    if (dtPackageName && dtPackage) {
+    if (dtPackageName && dtPackage.data) {
       const search = new URLSearchParams(location.search);
 
       for (const key of search.keys())


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The website reports incorrect results regarding `@types` package because it is reading the truthiness of the `react-query` return object instead of the result `data` boolean.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

Read the correct data

Fixes #5761

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
