### PR TITLE
Adds tests for the pack list generation

### DIFF
--- a/.yarn/versions/5452f3ea.yml
+++ b/.yarn/versions/5452f3ea.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/core"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -1,7 +1,7 @@
-import {miscUtils}         from '@yarnpkg/core';
-import {xfs, npath, ppath} from '@yarnpkg/fslib';
-import {fs as fsUtils}     from 'pkg-tests-core';
-import tar                 from 'tar';
+import {miscUtils}     from '@yarnpkg/core';
+import {xfs, npath}    from '@yarnpkg/fslib';
+import {fs as fsUtils} from 'pkg-tests-core';
+import tar             from 'tar';
 
 async function genPackList(run) {
   const {stdout} = await run(`pack`, `--dry-run`, `--json`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -1,16 +1,13 @@
-import {miscUtils}     from '@yarnpkg/core';
-import {xfs, npath}    from '@yarnpkg/fslib';
-import {fs as fsUtils} from 'pkg-tests-core';
-import tar             from 'tar';
+import {xfs, npath}          from '@yarnpkg/fslib';
+import {fs as fsUtils, misc} from 'pkg-tests-core';
+import tar                   from 'tar';
 
 async function genPackList(run) {
   const {stdout} = await run(`pack`, `--dry-run`, `--json`);
 
-  return miscUtils.parseJsonStream(stdout).map(entry => {
+  return misc.parseJsonStream(stdout).map(entry => {
     return entry.location;
-  }).filter(location => {
-    return !!location;
-  });
+  }).filter(location => !!location);
 }
 
 describe(`Commands`, () => {

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -598,3 +598,8 @@ export function groupBy<T extends Record<string, any>, K extends keyof T>(items:
 export function parseInt(val: string | number) {
   return typeof val === `string` ? Number.parseInt(val, 10) : val;
 }
+
+/** @internal */
+export function parseJsonStream(stream: string) {
+  return stream.split(/\n/g).filter(line => line.trim() !== ``).map(line => JSON.parse(line));
+}

--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -598,8 +598,3 @@ export function groupBy<T extends Record<string, any>, K extends keyof T>(items:
 export function parseInt(val: string | number) {
   return typeof val === `string` ? Number.parseInt(val, 10) : val;
 }
-
-/** @internal */
-export function parseJsonStream(stream: string) {
-  return stream.split(/\n/g).filter(line => line.trim() !== ``).map(line => JSON.parse(line));
-}


### PR DESCRIPTION
**What's the problem this PR addresses?**

#5872 made me notice that we have few tests covering how the `*` / `**` patterns are interpreted.

**How did you fix it?**

This diff fixes that by adding a couple of tests, along with comments on the few places where we seem to diverge from npm. It doesn't try to change the pack list generation, just to increase its coverage and make it easier to add more tests in the future.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
