### PR TITLE
ci: add `vitest` e2e tests

### DIFF
--- a/.github/workflows/e2e-vitest-workflow.yml
+++ b/.github/workflows/e2e-vitest-workflow.yml
@@ -1,0 +1,40 @@
+on:
+  schedule:
+  - cron: '0 */4 * * *'
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - .github/actions/prepare/action.yml
+    - .github/workflows/e2e-vitest-workflow.yml
+    - scripts/e2e-setup-ci.sh
+
+name: 'E2E Vitest'
+jobs:
+  chore:
+    name: 'Validating Vitest'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
+
+    - name: 'Running the integration test'
+      run: |
+        source scripts/e2e-setup-ci.sh
+
+        yarn init -p
+        yarn add vitest
+
+        echo "import { it, expect } from 'vitest'; it('should pass', () => { expect(true).toBeTruthy(); });" | tee pass.test.js
+        yarn vitest run pass.test.js
+
+        echo "import { it, expect } from 'vitest'; it('should fail', () => { expect(false).toBeTruthy(); });" | tee fail.test.js
+        ! yarn vitest run fail.test.js
+
+        yarn add left-pad
+
+        echo "import { it, expect } from 'vitest'; import leftPad from 'left-pad'; it('should resolve a module', () => { expect(typeof leftPad).toBe('function');});" | tee module.test.js
+        yarn vitest run module.test.js

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ On top of our classic integration tests, we also run Yarn every day against the 
 [![](https://github.com/yarnpkg/berry/actions/workflows/e2e-rollup-workflow.yml/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/actions/workflows/e2e-rollup-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/actions/workflows/e2e-storybook-workflow.yml/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/actions/workflows/e2e-storybook-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/actions/workflows/e2e-typescript-workflow.yml/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/actions/workflows/e2e-typescript-workflow.yml)<br/>
+[![](https://github.com/yarnpkg/berry/actions/workflows/e2e-vitest-workflow.yml/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/actions/workflows/e2e-vitest-workflow.yml)<br/>
 [![](https://github.com/yarnpkg/berry/actions/workflows/e2e-webpack-workflow.yml/badge.svg?event=schedule)](https://github.com/yarnpkg/berry/actions/workflows/e2e-webpack-workflow.yml)<br/>
 </td></tr>
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Vitest is increasingly important tool in JS ecosystem. While nowhere near "industry standard", it's [quickly gaining traction](https://npmtrends.com/vitest).

...

**How did you fix it?**

Copy Jest's E2E and "migrate" it to Vitest.
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
