### PR TITLE
test: disable custom certificate tests on Windows

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/check.test.ts
@@ -5,7 +5,8 @@ import {createMockPlugin, mockPluginServer} from '../../features/plugins.utility
 
 describe(`Commands`, () => {
   describe(`plugin check`, () => {
-    test(
+    // FIXME: Fails with `RequestError: unsuitable certificate purpose` on win32
+    (process.platform === `win32` ? test.skip : test)(
       `it should run successfully and do nothing`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await mockPluginServer(async mockServer => {
@@ -26,7 +27,8 @@ describe(`Commands`, () => {
       }),
     );
 
-    test(
+    // FIXME: Fails with `RequestError: unsuitable certificate purpose` on win32
+    (process.platform === `win32` ? test.skip : test)(
       `it should print out the plugin when it has a different checksum`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await mockPluginServer(async mockServer => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/plugin/import.test.ts
@@ -29,7 +29,8 @@ describe(`Commands`, () => {
       }),
     );
 
-    test(
+    // FIXME: Fails with `RequestError: unsuitable certificate purpose` on win32
+    (process.platform === `win32` ? test.skip : test)(
       `it should update plugin's checksum, if it's different`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await mockPluginServer(async mockServer => {
@@ -60,7 +61,8 @@ describe(`Commands`, () => {
       }),
     );
 
-    test(
+    // FIXME: Fails with `RequestError: unsuitable certificate purpose` on win32
+    (process.platform === `win32` ? test.skip : test)(
       `it should clear the plugin's checksum, if it using \`--no-checksum\` option`,
       makeTemporaryEnv({}, async ({path, run, source}) => {
         await mockPluginServer(async mockServer => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/plugins.test.ts
@@ -156,7 +156,8 @@ describe(`Features`, () => {
       expect(configuration.get(`baz`)).toBe(true);
     }));
 
-    test(`it should fetch missing plugins`, makeTemporaryEnv(
+    // FIXME: Fails with `RequestError: unsuitable certificate purpose` on win32
+    (process.platform === `win32` ? test.skip : test)(`it should fetch missing plugins`, makeTemporaryEnv(
       {},
       async ({path, run, source}) => {
         await mockPluginServer(async mockServer => {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/https.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/https.test.js
@@ -3,7 +3,8 @@ const {
   tests: {startPackageServer, getHttpsCertificates, validLogins},
 } = require(`pkg-tests-core`);
 
-describe(`Https tests`, () => {
+// FIXME: Fails with `RequestError: unsuitable certificate purpose` on win32
+(process.platform === `win32` ? describe.skip : describe)(`Https tests`, () => {
   test(
     `it should fail to install if server uses non trusted certificate`,
     makeTemporaryEnv(


### PR DESCRIPTION
**What's the problem this PR addresses?**

The tests using custom certificates have been failing on the WIndows CI for months and I can't reproduce it locally to debug it.

**How did you fix it?**

Disable the tests on WIndows.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.