### PR TITLE
Fixed bug #6491

### DIFF
--- a/packages/yarnpkg-core/sources/miscUtils.ts
+++ b/packages/yarnpkg-core/sources/miscUtils.ts
@@ -467,25 +467,26 @@ export function buildIgnorePattern(ignorePatterns: Array<string>) {
   }).join(`|`);
 }
 
-export function replaceEnvVariables(value: string, {env}: {env: {[key: string]: string | undefined}}) {
-  const regex = /\${(?<variableName>[\d\w_]+)(?<colon>:)?(?:-(?<fallback>[^}]*))?}/g;
+export function replaceEnvVariables(value: string, { env }: { env: { [key: string]: string | undefined } }) {
+  const regex = /\${(?<variableName>[\w_]+)(?::(?<fallback>[^}]*))?}/g;
 
   return value.replace(regex, (...args) => {
-    const {variableName, colon, fallback} = args[args.length - 1];
+    const { variableName, fallback } = args[args.length - 1];
 
-    const variableExist = Object.hasOwn(env, variableName);
     const variableValue = env[variableName];
 
-    if (variableValue)
+    if (variableValue !== undefined) {
       return variableValue;
-    if (variableExist && !colon)
-      return variableValue;
-    if (fallback != null)
+    }
+
+    if (fallback != null) {
       return fallback;
+    }
 
     throw new UsageError(`Environment variable not found (${variableName})`);
   });
 }
+
 
 export function parseBoolean(value: unknown): boolean {
   switch (value) {


### PR DESCRIPTION
## What's the problem this PR addresses?

The bug is that, If your ENV variable needs to have a value with ${} in it, yarn will error:
```
Usage Error: Environment variable not found 
```
on windows. 

Related issue: #6491 


## How did you fix it?

I simply updated the regex and the way the variable `variableValue` is validated.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).


- [x] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
