### PR TITLE
add a config option to disallow the cache clean command

### DIFF
--- a/.yarn/versions/c6c3dd7a.yml
+++ b/.yarn/versions/c6c3dd7a.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/cache/clean.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/cache/clean.test.js
@@ -37,5 +37,16 @@ describe(`Commands`, () => {
       expect(xfs.existsSync(`${path}/.yarn/cache`)).toEqual(false);
       expect(xfs.existsSync(`${path}/.yarn/global/cache`)).toEqual(false);
     }));
+
+    test(`it should follow the enableCacheClean configuration`, makeTemporaryEnv({
+      dependencies: {
+        [`no-deps`]: `1.0.0`,
+      },
+    }, {
+      enableCacheClean: false,
+    }, async ({path, run, source}) => {
+      await run(`install`);
+      await expect(run(`cache`, `clean`)).rejects.toThrowError();
+    }));
   });
 });

--- a/packages/plugin-essentials/sources/commands/cache/clean.ts
+++ b/packages/plugin-essentials/sources/commands/cache/clean.ts
@@ -1,7 +1,7 @@
 import {BaseCommand}                               from '@yarnpkg/cli';
 import {Configuration, Cache, StreamReport, Hooks} from '@yarnpkg/core';
 import {xfs}                                       from '@yarnpkg/fslib';
-import {Command, Option, Usage}                    from 'clipanion';
+import {Command, Option, Usage, UsageError}        from 'clipanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class CacheCleanCommand extends BaseCommand {
@@ -34,6 +34,10 @@ export default class CacheCleanCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+
+    if (!configuration.get(`enableCacheClean`))
+      throw new UsageError(`Cache cleaning is currently disabled. To enable it, set \`enableCacheClean: true\` in your configuration file. Note: Cache cleaning is typically not required and should be avoided when using Zero-Installs.`);
+
     const cache = await Cache.find(configuration);
 
     const report = await StreamReport.start({

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -567,6 +567,11 @@ export const coreDefinitions: {[coreSettingName: string]: SettingsDefinition} = 
     type: SettingsType.BOOLEAN,
     default: false,
   },
+  enableCacheClean: {
+    description: `If false, disallows the \`cache clean\` command`,
+    type: SettingsType.BOOLEAN,
+    default: true,
+  },
   checksumBehavior: {
     description: `Enumeration defining what to do when a checksum doesn't match expectations`,
     type: SettingsType.STRING,


### PR DESCRIPTION
## What's the problem this PR addresses?

At [Datadog](https://github.com/datadog) we are using `yarn` inside a huge monorepository using the PnP linker and Zero-Installs with all the dependencies versioned through git.

The issue we have is that people frequently have the tendency to think that this kind of environment works like others, and that cleaning the cache is the way to go whenever they encounter an install issue (like deleting `node_modules`).

This is obviously not the case and we have to tell them to restore their packages from the git remote when that happens, which is a bit cumbersome.

_see also: https://github.com/yarnpkg/berry/discussions/6518_

## How did you fix it?

This PR adds a non-breaking option inside the `.yarnrc` file to disallow running `yarn clean cache`.

cc @arcanis 

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
