### PR TITLE
docs: Add Zed to the list of supported IDEs

### DIFF
--- a/packages/docusaurus/docs/getting-started/extra/editor-sdks.mdx
+++ b/packages/docusaurus/docs/getting-started/extra/editor-sdks.mdx
@@ -113,3 +113,12 @@ yarn dlx @yarnpkg/sdks vscode
     3. Pick "Use Workspace Version"
 
 Your VSCode project is now configured to use the exact same version of TypeScript as the one you usually use, except that it will be able to properly resolve the type definitions.
+
+### Zed
+
+1. Run the following command, which will generate a new directory called `.yarn/sdks`:
+
+```bash
+yarn dlx @yarnpkg/sdks
+```
+2. Set Typescript path for your language server of choice to `.yarn/sdks/typescript/lib`. The actual setting for that depends on the language server that's being used.


### PR DESCRIPTION
## What's the problem this PR addresses?

We've added support for Yarn projects in https://github.com/zed-industries/zed/pull/13644

## How did you fix it?

By writing up a short doc that states which sdk should be used with Zed.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
