### PR TITLE
Adds a `createFolderMount` util

### DIFF
--- a/packages/yarnpkg-fslib/sources/index.ts
+++ b/packages/yarnpkg-fslib/sources/index.ts
@@ -50,7 +50,7 @@ export {ProxiedFS}                                         from './ProxiedFS';
 export {SubFS}                                             from './SubFS';
 export {VirtualFS}                                         from './VirtualFS';
 
-export {patchFs, extendFs} from './patchFs/patchFs';
+export {applyFsLayer, extendFs, patchFs} from './patchFs/patchFs';
 
 export {xfs} from './xfs';
 export type {XFS} from './xfs';


### PR DESCRIPTION
> [!NOTE]
>
> This PR is stacked on top of https://github.com/yarnpkg/berry/pull/6161

**What's the problem this PR addresses?**

Creating a folder mount requires a bit of non-trivial boilerplate. Not that much code, but a little tricky to remember.

**How did you fix it?**

Added two functions:

- `applyFsLayer` applies a `FakeFS<PortablePath>` on top of the `fs` module.
- `MountFS.createFolderMount` returns a `MountFS` that replaces all access to folder `X` by accesses to folder `Y`.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
