### PR TITLE
Fix incorrect `node:…` module warnings in doctor

### DIFF
--- a/.yarn/versions/a4f6973d.yml
+++ b/.yarn/versions/a4f6973d.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/doctor": patch

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -6,16 +6,10 @@ import {PortablePath, npath, ppath, xfs}                                        
 import {Cli, Command, Builtins, Option}                                                                                                                                                     from 'clipanion';
 import globby                                                                                                                                                                               from 'globby';
 import micromatch                                                                                                                                                                           from 'micromatch';
-import {Module}                                                                                                                                                                             from 'module';
+import {isBuiltin}                                                                                                                                                                          from 'module';
 import * as ts                                                                                                                                                                              from 'typescript';
 
 import * as ast                                                                                                                                                                             from './ast';
-
-const BUILTINS = new Set([
-  ...(Module.builtinModules || []),
-  ...(Module.builtinModules || []).map(mod => `node:${mod}`),
-  `pnpapi`,
-]);
 
 function probablyMinified(content: string) {
   if (content.length > 1024 * 1024)
@@ -84,7 +78,7 @@ function isValidDependency(ident: Ident, {workspace}: {workspace: Workspace}) {
 }
 
 function checkForUndeclaredDependency(workspace: Workspace, referenceNode: ts.Node, moduleName: string, {configuration, report}: {configuration: Configuration, report: Report}) {
-  if (BUILTINS.has(moduleName))
+  if (isBuiltin(moduleName) || moduleName === `pnpapi`)
     return;
 
   const idents = extractIdents(moduleName);


### PR DESCRIPTION
This swaps to use `isBuiltin` from Node rather than constructing a custom set of module names with `node:` prefix. For some modules that didn't have a "bare" module (e.g. `node:test`) this fixes false positive errors.

## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Closes #6343

## How did you fix it?

<!-- A detailed description of your implementation. -->

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
