### PR TITLE
docs: document removing patches

### DIFF
--- a/packages/docusaurus/docs/features/patching.mdx
+++ b/packages/docusaurus/docs/features/patching.mdx
@@ -25,6 +25,10 @@ Once you're done with your changes, run `yarn patch-commit -s` with the temporar
 
 By default, `yarn patch` will always reset the patch. If you wish to add new changes, use the `yarn patch ! --update` flag and follow the same procedure as before - your patch will be regenerated.
 
+## Removing patches
+
+To remove a patch, remove the matching `.patch` file in `.yarn/patches`. Finally, remove the reference to the patch from the `resolutions` section of your `package.json`.
+
 ## Limitations
 
 - Because they're currently computed at fetch time rather than resolution time, the package dependencies have already been resolved and patches won't be able to alter them. Instead, use the `packageExtensions` mechanism which is specifically made to add new runtime dependencies to packages.


### PR DESCRIPTION
## What's the problem this PR addresses?

This PR documents removing patches.

Closes #4890.

## How did you fix it?

Wrote a bit of markdown.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
