### PR TITLE
test: fix custom certification tests on Windows

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -927,6 +927,7 @@ export const getHttpsCertificates = async () => {
     csr,
     clientKey,
     selfSigned: true,
+    config: [`[v3_req]`, `basicConstraints = critical,CA:TRUE\``].join(`\n`),
   });
 
   const serverCSRResult = await createCSR({commonName: `localhost`});


### PR DESCRIPTION
## What's the problem this PR addresses?

The integration tests using custom certificates have been failing for quite a while on Windows with the error `RequestError: unsuitable certificate purpose`. 

## How did you fix it?

This error was caused by the test CA certificate used; it was not configured to be used as a CA when it was generated. 

The test script that generates the CA certificate has been updated to generate it correctly. I used the same configuration options used by the test suite of the `pem` library that we are using for certificate generation: https://github.com/Dexus/pem/blob/3d71b87cec08a565ce5e73e26dd18f53b9e1fdea/test/pem.spec.js#L856

The problem does not seem to be specific to Windows; I was able to reproduce it locally on macOS as well. I don't yet know why it's passing on CI for Ubuntu and macOS, but not for Windows. Perhaps some difference in the images, like the OpenSSL version (they should all be using OpenSSL v1.1.1, but I've seen reports of Windows having v3 installed as well).

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
