### PR TITLE
feat(plugin-typescript): check workspace tsconfig.json

### DIFF
--- a/.yarn/versions/dca3f277.yml
+++ b/.yarn/versions/dca3f277.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-typescript": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
@@ -51,7 +51,9 @@ describe(`Plugins`, () => {
         }, {[`packages/foo`]: {}}, async ({path, run, source}) => {
           await xfs.writeFilePromise(ppath.join(path, `packages/foo/tsconfig.json`), ``);
 
-          await run(`add`, `is-number`);
+          await run(`add`, `is-number`, {
+            cwd: `${path}/packages/foo` as PortablePath,
+          });
 
           await expect(readManifest(`${path}/packages/foo` as PortablePath)).resolves.toMatchObject({
             dependencies: {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
@@ -66,7 +66,6 @@ describe(`Plugins`, () => {
         }),
       );
 
-
       test(
         `it should not automatically enable automatic @types insertion when a tsconfig is present in a sibling workspace`,
         makeTemporaryMonorepoEnv({
@@ -79,6 +78,25 @@ describe(`Plugins`, () => {
           });
 
           await expect(readManifest(`${path}/packages/bar` as PortablePath)).resolves.toMatchObject({
+            dependencies: {
+              [`is-number`]: `^2.0.0`,
+            },
+          });
+        }),
+      );
+
+      test(
+        `it should not automatically enable automatic @types insertion when a tsconfig is detected in the root project of the current workspace`,
+        makeTemporaryMonorepoEnv({
+          workspaces: [`packages/*`],
+        }, {[`packages/foo`]: {}}, async ({path, run, source}) => {
+          await xfs.writeFilePromise(ppath.join(path, `tsconfig.json`), ``);
+
+          await run(`add`, `is-number`, {
+            cwd: `${path}/packages/foo` as PortablePath,
+          });
+
+          await expect(readManifest(`${path}/packages/foo` as PortablePath)).resolves.toMatchObject({
             dependencies: {
               [`is-number`]: `^2.0.0`,
             },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
@@ -27,13 +27,35 @@ describe(`Plugins`, () => {
       );
 
       test(
-        `it should automatically enable automatic @types insertion when a tsconfig is detected`,
+        `it should automatically enable automatic @types insertion when a tsconfig is detected at the root of the project`,
         makeTemporaryEnv({}, async ({path, run, source}) => {
           await xfs.writeFilePromise(ppath.join(path, `tsconfig.json`), ``);
 
           await run(`add`, `is-number`);
 
           await expect(readManifest(path)).resolves.toMatchObject({
+            dependencies: {
+              [`is-number`]: `^2.0.0`,
+            },
+            devDependencies: {
+              [`@types/is-number`]: `^2`,
+            },
+          });
+        }),
+      );
+
+      test(
+        `it should automatically enable automatic @types insertion when a tsconfig is detected in the current workspace`,
+        makeTemporaryMonorepoEnv({
+          workspaces: [`packages/*`],
+        }, {[`packages/foo`]: {}}, async ({path, run, source}) => {
+          await xfs.writeFilePromise(ppath.join(path, `packages/foo/tsconfig.json`), ``);
+
+          await run(`add`, `is-number`, {
+            cwd: `${path}/packages/foo` as PortablePath,
+          });
+
+          await expect(readManifest(`${path}/packages/foo` as PortablePath)).resolves.toMatchObject({
             dependencies: {
               [`is-number`]: `^2.0.0`,
             },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
@@ -106,7 +106,7 @@ describe(`Plugins`, () => {
       );
 
       test(
-        `it should not automatically enable automatic @types insertion when a tsconfig is detected in the root project of the current workspace`,
+        `it should automatically enable automatic @types insertion when a tsconfig is detected in the root project of the current workspace`,
         makeTemporaryMonorepoEnv({
           workspaces: [`packages/*`],
         }, {[`packages/foo`]: {}}, async ({path, run, source}) => {
@@ -119,6 +119,9 @@ describe(`Plugins`, () => {
           await expect(readManifest(`${path}/packages/foo` as PortablePath)).resolves.toMatchObject({
             dependencies: {
               [`is-number`]: `^2.0.0`,
+            },
+            devDependencies: {
+              [`@types/is-number`]: `^2`,
             },
           });
         }),
@@ -450,7 +453,7 @@ describe(`Plugins`, () => {
         );
 
         test(
-          `it should not automatically remove @types ${type} from the current workspace when a tsconfig is detected in the root project of the current workspace`,
+          `it should automatically remove @types ${type} from the current workspace when a tsconfig is detected in the root project of the current workspace`,
           makeTemporaryMonorepoEnv({
             workspaces: [`packages/*`],
           },
@@ -465,7 +468,7 @@ describe(`Plugins`, () => {
               cwd: `${path}/packages/foo` as PortablePath,
             });
 
-            await expect(readManifest(`${path}/packages/foo` as PortablePath)).resolves.toHaveProperty(`${type}.@types/is-number`);
+            await expect(readManifest(`${path}/packages/foo` as PortablePath)).resolves.not.toHaveProperty(`${type}.@types/is-number`);
           }),
         );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
@@ -66,6 +66,26 @@ describe(`Plugins`, () => {
         }),
       );
 
+
+      test(
+        `it should not automatically enable automatic @types insertion when a tsconfig is present in a sibling workspace`,
+        makeTemporaryMonorepoEnv({
+          workspaces: [`packages/*`],
+        }, {[`packages/foo`]: {}, [`packages/bar`]: {}}, async ({path, run, source}) => {
+          await xfs.writeFilePromise(ppath.join(path, `packages/foo/tsconfig.json`), ``);
+
+          await run(`add`, `is-number`, {
+            cwd: `${path}/packages/bar` as PortablePath,
+          });
+
+          await expect(readManifest(`${path}/packages/bar` as PortablePath)).resolves.toMatchObject({
+            dependencies: {
+              [`is-number`]: `^2.0.0`,
+            },
+          });
+        }),
+      );
+
       test(
         `it should automatically add @types to devDependencies when package doesn't provide types`,
         makeTemporaryEnv({}, {

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -835,7 +835,7 @@
     "tsEnableAutoTypes": {
       "_package": "@yarnpkg/plugin-typescript",
       "title": "Define whether to automatically install @types dependencies.",
-      "description": "If true, Yarn will automatically add `@types` dependencies when running `yarn add` with packages that don't provide their own typings (as reported by the Algolia npm database). This behavior is enabled by default if you have a tsconfig file at the root of your project.",
+      "description": "If true, Yarn will automatically add `@types` dependencies when running `yarn add` with packages that don't provide their own typings (as reported by the Algolia npm database). This behavior is enabled by default if you have a tsconfig.json file at the root of your project, or in your current workspace.",
       "type": "boolean",
       "examples": [true]
     },

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -9,6 +9,10 @@
 
 This plugin is included by default starting from Yarn 4.
 
+## Configuration
+
+This plugin is enabled by default if you have a `tsconfig.json` file at the root of your project, or in your current workspace. See [`tsEnableAutoTypes`](https://yarnpkg.com/configuration/yarnrc#tsEnableAutoTypes) for more information.
+
 ## Example
 
 ```

--- a/packages/plugin-typescript/sources/index.ts
+++ b/packages/plugin-typescript/sources/index.ts
@@ -26,9 +26,10 @@ const afterWorkspaceDependencyAddition = async (
   const {project} = workspace;
   const {configuration} = project;
 
-  const tsEnableAutoTypes = configuration.get(`tsEnableAutoTypes`)
-    ?? xfs.existsSync(ppath.join(workspace.cwd, `tsconfig.json`))
-    ?? xfs.existsSync(ppath.join(project.cwd, `tsconfig.json`));
+  const tsEnableAutoTypes = configuration.get(`tsEnableAutoTypes`) ?? (
+    xfs.existsSync(ppath.join(workspace.cwd, `tsconfig.json`))
+      || xfs.existsSync(ppath.join(project.cwd, `tsconfig.json`))
+  );
 
   if (!tsEnableAutoTypes)
     return;
@@ -119,9 +120,10 @@ const afterWorkspaceDependencyRemoval = async (
   const {project} = workspace;
   const {configuration} = project;
 
-  const tsEnableAutoTypes = configuration.get(`tsEnableAutoTypes`)
-    ?? xfs.existsSync(ppath.join(workspace.cwd, `tsconfig.json`))
-    ?? xfs.existsSync(ppath.join(project.cwd, `tsconfig.json`));
+  const tsEnableAutoTypes = configuration.get(`tsEnableAutoTypes`) ?? (
+    xfs.existsSync(ppath.join(workspace.cwd, `tsconfig.json`))
+      || xfs.existsSync(ppath.join(project.cwd, `tsconfig.json`))
+  );
 
   if (!tsEnableAutoTypes)
     return;

--- a/packages/plugin-typescript/sources/index.ts
+++ b/packages/plugin-typescript/sources/index.ts
@@ -120,6 +120,7 @@ const afterWorkspaceDependencyRemoval = async (
   const {configuration} = project;
 
   const tsEnableAutoTypes = configuration.get(`tsEnableAutoTypes`)
+    ?? xfs.existsSync(ppath.join(workspace.cwd, `tsconfig.json`))
     ?? xfs.existsSync(ppath.join(project.cwd, `tsconfig.json`));
 
   if (!tsEnableAutoTypes)

--- a/packages/plugin-typescript/sources/index.ts
+++ b/packages/plugin-typescript/sources/index.ts
@@ -27,6 +27,7 @@ const afterWorkspaceDependencyAddition = async (
   const {configuration} = project;
 
   const tsEnableAutoTypes = configuration.get(`tsEnableAutoTypes`)
+    ?? xfs.existsSync(ppath.join(workspace.cwd, `tsconfig.json`))
     ?? xfs.existsSync(ppath.join(project.cwd, `tsconfig.json`));
 
   if (!tsEnableAutoTypes)


### PR DESCRIPTION
**What's the problem this PR addresses?**
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Given the following monorepo setup, `plugin-typescript` is currently not enabled by default in the `foo` workspace, as it only checks that a `tsconfig.json` exists at the root of the project:

```
package.json
workspace/foo/package.json
workspace/foo/tsconfig.json
```

I also found the [current `README` of `plugin-typescript`](https://github.com/yarnpkg/berry/blob/daa574791b3b2df01e76c1fdfd9c975050a0fb9d/packages/plugin-typescript/README.md) not to be helpful in diagnosing my issue

**How did you fix it?**
<!-- A detailed description of your implementation. -->

I've added a check to see if the current workspace had a `tsconfig.json`

I've also added a Configuration section to `plugin-typescript/README.md`, to help users find the `tsEnableAutoTypes` option.

**Checklist**
<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

  - I have only bumped `@yarnpkg/plugin-typescript` and `@yarnpkg/cli`, let me know if I should also select the other plugins/core etc.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
