### PR TITLE
Fix links in zero-installs explanation

### DIFF
--- a/packages/docusaurus/docs/features/caching.md
+++ b/packages/docusaurus/docs/features/caching.md
@@ -29,7 +29,7 @@ Zero-installs are the combination of two Yarn features that allow you to skip ha
 
 As we saw, the offline mirror removes your project's dependency on the npm registry by keeping the Yarn cache within the repository. But can we go further, and directly make this cache the actual? The answer is yes!
 
-As long as your project uses [Yarn PnP](/) **and** the offline mirror, all you have to do is add the loader files to Git, and you can forget `yarn install` most of the time. Since the PnP loaders have exactly the same content regardless of the machine that generated them, and since the offline cache will contain all the files that the loaders reference, the `git checkout` calls effectively double as `yarn install` of sort.
+As long as your project uses [Yarn PnP](/features/pnp) **and** the [offline mirror](#offline-mirror), all you have to do is add the loader files to Git, and you can forget `yarn install` most of the time. Since the PnP loaders have exactly the same content regardless of the machine that generated them, and since the offline cache will contain all the files that the loaders reference, the `git checkout` calls effectively double as `yarn install` of sort.
 
 One caveat: adding or removing packages with native dependencies will still require `yarn install` to be run, as such packages depend on files that, unlike Node.js scripts, can't be evaluated directly from within their zip archives. Those packages are quite rare in practice, aren't frequently updated, and Yarn will display an helpful error message should you forget to do it, so this doesn't significantly impact the usefulness of the pattern.
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

I spent a long time debugging a failing `yarn install --immutable --immutable-cache --check-cache` in my CI environment.

I was seeing the error `YN0056: PACKAGE@npm:x.x.x: Cache entry required but missing for PACKAGE@npm:x.x.x` for every package in the cache. (The issue was clearly not just for packages with native dependencies like in https://github.com/yarnpkg/berry/issues/4514.)

After trying in multiple environments, I finally realized `.pnp.cjs` was changing based on the nesting depth of the repo, as `enableGlobalCache` was not set to `false` in `.yarnrc.yml`. (This occurred after an upgrade from Yarn v3 to Yarn v4.)

(Including the above to help anyone searching for this issue on GitHub.)

**How did you fix it?**

This PR fixes the broken PnP link and makes the `offline mirror` text a link as well. Hopefully that will help others to realize that to get Zero Installs working they'll need to read that section too.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
