### PR TITLE
fix(extensions): resolve transitive `@mui/system` dependency on `@mui/x-*` packages

### DIFF
--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -995,4 +995,23 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       resolve: `^1.22.8`,
     },
   }],
+  // https://github.com/mui/mui-x/issues/15267
+  ...[
+    `@mui/x-charts-pro@>=7.0.0-alpha.3`,
+    `@mui/x-charts@>=7.15.0`,
+    `@mui/x-data-grid-premium@>=7.15.0`,
+    `@mui/x-data-grid-pro@>=7.15.0`,
+    `@mui/x-data-grid@>=7.15.0`,
+    `@mui/x-date-pickers-pro@>=7.15.0`,
+    `@mui/x-date-pickers@>=7.15.0`,
+    `@mui/x-tree-view-pro@>=7.15.0`,
+    `@mui/x-tree-view@>=7.15.0`,
+  ].map<[string, PackageExtensionData]>(descriptorString => [
+    descriptorString,
+    {
+      dependencies: {
+        '@mui/system': `>=5.15.14`,
+      },
+    },
+  ]),
 ];


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Related issue: https://github.com/mui/mui-x/issues/15267

All `@mui/x-*` packages depend on `@mui/material`, which directly depends on `@mui/system`.
The `@mui/system` package has a singleton. Hence, it is listed as a peer dependency on the `@mui/x-*` packages. 

## How did you fix it?

<!-- A detailed description of your implementation. -->

I'm proposing to add these rules to the `yarnpkg` extensions because Yarn PnP fails to resolve this transitive dependency.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
