### PR TITLE
test: update Node.js range for extensionless files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   ],
   "eslint.nodePath": ".yarn/sdks",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "pasteImage.path": "${projectRoot}/packages/gatsby/static",
   "pasteImage.basePath": "${projectRoot}/packages/gatsby/static",

--- a/.yarn/versions/0fefb43f.yml
+++ b/.yarn/versions/0fefb43f.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/pnp"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/pnp-esm.test.ts
@@ -1,10 +1,6 @@
-import {nodeUtils}                     from '@yarnpkg/core';
-import {Filename, npath, ppath, xfs}   from '@yarnpkg/fslib';
-import {HAS_LOADERS_AFFECTING_LOADERS} from '@yarnpkg/pnp/sources/esm-loader/loaderFlags';
-import {pathToFileURL}                 from 'url';
-
-const ifAtLeastNode21It = nodeUtils.major >= 21 ? it : it.skip;
-const ifAtMostNode20It = nodeUtils.major <= 20 ? it : it.skip;
+import {Filename, npath, ppath, xfs}                               from '@yarnpkg/fslib';
+import {ALLOWS_EXTENSIONLESS_FILES, HAS_LOADERS_AFFECTING_LOADERS} from '@yarnpkg/pnp/sources/esm-loader/loaderFlags';
+import {pathToFileURL}                                             from 'url';
 
 describe(`Plug'n'Play - ESM`, () => {
   test(
@@ -404,7 +400,7 @@ describe(`Plug'n'Play - ESM`, () => {
     ),
   );
 
-  ifAtMostNode20It(
+  (ALLOWS_EXTENSIONLESS_FILES ? it.skip : it)(
     `it should not allow extensionless commonjs imports`,
     makeTemporaryEnv(
       { },
@@ -425,7 +421,7 @@ describe(`Plug'n'Play - ESM`, () => {
     ),
   );
 
-  ifAtLeastNode21It(
+  (ALLOWS_EXTENSIONLESS_FILES ? it : it.skip)(
     `it should allow extensionless commonjs imports`,
     makeTemporaryEnv(
       { },
@@ -445,7 +441,7 @@ describe(`Plug'n'Play - ESM`, () => {
     ),
   );
 
-  ifAtMostNode20It(
+  (ALLOWS_EXTENSIONLESS_FILES ? it.skip : it)(
     `it should not allow extensionless files with {"type": "module"}`,
     makeTemporaryEnv(
       {
@@ -467,7 +463,7 @@ describe(`Plug'n'Play - ESM`, () => {
     ),
   );
 
-  ifAtLeastNode21It(
+  (ALLOWS_EXTENSIONLESS_FILES ? it : it.skip)(
     `it should allow extensionless files with {"type": "module"}`,
     makeTemporaryEnv(
       {

--- a/packages/yarnpkg-pnp/sources/esm-loader/loaderFlags.ts
+++ b/packages/yarnpkg-pnp/sources/esm-loader/loaderFlags.ts
@@ -11,3 +11,6 @@ export const HAS_LAZY_LOADED_TRANSLATORS = (major === 20 && minor < 6) || (major
 // https://github.com/nodejs/node/pull/43772
 // TODO: Update the version range if it gets backported to v18.
 export const HAS_LOADERS_AFFECTING_LOADERS = major > 19 || (major === 19 && minor >= 6);
+
+// https://github.com/nodejs/node/pull/49869
+export const ALLOWS_EXTENSIONLESS_FILES = major >= 21 || (major === 20 && minor >= 10) || (major === 18 && minor >= 19);


### PR DESCRIPTION
**What's the problem this PR addresses?**

Node.js v18.19 has been released and contains https://github.com/nodejs/node/pull/49869 so we need to update tests.

**How did you fix it?**

Updated the version range.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.