### PR TITLE
Update Svelte Language Server PnP Configuration

### DIFF
--- a/.yarn/versions/ddf3a56f.yml
+++ b/.yarn/versions/ddf3a56f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -113,6 +113,7 @@ export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = a
         `bin/server.js` as PortablePath,
       ),
     ),
+    [`svelte.language-server.runtime-args`]: [`--loader`, `./.pnp.loader.mjs`],
   });
 
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {


### PR DESCRIPTION
**What's the problem this PR addresses?**
My PR https://github.com/sveltejs/language-tools/issues/2196 introduces a small change alongside a new setting that allows sveltejs-language-tools to resolve PnP in ESM files, most importantly in a `svelte.config.js`. Please note that this PR shouldn't go in until that PR is ready as otherwise the Svelte language server itself will not have the setting available.

Also I'm no expert in Yarn PnP so if this is the wrong implementation avenue I would welcome advice!

**How did you fix it?**
The main portion of the solution is in the linked PR. The addition here is to set `svelte.language-server.runtime-args` to `["--loader", "./.pnp.loader.mjs"]`.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective. 
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
