### PR TITLE
ci(e2e): use Node.js v20 for angular pnp test

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,13 +3,17 @@ inputs:
     description: 'Whether to minify the bundle'
     required: false
     default: 'false'
+  node-version:
+    description: 'The version of Node.js to use'
+    required: false
+    default: 'current'
 
 runs:
   using: composite
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: current
+        node-version: ${{ inputs.node-version }}
 
     #region Build the standard bundle
     - uses: actions/cache@v3

--- a/.github/workflows/e2e-pnp-angular-workflow.yml
+++ b/.github/workflows/e2e-pnp-angular-workflow.yml
@@ -20,6 +20,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: ./.github/actions/prepare
+      with:
+        # TODO: Remove when the issue causing timeouts / crashes in Node.js >= 21 is fixed.
+        node-version: 20
 
     - name: 'Running the integration test'
       run: |


### PR DESCRIPTION
**What's the problem this PR addresses?**

The angular PnP test started failing with https://github.com/yarnpkg/berry/pull/5051.

**How did you fix it?**

Lock the Angular PnP test to Node.js v20 for now.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.