### PR TITLE
refactor(cli): simplify empty event loop handling

### DIFF
--- a/.yarn/versions/3829ec64.yml
+++ b/.yarn/versions/3829ec64.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -920,8 +920,8 @@ module.exports = {
         });
 
         await expect(run(`install`)).rejects.toMatchObject({
-          code: 42,
-          stdout: expect.stringContaining(`Yarn is terminating due to an unexpected empty event loop`),
+          code: 1,
+          stderr: expect.stringContaining(`Yarn is terminating due to an unexpected empty event loop`),
         });
       }),
     );

--- a/packages/yarnpkg-cli/sources/lib.ts
+++ b/packages/yarnpkg-cli/sources/lib.ts
@@ -187,17 +187,12 @@ export async function runExit(argv: Array<string>, {cwd = ppath.cwd(), selfPath,
   const cli = getBaseCli({cwd, pluginConfiguration});
 
   function unexpectedTerminationHandler() {
-    Cli.defaultContext.stdout.write(`ERROR: Yarn is terminating due to an unexpected empty event loop.\nPlease report this issue at https://github.com/yarnpkg/berry/issues.`);
+    throw new Error(`Yarn is terminating due to an unexpected empty event loop.\nPlease report this issue at https://github.com/yarnpkg/berry/issues`);
   }
 
   process.once(`beforeExit`, unexpectedTerminationHandler);
 
   try {
-    // The exit code is set to an error code before the CLI runs so that
-    // if the event loop becomes empty and node terminates without
-    // finishing the execution of this function it counts as an error.
-    // https://github.com/yarnpkg/berry/issues/6398
-    process.exitCode = 42;
     process.exitCode = await run(cli, argv, {selfPath, pluginConfiguration});
   } catch (error) {
     Cli.defaultContext.stdout.write(cli.error(error));


### PR DESCRIPTION
**What's the problem this PR addresses?**

The error added in https://github.com/yarnpkg/berry/pull/6399 should have used `throw new Error()` so that Node.js can handle the printing and provide a stack trace.

**How did you fix it?**

Use `throw new Error()` instead of printing an error ourselves.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.