### PR TITLE
docs: correct default globalFolder in docs

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -262,7 +262,7 @@
       "description": "Various files we be stored there: global cache, metadata cache, ...",
       "type": "string",
       "format": "uri-reference",
-      "examples": ["${HOME}/.yarn/berry/global"]
+      "examples": ["${HOME}/.yarn/berry"]
     },
     "httpProxy": {
       "_package": "@yarnpkg/core",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Currently, the documentation states that the default `globalFolder` location is `~/.yarn/berry/global`. However, based on my testing, this is not accurate.

```shell
 docker run -it --entrypoint bash node:20
root@29746f15333c:/# mkdir test-berry
root@29746f15333c:/# cd test-berry/
root@29746f15333c:/test-berry# yarn init -y
yarn init v1.22.19
warning The yes flag has been set. This will automatically answer yes to all questions, which may have security implications.
success Saved package.json
Done in 0.02s.
root@29746f15333c:/test-berry# cat package.json
{
  "name": "test-berry",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT"
}
root@29746f15333c:/test-berry# yarn set version berry
➤ YN0000: Retrieving https://repo.yarnpkg.com/4.0.2/packages/yarnpkg-cli/bin/yarn.js
➤ YN0000: Saving the new release in .yarn/releases/yarn-4.0.2.cjs
➤ YN0000: Done in 0s 322ms
root@29746f15333c:/test-berry# corepack enable
root@29746f15333c:/test-berry# yarn --version
4.0.2
root@29746f15333c:/test-berry# echo 'enableGlobalCache: true' > .yarnrc.yml
root@29746f15333c:/test-berry# yarn add semver
➤ YN0000: · Yarn 4.0.2
➤ YN0000: ┌ Resolution step
➤ YN0085: │ + semver@npm:7.5.4, lru-cache@npm:6.0.0, yallist@npm:4.0.0
➤ YN0000: └ Completed in 0s 342ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 3 packages were added to the project (+ 130.97 KiB).
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: · Done in 0s 516ms
root@29746f15333c:/test-berry# ls ~/.yarn/berry/
cache  index  metadata	telemetry.json
root@29746f15333c:/test-berry# ls ~/.yarn/berry/cache/
lru-cache-npm-6.0.0-b4c8668fe1-10c0.zip  yallist-npm-4.0.0-b493d9e907-10c0.zip
semver-npm-7.5.4-c4ad957fcd-10c0.zip
```

As you can see, the `globalFolder` appears to be `~/.yarn/berry`, not `~/.yarn/berry/global`. This also appears to be true in code: https://github.com/yarnpkg/berry/blob/db6210f48355d2986e965f90009b22f18d3b6342/packages/yarnpkg-core/sources/folderUtils.ts#L15

**How did you fix it?**

I updated the documentation to reference the correct default `globalPath`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
