### PR TITLE
fix(extensions): vue-loader@<16

### DIFF
--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -516,6 +516,17 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       twing: optionalPeerDep,
     },
   }],
+  // https://github.com/yarnpkg/berry/issues/6418#event-13666137894
+  // https://github.com/vuejs/vue-loader/commit/089473af97077b8e14b3feff48d32d2733ad792c
+  [`vue-loader@<16`, {
+    peerDependencies: {
+      "@vue/compiler-sfc": `^2.7.0 || ^3.0.8`,
+      webpack: `^4.1.0 || ^5.0.0-0`,
+    },
+    peerDependenciesMeta: {
+      "@vue/compiler-sfc": optionalPeerDep,
+    },
+  }],
   // https://github.com/vuejs/vue-loader/pull/1853
   // https://github.com/vuejs/vue-loader/commit/089473af97077b8e14b3feff48d32d2733ad792c
   [`vue-loader@<=16.3.3`, {


### PR DESCRIPTION
## What's the problem this PR addresses?
https://v2.vuejs.org/v2/guide/migration-vue-2-7#Vue-CLI-webpack
`vue-loader<16` supports `@vue/compiler-sfc@2.7.0`
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Closes/Resolves #6418
...

## How did you fix it?

<!-- A detailed description of your implementation. -->
```diff
+  // https://github.com/yarnpkg/berry/issues/6418#event-13666137894
+  // https://github.com/vuejs/vue-loader/commit/089473af97077b8e14b3feff48d32d2733ad792c
+  [`vue-loader@<16`, {
+    peerDependencies: {
+      "@vue/compiler-sfc": `^2.7.0 || ^3.0.8`,
+      webpack: `^4.1.0 || ^5.0.0-0`,
+    },
+    peerDependenciesMeta: {
+      "@vue/compiler-sfc": optionalPeerDep,
+    },
+  }],
  // https://github.com/vuejs/vue-loader/pull/1853
  // https://github.com/vuejs/vue-loader/commit/089473af97077b8e14b3feff48d32d2733ad792c
  [`vue-loader@<=16.3.3`, {
    peerDependencies: {
      '@vue/compiler-sfc': `^3.0.8`,
      webpack: `^4.1.0 || ^5.0.0-0`,
    },
    peerDependenciesMeta: {
      '@vue/compiler-sfc': optionalPeerDep,
    },
  }],
```
...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
