### PR TITLE
docs(yarnrc): move compressionLevel 'mixed' enum value to the end

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -83,7 +83,7 @@
       "type": ["number", "string"],
       "title": "Compression level employed for zip archives",
       "description": "Possible values go from `0` (\"no compression, faster\") to `9` (\"heavy compression, slower\"). The value `mixed` is a variant of `9` where files are stored uncompressed if the gzip overhead would exceed the size gain.\n\nThe default is `0`, which tends to be significantly faster to install. Projects using zero-installs are advised to keep it this way, as experiments showed that Git stores uncompressed package archives more efficiently than gzip-compressed ones.",
-      "enum": ["mixed", 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, "mixed"],
       "default": "mixed"
     },
     "constraintsPath": {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Refs: https://github.com/yarnpkg/berry/issues/5843

**How did you fix it?**

Moves compressionLevel `mixed` enum value to the end as:
* `mixed` is no longer the default in yarn@4.0.0
* `mixed` is a variant of 9. Visually keeping it closer to 9 is more intuitive.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
