### PR TITLE
Fix website code highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,7 +852,7 @@ To see a comprehensive documentation about each possible field, please check our
 
   - The `resolutions` field no longer support the glob syntax within its patterns, as it was redundant with its own glob-less syntax and caused unnecessary confusion.
 
-    ```diff-json
+    ```diff
     {
       "resolutions": {
     -    "**/@babel/core": "7.5.5",

--- a/packages/docusaurus/blog/2020-01-24-release-2.0.mdx
+++ b/packages/docusaurus/blog/2020-01-24-release-2.0.mdx
@@ -312,7 +312,7 @@ To give you an idea, we've built a [typescript plugin](https://github.com/yarnpk
 
 One very common piece of feedback we got regarding Yarn 1 was about our configuration pipeline. When Yarn was released we tried to be as compatible with npm as possible, which prompted us to for example try to read the npm configuration files etc. This made it fairly difficult for our users to understand where settings should be configured.
 
-```yml
+```yaml
 initScope: yarnpkg
 npmPublishAccess: public
 yarnPath: scripts/run-yarn.js
@@ -328,7 +328,7 @@ Packages aren't allowed to require other packages unless they actually list them
 // Error: Something that got detected as your top-level application
 // (because it doesn't seem to belong to any package) tried to access
 // a package that is not declared in your dependencies
-// 
+//
 // Required package: not-a-dependency (via "not-a-dependency")
 // Required by: /Users/mael/my-app/
 require(`not-a-dependency`);

--- a/packages/docusaurus/blog/2021-09-25-release-3.1.mdx
+++ b/packages/docusaurus/blog/2021-09-25-release-3.1.mdx
@@ -67,7 +67,7 @@ Yarn 3.1 features a new optimization that kicks in when a package is listed as `
 
 In case you need to manually configure a strict set of package architectures to support (for example like in a zero-install case, where you want to read from an immutable set of packages), you can use the `supportedArchitectures` setting:
 
-```yml
+```yaml
 supportedArchitectures:
   os: [linux, darwin]
   cpu: [x64, arm64]
@@ -84,7 +84,7 @@ yarn workspaces foreach --since run eslint .
 yarn workspaces list --since
 ```
 
-The `--since` flag also accepts an optional argument (`--since=${commit-ish}`) to manually define a source from which the changes should be derived. 
+The `--since` flag also accepts an optional argument (`--since=${commit-ish}`) to manually define a source from which the changes should be derived.
 
 ### New Workspace Syntax: `workspace:^`
 

--- a/packages/docusaurus/docs/getting-started/extra/recipes.mdx
+++ b/packages/docusaurus/docs/getting-started/extra/recipes.mdx
@@ -45,7 +45,7 @@ touch nm-packages/myproj/yarn.lock
 yarn --cwd packages/myproj config set nodeLinker node-modules
 ```
 - Add a PnP ignore pattern for this path in your main `.yarnrc.yml` at the root of your monorepo:
-```yml
+```yaml
 pnpIgnorePatterns:
   - ./nm-packages/**
 ```

--- a/packages/docusaurus/docusaurus.config.ts
+++ b/packages/docusaurus/docusaurus.config.ts
@@ -288,7 +288,7 @@ export default async function (): Promise<Config> {
       prism: {
         theme: themes.github,
         darkTheme: themes.dracula,
-        additionalLanguages: [`bash`, `json`],
+        additionalLanguages: [`bash`, `diff`, `ignore`, `lisp`, `json`, `prolog`],
       },
     },
   };

--- a/packages/plugin-nm/README.md
+++ b/packages/plugin-nm/README.md
@@ -6,7 +6,7 @@ This plugin adds support for installing packages through a `node_modules` folder
 
 This plugin is included by default in Yarn 2, but is still considered experimental. For this reason, you must enable it manually by adding the following to your `.yarnrc.yml` file:
 
-```yml
+```yaml
 nodeLinker: node-modules
 ```
 


### PR DESCRIPTION
## What's the problem this PR addresses?

Some code blocks on the website were not highlighted correctly

## How did you fix it?

- Added used languages to Docusaurus config
- Fixed some language names on code blocks
  - Turns out `yml` vs `yaml` doesn't matter but consistency is always nice
  - 
## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
