### PR TITLE
docs(yarnrc): create list item for cacheMigrationMode 'always' option

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -31,7 +31,7 @@
       "_package": "@yarnpkg/core",
       "type": "string",
       "title": "Behavior that Yarn should follow when it detects that a cache entry is outdated.",
-      "description": "Whether or not a cache entry is outdated depends on whether it has been built and checksumed by an earlier release of Yarn, or under a different compression settings. Possible behaviors are:\n\n- If `required-only`, it'll keep using the file as-is, unless the version that generated it was decidedly too old.\n- If `match-spec`, it'll also rebuild the file if the compression level has changed. If `always`, it'll always regenerate the cache files so they use the current cache version.\n- If `auto` (the default), it'll act as either `required-only` or `always` depending on whether `enableGlobalCache` is enabled (with `always` being selected in that case).",
+      "description": "Whether or not a cache entry is outdated depends on whether it has been built and checksumed by an earlier release of Yarn, or under a different compression settings. Possible behaviors are:\n\n- If `required-only`, it'll keep using the file as-is, unless the version that generated it was decidedly too old.\n- If `match-spec`, it'll also rebuild the file if the compression level has changed.\n- If `always`, it'll always regenerate the cache files so they use the current cache version.\n- If `auto` (the default), it'll act as either `required-only` or `always` depending on whether `enableGlobalCache` is enabled (with `always` being selected in that case).",
       "enum": ["required-only", "match-spec", "always", "auto"],
       "default": "auto"
     },


### PR DESCRIPTION
**What's the problem this PR addresses?**

N/A

**How did you fix it?**

Adds a missing newline and creates list item for 'always' option.

<details>
<summary>Before</summary>

<img width="667" alt="before" src="https://github.com/yarnpkg/berry/assets/16024985/1a8d7207-df69-4284-b346-99aaa19b8139">

</details>

<details>
<summary>After</summary>

<img width="669" alt="after" src="https://github.com/yarnpkg/berry/assets/16024985/0fce0572-b80c-4d98-8401-53a32709e5b2">

</details>


**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
