### PR TITLE
feat: yarn run --json

### DIFF
--- a/.yarn/versions/4db9f07d.yml
+++ b/.yarn/versions/4db9f07d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
@@ -158,6 +158,33 @@ describe(`Commands`, () => {
         },
       ),
     );
+    test(`it should print the list of available scripts as JSON if no parameters passed to command`,
+      makeTemporaryEnv(
+        {
+          scripts: {
+            foo: `echo hello`,
+            bar: `echo hi`,
+          },
+        },
+        async ({path, run, source}) => {
+          const {code, stdout, stderr} = await run(`run`, `--json`);
+          expect({code, stdout, stderr}).toMatchObject({
+            code: 0,
+            stderr: ``,
+            stdout: expect.stringMatching(JSON.stringify([
+              {
+                name: `"foo"`,
+                value: `"echo hello"`,
+              },
+              {
+                name: `"bar"`,
+                value: `"echo hi"`,
+              },
+            ])),
+          });
+        },
+      ),
+    );
 
     test(`it should normalize scoped bin entries`,
       makeTemporaryEnv(

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
@@ -174,11 +174,11 @@ describe(`Commands`, () => {
             stdout: expect.stringMatching(JSON.stringify([
               {
                 name: `"foo"`,
-                value: `"echo hello"`,
+                script: `"echo hello"`,
               },
               {
                 name: `"bar"`,
-                value: `"echo hi"`,
+                script: `"echo hi"`,
               },
             ])),
           });

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
@@ -168,7 +168,7 @@ describe(`Commands`, () => {
           },
         },
         async ({path, run, source}) => {
-          const {code, stdout, stderr} = await run(`run`, `--json`);
+          const {stdout} = await run(`run`, `--json`);
 
           expect(misc.parseJsonStream(stdout)).toEqual([{
             name: `foo`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/run.test.js
@@ -1,4 +1,5 @@
 import {ppath, xfs} from '@yarnpkg/fslib';
+import {misc}       from 'pkg-tests-core';
 
 describe(`Commands`, () => {
   for (const [description, args] of [[`with prefix`, [`run`]], [`without prefix`, []]]) {
@@ -168,20 +169,14 @@ describe(`Commands`, () => {
         },
         async ({path, run, source}) => {
           const {code, stdout, stderr} = await run(`run`, `--json`);
-          expect({code, stdout, stderr}).toMatchObject({
-            code: 0,
-            stderr: ``,
-            stdout: expect.stringMatching(JSON.stringify([
-              {
-                name: `"foo"`,
-                script: `"echo hello"`,
-              },
-              {
-                name: `"bar"`,
-                script: `"echo hi"`,
-              },
-            ])),
-          });
+
+          expect(misc.parseJsonStream(stdout)).toEqual([{
+            name: `foo`,
+            script: `echo hello`,
+          }, {
+            name: `bar`,
+            script: `echo hi`,
+          }]);
         },
       ),
     );

--- a/packages/plugin-essentials/sources/commands/runIndex.ts
+++ b/packages/plugin-essentials/sources/commands/runIndex.ts
@@ -38,9 +38,9 @@ export default class RunIndexCommand extends BaseCommand {
         return Math.max(max, key.length);
       }, 0);
 
-      for (const [key, value] of scripts.entries()) {
-        report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${inspect(value, inspectConfig)}`);
-        report.reportJson({name: key, value});
+      for (const [key, script] of scripts.entries()) {
+        report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${inspect(script, inspectConfig)}`);
+        report.reportJson({name: key, script});
       }
     });
 

--- a/packages/plugin-essentials/sources/commands/runIndex.ts
+++ b/packages/plugin-essentials/sources/commands/runIndex.ts
@@ -1,6 +1,7 @@
 import {BaseCommand, WorkspaceRequiredError}  from '@yarnpkg/cli';
 import {Configuration, Project, StreamReport} from '@yarnpkg/core';
 import {miscUtils}                            from '@yarnpkg/core';
+import {Option}                               from 'clipanion';
 import {inspect}                              from 'util';
 
 // eslint-disable-next-line arca/no-default-export
@@ -8,6 +9,10 @@ export default class RunIndexCommand extends BaseCommand {
   static paths = [
     [`run`],
   ];
+
+  json = Option.Boolean(`--json`, false, {
+    description: `Format the output as an NDJSON stream`,
+  });
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
@@ -19,6 +24,7 @@ export default class RunIndexCommand extends BaseCommand {
     const report = await StreamReport.start({
       configuration,
       stdout: this.context.stdout,
+      json: this.json,
     }, async report => {
       const scripts = workspace!.manifest.scripts;
       const keys = miscUtils.sortMap(scripts.keys(), key => key);
@@ -34,6 +40,7 @@ export default class RunIndexCommand extends BaseCommand {
 
       for (const [key, value] of scripts.entries()) {
         report.reportInfo(null, `${key.padEnd(maxKeyLength, ` `)}   ${inspect(value, inspectConfig)}`);
+        report.reportJson({name: key, value});
       }
     });
 


### PR DESCRIPTION
**What's the problem this PR addresses?**
Adds a `--json` option to the `yarn run` CLI command

Closes #5539 

**How did you fix it?**
Changed the command object defined in berry/packages/plugin-essentials/sources/commands/runindex.ts in order to add a `--json` option, and format the output.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
