### PR TITLE
docs: add `yarn-plugin-cyclonedx` to contrib plugins list

### DIFF
--- a/packages/gatsby/content/features/plugins.md
+++ b/packages/gatsby/content/features/plugins.md
@@ -117,4 +117,6 @@ This is just a centralized list of third-party plugins to make discovery easier.
 
 - [**yarn-plugin-env-vars**](https://github.com/scinos/yarn-plugin-env-vars) by [**Sergio Cinos**](https://github.com/scinos) - A Yarn plugin that ensures your environment variables are set before running any npm scripts. 
 
+- [**yarn-plugin-cyclonedx**](https://github.com/CycloneDX/cyclonedx-node-yarn) by [**OWASP CycloneDX**](https://github.com/CycloneDX) - Create CycloneDX Software Bill of Materials (SBOM) from Yarn projects.
+
 If you wrote a plugin yourself, feel free to [open a PR](https://github.com/yarnpkg/berry/edit/master/packages/gatsby/content/features/plugins.md) to add it at the end of this list!


### PR DESCRIPTION
## What's the problem this PR addresses?

Plugin `yarn-plugin-cyclonedx` is missing on the list of contributed plugins

...

## How did you fix it?

Added `yarn-plugin-cyclonedx` contribution to the list of plugins.

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
