### PR TITLE
fix(nm): optimize hoisting by treating peer deps same as other deps

### DIFF
--- a/.yarn/versions/a6283714.yml
+++ b/.yarn/versions/a6283714.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/pnpify": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features in `master` can be tried out by running `yarn set version from sources`
 - `node-modules` linker now honors user-defined symlinks for `<workspace>/node_modules` directories
 - `node-modules` linker supports hoisting into inner workspaces that are parents of other workspaces
 - `node-modules` linker attemps to hoist tree more exhaustivel until nothing can be hoisted
+- `node-modules` linker uses aggregated count of peer and regular usages to decide hoisting priority, instead of preferring peer usages over regular as before, which should result in fewer duplicates
 
 ## 4.1.0
 

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -298,10 +298,10 @@ const getHoistIdentMap = (rootNode: HoisterWorkTree, preferenceMap: PreferenceMa
     const entry2 = preferenceMap.get(key2)!;
     if (entry2.hoistPriority !== entry1.hoistPriority) {
       return entry2.hoistPriority - entry1.hoistPriority;
-    } else if (entry2.peerDependents.size !== entry1.peerDependents.size) {
-      return entry2.peerDependents.size - entry1.peerDependents.size;
     } else {
-      return entry2.dependents.size - entry1.dependents.size;
+      const entry1Usages = entry1.dependents.size + entry1.peerDependents.size;
+      const entry2Usages = entry2.dependents.size + entry2.peerDependents.size;
+      return entry2Usages - entry1Usages;
     }
   });
 


### PR DESCRIPTION
## What's the problem this PR addresses?

Fixes #6516

## How did you fix it?

Simplified the sorting algorithm in `getHoistIndetMap`.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
