### PR TITLE
Update links for yarn explain to Docosaurus versions

### DIFF
--- a/.yarn/versions/39208ab7.yml
+++ b/.yarn/versions/39208ab7.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/explain.ts
+++ b/packages/plugin-essentials/sources/commands/explain.ts
@@ -16,7 +16,7 @@ export async function getErrorCodeDetails(configuration: Configuration) {
     ? YarnVersion
     : await resolveTag(configuration, `canary`);
 
-  const errorCodesUrl = `https://repo.yarnpkg.com/${version}/packages/gatsby/content/advanced/error-codes.md`;
+  const errorCodesUrl = `https://repo.yarnpkg.com/${version}/packages/docusaurus/docs/advanced/01-general-reference/error-codes.mdx`;
   const raw: Buffer = await httpUtils.get(errorCodesUrl, {configuration});
 
   return new Map<string, string>(Array.from(raw.toString().matchAll(ERROR_CODE_DOC_REGEXP), ({groups}) => {
@@ -88,7 +88,7 @@ export default class ExplainCommand extends BaseCommand {
         : `This error code does not have a description.\n\nYou can help us by editing this page on GitHub 🙂:\n${
           formatUtils.jsonOrPretty(this.json, configuration, formatUtils.tuple(
             formatUtils.Type.URL,
-            `https://github.com/yarnpkg/berry/blob/master/packages/gatsby/content/advanced/error-codes.md`,
+            `https://github.com/yarnpkg/berry/blob/master/packages/docusaurus/docs/advanced/01-general-reference/error-codes.mdx`,
           ))
         }\n`;
 


### PR DESCRIPTION
## What's the problem this PR addresses?

This updates the URLs for the `yarn explain` command to make it work after the move from Gatsby to Docusaurus.

Resolves #6249.

## How did you fix it?

- Change the version-tagged link (`repo.yarnpkg.com`) to what @arcanis says will be published after the next release
- Change the Github link for hint about how to help updating documentation
