### PR TITLE
ci(e2e): fix SvelteKit test

### DIFF
--- a/.github/workflows/e2e-svelte-kit-workflow.yml
+++ b/.github/workflows/e2e-svelte-kit-workflow.yml
@@ -24,6 +24,6 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        yes | yarn create svelte@next my-app && cd my-app
+        yes | yarn create svelte my-app && cd my-app
         yarn
         yarn build


### PR DESCRIPTION
**What's the problem this PR addresses?**

`create-svelte` no longer has a `next` tag.

**How did you fix it?**

Stop specifying the tag.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.