### PR TITLE
Stops reporting identical objects as being different

### DIFF
--- a/.yarn/versions/68e485e1.yml
+++ b/.yarn/versions/68e485e1.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-constraints": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-constraints/sources/constraintUtils.ts
+++ b/packages/plugin-constraints/sources/constraintUtils.ts
@@ -203,7 +203,7 @@ export function applyEngineReport(project: Project, {manifestUpdates, reportedEr
         const [[newValue]] = newValues;
 
         const currentValue = get(manifest, fieldPath);
-        if (currentValue === newValue)
+        if (JSON.stringify(currentValue) === JSON.stringify(newValue))
           continue;
 
         if (!fix) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The constraints engine is making a `===` check, so using the `set` method with a JS object will never match and will report an error (example [here](https://github.com/babel/babel/actions/runs/6711592648/job/18239331717?pr=16069#step:4:8)).

**How did you fix it?**

We now compare stringified values to check sameness. I considered using something like `_.equals`, but using stringify only returns `true` when the key are in the same order, which is important for fields like `exports`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
