### PR TITLE
Update init.ts add infor about `-2` option

### DIFF
--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -21,6 +21,8 @@ export default class InitCommand extends BaseCommand {
 
       If the \`-i,--install\` option is given a value, Yarn will first download it using \`yarn set version\` and only then forward the init call to the newly downloaded bundle. Without arguments, the downloaded bundle will be \`latest\`.
 
+      If the  \`-2\` is used Yarn will automatically setup a Yarn Modern project, setting its packageManager field as required.
+
       The initial settings of the manifest can be changed by using the \`initScope\` and \`initFields\` configuration values. Additionally, Yarn will generate an EditorConfig file whose rules can be altered via \`initEditorConfig\`, and will initialize a Git repository in the current directory.
     `,
     examples: [[


### PR DESCRIPTION
A question about the still undocumented option `-2` was asked 

 - here https://github.com/yarnpkg/berry/issues/4957 and
 - and here https://github.com/yarnpkg/berry/issues/4507

## What's the problem this PR addresses?

Adds information about the `-2` option. 

<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

 - https://github.com/yarnpkg/berry/issues/4957 
 - https://github.com/yarnpkg/berry/issues/4507
...

## How did you fix it?

<!-- A detailed description of your implementation. -->

Information from other issue comments and a blog post about [3.1 release](https://github.com/yarnpkg/berry/blob/3415a677051b56e67f8bf2aee0753bf1ea9aa890/packages/docusaurus/blog/2021-09-25-release-3.1.mdx#L38)
...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
