### PR TITLE
Update links for yarn explain to Docosaurus versions

### DIFF
--- a/.yarn/versions/78375b7e.yml
+++ b/.yarn/versions/78375b7e.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
     "chalk": "^3.0.0",
     "micromatch": "^4.0.2",
     "semver": "^7.1.2"
-  }
+  },
+  "packageManager": "yarn@4.2.1+sha256.15ce76682a8cd2090257b883cd69c637925b29573f9573e8403ec227d5ab6815"
 }

--- a/packages/plugin-essentials/sources/commands/explain.ts
+++ b/packages/plugin-essentials/sources/commands/explain.ts
@@ -16,7 +16,7 @@ export async function getErrorCodeDetails(configuration: Configuration) {
     ? YarnVersion
     : await resolveTag(configuration, `canary`);
 
-  const errorCodesUrl = `https://repo.yarnpkg.com/${version}/packages/gatsby/content/advanced/error-codes.md`;
+  const errorCodesUrl = `https://repo.yarnpkg.com/${version}/packages/docusaurus/docs/advanced/01-general-reference/error-codes.mdx`;
   const raw: Buffer = await httpUtils.get(errorCodesUrl, {configuration});
 
   return new Map<string, string>(Array.from(raw.toString().matchAll(ERROR_CODE_DOC_REGEXP), ({groups}) => {
@@ -88,7 +88,7 @@ export default class ExplainCommand extends BaseCommand {
         : `This error code does not have a description.\n\nYou can help us by editing this page on GitHub 🙂:\n${
           formatUtils.jsonOrPretty(this.json, configuration, formatUtils.tuple(
             formatUtils.Type.URL,
-            `https://github.com/yarnpkg/berry/blob/master/packages/gatsby/content/advanced/error-codes.md`,
+            `https://github.com/yarnpkg/berry/blob/master/packages/docusaurus/docs/advanced/01-general-reference/error-codes.mdx`,
           ))
         }\n`;
 


### PR DESCRIPTION
## What's the problem this PR addresses?

This updates the URLs for the `yarn explain` command to make it work after the move from Gatsby to Docusaurus.

Resolves #6249.

## How did you fix it?

- Change the version-tagged link (`repo.yarnpkg.com`) to what @arcanis says will be published after the next release
- Change the Github link for hint about how to help updating documentation


## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
