### PR TITLE
Fixes missing `--json` output on `yarn install`

### DIFF
--- a/.yarn/versions/45fda3ad.yml
+++ b/.yarn/versions/45fda3ad.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -1,8 +1,59 @@
 import {Filename, xfs, ppath, npath} from '@yarnpkg/fslib';
-import {tests}                       from 'pkg-tests-core';
+import {tests, misc}                 from 'pkg-tests-core';
 
 describe(`Commands`, () => {
   describe(`install`, () => {
+    test(
+      `it should print regular messages as JSON items when using --json`,
+      makeTemporaryEnv({}, async ({path, run, source}) => {
+        const {stdout} = await run(`install`, `--json`);
+
+        expect(misc.parseJsonStream(stdout)).toEqual([{
+          data: `┌ Resolution step`,
+          displayName: `YN0000`,
+          indent: ``,
+          name: null,
+          type: `info`,
+        }, {
+          data: `└ Completed`,
+          displayName: `YN0000`,
+          indent: ``,
+          name: null,
+          type: `info`,
+        }, {
+          data: `┌ Fetch step`,
+          displayName: `YN0000`,
+          indent: ``,
+          name: null,
+          type: `info`,
+        }, {
+          data: `└ Completed`,
+          displayName: `YN0000`,
+          indent: ``,
+          name: null,
+          type: `info`,
+        }, {
+          data: `┌ Link step`,
+          displayName: `YN0000`,
+          indent: ``,
+          name: null,
+          type: `info`,
+        }, {
+          data: `└ Completed`,
+          displayName: `YN0000`,
+          indent: ``,
+          name: null,
+          type: `info`,
+        }, {
+          data: `Done`,
+          displayName: `YN0000`,
+          indent: `· `,
+          name: 0,
+          type: `info`,
+        }]);
+      }),
+    );
+
     test(
       `it should print the logs to the standard output when using --inline-builds`,
       makeTemporaryEnv({

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -9,6 +9,12 @@ describe(`Commands`, () => {
         const {stdout} = await run(`install`, `--json`);
 
         expect(misc.parseJsonStream(stdout)).toEqual([{
+          data: `Yarn 0.0.0`,
+          displayName: `YN0000`,
+          indent: `· `,
+          name: 0,
+          type: `info`,
+        }, {
           data: `┌ Resolution step`,
           displayName: `YN0000`,
           indent: ``,

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -350,6 +350,7 @@ export default class YarnCommand extends BaseCommand {
       stdout: this.context.stdout,
       forceSectionAlignment: true,
       includeLogs: true,
+      includeVersion: true,
     }, async report => {
       await project.install({cache, report, immutable, checkResolutions, mode: this.mode});
     });

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -344,15 +344,17 @@ export default class YarnCommand extends BaseCommand {
     // the Configuration and Install classes). Feel free to open an issue
     // in order to ask for design feedback before writing features.
 
-    return await project.installWithNewReport({
+    const report = await StreamReport.start({
+      configuration,
       json: this.json,
       stdout: this.context.stdout,
-    }, {
-      cache,
-      immutable,
-      checkResolutions,
-      mode: this.mode,
+      forceSectionAlignment: true,
+      includeLogs: true,
+    }, async report => {
+      await project.install({cache, report, immutable, checkResolutions, mode: this.mode});
     });
+
+    return report.exitCode();
   }
 }
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The refactoring in #5509 accidentally dropped the `includeLogs: true` from the `yarn install` implementation.

Fixes #5866 

**How did you fix it?**

I considered extending `installWithNewReport` to have a new `includeLogs` property, but it felt like this behaviour was unneeded for other use cases than `yarn install`, so I simply switched the `yarn install` implementation so that it manually creates the report stream rather than delegate to `installWithNewReport`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
