### PR TITLE
Add second level of --verbose to `workspaces foreach` to permit specifying less logging.

### DIFF
--- a/.yarn/versions/07edaf86.yml
+++ b/.yarn/versions/07edaf86.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-workspace-tools": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/__snapshots__/foreach.test.js.snap
@@ -230,7 +230,7 @@ Done
 }
 `;
 
-exports[`Commands workspace foreach should prefix the output with run with --verbose 1`] = `
+exports[`Commands workspace foreach should prefix the output and include timing information when run with -vv (two verbose levels) 1`] = `
 {
   "code": 0,
   "stderr": "",
@@ -261,6 +261,22 @@ exports[`Commands workspace foreach should prefix the output with run with --ver
 [workspace-g]: Process started
 [workspace-g]: Test Workspace G
 [workspace-g]: Process exited (exit code 0)
+Done
+",
+}
+`;
+
+exports[`Commands workspace foreach should prefix the output when run with one --verbose 1`] = `
+{
+  "code": 0,
+  "stderr": "",
+  "stdout": "[workspace-a]: Test Workspace A
+[workspace-b]: Test Workspace B
+[workspace-c]: Test Workspace C
+[workspace-d]: Test Workspace D
+[workspace-e]: Test Workspace E
+[workspace-f]: Test Workspace F
+[workspace-g]: Test Workspace G
 Done
 ",
 }

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -216,8 +216,9 @@ describe(`Commands`, () => {
       ),
     );
 
+
     test(
-      `should prefix the output with run with --verbose`,
+      `should prefix the output when run with one --verbose`,
       makeTemporaryEnv(
         {
           private: true,
@@ -228,6 +229,22 @@ describe(`Commands`, () => {
           await run(`install`);
 
           await expect(run(`workspaces`, `foreach`, `--all`, `--verbose`, `run`, `print`)).resolves.toMatchSnapshot();
+        },
+      ),
+    );
+
+    test(
+      `should prefix the output and include timing information when run with -vv (two verbose levels)`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await setupWorkspaces(path);
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--all`, `-vv`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -259,7 +276,7 @@ describe(`Commands`, () => {
           await setupWorkspaces(path);
           await run(`install`);
 
-          await expect(run(`workspaces`, `foreach`, `--all`, `--verbose`, `--include`, `workspace-a`, `--include`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--all`, `-vv`, `--include`, `workspace-a`, `--include`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -275,7 +292,7 @@ describe(`Commands`, () => {
           await setupWorkspaces(path);
           await run(`install`);
 
-          await expect(run(`workspaces`, `foreach`, `--all`, `--verbose`, `--include`, `packages/workspace-c/**`, `run`, `print`)).resolves.toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--all`, `-vv`, `--include`, `packages/workspace-c/**`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -291,7 +308,7 @@ describe(`Commands`, () => {
           await setupWorkspaces(path);
           await run(`install`);
 
-          await expect(run(`workspaces`, `foreach`, `--all`, `--verbose`, `--exclude`, `workspace-a`, `--exclude`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
+          await expect(run(`workspaces`, `foreach`, `--all`, `-vv`, `--exclude`, `workspace-a`, `--exclude`, `packages/workspace-b`, `run`, `print`)).resolves.toMatchSnapshot();
         },
       ),
     );
@@ -359,7 +376,7 @@ describe(`Commands`, () => {
           await setupWorkspaces(path);
           await run(`install`);
 
-          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--all`, `--parallel`, `--jobs`, `unlimited`, `--verbose`, `run`, `print`);
+          const {code, stdout, stderr} = await run(`workspaces`, `foreach`, `--all`, `--parallel`, `--jobs`, `unlimited`, `-vv`, `run`, `print`);
 
           // We don't care what order they start in, just that they all started at the beginning.
           const first7Lines = stdout.split(`\n`).slice(0, 7).sort().join(`\n`);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Fixes #6033.

**How did you fix it?**

Changes the `-v,--verbose` flag in `workspaces foreach` to be a counter rather than a boolean. With one level it prints prefixes, with two levels it additionally prints start/finish/timing information (as was the behavior before).

The default TTY behavior has not changed (maximum verbosity). The behavior with a single `--verbose` _has_ changed, to be less verbose.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
