### PR TITLE
Fix error handling when looking for configuration files

### DIFF
--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -1406,10 +1406,10 @@ export class Configuration {
       const rcPath = ppath.join(currentCwd, rcFilename as PortablePath);
 
       if (xfs.existsSync(rcPath)) {
-        const content = await xfs.readFilePromise(rcPath, `utf8`);
-
         let data;
+        let content;
         try {
+          content = await xfs.readFilePromise(rcPath, `utf8`);
           data = parseSyml(content) as any;
         } catch (error) {
           let tip = ``;


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

When looking for configuration files if reading a candidate throws an exception the exception is not caught and the user gets a cryptic and non-informative message. e.g. if you happen to have a directory named `.yarnrc.yml` in the root of your project every yarn command will result with this message:
```
Internal Error: EISDIR: illegal operation on a directory, read
Error: EISDIR: illegal operation on a directory, read
```
which doesn't include the file.

## How did you fix it?

<!-- A detailed description of your implementation. -->

This change moves the reading operation into the try clause and handles read errors in the same way parsing errors are handled.

## Checklist

I did it from GH online editor so I can't run stuff. Sorry.
Hopefully someone can pick it up it would save the next poor soul a few hours.

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
