### PR TITLE
enable fallback to root for scripts/bins

### DIFF
--- a/packages/plugin-essentials/sources/commands/bin.ts
+++ b/packages/plugin-essentials/sources/commands/bin.ts
@@ -1,7 +1,6 @@
-import {BaseCommand}                          from '@yarnpkg/cli';
-import {Configuration, Project, StreamReport} from '@yarnpkg/core';
-import {scriptUtils, structUtils}             from '@yarnpkg/core';
-import {Command, Option, Usage, UsageError}   from 'clipanion';
+import {BaseCommand}                                                    from '@yarnpkg/cli';
+import {Configuration, Project, scriptUtils, StreamReport, structUtils} from '@yarnpkg/core';
+import {Command, Option, Usage}                                         from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class BinCommand extends BaseCommand {
@@ -33,20 +32,32 @@ export default class BinCommand extends BaseCommand {
     description: `Format the output as an NDJSON stream`,
   });
 
+  topLevel = Option.Boolean(`-T,--top-level`, false, {
+    description: `Check the root workspace for binaries instead of the current one`,
+  });
+
+  currentWorkspaceOnly = Option.Boolean(`-C,--current-workspace-only`, false, {
+    description: `Stick to the current workspace for binaries and do not look elsewhere if unavailable`,
+  });
+
   name = Option.String({required: false});
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
     const {project, locator} = await Project.find(configuration, this.context.cwd);
+    const topLevelLocator = project.topLevelWorkspace.anchoredLocator;
+    const effectiveLocator = this.topLevel ? topLevelLocator : locator;
 
     await project.restoreInstallState();
 
     if (this.name) {
-      const binaries = await scriptUtils.getPackageAccessibleBinaries(locator, {project});
+      const binaries = await scriptUtils.getPackageAccessibleBinaries(effectiveLocator, {project, currentWorkspaceOnly: this.currentWorkspaceOnly, topLevel: this.topLevel});
 
       const binary = binaries.get(this.name);
-      if (!binary)
-        throw new UsageError(`Couldn't find a binary named "${this.name}" for package "${structUtils.prettyLocator(configuration, locator)}"`);
+      if (!binary) {
+        console.error(`Couldn't find a binary named "${this.name}" for package "${structUtils.prettyLocator(configuration, effectiveLocator)}"`);
+        return 1;
+      }
 
       const [/*pkg*/, binaryFile] = binary;
       this.context.stdout.write(`${binaryFile}\n`);
@@ -59,7 +70,7 @@ export default class BinCommand extends BaseCommand {
       json: this.json,
       stdout: this.context.stdout,
     }, async report => {
-      const binaries = await scriptUtils.getPackageAccessibleBinaries(locator, {project});
+      const binaries = await scriptUtils.getPackageAccessibleBinaries(locator, {project, currentWorkspaceOnly: this.currentWorkspaceOnly, topLevel: this.topLevel});
 
       const keys = Array.from(binaries.keys());
       const maxKeyLength = keys.reduce((max, key) => Math.max(max, key.length), 0);

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -1,25 +1,24 @@
-import capitalize from 'lodash/capitalize';
-import pLimit from 'p-limit';
-import { PassThrough, Readable, Writable } from 'stream';
+import {CwdFS, Filename, NativePath, npath, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
+import {ZipOpenFS}                                                    from '@yarnpkg/libzip';
+import {execute}                                                      from '@yarnpkg/shell';
+import capitalize                                                     from 'lodash/capitalize';
+import pLimit                                                         from 'p-limit';
+import {PassThrough, Readable, Writable}                              from 'stream';
 
-import { CwdFS, Filename, NativePath, npath, PortablePath, ppath, xfs } from '@yarnpkg/fslib';
-import { ZipOpenFS } from '@yarnpkg/libzip';
-import { execute } from '@yarnpkg/shell';
-
-import { Configuration } from './Configuration';
-import * as execUtils from './execUtils';
-import * as formatUtils from './formatUtils';
-import { Manifest } from './Manifest';
-import { MessageName } from './MessageName';
-import * as miscUtils from './miscUtils';
-import { Project } from './Project';
-import { Report, ReportError } from './Report';
-import * as semverUtils from './semverUtils';
-import { StreamReport } from './StreamReport';
-import * as structUtils from './structUtils';
-import { Locator, LocatorHash, Package } from './types';
-import { Workspace } from './Workspace';
-import { YarnVersion } from './YarnVersion';
+import {Configuration}                                                from './Configuration';
+import {Manifest}                                                     from './Manifest';
+import {MessageName}                                                  from './MessageName';
+import {Project}                                                      from './Project';
+import {Report, ReportError}                                          from './Report';
+import {StreamReport}                                                 from './StreamReport';
+import {Workspace}                                                    from './Workspace';
+import {YarnVersion}                                                  from './YarnVersion';
+import * as execUtils                                                 from './execUtils';
+import * as formatUtils                                               from './formatUtils';
+import * as miscUtils                                                 from './miscUtils';
+import * as semverUtils                                               from './semverUtils';
+import * as structUtils                                               from './structUtils';
+import {Locator, LocatorHash, Package}                                from './types';
 
 /**
  * @internal
@@ -678,7 +677,7 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project, c
   // Running this after the root fallback makes current workspace version
   // take priority over root version
   if (!topLevel)
-  getPackageVisibleLocators(project, pkg, visibleLocators);
+    getPackageVisibleLocators(project, pkg, visibleLocators);
 
   const dependenciesWithBinaries = await Promise.all(Array.from(visibleLocators, async locatorHash => {
     const dependency = project.storedPackages.get(locatorHash);

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -668,7 +668,7 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project, c
 
   const visibleLocators: Set<LocatorHash> = new Set([locator.locatorHash]);
 
-  if (!currentWorkspaceOnly || topLevel) {
+  if (!currentWorkspaceOnly) {
     const rootLocator = project.topLevelWorkspace.anchoredLocator;
     const rootPkg = project.storedPackages.get(rootLocator.locatorHash)!;
     getPackageVisibleLocators(project, rootPkg, visibleLocators);
@@ -676,7 +676,7 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project, c
 
   // Running this after the root fallback makes current workspace version
   // take priority over root version
-  if (!topLevel)
+  if (!topLevel || currentWorkspaceOnly)
     getPackageVisibleLocators(project, pkg, visibleLocators);
 
   const dependenciesWithBinaries = await Promise.all(Array.from(visibleLocators, async locatorHash => {

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -667,13 +667,16 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project, e
 
   const visibleLocators: Set<LocatorHash> = new Set([locator.locatorHash]);
 
-  getPackageVisibleLocators(project, pkg, visibleLocators);
-
   if (!excludeRoot) {
     const rootLocator = project.topLevelWorkspace.anchoredLocator;
     const rootPkg = project.storedPackages.get(rootLocator.locatorHash)!;
     getPackageVisibleLocators(project, rootPkg, visibleLocators);
   }
+
+  // Running this after the root fallback makes current workspace version
+  // take priority over root version
+
+  getPackageVisibleLocators(project, pkg, visibleLocators);
 
   const dependenciesWithBinaries = await Promise.all(Array.from(visibleLocators, async locatorHash => {
     const dependency = project.storedPackages.get(locatorHash);

--- a/packages/yarnpkg-core/sources/scriptUtils.ts
+++ b/packages/yarnpkg-core/sources/scriptUtils.ts
@@ -1,25 +1,24 @@
-import {CwdFS, Filename, NativePath, PortablePath} from '@yarnpkg/fslib';
-import {xfs, npath, ppath}                         from '@yarnpkg/fslib';
-import {ZipOpenFS}                                 from '@yarnpkg/libzip';
-import {execute}                                   from '@yarnpkg/shell';
-import capitalize                                  from 'lodash/capitalize';
-import pLimit                                      from 'p-limit';
-import {PassThrough, Readable, Writable}           from 'stream';
+import {CwdFS, Filename, NativePath, npath, PortablePath, ppath, xfs} from '@yarnpkg/fslib';
+import {ZipOpenFS}                                                    from '@yarnpkg/libzip';
+import {execute}                                                      from '@yarnpkg/shell';
+import capitalize                                                     from 'lodash/capitalize';
+import pLimit                                                         from 'p-limit';
+import {PassThrough, Readable, Writable}                              from 'stream';
 
-import {Configuration}                             from './Configuration';
-import {Manifest}                                  from './Manifest';
-import {MessageName}                               from './MessageName';
-import {Project}                                   from './Project';
-import {ReportError, Report}                       from './Report';
-import {StreamReport}                              from './StreamReport';
-import {Workspace}                                 from './Workspace';
-import {YarnVersion}                               from './YarnVersion';
-import * as execUtils                              from './execUtils';
-import * as formatUtils                            from './formatUtils';
-import * as miscUtils                              from './miscUtils';
-import * as semverUtils                            from './semverUtils';
-import * as structUtils                            from './structUtils';
-import {LocatorHash, Locator}                      from './types';
+import {Configuration}                                                from './Configuration';
+import {Manifest}                                                     from './Manifest';
+import {MessageName}                                                  from './MessageName';
+import {Project}                                                      from './Project';
+import {Report, ReportError}                                          from './Report';
+import {StreamReport}                                                 from './StreamReport';
+import {Workspace}                                                    from './Workspace';
+import {YarnVersion}                                                  from './YarnVersion';
+import * as execUtils                                                 from './execUtils';
+import * as formatUtils                                               from './formatUtils';
+import * as miscUtils                                                 from './miscUtils';
+import * as semverUtils                                               from './semverUtils';
+import * as structUtils                                               from './structUtils';
+import {Locator, LocatorHash, Package}                                from './types';
 
 /**
  * @internal
@@ -641,6 +640,7 @@ export function isNodeScript(p: PortablePath) {
 
 type GetPackageAccessibleBinariesOptions = {
   project: Project;
+  excludeRoot?: boolean;
 };
 
 type Binary = [Locator, NativePath, boolean];
@@ -652,7 +652,7 @@ type PackageAccessibleBinaries = Map<string, Binary>;
  * @param locator The queried package
  * @param project The project owning the package
  */
-export async function getPackageAccessibleBinaries(locator: Locator, {project}: GetPackageAccessibleBinariesOptions): Promise<PackageAccessibleBinaries> {
+export async function getPackageAccessibleBinaries(locator: Locator, {project, excludeRoot}: GetPackageAccessibleBinariesOptions): Promise<PackageAccessibleBinaries> {
   const configuration = project.configuration;
   const binaries: PackageAccessibleBinaries = new Map();
 
@@ -667,12 +667,12 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project}: 
 
   const visibleLocators: Set<LocatorHash> = new Set([locator.locatorHash]);
 
-  for (const descriptor of pkg.dependencies.values()) {
-    const resolution = project.storedResolutions.get(descriptor.descriptorHash);
-    if (!resolution)
-      throw new Error(`Assertion failed: The resolution (${structUtils.prettyDescriptor(configuration, descriptor)}) should have been registered`);
+  getPackageVisibleLocators(project, pkg, visibleLocators);
 
-    visibleLocators.add(resolution);
+  if (!excludeRoot) {
+    const rootLocator = project.topLevelWorkspace.anchoredLocator;
+    const rootPkg = project.storedPackages.get(rootLocator.locatorHash)!;
+    getPackageVisibleLocators(project, rootPkg, visibleLocators);
   }
 
   const dependenciesWithBinaries = await Promise.all(Array.from(visibleLocators, async locatorHash => {
@@ -717,6 +717,16 @@ export async function getPackageAccessibleBinaries(locator: Locator, {project}: 
   }
 
   return binaries;
+}
+
+function getPackageVisibleLocators(project: Project, pkg: Package, visibleLocators: Set<LocatorHash>) {
+  for (const descriptor of pkg.dependencies.values()) {
+    const resolution = project.storedResolutions.get(descriptor.descriptorHash);
+    if (!resolution)
+      throw new Error(`Assertion failed: The resolution (${structUtils.prettyDescriptor(project.configuration, descriptor)}) should have been registered`);
+
+    visibleLocators.add(resolution);
+  }
 }
 
 /**


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
This PR addresses an issue I noticed while upgrading from yarn v1 to v4: the inability for yarn to fallback to the root workspace for scripts and binaries if not found in the current workspace, while not looking exclusively in either the top level or current workspace.
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
#6045 
...

**How did you fix it?**
<!-- A detailed description of your implementation. -->
When we're looking for dependencies/scripts available to the package in `getPackageAccessibleBinaries`, a new flag tells us whether to limit our search to the current workspace workspace (**CW**) or, if omitted, expand our search to the root workspace (**RW**). The edited utility is shared between `yarn bin` and `yarn run` and keeps the two consistent.

**Flags Added**
- For `yarn bin`
  1. `-T,--top-level`: same behavior as in `yarn run`
  2. `-C,--current-workspace-only`: Limits dep/script search to the CW only
- For `yarn run`
  1. `-C,--current-workspace-only`: As above

I edited `yarn bin`'s flags because we get functionality for free from the utils changes, and for consistency with `yarn run` if the user needs to debug where their running binaries are.

**Scripts Behavior**
Based on the flags, we may check the RW for the script and run the same steps as if a script existed in the CW.

**Dependencies Behavior**
In `getPackageAccessibleBinaries`: we start by feeding the RW deps into our set, followed by the CW deps. The "fallback" behavior comes from the insertion order, letting `binaries.set(name, ...)` prioritize the CW's deps. 

**New Default Behavior** 
If RW has jest 29 and CW has jest 28, running `jest --version` in CW will output 28 and `yarn bin jest` will output the path to v28.

If flag `-T` is given, we check the top level only (existing functionality). If `-C` is specified, no deps outside of CW will be considered. If both are specified, `-C` takes priority.
...

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
