### PR TITLE
Fix Integration test failures for Big endian on GA CI

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -273,7 +273,7 @@ jobs:
         shard: ['1/4', '2/4', '3/4', '4/4']
 
     name: 'Big-endian debian w/ Node.js latest (${{matrix.shard}})'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       github.ref == 'refs/heads/master'
     needs: build

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -27,7 +27,7 @@ const staticServer = serveStatic(npath.fromPortablePath(require(`pkg-tests-fixtu
 
 // Testing things inside a big-endian container takes forever
 export const TEST_TIMEOUT = os.endianness() === `BE`
-  ? 150000
+  ? 200000
   : 75000;
 
 export type PackageEntry = Map<string, {path: string, packageJson: Record<string, any>}>;


### PR DESCRIPTION
## What's the problem this PR addresses?

Fixes the GA CI Integration jobs failing for Big endian.

## How did you fix it?

1. Changed the Ubuntu image to Ubuntu 22.04 for Big Endian jobs as it fixes the test case failures. 
Also Ubuntu 20.04 is EOL in April 2025
2. Increased TEST_TIMEOUT for Big Endian to fix the following TC failing due to timeout issue:
`pkg-tests-specs/sources/commands/constraints/fix.test.js`


## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
