### PR TITLE
build(compat): use a treeless TypeScript clone

### DIFF
--- a/packages/plugin-compat/extra/typescript/gen-typescript-patch.js
+++ b/packages/plugin-compat/extra/typescript/gen-typescript-patch.js
@@ -6,7 +6,7 @@ const https = require(`https`);
 const path = require(`path`);
 const semver = require(`semver`);
 
-const TS_REPO = `/tmp/ts-repo`;
+const TS_REPO = `/tmp/ts-repo-treeless`;
 const TS_REPO_SPAWN = {cwd: TS_REPO};
 
 const TMP_DIR = `/tmp/ts-builds`;
@@ -93,7 +93,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.2
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.2
   {
     from: `8e0e8703b9c95013aec7819e4593d099cdf7763a`,
     to: `178a67b4663d80b0fcbea542e7255b4499b51708`,
@@ -104,7 +104,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.3
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.3
   {
     from: `530aad19e4ac19d35cb6b200168c91ce86cb0050`,
     to: `ffa54c5a104e7940b5c23666ddffbf44878f9d9f`,
@@ -114,7 +114,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.4
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.4
   {
     from: `793bfe32745bf6797924354b0fd5be62cf01950c`,
     to: `20ffca2f3c48591c971e6606a55b7b1820d8a64f`,
@@ -124,7 +124,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.5
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.5
   {
     from: `9232978f8e54f073b5451d0bf2737d42a0fd672f`,
     to: `3a2388d39d41d000b5c5f9bcd48096b39fcedf8f`,
@@ -134,7 +134,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.6
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.6
   {
     from: `fbec717ef33fc2db5791f2a1d5f9a315e293a50a`,
     to: `fbec717ef33fc2db5791f2a1d5f9a315e293a50a`,
@@ -144,7 +144,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.7
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.7
   {
     from: `cd8d000510ed2d2910e0ebaa903a51adda546a0a`,
     to: `cd8d000510ed2d2910e0ebaa903a51adda546a0a`,
@@ -154,7 +154,7 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.8.0-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.8.0-beta
   {
     from: `3287098f4785fd652112beadf3b33a960fcd19aa`,
     to: `3287098f4785fd652112beadf3b33a960fcd19aa`,
@@ -164,105 +164,105 @@ const SLICES = [
       npm: `6.14.11`,
     },
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.8-stable
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.8-stable
   {
     from: `623a7ac5aa49250155d39e604b09b4d015468a9c`,
     to: `30840e0c2ad8e115c518f87379b7cb55fdf77f03`,
     onto: `60b5167a2a7015759d048cdd4655d1f66a8416a2`,
     range: `>=4.8.1-rc <4.8.4`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.8
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.8
   {
     from: `d3747e92c3cd2d1f98739382c14226a725df38fd`,
     to: `5b9a74243e47db6113e857eabe5d26589fa0b64f`,
     onto: `a614119c1921ca61d549a7eee65c0b8c69c28752`,
     range: `>=4.8.4 <4.9.1-beta`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.9-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.9-beta
   {
     from: `69c84aacfcea603c4d74721366cdcbbebd1c1681`,
     to: `18b67922d3dcc5215541a38bf6417972270bf60f`,
     onto: `549b5429d4837344e8c99657109bb6538fd2dbb5`,
     range: `>=4.9.1-beta <4.9.2-rc`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.9-rc
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.9-rc
   {
     from: `5613f8d8e30dfa9fb3da15e2b8432ed7e2347a12`,
     to: `d3a8a86ce4774d607c5a4a225cc5b59b1f96f42f`,
     onto: `107f832b80df2dc97748021cb00af2b6813db75b`,
     range: `>=4.9.2-rc <4.9.4`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-4.9
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-4.9
   {
     from: `a0859a75a408ec95222a3f0175ba0644d60396f1`,
     to: `936e68ba96e004bd32e438d64ac720c3bfe5576b`,
     onto: `e2868216f637e875a74c675845625eb15dcfe9a2`,
     range: `>=4.9.4 <5.0.0-beta`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.0-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.0-beta
   {
     from: `65bff6fadce4736bb9a77213ba8016f1ac7d25e5`,
     to: `6225be2771938c6a1fce825eabe66292e4ace489`,
     onto: `dcad07ffd29854e2b93a86da0ba197f6eec21698`,
     range: `>=5.0.0-beta <5.0.1-rc`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.0
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.0
   {
     from: `2c85874875fdf1f1182733b99afe47604915bfec`,
     to: `9a2c1c80b05a5fbd5bc6d2bfcbaa617793a236ab`,
     onto: `89515ce7e31d0bfaef776ac25929a78015cceb82`,
     range: `>=5.0.1-rc <5.1.0-beta`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.1-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.1-beta
   {
     from: `a6ef895fb06014c416cce2f80969912ec5ea47d5`,
     to: `a6ef895fb06014c416cce2f80969912ec5ea47d5`,
     onto: `1c5cc6152322cd5b131b6e617e0947bcb068fc4a`,
     range: `>=5.1.0-beta <5.1.1-rc`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.1
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.1
   {
     from: `20514ce182c598568e4a9c7ed60a4ce84740cecd`,
     to: `20514ce182c598568e4a9c7ed60a4ce84740cecd`,
     onto: `5c47c6ab567cace50ab5f331a7381b9f0edb56ca`,
     range: `>=5.1.1-rc <5.2.0-beta`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.2-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.2-beta
   {
     from: `8781702c1b45bd2d5d437c0a138dd62b57b9b284`,
     to: `8781702c1b45bd2d5d437c0a138dd62b57b9b284`,
     onto: `d6e7eb6cf08a1cc8fb6d9888f74b0e694cc2a7b0`,
     range: `>=5.2.0-beta <5.2.1-rc`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.2
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.2
   {
     from: `8c288a316928c9c161215fdf91ef015caa610d5b`,
     to: `8c288a316928c9c161215fdf91ef015caa610d5b`,
     onto: `6074b9d12b70757fe68ab2b4da059ea363c4df04`,
     range: `>=5.2.1-rc <5.3.0-beta`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.3-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.3-beta
   {
     from: `2b564c684dc5338c59c31f4658b737912ad46336`,
     to: `2b564c684dc5338c59c31f4658b737912ad46336`,
     onto: `c5de6b57b7f09a6d17eb4a5dab91ecf8f5b25f29`,
     range: `>=5.3.0-beta <5.3.1-rc`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.3
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.3
   {
     from: `9fb5c1cac14376fe615dfd48ddbe4e97c2e6ac90`,
     to: `9fb5c1cac14376fe615dfd48ddbe4e97c2e6ac90`,
     onto: `88f80c75e1a4ab6aaec605aa4ec6281b87871ff0`,
     range: `>=5.3.1-rc <5.4.0-beta`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.4-beta
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.4-beta
   {
     from: `9420c380b6f1f072ff66372cbf776fafd6eeed1c`,
     to: `9420c380b6f1f072ff66372cbf776fafd6eeed1c`,
     onto: `e80675868dff622d0870939e7c9930c68904e7e7`,
     range: `>=5.4.0-beta <5.4.1-rc`,
   },
-  // https://github.com/merceyz/TypeScript/tree/merceyz/pnp-5.4-rc
+  // https://github.com/yarnpkg/TypeScript/tree/merceyz/pnp-5.4-rc
   {
     from: `786e26825dad9dcc0eff79610bffd8bb121e7e8a`,
     to: `786e26825dad9dcc0eff79610bffd8bb121e7e8a`,
@@ -374,11 +374,8 @@ async function fetchVersions(range) {
 }
 
 async function cloneRepository() {
-  if (!fs.existsSync(TS_REPO)) {
-    await execFile(`git`, [`clone`, `https://github.com/arcanis/typescript`, TS_REPO]);
-    await execFile(`git`, [`remote`, `add`, `upstream`, `https://github.com/microsoft/typescript`], TS_REPO_SPAWN);
-    await execFile(`git`, [`remote`, `add`, `upstream2`, `https://github.com/merceyz/typescript`], TS_REPO_SPAWN);
-  }
+  if (!fs.existsSync(TS_REPO))
+    await execFile(`git`, [`clone`, `--filter=tree:0`, `https://github.com/yarnpkg/TypeScript`, TS_REPO]);
 
   try {
     await execFile(`git`, [`cherry-pick`, `--abort`], TS_REPO_SPAWN);
@@ -388,8 +385,6 @@ async function cloneRepository() {
   await execFile(`git`, [`config`, `user.name`, `Your Name`], TS_REPO_SPAWN);
 
   await execFile(`git`, [`fetch`, `origin`], TS_REPO_SPAWN);
-  await execFile(`git`, [`fetch`, `upstream`], TS_REPO_SPAWN);
-  await execFile(`git`, [`fetch`, `upstream2`], TS_REPO_SPAWN);
 }
 
 async function resetGit(hash) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

Building the latest TypeScript patch requires fetching https://github.com/arcanis/typescript, https://github.com/microsoft/typescript, and https://github.com/merceyz/typescript which, according to git, requires fetching 1.87 GiB, 452 MiB, and 42 MiB of data and produces a 2.7GB `.git` folder.

**How did you fix it?**

Fork TypeScript to https://github.com/yarnpkg/TypeScript and push the branches required to build all the patches to it and change the script to use a treeless clone of it which only needs to fetch 55 MiB of data and produces a 74MB `.git` folder.

Depends on 
- https://github.com/yarnpkg/berry/pull/6186

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.