### PR TITLE
feat: add yarnpkg/nm/hoist export

### DIFF
--- a/.yarn/versions/ce211f43.yml
+++ b/.yarn/versions/ce211f43.yml
@@ -1,0 +1,6 @@
+releases:
+  "@yarnpkg/nm": patch
+
+declined:
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-nm/package.json
+++ b/packages/yarnpkg-nm/package.json
@@ -5,6 +5,7 @@
   "main": "./sources/index.ts",
   "exports": {
     ".": "./sources/index.ts",
+    "./hoist": "./sources/hoist.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -23,6 +24,7 @@
     "main": "./lib/index.js",
     "exports": {
       ".": "./lib/index.js",
+      "./hoist": "./lib/hoist.js",
       "./package.json": "./package.json"
     }
   },


### PR DESCRIPTION
## What's the problem this PR addresses?

Bundling `@yarnpkg/nm` (due to subdeps) is large and not needed when one needs only a few exports from `./hoist` file: https://github.com/yarnpkg/berry/blob/b3dfa91abd591a3d572daadfdba54c671c7d882b/packages/yarnpkg-nm/sources/buildNodeModulesTree.ts#L1-L4

But `hoist.ts` is a zero-dep lib:
https://github.com/yarnpkg/berry/blob/b3dfa91abd591a3d572daadfdba54c671c7d882b/packages/yarnpkg-nm/sources/hoist.ts#L1-L3

It's already built/distrubuted separately (see https://www.npmjs.com/package/@yarnpkg/nm?activeTab=code), just an entry in package.json was missing

Both its exports (and types) are already re-exported:
https://github.com/yarnpkg/berry/blob/b3dfa91abd591a3d572daadfdba54c671c7d882b/packages/yarnpkg-nm/sources/index.ts#L23-L24

So this is not increasing public API surface, just adds a more convenient way to import it without pulling in the whole of `@yarnpkg/core` and `@yarnpkg/pnp`

## How did you fix it?

Added `./hoist` to exports to point to `./lib/hoist.js`

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
