### PR TITLE
fix: remove unused --save option for set resolution command

### DIFF
--- a/.yarn/versions/3bcde5b8.yml
+++ b/.yarn/versions/3bcde5b8.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/.yarn/versions/3bcde5b8.yml
+++ b/.yarn/versions/3bcde5b8.yml
@@ -3,5 +3,21 @@ releases:
   "@yarnpkg/plugin-essentials": patch
 
 declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
   - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/3bcde5b8.yml
+++ b/.yarn/versions/3bcde5b8.yml
@@ -1,7 +1,7 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-essentials": patch
 
 declined:
   - "@yarnpkg/plugin-interactive-tools"
   - "@yarnpkg/plugin-typescript"
-  - "@yarnpkg/cli"

--- a/packages/plugin-essentials/sources/commands/set/resolution.ts
+++ b/packages/plugin-essentials/sources/commands/set/resolution.ts
@@ -14,7 +14,7 @@ export default class SetResolutionCommand extends BaseCommand {
     details: `
       This command updates the resolution table so that \`descriptor\` is resolved by \`resolution\`.
 
-      Note that by default this command only affect the current resolution table - meaning that this "manual override" will disappear if you remove the lockfile, or if the package disappear from the table. If you wish to make the enforced resolution persist whatever happens, add the \`-s,--save\` flag which will also edit the \`resolutions\` field from your top-level manifest.
+      Note that by default this command only affect the current resolution table - meaning that this "manual override" will disappear if you remove the lockfile, or if the package disappear from the table. If you wish to make the enforced resolution persist whatever happens, edit the \`resolutions\` field in your top-level manifest.
 
       Note that no attempt is made at validating that \`resolution\` is a valid resolution entry for \`descriptor\`.
     `,
@@ -22,10 +22,6 @@ export default class SetResolutionCommand extends BaseCommand {
       `Force all instances of lodash@npm:^1.2.3 to resolve to 1.5.0`,
       `$0 set resolution lodash@npm:^1.2.3 1.5.0`,
     ]],
-  });
-
-  save = Option.Boolean(`-s,--save`, false, {
-    description: `Persist the resolution inside the top-level manifest`,
   });
 
   descriptor = Option.String();


### PR DESCRIPTION
The option was never implemented in berry, but it's mentioned in the docs as well as in the CLI output.

I don't have the expertise to actually implement the flag, so the second best thing to do here is to remove it, so that people are no longer mislead.

**What's the problem this PR addresses?**

Mitigates https://github.com/yarnpkg/berry/issues/2202 (actual resolution should be implementing the flag).

**How did you fix it?**

Removed unnecessary flag.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
