### PR TITLE
Fix parser stringify subshell brackets

### DIFF
--- a/.yarn/versions/d497ae00.yml
+++ b/.yarn/versions/d497ae00.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/parsers": patch
+  "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-parsers/sources/shell.ts
+++ b/packages/yarnpkg-parsers/sources/shell.ts
@@ -138,7 +138,7 @@ export function stringifyArgumentSegment(argumentSegment: ArgumentSegment): stri
       return argumentSegment.pattern;
 
     case `shell`:
-      return doubleQuoteIfRequested(`\${${stringifyShellLine(argumentSegment.shell)}}`, argumentSegment.quoted);
+      return doubleQuoteIfRequested(`$(${stringifyShellLine(argumentSegment.shell)})`, argumentSegment.quoted);
 
     case `variable`:
       return doubleQuoteIfRequested(

--- a/packages/yarnpkg-parsers/tests/shell.test.ts
+++ b/packages/yarnpkg-parsers/tests/shell.test.ts
@@ -186,6 +186,7 @@ const STRINGIFIER_TESTS: Array<[string, string]> = [
   [`echo foo > bar`, `echo foo > bar`],
   [`echo a$B"c"'d'`, `echo a\${B}cd`],
   [`echo a$B"c"'d'`, `echo a\${B}cd`],
+  [`echo $(echo a)`, `echo $(echo a)`],
   [`echo $(( 1 + 2 * 3 - 4 / 5 ))`, `echo $(( ( 1 + ( 2 * 3 ) ) - ( 4 / 5 ) ))`],
   [`echo $(( 7 - 2 - 3 * 5 / 6 ))`, `echo $(( ( 7 - 2 ) - ( ( 3 * 5 ) / 6 ) ))`],
   [`(echo foo && echo bar)`, `(echo foo && echo bar)`],


### PR DESCRIPTION
## What's the problem this PR addresses?

With `@yarnpkg/parsers`, stringifying a subshell (e.g. `echo $(echo a)`) uses the wrong brackets (e.g. `echo ${echo a}`)

## How did you fix it?

Change to use the correct brackets.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
