### PR TITLE
ci(e2e): remove gatsby development server test

### DIFF
--- a/.github/workflows/e2e-gatsby-workflow.yml
+++ b/.github/workflows/e2e-gatsby-workflow.yml
@@ -30,7 +30,3 @@ jobs:
 
         # Test production build
         yarn build
-
-        # Test development server (which includes development only loaders like eslint-loader)
-        # Redirect the output to log.txt and check if it contains "ERROR #"
-        yarn dlx start-server-and-test "yarn start > log.txt 2>&1" :8000 "! cat log.txt | grep \"ERROR #\""


### PR DESCRIPTION
**What's the problem this PR addresses?**

The Gatsby development server test has been timing out in the CI for months now, though it passes locally.

**How did you fix it?**

Disable to so we notice when the build stops working.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.