### PR TITLE
Remove "sherlock" from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,17 +26,6 @@ body:
       label: To reproduce
       description: |
         The _minimal_ information needed to reproduce your issue (ideally a package.json with a single dep). Note that bugs without minimal reproductions **will** be closed as non-actionable.
-
-        **IMPORTANT**: We **strongly** prefer reproductions that use Sherlock. Please check our documentation for more information: https://yarnpkg.com/advanced/sherlock
-      placeholder: |
-        ```js repro
-        // Sherlock reproduction. For instance:
-        await packageJsonAndInstall({
-          dependencies: {
-            [`packageName`]: `x.y.z`,
-          },
-        });
-        ```
     validations:
         required: true
 


### PR DESCRIPTION
The linked documentation doesn't exist anymore.
The associated website for the tool [1] shows some useful information, but (IMHO) it's unclear to see how to apply it in a fresh repo.

Additionally, `arcanis` mentioned in a comment here [2] that perhaps it should be removed since it's not often used and the playground is broken.

Fixes #5837
Fixes #5950

[1] https://github.com/arcanis/sherlock
[2] https://github.com/yarnpkg/berry/pull/6139#issuecomment-1977286294


## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
