### PR TITLE
Use Node 22 for GitHub actions for now

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,7 +6,7 @@ inputs:
   node-version:
     description: 'The version of Node.js to use'
     required: false
-    default: 'current'
+    default: '22'
 
 runs:
   using: composite


### PR DESCRIPTION
## What's the problem this PR addresses?

There are a number of issues affecting Node 23, causing our E2E suite and performance benchmarks to fail since its release:

https://github.com/nodejs/node/pull/54224#issuecomment-2361850159
evanw/esbuild#3951

## How did you fix it?

Drop down to Node 22 for those actions until the issues are cleared

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
