### PR TITLE
ci: split some E2Es to run in parallel

### DIFF
--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -14,7 +14,7 @@ on:
 name: 'E2E CRA'
 jobs:
   chore:
-    name: 'Validating Create-React-App'
+    name: 'Validating Create-React-App (JavaScript)'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +32,17 @@ jobs:
 
         yarn build
         yarn test
+      if: |
+        success() || failure()
+
+  chore-ts:
+    name: 'Validating Create-React-App'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
 
     - name: 'Running the TypeScript integration test'
       run: |

--- a/.github/workflows/e2e-create-vue-workflow.yml
+++ b/.github/workflows/e2e-create-vue-workflow.yml
@@ -14,7 +14,28 @@ on:
 name: 'E2E Create-Vue'
 jobs:
   chore:
-    name: 'Validating Create-Vue'
+    name: 'Validating Create-Vue (Vue 2)'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
+
+    - name: 'Running the integration test (Vue 2)'
+      run: |
+        source scripts/e2e-setup-ci.sh
+
+        yarn dlx create-vue@2 vue-project --default --typescript
+        cd vue-project
+        yarn
+
+        yarn build
+      if: |
+        success() || failure()
+
+  chore-v3:
+    name: 'Validating Create-Vue (Vue 3)'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,15 +53,5 @@ jobs:
 
         yarn build
         yarn lint
-
-    - name: 'Running the integration test (Vue 2)'
-      run: |
-        source scripts/e2e-setup-ci.sh
-
-        yarn dlx create-vue@2 vue-project --default --typescript
-        cd vue-project
-        yarn
-
-        yarn build
       if: |
         success() || failure()

--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -13,7 +13,7 @@ on:
 name: 'E2E Docusaurus'
 jobs:
   chore:
-    name: 'Validating Docusaurus'
+    name: 'Validating Docusaurus (JavaScript)'
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +26,17 @@ jobs:
         source scripts/e2e-setup-ci.sh
         yarn dlx create-docusaurus@latest my-website classic && cd my-website
         yarn build
+      if: |
+        success() || failure()
+
+  chore-ts:
+    name: 'Validating Docusaurus (TypeScript)'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
 
     - name: 'Running the TypeScript integration test'
       run: |

--- a/.github/workflows/e2e-eslint-workflow.yml
+++ b/.github/workflows/e2e-eslint-workflow.yml
@@ -35,6 +35,17 @@ jobs:
 
         echo '42' | tee ko.js
         ! yarn eslint ko.js
+      if: |
+        success() || failure()
+
+  chore-ts:
+    name: 'Validating ESLint (TypeScript)'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
 
     - name: 'Running the TypeScript integration test'
       run: |

--- a/.github/workflows/e2e-fsevents-workflow.yml
+++ b/.github/workflows/e2e-fsevents-workflow.yml
@@ -14,7 +14,7 @@ on:
 name: 'E2E FSEvents'
 jobs:
   chore:
-    name: 'Validating FSEvents'
+    name: 'Validating FSEvents (^1)'
     runs-on: macos-latest
 
     steps:
@@ -102,6 +102,17 @@ jobs:
         EOT
 
         yarn node ./test.js
+      if: |
+        success() || failure()
+
+  chore-latest:
+    name: 'Validating FSEvents (latest)'
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
 
     - name: 'Running the integration test (FSEvents latest)'
       run: |

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -13,7 +13,7 @@ on:
 name: 'E2E Next'
 jobs:
   chore:
-    name: 'Validating Next.js'
+    name: 'Validating Next.js (JavaScript)'
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,7 @@ jobs:
 
     - uses: ./.github/actions/prepare
 
-    - name: 'Running the integration test, without TypeScript'
+    - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
         yarn init
@@ -37,8 +37,19 @@ jobs:
         echo 'hello world!' | tee pages/text.txt
 
         yarn next build
+      if: |
+        success() || failure()
 
-    - name: 'Running the integration test, with TypeScript'
+  chore-ts:
+    name: 'Validating Next.js (TypeScript)'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/actions/prepare
+
+    - name: 'Running the TypeScript integration test'
       run: |
         source scripts/e2e-setup-ci.sh
         yarn init


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Certain E2E tests were running a bit longer than the others, and that was caused by chaining unrelated tests.

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
