### PR TITLE
Adds a guard against WebGL errors

### DIFF
--- a/packages/docusaurus/src/components/StarrySky.tsx
+++ b/packages/docusaurus/src/components/StarrySky.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useRef} from 'react';
-import * as THREE                 from 'three';
+import React, {useEffect, useRef, useState} from 'react';
+import * as THREE                           from 'three';
 
-import styles                     from './StarrySky.module.css';
+import styles                               from './StarrySky.module.css';
 
 const r = 1000;
 const FACTOR = 4;

--- a/packages/docusaurus/src/components/StarrySky.tsx
+++ b/packages/docusaurus/src/components/StarrySky.tsx
@@ -143,10 +143,18 @@ function installSky(canvas: HTMLCanvasElement) {
 
 export function StarrySky() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isCrashed, setIsCrashed] = useState(false);
 
   useEffect(() => {
-    return installSky(canvasRef.current!);
+    try {
+      installSky(canvasRef.current!);
+    } catch {
+      setIsCrashed(true);
+    }
   }, []);
+
+  if (isCrashed)
+    return null;
 
   return (
     <canvas className={styles.canvas} ref={canvasRef}/>


### PR DESCRIPTION
## What's the problem this PR addresses?

When the starry sky crashes, we accidentally report an error on the homepage.

Fixes #6365

## How did you fix it?

Adds a guard against errors occurring during the WebGL initialization.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
