### PR TITLE
fix(ci): add workaround for Parcel not working with Yarn PnP

### DIFF
--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -29,6 +29,13 @@ jobs:
         yarn init -p
         yarn add -D parcel@nightly lodash @babel/core
 
+        # See https://github.com/parcel-bundler/parcel/issues/9114
+
+        echo "packageExtensions:
+  \"@parcel/fs@*\":
+    dependencies:
+      \"@parcel/core\": '*'" > .yarnrc.yml
+
         # JavaScript
 
         echo "import _ from 'lodash';function printHello() { console.log(_.join(['Hello', 'JS'], ' '))}; printHello();" | tee index.js


### PR DESCRIPTION
## What's the problem this PR addresses?

It seems like the issue (https://github.com/parcel-bundler/parcel/issues/9114) is stuck on Parcel's side with no interest of it being fixed. 

## How did you fix it?

While this is not ideal, that leaves us with two choices: add a workaround and continue testing Parcel, or remove E2E tests for Parcel altogether. I chose the former.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
