### PR TITLE
Reimplements yarn explain peer-requirements

### DIFF
--- a/.yarn/versions/17861fba.yml
+++ b/.yarn/versions/17861fba.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/peerDependenciesMeta.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/peerDependenciesMeta.test.ts
@@ -40,7 +40,7 @@ describe(`Features`, () => {
         async ({path, run, source}) => {
           const {stdout} = await run(`install`);
 
-          expect(stdout).toContain(`no-deps is listed by your project with version 1.1.0, which doesn't satisfy what mismatched-peer-deps-lvl0 requests (1.0.0)`);
+          expect(stdout).toMatch(/no-deps is listed by your project with version 1\.1\.0, which doesn't satisfy what mismatched-peer-deps-lvl0 \(p[a-f0-9]{5}\) and other dependencies request \(1\.0\.0\)/);
         },
       ),
     );

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -2615,7 +2615,7 @@ function applyVirtualResolutionMutations({
               requesters: new Map(),
               links: new Map(),
               version: peerVersion,
-              hash: `p${hashUtils.makeHash(identStr).slice(0, 5)}`,
+              hash: `p${peerResolution.locatorHash.slice(0, 5)}`,
             }));
 
             aggregatedWarning.dependents.set(dependent.locatorHash, dependent);
@@ -2670,7 +2670,7 @@ function emitPeerDependencyWarnings(project: Project, report: Report) {
       return peerDependency.range;
     });
 
-    const andDescendants = warning.dependents.size > 1
+    const andDescendants = warning.links.size > 1
       ? `and other dependencies request`
       : `requests`;
 
@@ -2685,7 +2685,7 @@ function emitPeerDependencyWarnings(project: Project, report: Report) {
       structUtils.prettyReference(project.configuration, warning.version)
     }, which doesn't satisfy what ${
       structUtils.prettyIdent(project.configuration, warning.requesters.values().next().value)
-    } ${andDescendants} (${rangeDescription}).`;
+    } (${formatUtils.pretty(project.configuration, warning.hash, formatUtils.Type.CODE)}) ${andDescendants} (${rangeDescription}).`;
   }) ?? [];
 
   const omittedWarnings = warningsByType[PeerWarningType.NotProvided]?.map(warning => {

--- a/packages/yarnpkg-core/sources/index.ts
+++ b/packages/yarnpkg-core/sources/index.ts
@@ -28,8 +28,8 @@ export type {AllDependencies, HardDependencies, DependencyMeta, PeerDependencyMe
 export {MessageName, parseMessageName, stringifyMessageName}                                                        from './MessageName';
 export {MultiFetcher}                                                                                               from './MultiFetcher';
 export type {CommandContext, Hooks, Plugin, WrapNetworkRequestInfo}                                                 from './Plugin';
-export type {PeerRequirement}                                                                                       from './Project';
-export {LOCKFILE_VERSION, Project, InstallMode}                                                                     from './Project';
+export type {PeerRequirement, PeerWarning}                                                                          from './Project';
+export {LOCKFILE_VERSION, PeerWarningType, Project, InstallMode}                                                    from './Project';
 export {ReportError, Report}                                                                                        from './Report';
 export type {Resolver, ResolveOptions, MinimalResolveOptions}                                                       from './Resolver';
 export {StreamReport, reportOptionDeprecations}                                                                     from './StreamReport';


### PR DESCRIPTION
**What's the problem this PR addresses?**

I didn't update the `yarn explain peer-requirements` when I refactored the peer dependency warnings to report aggregates rather than independent entries. As a result, the reported hash doesn't work.

Fixes #5826

**How did you fix it?**

I reimplemented `yarn explain peer-requirements` to take those warnings into account. I also updated the output to use a more natural language which might help better understand the situation:

<img width="933" alt="Screenshot 2023-10-24 at 12 04 20" src="https://github.com/yarnpkg/berry/assets/1037931/62b4dbc7-d029-4997-9990-52bdd752f0a2">

Note that I temporarily removed support for calling `yarn explain peer-requirements` on missing peer dependencies, as I'd like to take another look at those warnings in general (I noticed they aren't aggregated, but they probably should be too). Since they are fairly easy to understand by themselves, I don't feel like this is a significant regression.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
