### PR TITLE
add `localhost` to `unsafeHttpWhitelist`

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -845,7 +845,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
+        "pattern": "localhost|[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
       },
       "default": [],
       "_exampleItems": ["*.example.org", "example.org"]


### PR DESCRIPTION
**What's the problem this PR addresses?**

My development environment uses an internal NPM registry proxied via a port on `localhost`. Like most `localhost`s, it does not support `https`. As a result, my `.yarnrc.yml` file is in a constant state of error: `String does not match the pattern of "[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)".yaml-schema: Array of hostname glob patterns for which using the HTTP protocol is allowed.`

...

**How did you fix it?**
I added `localhost` to the allowed pattern.

...

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
