### PR TITLE
Enable dark mode on website

### DIFF
--- a/packages/docusaurus/docusaurus.config.js
+++ b/packages/docusaurus/docusaurus.config.js
@@ -93,9 +93,7 @@ const config = {
     ({
       image: `img/social-preview.png`,
       colorMode: {
-        defaultMode: `light`,
-        disableSwitch: true,
-        respectPrefersColorScheme: false,
+        respectPrefersColorScheme: true,
       },
       algolia: {
         appId: `STXW7VT1S5`,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes: https://github.com/yarnpkg/berry/issues/4058
Docusaurus theme configuration: https://docusaurus.io/docs/api/themes/configuration

**How did you fix it?**

Enable dark mode on website by setting `colorMode.respectPrefersColorScheme: true`, and enabling switch between modes.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
