### PR TITLE
Adds a note that yarn install doesn't generate a node_modules folder

### DIFF
--- a/packages/docusaurus/docs/getting-started/basics/usage.mdx
+++ b/packages/docusaurus/docs/getting-started/basics/usage.mdx
@@ -9,6 +9,11 @@ sidebar_position: 4
 If you're coming from npm, the main changes are:
 
 - Running `yarn` is enough to run an install! It's an alias to `yarn install`.
+
+:::note
+By default `yarn install` uses the [Plug'n'Play](/features/pnp) install strategy, which doesn't generate a `node_modules` folder. This can be changed using the `nodeLinker` configuration setting.
+:::
+
 - Adding or updating a dependency to a single package is done with `yarn add`.
 - Upgrading a dependency across the whole project is done with `yarn up`.
 - Your scripts are aliased. Calling `yarn build` is the same as `yarn run build`!


### PR DESCRIPTION
Fix #6198
