### PR TITLE
Fix crash case

### DIFF
--- a/.yarn/versions/9d67e475.yml
+++ b/.yarn/versions/9d67e475.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -78,7 +78,7 @@ export class NpmTagResolver implements Resolver {
       if (parsedRange.params?.__archiveUrl) {
         const newRange = structUtils.makeRange({protocol: PROTOCOL, selector: parsedRange.selector, source: null, params: null});
         const [resolvedLocator] = await opts.resolver.getCandidates(structUtils.makeDescriptor(descriptor, newRange), dependencies, opts);
-        if (locator.reference !== resolvedLocator.reference) {
+        if (resolvedLocator && locator.reference !== resolvedLocator.reference) {
           continue;
         }
       }


### PR DESCRIPTION
**What's the problem this PR addresses?**

I raised a bug about deduping patch's (https://github.com/yarnpkg/berry/issues/6055) and thought the crash in yarn was about the patch, but it was not.

This change stops yarn crashing.

**How did you fix it?**

The problem is that alot of dependencies reference node-gyp with npm:latest.
The latest version in my yarn.lock file is 9.0.0, but yarn is finding the latest available to be 10.0.0.

So in getSatisfying, the descriptor is this:

```
{
  identHash: 'c463d28440264a050b6c82da90fae465d199a53c829a9fe2e382b672d4cbe014f84892bf0c630287a36347a4e407d33459c9581068c99d313332886ced75b781',
  scope: null,
  name: 'node-gyp',
  descriptorHash: '899f4448539abee8008ed64335a3b2bfb86e39a574e1267d2582a99b0865c3b00672068397645824a04ed0141f7f43c439ae8248539b250f8c76e24831ed0b94',
  range: 'npm:latest'
```

and makeDescriptor returns:

```
{
  identHash: 'c463d28440264a050b6c82da90fae465d199a53c829a9fe2e382b672d4cbe014f84892bf0c630287a36347a4e407d33459c9581068c99d313332886ced75b781',
  scope: null,
  name: 'node-gyp',
  descriptorHash: '48708ce70bc76e1f879f77affa6f744312cff313a2af15712d70a94f1b5e9382a4e1566ac8a75fb8c82ddbad727beca280bb7610d278c54b8c2d6ccbab77d231',
  range: 'npm:10.0.1'
}
```

but I guess because v10.0.1 is not in my yarn.lock file, getCandidates returns [] so resolvedLocator is undefined and yarn crashes.

I don't really know what I am doing so please feel free to suggest a different fix.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [x] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
