### PR TITLE
chore: Update GitHub actions versions

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -16,7 +16,7 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     #region Build the standard bundle
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache-build
       with:
         path: packages/yarnpkg-cli/bundles/yarn.js
@@ -35,7 +35,7 @@ runs:
       run: echo "globalFolder=$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js config get globalFolder)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ${{ steps.global-path.outputs.globalFolder }}/cache

--- a/.github/workflows/benchmark-workflow.yml
+++ b/.github/workflows/benchmark-workflow.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
       with:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup upterm session
       uses: lhotari/action-upterm@d23c2722bdab893785c9fbeae314cbf080645bd7
       with:

--- a/.github/workflows/e2e-cra-workflow.yml
+++ b/.github/workflows/e2e-cra-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-create-vue-workflow.yml
+++ b/.github/workflows/e2e-create-vue-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-esbuild-workflow.yml
+++ b/.github/workflows/e2e-esbuild-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-eslint-workflow.yml
+++ b/.github/workflows/e2e-eslint-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-fsevents-workflow.yml
+++ b/.github/workflows/e2e-fsevents-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-gatsby-workflow.yml
+++ b/.github/workflows/e2e-gatsby-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-gulp-workflow.yml
+++ b/.github/workflows/e2e-gulp-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-husky-workflow.yml
+++ b/.github/workflows/e2e-husky-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-jest-workflow.yml
+++ b/.github/workflows/e2e-jest-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-mocha-workflow.yml
+++ b/.github/workflows/e2e-mocha-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nm-angular-workflow.yml
+++ b/.github/workflows/e2e-nm-angular-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Enable git longpaths
       run: git config --global core.longpaths true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Enable git longpaths
       run: git config --global core.longpaths true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nyc-workflow.yml
+++ b/.github/workflows/e2e-nyc-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-pnp-angular-workflow.yml
+++ b/.github/workflows/e2e-pnp-angular-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
       with:

--- a/.github/workflows/e2e-prettier-workflow.yml
+++ b/.github/workflows/e2e-prettier-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-rollup-workflow.yml
+++ b/.github/workflows/e2e-rollup-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-svelte-kit-workflow.yml
+++ b/.github/workflows/e2e-svelte-kit-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-typescript-workflow.yml
+++ b/.github/workflows/e2e-typescript-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-vite-workflow.yml
+++ b/.github/workflows/e2e-vite-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-vitest-workflow.yml
+++ b/.github/workflows/e2e-vitest-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-webpack-workflow.yml
+++ b/.github/workflows/e2e-webpack-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         git fetch --no-tags --unshallow origin HEAD master
 
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4
@@ -182,7 +182,7 @@ jobs:
         node ./scripts/run-yarn.js build:cli --no-minify
       shell: bash
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: yarn-artifacts
         path: |
@@ -196,7 +196,7 @@ jobs:
       if: |
         success() || failure()
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: vscode-zipfs
         path: ./packages/vscode-zipfs/vscode-zipfs-*.vsix
@@ -234,14 +234,14 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: 'Use Node.js ${{matrix.node}}.x'
       uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.node}}.x
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: yarn-artifacts
         path: packages
@@ -271,9 +271,9 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: yarn-artifacts
         path: packages

--- a/.github/workflows/plugin-compat-workflow.yml
+++ b/.github/workflows/plugin-compat-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/pr-smart-merge.yml
+++ b/.github/workflows/pr-smart-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.sha}}
         fetch-depth: 0
@@ -81,7 +81,7 @@ jobs:
         git diff > merge-conflict-resolution.patch
 
     - name: Store the merge conflict resolution
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: merge-conflict-resolution
         path: merge-conflict-resolution.patch
@@ -92,13 +92,13 @@ jobs:
     needs: generate
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha}}
           fetch-depth: 0
 
       - name: Retrieve the merge conflict resolution
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: merge-conflict-resolution
 

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_OPTIONS: --max_old_space_size=8192
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{github.event.inputs.branch}}
         token: ${{secrets.YARNBOT_TOKEN}}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_OPTIONS: --max_old_space_size=8192
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: master
         token: ${{secrets.YARNBOT_TOKEN}}

--- a/.github/workflows/sherlock-workflow.yml
+++ b/.github/workflows/sherlock-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: 'Use Node.js ${{ env.node-version }}'
       uses: actions/setup-node@v4


### PR DESCRIPTION
Saw a bunch of warnings while checking a log, apparently these versions use node 16 which is deprecated, and the v3 of upload-artifact and download-artifact will stop working in November.