### PR TITLE
docs: fix package bundled TS type check

### DIFF
--- a/packages/docusaurus/src/lib/packageChecks.tsx
+++ b/packages/docusaurus/src/lib/packageChecks.tsx
@@ -141,8 +141,8 @@ export const checks: Array<Check> = [{
       name,
       version,
     }, {
-      mainFields: [`main`, `types`, `typings`],
-      conditions: [`default`, `require`, `import`, `node`, `types`],
+      mainFields: [`types`, `typings`, `main`],
+      conditions: [`types`, `default`, `require`, `import`, `node`],
       extensions,
     });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The existence of bundled TS types are not detected on some package page (e.g. [xterm-headless](https://yarnpkg.com/package?name=xterm-headless))

![image](https://github.com/yarnpkg/berry/assets/41266433/65532dc2-cacc-46ff-8d24-17560681f9bb)

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The check was resolving the main (JS) entrypoint of the package then checking for an adjacent `.ts`, `.tsx` or `.d.ts` file. It should instead prioritize type entrypoints (`types` and `typings` fields in `pacakge.json`, `types` condition) before falling back to the main entrypoint.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
