### PR TITLE
ci: use latest actions/setup-node version

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -11,7 +11,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - name: 'Use Node.js 18.x'
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         check-latest: true

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: 'Use Node.js 18.x'
+    - name: 'Use Node.js ${{ inputs.node-version }}'
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -13,6 +13,9 @@ concurrency:
   # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{startsWith(github.ref, 'refs/pull/')}}
 
+env:
+  node-version: '18.x'
+
 name: 'Integration'
 jobs:
   chore:
@@ -24,10 +27,10 @@ jobs:
     - run: |
         git fetch --no-tags --unshallow origin HEAD master
 
-    - name: 'Use Node.js 18.x'
+    - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: ${{ env.node-version }}
 
     - name: 'Check that the Yarn files don''t change on new installs (fix w/ "yarn install")'
       run: |
@@ -164,10 +167,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: 'Use Node.js 18.x'
+    - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: ${{ env.node-version }}
 
     - name: 'Build bundle & plugins'
       run: |

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -24,7 +24,8 @@ jobs:
     - run: |
         git fetch --no-tags --unshallow origin HEAD master
 
-    - uses: actions/setup-node@v3
+    - name: 'Use Node.js 18.x'
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 
@@ -163,7 +164,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-node@v3
+    - name: 'Use Node.js 18.x'
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 
@@ -232,7 +234,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: 'Use Node.js ${{matrix.node}}.x'
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.node}}.x
 

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -6,6 +6,9 @@ on:
         required: true
         default: 'cherry-pick/'
 
+env:
+  node-version: '18.x'
+
 name: 'Release Branch'
 jobs:
   release:
@@ -24,10 +27,10 @@ jobs:
     - name: 'Retrieve all the relevant tags'
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - name: 'Use Node.js 18.x'
+    - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: ${{ env.node-version }}
 
     - name: 'Build a binary for convenience'
       run: |

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -25,7 +25,7 @@ jobs:
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
     - name: 'Use Node.js 18.x'
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -6,6 +6,9 @@ on:
         required: false
         default: '1'
 
+env:
+  node-version: '18.x'
+
 name: 'Release Candidate'
 jobs:
   release:
@@ -24,10 +27,10 @@ jobs:
     - name: 'Retrieve all the relevant tags'
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - name: 'Use Node.js 18.x'
+    - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: ${{ env.node-version }}
 
     - name: 'Build a binary for convenience'
       run: |

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -24,7 +24,8 @@ jobs:
     - name: 'Retrieve all the relevant tags'
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-    - uses: actions/setup-node@v3
+    - name: 'Use Node.js 18.x'
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 

--- a/.github/workflows/sherlock-workflow.yml
+++ b/.github/workflows/sherlock-workflow.yml
@@ -1,5 +1,8 @@
 on: [issues]
 
+env:
+  node-version: '18.x'
+
 name: 'Sherlock for Yarn'
 jobs:
   issue:
@@ -9,10 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: 'Use Node.js 18.x'
+    - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: ${{ env.node-version }}
 
     - name: 'Always use the latest sherlock'
       run: |

--- a/.github/workflows/sherlock-workflow.yml
+++ b/.github/workflows/sherlock-workflow.yml
@@ -9,7 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-node@v3
+    - name: 'Use Node.js 18.x'
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

The primary reason for v4 update is that v4 uses Node 20 runtime, as opposed to Node 16 in v3.

...

**How did you fix it?**
<!-- A detailed description of your implementation. -->

...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
