### PR TITLE
fix: only enable interactivity if stdin is a TTY too

### DIFF
--- a/.yarn/versions/d5fa480f.yml
+++ b/.yarn/versions/d5fa480f.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -137,6 +137,7 @@ export default class AddCommand extends BaseCommand {
     const fixed = this.fixed;
     const interactive = configuration.isInteractive({
       interactive: this.interactive,
+      stdin: this.context.stdin,
       stdout: this.context.stdout,
     });
     const reuse = interactive || configuration.get(`preferReuse`);

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -164,6 +164,7 @@ export default class UpCommand extends BaseCommand {
     const fixed = this.fixed;
     const interactive = configuration.isInteractive({
       interactive: this.interactive,
+      stdin: this.context.stdin,
       stdout: this.context.stdout,
     });
 

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -7,8 +7,8 @@ import {UsageError}                                                             
 import {parse as parseDotEnv}                                                                                    from 'dotenv';
 import {builtinModules}                                                                                          from 'module';
 import pLimit, {Limit}                                                                                           from 'p-limit';
-import {PassThrough, Writable}                                                                                   from 'stream';
-import {WriteStream}                                                                                             from 'tty';
+import {PassThrough, Readable, Writable}                                                                         from 'stream';
+import {ReadStream, WriteStream}                                                                                 from 'tty';
 
 import {CorePlugin}                                                                                              from './CorePlugin';
 import {Manifest, PeerDependencyMeta}                                                                            from './Manifest';
@@ -1790,7 +1790,10 @@ export class Configuration {
     return {os, cpu, libc};
   }
 
-  isInteractive({interactive, stdout}: {interactive?: boolean, stdout: Writable}): boolean {
+  isInteractive({interactive, stdin, stdout}: {interactive?: boolean, stdin: Readable, stdout: Writable}): boolean {
+    if (!(stdin as ReadStream).isTTY)
+      return false;
+
     if (!(stdout as WriteStream).isTTY)
       return false;
 


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Addresses https://github.com/yarnpkg/berry/pull/6419#discussion_r1693655300.

https://github.com/yarnpkg/berry/pull/6419 made Yarn non-interactive when the `stdout` isn't a TTY, but it makes sense to disable interactivity when the `stdin` isn't interactive too.

## How did you fix it?

<!-- A detailed description of your implementation. -->

Made it check whether both `stdout` and `stdin` are TTYs before enabling interactivity.

This way both of the following commands will always be non-interactive:
- `yarn add lodash > foo.txt`
- `echo '' | yarn add lodash`

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
