### PR TITLE
update `isConventionalTarballUrl`

### DIFF
--- a/.yarn/versions/8ac514db.yml
+++ b/.yarn/versions/8ac514db.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm/sources/NpmSemverFetcher.ts
+++ b/packages/plugin-npm/sources/NpmSemverFetcher.ts
@@ -81,6 +81,13 @@ export class NpmSemverFetcher implements Fetcher {
     registry = registry.replace(/^https:\/\/registry\.npmjs\.org($|\/)/, `https://registry.yarnpkg.com$1`);
     url = url.replace(/^https:\/\/registry\.npmjs\.org($|\/)/, `https://registry.yarnpkg.com$1`);
 
+    // some registries store the tar ball in a path with duplicated scope,
+    // e.g. `https://my.registry.com/@my-scope/package-a/-/@my-scope/package-a-0.0.1.tgz`
+    url = url.replace(/%2f/g, `/`)
+      .replace(
+        new RegExp(`^(.+)\\/@${locator.scope}\\/(.+)\\/@${locator.scope}\\/(.+)$`),
+        `$1/@${locator.scope}/$2/$3`);
+
     if (url === registry + path)
       return true;
     if (url === registry + path.replace(/%2f/g, `/`))

--- a/packages/plugin-npm/tests/NpmSemverFetcher.test.js
+++ b/packages/plugin-npm/tests/NpmSemverFetcher.test.js
@@ -20,8 +20,10 @@ describe(`NpmSemverFetcher`, () => {
 
       const locator = structUtils.makeLocator(structUtils.makeIdent(`scope`, `foo`), `npm:1.0.0`);
       const url = `${configuration.get(`npmRegistryServer`)}/@scope/foo/-/foo-1.0.0.tgz`;
+      const url2 = `${configuration.get(`npmRegistryServer`)}/@scope/foo/-/@scope/foo-1.0.0.tgz`;
 
       expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url, {configuration})).toEqual(true);
+      expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url2, {configuration})).toEqual(true);
     });
 
     it(`it should detect a conventional path (@scope%2ffoo)`, async () => {
@@ -29,8 +31,10 @@ describe(`NpmSemverFetcher`, () => {
 
       const locator = structUtils.makeLocator(structUtils.makeIdent(`scope`, `foo`), `npm:1.0.0`);
       const url = `${configuration.get(`npmRegistryServer`)}/@scope%2ffoo/-/foo-1.0.0.tgz`;
+      const url2 = `${configuration.get(`npmRegistryServer`)}/@scope%2ffoo/-/@scope%2ffoo-1.0.0.tgz`;
 
       expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url, {configuration})).toEqual(true);
+      expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url2, {configuration})).toEqual(true);
     });
 
     it(`it should detect non-conventional path (different registry)`, async () => {


### PR DESCRIPTION
## What's the problem this PR addresses?

Some registries(e.g. [JFrog Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/jfrog-artifactory)) store the tar ball in a path with duplicated scope, e.g. `https://my.registry.com/@my-scope/package-a/-/@my-scope/package-a-0.0.1.tgz`, while `https://my.registry.com/@my-scope/package-a/-/package-a-0.0.1.tgz` works as well.

Actually I'm not sure whether urls like this should be conventional ones, but I have tested locally this does work and no `__archiveUrl` added in `yarn.lock`. 

Remove the entire `node_modules` and re-run `yarn install` works as well with this change.

I'm wondering what is the `__archiveUrl` for? **_If a package was resolved as a url with `__archiveUrl`, `yarn patch-commit` for this package would fail_**
    
## How did you fix it?

```js
url = url.replace(
  new RegExp(`^(.+)\\/@${locator.scope}\\/(.+)\\/@${locator.scope}\\/(.+)$`), 
  `$1/@${locator.scope}/$2/$3`
);
```

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
