### PR TITLE
chore: unlock cross-spawn range

### DIFF
--- a/.yarn/versions/ce18c01f.yml
+++ b/.yarn/versions/ce18c01f.yml
@@ -1,2 +1,3 @@
 releases:
   "@yarnpkg/core": patch
+  "@yarnpkg/shell": patch

--- a/.yarn/versions/ce18c01f.yml
+++ b/.yarn/versions/ce18c01f.yml
@@ -1,33 +1,35 @@
 releases:
-  "@yarnpkg/builder": patch
-  "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
-  "@yarnpkg/doctor": patch
-  "@yarnpkg/extensions": patch
-  "@yarnpkg/nm": patch
-  "@yarnpkg/plugin-compat": patch
-  "@yarnpkg/plugin-constraints": patch
-  "@yarnpkg/plugin-dlx": patch
-  "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-exec": patch
-  "@yarnpkg/plugin-file": patch
-  "@yarnpkg/plugin-git": patch
-  "@yarnpkg/plugin-github": patch
-  "@yarnpkg/plugin-http": patch
-  "@yarnpkg/plugin-init": patch
-  "@yarnpkg/plugin-interactive-tools": patch
-  "@yarnpkg/plugin-link": patch
-  "@yarnpkg/plugin-nm": patch
-  "@yarnpkg/plugin-npm": patch
-  "@yarnpkg/plugin-npm-cli": patch
-  "@yarnpkg/plugin-pack": patch
-  "@yarnpkg/plugin-patch": patch
-  "@yarnpkg/plugin-pnp": patch
-  "@yarnpkg/plugin-pnpm": patch
-  "@yarnpkg/plugin-stage": patch
-  "@yarnpkg/plugin-typescript": patch
-  "@yarnpkg/plugin-version": patch
-  "@yarnpkg/plugin-workspace-tools": patch
-  "@yarnpkg/pnpify": patch
-  "@yarnpkg/sdks": patch
   "@yarnpkg/shell": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/.yarn/versions/ce18c01f.yml
+++ b/.yarn/versions/ce18c01f.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/core": patch

--- a/.yarn/versions/ce18c01f.yml
+++ b/.yarn/versions/ce18c01f.yml
@@ -1,3 +1,33 @@
 releases:
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": patch
   "@yarnpkg/core": patch
+  "@yarnpkg/doctor": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-compat": patch
+  "@yarnpkg/plugin-constraints": patch
+  "@yarnpkg/plugin-dlx": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-file": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+  "@yarnpkg/plugin-http": patch
+  "@yarnpkg/plugin-init": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-link": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-patch": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+  "@yarnpkg/plugin-stage": patch
+  "@yarnpkg/plugin-typescript": patch
+  "@yarnpkg/plugin-version": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+  "@yarnpkg/pnpify": patch
+  "@yarnpkg/sdks": patch
   "@yarnpkg/shell": patch

--- a/packages/yarnpkg-core/package.json
+++ b/packages/yarnpkg-core/package.json
@@ -20,7 +20,7 @@
     "chalk": "^3.0.0",
     "ci-info": "^4.0.0",
     "clipanion": "^4.0.0-rc.2",
-    "cross-spawn": "7.0.3",
+    "cross-spawn": "^7.0.3",
     "diff": "^5.1.0",
     "dotenv": "^16.3.1",
     "fast-glob": "^3.2.2",

--- a/packages/yarnpkg-shell/package.json
+++ b/packages/yarnpkg-shell/package.json
@@ -14,7 +14,7 @@
     "@yarnpkg/parsers": "workspace:^",
     "chalk": "^3.0.0",
     "clipanion": "^4.0.0-rc.2",
-    "cross-spawn": "7.0.3",
+    "cross-spawn": "^7.0.3",
     "fast-glob": "^3.2.2",
     "micromatch": "^4.0.2",
     "tslib": "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,7 +5512,7 @@ __metadata:
     ci-info: "npm:^4.0.0"
     clipanion: "npm:^4.0.0-rc.2"
     comment-json: "npm:^2.2.0"
-    cross-spawn: "npm:7.0.3"
+    cross-spawn: "npm:^7.0.3"
     diff: "npm:^5.1.0"
     dotenv: "npm:^16.3.1"
     esbuild: "npm:esbuild-wasm@^0.23.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6279,7 +6279,7 @@ __metadata:
     "@yarnpkg/parsers": "workspace:^"
     chalk: "npm:^3.0.0"
     clipanion: "npm:^4.0.0-rc.2"
-    cross-spawn: "npm:7.0.3"
+    cross-spawn: "npm:^7.0.3"
     fast-glob: "npm:^3.2.2"
     micromatch: "npm:^4.0.2"
     strip-ansi: "npm:^6.0.0"
@@ -8449,17 +8449,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
-  dependencies:
-    path-key: "npm:^3.1.0"
-    shebang-command: "npm:^2.0.0"
-    which: "npm:^2.0.1"
-  checksum: 10/e1a13869d2f57d974de0d9ef7acbf69dc6937db20b918525a01dacb5032129bd552d290d886d981e99f1b624cb03657084cc87bd40f115c07ecf376821c729ce
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^6.0.0":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -8470,6 +8459,17 @@ __metadata:
     shebang-command: "npm:^1.2.0"
     which: "npm:^1.2.9"
   checksum: 10/f07e643b4875f26adffcd7f13bc68d9dff20cf395f8ed6f43a23f3ee24fc3a80a870a32b246fd074e514c8fd7da5f978ac6a7668346eec57aa87bac89c1ed3a1
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-spawn@npm:7.0.3"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10/e1a13869d2f57d974de0d9ef7acbf69dc6937db20b918525a01dacb5032129bd552d290d886d981e99f1b624cb03657084cc87bd40f115c07ecf376821c729ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
cross-spawn has a vulnerability https://github.com/moxystudio/node-cross-spawn/issues/167.

This should allow the latest version of the cross-spawn package to work.

## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

## How did you fix it?

<!-- A detailed description of your implementation. -->

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
