### PR TITLE
3.x fix import fallback

### DIFF
--- a/packages/yarnpkg-cli/sources/main.ts
+++ b/packages/yarnpkg-cli/sources/main.ts
@@ -22,25 +22,14 @@ function runBinary(path: PortablePath) {
     // innermost process, whose end will cause our own to exit.
   });
 
-  if (physicalPath) {
-    execFileSync(process.execPath, [physicalPath, ...process.argv.slice(2)], {
-      stdio: `inherit`,
-      env: {
-        ...process.env,
-        YARN_IGNORE_PATH: `1`,
-        YARN_IGNORE_CWD: `1`,
-      },
-    });
-  } else {
-    execFileSync(process.execPath, process.argv.slice(2), {
-      stdio: `inherit`,
-      env: {
-        ...process.env,
-        YARN_IGNORE_PATH: `1`,
-        YARN_IGNORE_CWD: `1`,
-      },
-    });
-  }
+  execFileSync(process.execPath, [physicalPath, ...process.argv.slice(2)], {
+    stdio: `inherit`,
+    env: {
+      ...process.env,
+      YARN_IGNORE_PATH: `1`,
+      YARN_IGNORE_CWD: `1`,
+    },
+  });
 }
 
 export async function main({binaryVersion, pluginConfiguration}: {binaryVersion: string, pluginConfiguration: PluginConfiguration}) {


### PR DESCRIPTION
- **fix*yarnpkg-cli): properly handle missing physicalPath in runBinary**

https://github.com/yarnpkg/berry/pull/33/files#diff-0b87a3e94c60d5153e56080500921e63b9ce72910785f15fb9ff6d4a389126d9R27

Should the first argument here have been `process.execPath`? It seems odd to call `physicalPath` directly only if falsey?
