### PR TITLE
fix(sdks): only patch typescript entry point for >= 5.5

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -222,7 +222,7 @@ const moduleWrapper = tsserver => {
 };
 
 const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
-if (major >= 5 && minor >= 5) {
+if (major > 5 || (major === 5 && minor >= 5)) {
   moduleWrapper(absRequire(`typescript`));
 }
 

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -222,6 +222,8 @@ const moduleWrapper = tsserver => {
 };
 
 const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
+// In TypeScript@>=5.5 the tsserver uses the public TypeScript API so that needs to be patched as well.
+// Ref https://github.com/microsoft/TypeScript/pull/55326
 if (major > 5 || (major === 5 && minor >= 5)) {
   moduleWrapper(absRequire(`typescript`));
 }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -221,7 +221,10 @@ const moduleWrapper = tsserver => {
   return tsserver;
 };
 
-moduleWrapper(absRequire(`typescript`));
+const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
+if (major >= 5 && minor >= 5) {
+  moduleWrapper(absRequire(`typescript`));
+}
 
 // Defer to the real typescript/lib/tsserver.js your application uses
 module.exports = moduleWrapper(absRequire(`typescript/lib/tsserver.js`));

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -222,7 +222,7 @@ const moduleWrapper = tsserver => {
 };
 
 const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
-if (major >= 5 && minor >= 5) {
+if (major > 5 || (major === 5 && minor >= 5)) {
   moduleWrapper(absRequire(`typescript`));
 }
 

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -222,6 +222,8 @@ const moduleWrapper = tsserver => {
 };
 
 const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
+// In TypeScript@>=5.5 the tsserver uses the public TypeScript API so that needs to be patched as well.
+// Ref https://github.com/microsoft/TypeScript/pull/55326
 if (major > 5 || (major === 5 && minor >= 5)) {
   moduleWrapper(absRequire(`typescript`));
 }

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -221,7 +221,10 @@ const moduleWrapper = tsserver => {
   return tsserver;
 };
 
-moduleWrapper(absRequire(`typescript`));
+const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
+if (major >= 5 && minor >= 5) {
+  moduleWrapper(absRequire(`typescript`));
+}
 
 // Defer to the real typescript/lib/tsserverlibrary.js your application uses
 module.exports = moduleWrapper(absRequire(`typescript/lib/tsserverlibrary.js`));

--- a/.yarn/versions/f094b4b7.yml
+++ b/.yarn/versions/f094b4b7.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -251,6 +251,8 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
     };
 
     const [major, minor] = absRequire(\`typescript/package.json\`).version.split(\`.\`, 2).map(value => parseInt(value, 10));
+    // In TypeScript@>=5.5 the tsserver uses the public TypeScript API so that needs to be patched as well.
+    // Ref https://github.com/microsoft/TypeScript/pull/55326
     if (major > 5 || (major === 5 && minor >= 5)) {
       moduleWrapper(absRequire(\`typescript\`));
     }

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -251,7 +251,7 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
     };
 
     const [major, minor] = absRequire(\`typescript/package.json\`).version.split(\`.\`, 2).map(value => parseInt(value, 10));
-    if (major >= 5 && minor >= 5) {
+    if (major > 5 || (major === 5 && minor >= 5)) {
       moduleWrapper(absRequire(\`typescript\`));
     }
   `;

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -250,7 +250,10 @@ export const generateTypescriptBaseWrapper: GenerateBaseWrapper = async (pnpApi:
       return tsserver;
     };
 
-    moduleWrapper(absRequire(\`typescript\`));
+    const [major, minor] = absRequire(\`typescript/package.json\`).version.split(\`.\`, 2).map(value => parseInt(value, 10));
+    if (major >= 5 && minor >= 5) {
+      moduleWrapper(absRequire(\`typescript\`));
+    }
   `;
 
   const wrapper = new Wrapper(`typescript` as PortablePath, {pnpApi, target});


### PR DESCRIPTION
**What's the problem this PR addresses?**

The SDK changes in https://github.com/yarnpkg/berry/pull/6248 broke support for older TypeScript versions.
I tested it on `5.4.1-rc` (master) and it was fine but it crashes on 5.2.0-beta (https://github.com/yarnpkg/berry/blob/4308dca8091438e8f88682e59ef5ba5bc72241ca/package.json#L26)

**How did you fix it?**

Check the TypeScript version and only apply the patch if needed.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.