### PR TITLE
feat: allow modules prefixed with `node:`

### DIFF
--- a/.yarn/versions/e86d9554.yml
+++ b/.yarn/versions/e86d9554.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1261,8 +1261,11 @@ export class Configuration {
     const thirdPartyPlugins = new Map<string, Plugin>([]);
     if (pluginConfiguration !== null) {
       const requireEntries = new Map();
-      for (const request of builtinModules)
-        requireEntries.set(request, () => miscUtils.dynamicRequire(request));
+      for (const request of builtinModules) {
+        const dr = () => miscUtils.dynamicRequire(request);
+        requireEntries.set(request, dr);
+        requireEntries.set(`node:${request}`, dr);
+      }
       for (const [request, embedModule] of pluginConfiguration.modules)
         requireEntries.set(request, () => embedModule);
 


### PR DESCRIPTION
## What's the problem this PR addresses?



<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

in nodejs, it is allowed to import builtins by prefixing them with `node:`.
This PR enables this for yarn plugins.

fixes #5417

## How did you fix it?

Currently, all builtin modules are added to an import map.
I've added all these same modules to the import map a second time, but all with the prefix `node:`.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
