### PR TITLE
chore: switch esbuild output format from `iife` to `esm`

### DIFF
--- a/.yarn/versions/f5873988.yml
+++ b/.yarn/versions/f5873988.yml
@@ -1,0 +1,12 @@
+releases:
+  "@yarnpkg/builder": minor
+  "@yarnpkg/cli": minor
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -141,7 +141,7 @@ export default class BuildBundleCommand extends Command {
           // Default extensions + .mjs
           resolveExtensions: [`.tsx`, `.ts`, `.jsx`, `.mjs`, `.js`, `.css`, `.json`],
           logLevel: `silent`,
-          format: `iife`,
+          format: `esm`,
           platform: `node`,
           plugins: [valLoader],
           minify: !this.noMinify,


### PR DESCRIPTION

## What's the problem this PR addresses?

This setting currently blocks Berry from using ESM modules that use top-level await (e.g. ink).

## How did you fix it?

Switching output format to `esm` seems to be fixing it, while the executable still works.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
