### PR TITLE
fix(cli): always disable interactive mode in non-TTYs

### DIFF
--- a/.yarn/versions/34e33c5b.yml
+++ b/.yarn/versions/34e33c5b.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Yarn now accepts sponsors! Please take a look at our [OpenCollective](https://op
 Features in `master` can be tried out by running `yarn set version from sources` in your project.
 :::
 
+- Fixes `preferInteractive` forcing interactive mode in non-TTY environments.
+
 ## 4.1.0
 
 - Tweaks `-,--verbose` in `yarn workspaces foreach`; `-v` will now only print the prefixes, `-vv` will be necessary to also print the timings.

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -135,7 +135,10 @@ export default class AddCommand extends BaseCommand {
     });
 
     const fixed = this.fixed;
-    const interactive = this.interactive ?? configuration.get(`preferInteractive`);
+    const interactive = configuration.isInteractive({
+      interactive: this.interactive,
+      stdout: this.context.stdout,
+    });
     const reuse = interactive || configuration.get(`preferReuse`);
 
     const modifier = suggestUtils.getModifier(this, project);

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -162,7 +162,10 @@ export default class UpCommand extends BaseCommand {
     });
 
     const fixed = this.fixed;
-    const interactive = this.interactive ?? configuration.get(`preferInteractive`);
+    const interactive = configuration.isInteractive({
+      interactive: this.interactive,
+      stdout: this.context.stdout,
+    });
 
     const modifier = suggestUtils.getModifier(this, project);
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -8,6 +8,7 @@ import {parse as parseDotEnv}                                                   
 import {builtinModules}                                                                                          from 'module';
 import pLimit, {Limit}                                                                                           from 'p-limit';
 import {PassThrough, Writable}                                                                                   from 'stream';
+import {WriteStream}                                                                                             from 'tty';
 
 import {CorePlugin}                                                                                              from './CorePlugin';
 import {Manifest, PeerDependencyMeta}                                                                            from './Manifest';
@@ -30,7 +31,6 @@ import * as nodeUtils                                                           
 import * as semverUtils                                                                                          from './semverUtils';
 import * as structUtils                                                                                          from './structUtils';
 import {IdentHash, Package, Descriptor, PackageExtension, PackageExtensionType, PackageExtensionStatus, Locator} from './types';
-import { WriteStream } from 'tty';
 
 const isPublicRepository = (function () {
   if (!GITHUB_ACTIONS || !process.env.GITHUB_EVENT_PATH)

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -30,6 +30,7 @@ import * as nodeUtils                                                           
 import * as semverUtils                                                                                          from './semverUtils';
 import * as structUtils                                                                                          from './structUtils';
 import {IdentHash, Package, Descriptor, PackageExtension, PackageExtensionType, PackageExtensionStatus, Locator} from './types';
+import { WriteStream } from 'tty';
 
 const isPublicRepository = (function () {
   if (!GITHUB_ACTIONS || !process.env.GITHUB_EVENT_PATH)
@@ -313,6 +314,9 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     default: !isCI,
     defaultText: `<dynamic>`,
   },
+  /**
+   * @internal Prefer using `Configuration#isInteractive`.
+   */
   preferInteractive: {
     description: `If true, the CLI will automatically use the interactive mode when called from a TTY`,
     type: SettingsType.BOOLEAN,
@@ -1784,6 +1788,13 @@ export class Configuration {
       libc = miscUtils.mapAndFilter(libc, value => value === `current` ? architecture.libc ?? miscUtils.mapAndFilter.skip : value);
 
     return {os, cpu, libc};
+  }
+
+  isInteractive({interactive, stdout}: {interactive?: boolean, stdout: Writable}): boolean {
+    if (!(stdout as WriteStream).isTTY)
+      return false;
+
+    return interactive ?? this.get(`preferInteractive`);
   }
 
   private packageExtensions: PackageExtensions | null = null;


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When `preferInteractive` is set to `true`, `yarn {add,up}` are interactive even outside TTYs, which is unintended.

Can be checked by running `yarn add lodash > foo.txt` in our repository.

## How did you fix it?

<!-- A detailed description of your implementation. -->

Made it disable interactivity when `stdout` isn't a TTY (and added a new `configuration.isInteractive` helper).

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
