### PR TITLE
fix(ci): fix Next.js E2Es failing since next@canary requires React 19

### DIFF
--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -27,14 +27,10 @@ jobs:
         yarn init
 
         # Required
-        yarn add next@canary react react-dom
-
-        # Test itself
-        yarn add raw-loader
+        yarn add next@canary react@rc react-dom@rc
 
         mkdir pages
-        echo 'import text from "raw-loader!./text.txt"; export default () => <div>{text}</div>;' | tee pages/index.js
-        echo 'hello world!' | tee pages/text.txt
+        echo 'export default () => <div>Hello world!</div>;' | tee pages/index.js
 
         yarn next build
 
@@ -44,14 +40,13 @@ jobs:
         yarn init
 
         # Required
-        yarn add typescript next@canary react react-dom @types/react @types/react-dom @types/node
+        yarn add typescript next@canary react@rc react-dom@rc @types/react @types/react-dom @types/node
 
         # Test itself
         yarn add raw-loader
 
         mkdir pages
-        echo 'const text = require("raw-loader!./text.txt").default; export default () => <div>{text}</div>;' | tee pages/home.tsx
-        echo 'hello world!' | tee pages/text.txt
+        echo 'export default () => <div>Hello world!</div>;' | tee pages/index.tsx
 
         yarn next build
       if: |


### PR DESCRIPTION
## What's the problem this PR addresses?

Since next@canary requires React 19, builds were consistently failing.

## How did you fix it?

Used React 19 instead. Removed require() bit - didn't test anything particularly IMO and caused type errors.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
