### PR TITLE
ci: migrate e2e to eslint v9 flat config

### DIFF
--- a/.github/workflows/e2e-eslint-workflow.yml
+++ b/.github/workflows/e2e-eslint-workflow.yml
@@ -26,9 +26,22 @@ jobs:
         source scripts/e2e-setup-ci.sh
 
         yarn init -p
-        yarn add eslint
+        yarn add eslint @stylistic/eslint-plugin
 
-        echo '{"rules": {"semi": ["error", "always"]}}' > .eslintrc
+        cat > eslint.config.mjs <<EOT
+        import stylistic from '@stylistic/eslint-plugin'
+
+        export default [
+          {
+            plugins: {
+              '@stylistic': stylistic
+            },
+            rules: {
+              '@stylistic/semi': 'error',
+            }
+          }
+        ]
+        EOT
 
         echo '42;' | tee ok.js
         yarn eslint ok.js
@@ -41,9 +54,20 @@ jobs:
         source scripts/e2e-setup-ci.sh
 
         yarn init -p
-        yarn add eslint typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
+        yarn add eslint typescript typescript-eslint
 
-        echo '{"parser": "@typescript-eslint/parser", "plugins": ["@typescript-eslint"], "rules": {"@typescript-eslint/explicit-function-return-type": "error"}}' > .eslintrc
+        cat > eslint.config.mjs <<EOT
+        import tseslint from 'typescript-eslint';
+
+        export default tseslint.config(
+          tseslint.configs.recommended,
+          {
+            rules: {
+              '@typescript-eslint/explicit-function-return-type': 'error',
+              '@typescript-eslint/no-unused-vars': 'off',
+            },
+          });
+        EOT
 
         echo 'const f = (): number => 42;' | tee ok.ts
         yarn eslint ok.ts


### PR DESCRIPTION
## What's the problem this PR addresses?

- supersedes https://github.com/yarnpkg/berry/pull/6690

The workflow [.github/workflows/e2e-eslint-workflow.yml](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-eslint-workflow.yml) fails with

```text
Oops! Something went wrong! :(

ESLint: 9.20.1

ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
```

It was last successful 11 months ago on Apr 5, 2024 coinciding with the release of [ESLint 9.0.0](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/) which changed the default config to flat.

The workflow installs `eslint` with no version specified, therefore `eslint@latest` is used (currently `eslint@9.20.1`).

## How did you fix it?

In the workflow [.github/workflows/e2e-eslint-workflow.yml](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-eslint-workflow.yml)

each `.estlintrc` is changed to `eslint.config.mjs`

### Validating ESLint

The ESLint rule [semi](https://eslint.org/docs/latest/rules/semi) was [deprecated](https://eslint.org/blog/2023/10/deprecating-formatting-rules/) in [ESLint v8.53.0](https://eslint.org/blog/2023/11/eslint-v8.53.0-released/) and moved instead to [@stylistic/eslint-plugin-js](https://eslint.style/packages/js).

Following the [ESLint Stylistic Migration Guide](https://eslint.style/guide/migration) and using the recommended approach of one single plugin, additionally install [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin).

Use the rule [@stylistic/semi](https://eslint.style/rules/default/semi).

### Running the TypeScript integration test

[typescript-eslint v7](https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/) allows [switching](https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/#switching-to-typescript-eslint) from [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser) and [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin) to [typescript-eslint](https://www.npmjs.com/package/typescript-eslint).

## Checklist

- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [X] I have set the packages that need to be released for my changes to be effective. (none)
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
