### PR TITLE
Add test for #6058 nm mistreating link: deps as inner workspace

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -178,7 +178,6 @@ describe(`Node_Modules`, () => {
           [`app`]: `link:./app`,
         },
         workspaces: [
-          `packages/*`,
           `app/plugins/*`,
         ],
       },
@@ -186,14 +185,6 @@ describe(`Node_Modules`, () => {
         nodeLinker: `node-modules`,
       },
       async ({path, run, source}) => {
-        await writeJson(npath.toPortablePath(`${path}/packages/workspace/package.json`), {
-          name: `workspace`,
-          version: `10.3.0-pre`,
-          dependencies: {
-            [`no-deps`]: `2.0.0`,
-          },
-        });
-
         await writeJson(npath.toPortablePath(`${path}/app/plugins/foo-plugin/package.json`), {
           name: `foo-plugin`,
           version: `1.0.0`,
@@ -208,7 +199,6 @@ describe(`Node_Modules`, () => {
       },
     ),
   );
-
 
   test(`should support replacement of regular dependency with portal: protocol dependency`,
     makeTemporaryEnv(


### PR DESCRIPTION
**What's the problem this PR addresses?**

Adds an integration test for https://github.com/yarnpkg/berry/pull/6058 to assert that link: dependencies are not mistreated as inner workspaces.

It took a bit of trial and error to get the right dependency tree that causes the issue, but eventually figured it out. It's roughly the same as https://github.com/joshhunt/yarn-repro-uuid-install-location, but with the existing fixtures.

...

**How did you fix it?**

It's just a test :)

I wrote the test against main to make sure it fails, and then check out the PR with the test and it passed :)

<details>

<summary>Test output against main and branch</summary>

```shell


~/d/g/yarn-berry (master)> git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts

no changes added to commit (use "git add" and/or "git commit -a")


~/d/g/yarn-berry (master)> yarn test:integration node-modules --verbose=false -t "should not treat link: dependencies as an inner workspaces"
 FAIL  packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
  ● Node_Modules › should not treat link: dependencies as an inner workspaces

    Temporary fixture folder: /tmp/xfs-0e84f398/test

    expect(received).toBe(expected) // Object.is equality

    Expected: false
    Received: true

      169 |     ),
      170 |   );
    > 171 |
          | ^
      172 |   test(`should not treat link: dependencies as an inner workspaces`,
      173 |     makeTemporaryEnv(
      174 |       {

      at pkg-tests-specs/sources/node-modules.test.ts:171:101
      at Object.<anonymous> (pkg-tests-core/sources/utils/tests.ts:788:11)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 57 skipped, 58 total
Snapshots:   0 total
Time:        1.685 s, estimated 28 s
Ran all test suites matching /node-modules/i with tests matching "should not treat link: dependencies as an inner workspaces".


~/d/g/yarn-berry (master)> git co larixer/nm-mistreatment-link-as-workspace-fix
branch 'larixer/nm-mistreatment-link-as-workspace-fix' set up to track 'origin/larixer/nm-mistreatment-link-as-workspace-fix'.
Switched to a new branch 'larixer/nm-mistreatment-link-as-workspace-fix'


~/d/g/yarn-berry (larixer/nm-mistreatment-link-as-workspace-fix)> yarn; yarn build:cli
...


~/d/g/yarn-berry (larixer/nm-mistreatment-link-as-workspace-fix)> yarn test:integration node-modules --verbose=false -t "should not treat link: dependencies as an inner workspaces"
 PASS  packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts

Test Suites: 1 passed, 1 total
Tests:       57 skipped, 1 passed, 58 total
Snapshots:   0 total
Time:        2.242 s
Ran all test suites matching /node-modules/i with tests matching "should not treat link: dependencies as an inner workspaces".
```
</details>

...




**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
