### PR TITLE
Fix #6029 Avoid undefined checksums after merge conflict resolution

### DIFF
--- a/.yarn/versions/4c645b68.yml
+++ b/.yarn/versions/4c645b68.yml
@@ -1,0 +1,34 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-essentials": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-typescript": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/.yarn/versions/4c645b68.yml
+++ b/.yarn/versions/4c645b68.yml
@@ -1,12 +1,12 @@
 releases:
   "@yarnpkg/cli": patch
-  "@yarnpkg/core": patch
   "@yarnpkg/plugin-essentials": patch
-  "@yarnpkg/plugin-interactive-tools": patch
-  "@yarnpkg/plugin-npm": patch
-  "@yarnpkg/plugin-typescript": patch
 
 declined:
+  - "@yarnpkg/core"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -455,7 +455,7 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
         continue;
 
       const checksum = variant[key].checksum;
-      if (typeof checksum === `string` && checksum.includes(`/`))
+      if (typeof checksum === `string` && checksum.includes(`/`) || typeof checksum === `undefined`)
         continue;
 
       variant[key].checksum = `${variant.__metadata.cacheKey}/${checksum}`;

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -455,7 +455,7 @@ async function autofixMergeConflicts(configuration: Configuration, immutable: bo
         continue;
 
       const checksum = variant[key].checksum;
-      if (typeof checksum === `string` && checksum.includes(`/`) || typeof checksum === `undefined`)
+      if (typeof checksum === `undefined` || checksum.includes(`/`))
         continue;
 
       variant[key].checksum = `${variant.__metadata.cacheKey}/${checksum}`;


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

#### Resolves #6029

Running `yarn --mode=update-lockfile` during git conflict resolution, performs `autofixMergeConflicts`. If the `yarn.lock` file has entries that lack a `checksum` value, that process introduces an `undefined` checksum value which is likely to be committed by accident. Subsequent full installs will remove them, but they're a cause of friction during their temporary existence.

In my case under Yarn `4.5.3` using `nodeLinker: node-modules` it was injecting `checksum: 10/undefined`, while in #6029 it was injecting `checksum: undefined`. I note the `__metadata.cacheKey` prefix (`10/` in my case) can vary from project to project.

<img width="589" alt="Screenshot 2025-02-26 at 12 00 19 pm" src="https://github.com/user-attachments/assets/334b258c-03a5-4f07-bb32-e8bb85d0b442" />


...

## How did you fix it?

Explicitly checking for `undefined` in the `autofixMergeConflicts` method.

I struggled to figure out a way to add test coverage for this. I tried to add an extra dependency into the `it should properly fix merge conflicts` test case within `packages/acceptance-tests/pkg-tests-specs/sources/features/mergeConflictResolution.test.ts`, however it always injects a checksum value, so i'm not sure how to emulate a missing one? Open to guidance there.

In my project's `yarn.lock` most entries do have a checksum, while some do not, as a mixture of `npm:` and `workspace:` protocol entries, so i'm not sure what the rules are for when the checksum is added?

### Manual QA

I tested this by updating my project's `.yarnrc.yaml` `yarnPath` to point to `scripts/run-yarn.js` from my local `yarn-berry` checkout. Then in my external project i replicated a git conflict within a `yarn.lock` entry, and used `yarn --mode=update-lockfile` to validate my fix correctly avoided introducing `checksum: 10/undefined` for entries lacking a checksum value.

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ x ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ x ] I have set the packages that need to be released for my changes to be effective.

If i've selected the wrong packages please let me know. Given this PR touches a commonly used package i opted for a partial release rather than all dependents. Happy to change based on reviewer feedback.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ x ] I will check that all automated PR checks pass before the PR gets reviewed.
