### PR TITLE
Use title for issue sesctions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -16,23 +16,23 @@ assignees: ''
 - [ ] I'd be willing to implement this feature ([contributing guide](https://yarnpkg.com/advanced/contributing))
 - [ ] This feature is important to have in this repository; a contrib plugin wouldn't do
 
-**Describe the user story**
+## Describe the user story
 
 A clear and concise description of what workflow is meant to be improved.
 Example: "As a developer, I often want to do <something>, but I often face <problem>".
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 
 A clear and concise description of what you want to happen. Consider that Yarn is used
 by many people, and your particular use case might not make sense to implement in the core.
 
-**Describe the drawbacks of your solution**
+## Describe the drawbacks of your solution
 
 This section is important not only to identify future issues, but also for us to see whether
 you thought through your request. When filling it, ask yourself what are the problems we could
 have maintaining what you propose. How often will it break?
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 
 A clear and concise description of any alternative solutions or features you've considered,
 and why you think they wouldn't be good enough. Start by: why not make it a plugin?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,18 @@
-**What's the problem this PR addresses?**
+## What's the problem this PR addresses?
+
 <!-- Describe the rationale of your PR. -->
 <!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
 
 ...
 
-**How did you fix it?**
+## How did you fix it?
+
 <!-- A detailed description of your implementation. -->
 
 ...
 
-**Checklist**
+## Checklist
+
 <!--- Don't worry if you miss something, chores are automatically tested. -->
 <!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
 <!--- Put an `x` in all the boxes that apply. -->


### PR DESCRIPTION
In markdown, syntax have meaning. Those shouldn't be bold text, but titles:
- semantically it suggests something different
- `**text**` are easy to be removed as they could be interpreted as placeholders
- having titles allows deep linking