### PR TITLE
ci(e2e): fix docusaurus javascript test

### DIFF
--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -24,7 +24,7 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        yarn dlx create-docusaurus@latest my-website classic && cd my-website
+        yarn dlx create-docusaurus@latest my-website classic --javascript && cd my-website
         yarn build
 
     - name: 'Running the TypeScript integration test'


### PR DESCRIPTION
**What's the problem this PR addresses?**

The Docusaurus JavaScript e2e test started failing at 2024-03-29T20:01:12.000Z / https://github.com/yarnpkg/berry/actions/runs/8485023278 due to it prompting for which template to use.

**How did you fix it?**

Update the command to specify the JavaScript template.

**Checklist**
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.