### PR TITLE
Adds TEST_BINARY

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -27,9 +27,8 @@ const mte = generatePkgDriver({
       ? [projectFolder]
       : [];
 
-    const yarnBinary = process.env.TEST_FROM_SOURCES
-      ? require.resolve(`${__dirname}/../../../../../scripts/run-yarn.js`)
-      : require.resolve(`${__dirname}/../../../../yarnpkg-cli/bundles/yarn.js`);
+    const yarnBinary = process.env.TEST_BINARY
+      ?? require.resolve(`${__dirname}/../../../../yarnpkg-cli/bundles/yarn.js`);
 
     const res = await execFile(process.execPath, [...execArgv, yarnBinary, ...cwdArgs, command, ...args], {
       cwd: cwd || path,


### PR DESCRIPTION
## What's the problem this PR addresses?

I want to run the tests on an alternate Yarn build.

## How did you fix it?

Replaces the TEST_FROM_SOURCES environment variable by a more flexible TEST_BINARY which lets us select any binary on disk to run the tests.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
