### PR TITLE
fix: Update link to plugin tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Plugins can be developed by third-party entities. To use them within your applic
 
 ### Creating a new plugin
 
-To create your own plugin, please refer to the [documentation](https://yarnpkg.com/features/plugins).
+To create your own plugin, please refer to the [documentation](https://yarnpkg.com/advanced/plugin-tutorial).
 
 ## Generic packages
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
The link in the readme to the documentation for creating a new plugin is broken.
fixes https://github.com/yarnpkg/berry/issues/5861

...

**How did you fix it?**
Replace the link with a valid link to the documentation.

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
