### PR TITLE
docs: restore information about the YARN_RC_FILENAME environment variable

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -768,6 +768,13 @@
       "enum": ["patrick", "simba", "jack", "hogsfather", "default"],
       "examples": ["default"]
     },
+    "rcFilename": {
+      "_package": "@yarnpkg/core",
+      "title": "This setting defines the name of the files that Yarn looks for when resolving the rc files.",
+      "description": "For obvious reasons this settings cannot be set within rc files, and must be defined in the environment using the `YARN_RC_FILENAME` variable.",
+      "type": "string",
+      "default": ".yarnrc.yml"
+    },
     "supportedArchitectures": {
       "_package": "@yarnpkg/core",
       "title": "Systems for which Yarn should install packages.",


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

I found that starting from version 4.0.0, information about the `YARN_RC_FILENAME` environment variable is missing from the documentation. However, this environment variable is still supported.

Proof:
https://github.com/yarnpkg/berry/blob/c6764b28f8e8dbdac7ad318d6d98b5d5f0f4679e/packages/yarnpkg-core/sources/Configuration.ts#L980-L988

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I have updated the documentation to restore information about the `YARN_RC_FILENAME` environment variable

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
