### PR TITLE
Website: Wrap navbar when there is not enough space

### DIFF
--- a/packages/docusaurus/src/css/custom.css
+++ b/packages/docusaurus/src/css/custom.css
@@ -111,6 +111,14 @@ html.blog-wrapper .container {
 
 .navbar {
   top: -1px;
+  height: auto;
+}
+
+.navbar__items {
+  flex: 1 0 min-content;
+}
+.navbar__items--right {
+  margin-left: auto;
 }
 
 .navbar__brand {


### PR DESCRIPTION
## What's the problem this PR addresses?

When there isn't enough horizontal space, the scrollbar appears for the navbar.

Fixes #6070
Fixes #6537

## How did you fix it?

Wraps the navbar instead if there isn't enough horizontal space. The [VSCode website](https://code.visualstudio.com/) does that too so it isn't like out of the way either

https://github.com/user-attachments/assets/a7ed8307-d9df-4539-af21-59856ffe6463


## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
