### PR TITLE
chore: add package info to the output

### DIFF
--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -118,7 +118,7 @@ export default class NpmPublishCommand extends BaseCommand {
         });
       });
 
-      report.reportInfo(MessageName.UNNAMED, `Package archive published`);
+      report.reportInfo(MessageName.UNNAMED, `Package archive published: ${ident}@${version}`);
     });
 
     return report.exitCode();


### PR DESCRIPTION
**What's the problem this PR addresses?**

When succesfully publishing a package, there is no information regarding to which package was published

Resolves #5649

**How did you fix it?**

Now the publish command also reports the package name and version.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [] I will check that all automated PR checks pass before the PR gets reviewed.
