### PR TITLE
fix(yarnpkg-nm): Fixes creation of symlinks when inner workspace depends on outer workspace

### DIFF
--- a/.yarn/versions/3a508a64.yml
+++ b/.yarn/versions/3a508a64.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features in `master` can be tried out by running `yarn set version from sources`
 
 ## 4.0.1
 
+- Fixes creation of symlinks for `node-modules` linker when inner workspace depends on outer workspace
 - Fixes progress bars when the terminal is too large
 - Fixes crashes while running Yarn within Docker within GitHub Actions
 - Fixes `yarn npm audit --ignore NUM` which didn't apply to deprecations

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -605,6 +605,31 @@ describe(`Node_Modules`, () => {
     ),
   );
 
+  test(`should create circular symlinks when inner workspace depends on outer workspace`,
+    makeTemporaryEnv(
+      {
+        name: 'foo',
+        workspaces: [`ws`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmHoistingLimits: `workspaces`,
+      },
+      async ({path, run}) => {
+        await writeJson(npath.toPortablePath(`${path}/ws/package.json`), {
+          name: `ws`,
+          dependencies: {
+            foo: 'workspace:*'
+          }
+        });
+
+        await run(`install`);
+
+        expect(await xfs.existsPromise(`${path}/ws/node_modules/foo` as PortablePath)).toEqual(true);
+      },
+    ),
+  );
+
   test(`should not hoist multiple packages past workspace hoist border`,
     // . -> workspace -> dep1 -> dep2
     // should be hoisted to:

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -608,7 +608,7 @@ describe(`Node_Modules`, () => {
   test(`should create circular symlinks when inner workspace depends on outer workspace`,
     makeTemporaryEnv(
       {
-        name: 'foo',
+        name: `foo`,
         workspaces: [`ws`],
       },
       {
@@ -619,8 +619,8 @@ describe(`Node_Modules`, () => {
         await writeJson(npath.toPortablePath(`${path}/ws/package.json`), {
           name: `ws`,
           dependencies: {
-            foo: 'workspace:*'
-          }
+            foo: `workspace:*`,
+          },
         });
 
         await run(`install`);

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -521,7 +521,7 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
     for (const dep of pkg.dependencies) {
       const depReferences = Array.from(dep.references).sort().join(`#`);
       // We do not want self-references in node_modules, since they confuse existing tools
-      if (dep.identName === pkg.identName && depReferences === pkgReferences)
+      if (dep.identName === pkg.identName.replace(WORKSPACE_NAME_SUFFIX, '') && depReferences === pkgReferences)
         continue;
       const references = Array.from(dep.references).sort();
       const locator = {name: dep.identName, reference: references[0]};
@@ -544,9 +544,7 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
         isAnonymousWorkspace = !!(workspace && !workspace.manifest.name);
       }
 
-      const isCircularSymlink = leafNode.linkType === LinkType.SOFT && nodeModulesLocation.startsWith(leafNode.target);
-
-      if (!dep.name.endsWith(WORKSPACE_NAME_SUFFIX) && !isAnonymousWorkspace && !isCircularSymlink) {
+      if (!dep.name.endsWith(WORKSPACE_NAME_SUFFIX) && !isAnonymousWorkspace) {
         const prevNode = tree.get(nodeModulesLocation);
         if (prevNode) {
           if (prevNode.dirList) {

--- a/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
+++ b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts
@@ -521,7 +521,7 @@ const populateNodeModulesTree = (pnp: PnpApi, hoistedTree: HoisterResult, option
     for (const dep of pkg.dependencies) {
       const depReferences = Array.from(dep.references).sort().join(`#`);
       // We do not want self-references in node_modules, since they confuse existing tools
-      if (dep.identName === pkg.identName.replace(WORKSPACE_NAME_SUFFIX, '') && depReferences === pkgReferences)
+      if (dep.identName === pkg.identName.replace(WORKSPACE_NAME_SUFFIX, ``) && depReferences === pkgReferences)
         continue;
       const references = Array.from(dep.references).sort();
       const locator = {name: dep.identName, reference: references[0]};


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Fixes: #5793 

**How did you fix it?**
<!-- A detailed description of your implementation. -->

The nm linker now creates circular symlinks that were explicitly requested by the user, in this case when inner workspace depends on outer workspace. The nm linker continues to avoid circular symlinks for self-references, for now this is not changed.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
