### PR TITLE
fix(6706): pack creates sub-directories

### DIFF
--- a/.yarn/versions/c530da1b.yml
+++ b/.yarn/versions/c530da1b.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pack": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/pack.test.js
@@ -823,6 +823,21 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should create missing directories when using \`--out\``,
+      makeTemporaryEnv({
+        name: `@scope/test`,
+        version: `0.0.1`,
+      }, async ({path, run, source}) => {
+        await xfs.mkdirpPromise(path);
+
+        await run(`install`);
+
+        await run(`pack`, `--out`, `subdir/my-package.tgz`, {cwd: path});
+        expect(xfs.existsSync(`${path}/subdir/my-package.tgz`)).toEqual(true);
+      }),
+    );
+
+    test(
       `it should not include any extra files when the "files" field is empty`,
       makeTemporaryEnv({
         main: `lib/a.js`,

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -90,7 +90,8 @@ export default class PackCommand extends BaseCommand {
 
         if (!this.dryRun) {
           const pack = await packUtils.genPackStream(workspace, files);
-          await xfs.mkdirpPromise(ppath.dirname(target));
+
+          await xfs.mkdirPromise(ppath.dirname(target), {recursive: true});
           const write = xfs.createWriteStream(target);
 
           pack.pipe(write);

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -90,6 +90,7 @@ export default class PackCommand extends BaseCommand {
 
         if (!this.dryRun) {
           const pack = await packUtils.genPackStream(workspace, files);
+          await xfs.mkdirpPromise(ppath.dirname(target));
           const write = xfs.createWriteStream(target);
 
           pack.pipe(write);


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

It creates missing sub-directories instead of crashing; closes #6706.

## How did you fix it?

<!-- A detailed description of your implementation. -->

Added `await xfs.mkdirpPromise(ppath.dirname(target))` before packing

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
