### PR TITLE
Fixes bugs in yarn npm audit

### DIFF
--- a/.yarn/versions/1dfc7586.yml
+++ b/.yarn/versions/1dfc7586.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
@@ -164,7 +164,24 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        await run(`npm`, `audit`, `--exclude`, `vulnerable`);
+        await expect(run(`npm`, `audit`, `--exclude`, `vulnerable`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`No audit suggestions`),
+        });
+      }),
+    );
+
+    test(
+      `it should allow excluding packages (when using --json)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`vulnerable`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(run(`npm`, `audit`, `--exclude`, `vulnerable`, `--json`)).resolves.toMatchObject({
+          stdout: ``,
+        });
       }),
     );
 
@@ -177,7 +194,24 @@ describe(`Commands`, () => {
       }, async ({path, run, source}) => {
         await run(`install`);
 
-        await run(`npm`, `audit`, `--ignore`, `1`);
+        await expect(run(`npm`, `audit`, `--ignore`, `1`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`No audit suggestions`),
+        });
+      }),
+    );
+
+    test(
+      `it should allow ignoring advisories (when using --json)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`vulnerable`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(run(`npm`, `audit`, `--ignore`, `1`, `--json`)).resolves.toMatchObject({
+          stdout: ``,
+        });
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/audit.test.ts
@@ -171,6 +171,21 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should allow excluding packages (deprecations)`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps-deprecated`]: `1.0.0`,
+        },
+      }, async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(run(`npm`, `audit`, `--exclude`, `no-deps-deprecated`)).resolves.toMatchObject({
+          stdout: expect.stringContaining(`No audit suggestions`),
+        });
+      }),
+    );
+
+    test(
       `it should allow excluding packages (when using --json)`,
       makeTemporaryEnv({
         dependencies: {

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -110,7 +110,7 @@ export default class NpmAuditCommand extends BaseCommand {
       ...this.excludes,
     ]));
 
-    const payload = Object.create(null);
+    const payload: Record<string, Array<string>> = Object.create(null);
 
     for (const [packageName, versions] of packages)
       if (!excludedPackages.some(pattern => micromatch.isMatch(packageName, pattern)))
@@ -131,12 +131,12 @@ export default class NpmAuditCommand extends BaseCommand {
         registry,
       }) as unknown as Promise<npmAuditTypes.AuditResponse>;
 
-      const deprecations = await Promise.all(this.noDeprecations ? [] : Array.from(packages, async ([packageName, versions]) => {
+      const deprecations = await Promise.all(this.noDeprecations ? [] : Array.from(Object.entries(payload), async ([packageName, versions]) => {
         const registryData = await npmHttpUtils.getPackageMetadata(structUtils.parseIdent(packageName), {
           project,
         });
 
-        return miscUtils.mapAndFilter(versions.keys(), version => {
+        return miscUtils.mapAndFilter(versions, version => {
           const {deprecated} = registryData.versions[version];
 
           // Apparently some packages have a `deprecated` field set to an empty string
@@ -213,7 +213,7 @@ export default class NpmAuditCommand extends BaseCommand {
 
     const hasError = Object.keys(expandedResult).length > 0;
 
-    if (!this.json && hasError) {
+    if (hasError) {
       treeUtils.emitTree(npmAuditUtils.getReportTree(expandedResult), {
         configuration,
         json: this.json,
@@ -229,11 +229,7 @@ export default class NpmAuditCommand extends BaseCommand {
       json: this.json,
       stdout: this.context.stdout,
     }, async report => {
-      report.reportJson(result);
-
-      if (!hasError) {
-        report.reportInfo(MessageName.EXCEPTION, `No audit suggestions`);
-      }
+      report.reportInfo(MessageName.EXCEPTION, `No audit suggestions`);
     });
 
     return hasError ? 1 : 0;

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -131,7 +131,7 @@ export default class NpmAuditCommand extends BaseCommand {
         registry,
       }) as unknown as Promise<npmAuditTypes.AuditResponse>;
 
-      const deprecations = await Promise.all(this.noDeprecations ? [] : Array.from(Object.entries(payload), async ([packageName, versions]) => {
+      const deprecations = this.noDeprecations ? [] : await Promise.all(Array.from(Object.entries(payload), async ([packageName, versions]) => {
         const registryData = await npmHttpUtils.getPackageMetadata(structUtils.parseIdent(packageName), {
           project,
         });

--- a/packages/yarnpkg-core/sources/treeUtils.ts
+++ b/packages/yarnpkg-core/sources/treeUtils.ts
@@ -128,7 +128,7 @@ export function emitTree(tree: TreeNode, {configuration, stdout, json, separator
   // Another one for the second level fields. We run it twice because in some pathological cases the regex matches would
   if (separators >= 2)
     for (let t = 0; t < 2; ++t)
-      treeOutput = treeOutput.replace(/^([│ ].{2}[├│ ].{2}[^\n]+\n)(([│ ]).{2}[├└].{2}[^\n]*\n[│ ].{2}[│ ].{2}[├└]─)/gm, `$1$3  │ (\\n)?\n$2`).replace(/^│\n/, ``);
+      treeOutput = treeOutput.replace(/^([│ ].{2}[├│ ].{2}[^\n]+\n)(([│ ]).{2}[├└].{2}[^\n]*\n[│ ].{2}[│ ].{2}[├└]─)/gm, `$1$3  │ \n$2`).replace(/^│\n/, ``);
 
   if (separators >= 3)
     throw new Error(`Only the first two levels are accepted by treeUtils.emitTree`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

The rewrite of `yarn npm audit` broke a couple of things in the advisory reporting.

Fixes #5824 - The `--exclude` filter wasn't applied to deprecations
Fixes #5830 - The `--json` output was printing the raw registry output, not the filtered tree

**How did you fix it?**

Fixed the deprecation iterations (we were iterating the unfiltered data).

Fixed the json reporting to instead print the same tree as the one we would have displayed outside of `--json`. It's _technically_ a breaking change, but it was supposed to be like that so it's probably fine to treat it as a 7.0.1 bugfix.

Added tests to prevent regressions.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
