### PR TITLE
Add patch support to upgrade-interactive

### DIFF
--- a/.yarn/versions/4f3c8017.yml
+++ b/.yarn/versions/4f3c8017.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"


### PR DESCRIPTION
## What's the problem this PR addresses?

`yarn upgrade-interactive` does not currently support patches. It will always think a patch is upgradable even if no new version exists. Where there is a new version, the patch is lost from the resolutions and not reapplied.

I thought I saw an issue for this once upon a time, but I can't find it anymore.
...

## How did you fix it?

I've updated the interactive plugin. During the suggestion creation, I check if the spec uses the patch protocol. If it is, I unpack the version from the patch and pass that to the relevant functions. I then recreate the patch spec to apply to the new version.
...

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
