### PR TITLE
Info about `init -2` added

### DIFF
--- a/packages/docusaurus/docs/getting-started/basics/install.mdx
+++ b/packages/docusaurus/docs/getting-started/basics/install.mdx
@@ -21,6 +21,7 @@ The preferred way to manage Yarn is by-project and through [Corepack](/corepack)
 ```
 yarn init -2
 ```
+The `-2` ensures that the modern version of the yarn is used, otherwise the old yarn version 1 might be used for backward compatibility. 
 
 ## Updating Yarn
 


### PR DESCRIPTION
A question about the still undocumented parameter `-2`  was asked 

 - here https://github.com/yarnpkg/berry/issues/4957 and
 - and here https://github.com/yarnpkg/berry/issues/4507

## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->

Adds information about the still undocumented parameter `-2` for `yarn init -2` from the [getting started - install](https://yarnpkg.com/getting-started/install) guide. 

<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
It adresses this https://github.com/yarnpkg/berry/issues/4507
...

## How did you fix it?

<!-- A detailed description of your implementation. -->
Reading the comments in the issues linked above. 

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
