### PR TITLE
ci: use Node.js current release for e2e tests and benchmarks

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,19 +3,13 @@ inputs:
     description: 'Whether to minify the bundle'
     required: false
     default: 'false'
-  node-version:
-    description: 'The version of Node.js to use'
-    required: false
-    default: '18.x'
 
 runs:
   using: composite
   steps:
-    - name: 'Use Node.js ${{ inputs.node-version }}'
-      uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
-        check-latest: true
+        node-version: current
 
     #region Build the standard bundle
     - uses: actions/cache@v3


### PR DESCRIPTION
**What's the problem this PR addresses?**

Our e2e tests and benchmarks use Node.js v18 which means by the time they catch regressions in the runtime itself a decent amount of time has passed.

**How did you fix it?**

Run them on the Node.js current release to catch regressions earlier.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.