### PR TITLE
docs: change i.e. to e.g. in search placeholder

### DIFF
--- a/packages/docusaurus/src/pages/index.tsx
+++ b/packages/docusaurus/src/pages/index.tsx
@@ -69,7 +69,7 @@ export default function Home(): JSX.Element {
                 </div>
               </h1>
               <p>Yarn is a package manager that doubles down as project manager. Whether you work on simple projects or industry monorepos, whether you're an open source developer or an enterprise user, Yarn has your back.</p>
-              <input className={styles.search} placeholder={`Search packages (i.e. babel, webpack, react, ...)`} autoFocus={true} onChange={handleChange}/>
+              <input className={styles.search} placeholder={`Search packages (e.g. babel, webpack, react, ...)`} autoFocus={true} onChange={handleChange}/>
               <div className={styles.info}>
                 This documentation covers Yarn 4+. For the previous documentation dedicated to 3.6 and below, please refer to <a href={`https://v3.yarnpkg.com/`}>v3.yarnpkg.com</a>.
               </div>

--- a/packages/docusaurus/src/pages/search.tsx
+++ b/packages/docusaurus/src/pages/search.tsx
@@ -145,7 +145,7 @@ function SearchBar() {
   };
 
   return (
-    <input className={clsx(indexStyles.search, styles.search)} autoFocus={true} placeholder={`Search packages (i.e. babel, webpack, react, ...)`} value={query} onChange={handleChange}/>
+    <input className={clsx(indexStyles.search, styles.search)} autoFocus={true} placeholder={`Search packages (e.g. babel, webpack, react, ...)`} value={query} onChange={handleChange}/>
   );
 }
 

--- a/packages/plugin-interactive-tools/sources/commands/search.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/search.tsx
@@ -224,7 +224,7 @@ export default class SearchCommand extends BaseCommand {
               <InkTextInput
                 value={query}
                 onChange={handleQueryOnChange}
-                placeholder={`i.e. babel, webpack, react...`}
+                placeholder={`e.g. babel, webpack, react...`}
                 showCursor={false}
               />
             </Box>

--- a/packages/plugin-interactive-tools/sources/commands/search.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/search.tsx
@@ -224,7 +224,7 @@ export default class SearchCommand extends BaseCommand {
               <InkTextInput
                 value={query}
                 onChange={handleQueryOnChange}
-                placeholder={`e.g. babel, webpack, react...`}
+                placeholder={`i.e. babel, webpack, react...`}
                 showCursor={false}
               />
             </Box>


### PR DESCRIPTION
**What's the problem this PR addresses?**

In the website search placeholder text (something like `Search packages (i.e. babel, webpack, react, ...)`), the word "i.e." is used incorrectly. ["i.e." means "that is,"](https://en.wiktionary.org/wiki/i.e.#Usage_notes) but the intended meaning here is ["e.g.," meaning "for example."](https://en.wiktionary.org/wiki/e.g.)

**How did you fix it?**

Changed the three instances I found of this placeholder text to use "e.g." instead.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.
 ~👆 Not sure how to do that / if it's applicable to docs-only changes.~ never mind, see [comment](https://github.com/yarnpkg/berry/pull/6142#issuecomment-1963380206) below.
<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
