### PR TITLE
docs(yarnrc): set default compressionLevel to '0'

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -82,7 +82,7 @@
       "_package": "@yarnpkg/core",
       "type": ["number", "string"],
       "title": "Compression level employed for zip archives",
-      "description": "Possible values go from 0 (\"no compression, faster\") to 9 (\"heavy compression, slower\"). The default is 'mixed', which is a variant of 9 where files may be stored uncompressed if the builtin libzip heuristic thinks it will lead to a more sensible result.",
+      "description": "Possible values go from 0 (\"no compression, faster\") to 9 (\"heavy compression, slower\"). The value 'mixed' is a variant of 9 where files may be stored uncompressed if the builtin libzip heuristic thinks it will lead to a more sensible result. The default is '0'.",
       "enum": ["mixed", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
       "default": "mixed"
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**

Closes: https://github.com/yarnpkg/berry/issues/5843
Refs: https://github.com/yarnpkg/berry/pull/5526

**How did you fix it?**

Updated the default compressionLevel to '0' in documentation.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
