### PR TITLE
Adds support for argument passing to "yarn init <initializer>"

### DIFF
--- a/.yarn/versions/11405fb3.yml
+++ b/.yarn/versions/11405fb3.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-init": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-init/sources/commands/init-initializer.ts
+++ b/packages/plugin-init/sources/commands/init-initializer.ts
@@ -1,0 +1,21 @@
+import {Option}    from 'clipanion';
+
+import InitCommand from './init';
+
+// eslint-disable-next-line arca/no-default-export
+export default class InitInitializerCommand extends InitCommand {
+  static paths = [
+    [`init`],
+  ];
+
+  initializer = Option.String();
+  argv = Option.Proxy();
+
+  async initialize() {
+    this.context.stdout.write(`\n`);
+
+    await this.cli.run([`dlx`, this.initializer, ...this.argv], {
+      quiet: true,
+    });
+  }
+}

--- a/packages/plugin-init/sources/commands/init.ts
+++ b/packages/plugin-init/sources/commands/init.ts
@@ -55,10 +55,6 @@ export default class InitCommand extends BaseCommand {
     description: `Initialize a package with the given name`,
   });
 
-  initializer = Option.String({
-    required: false,
-  });
-
   // Options that only mattered on v1
   usev2 = Option.Boolean(`-2`, false, {hidden: true});
   yes = Option.Boolean(`-y,--yes`, {hidden: true});
@@ -115,6 +111,9 @@ export default class InitCommand extends BaseCommand {
 
       return code;
     });
+  }
+
+  async initialize() {
   }
 
   async executeRegular(configuration: Configuration) {
@@ -254,13 +253,7 @@ export default class InitCommand extends BaseCommand {
         quiet: true,
       });
 
-      if (this.initializer) {
-        this.context.stdout.write(`\n`);
-
-        await this.cli.run([`dlx`, this.initializer], {
-          quiet: true,
-        });
-      }
+      await this.initialize();
 
       if (!xfs.existsSync(ppath.join(this.context.cwd, `.git`))) {
         await execUtils.execvp(`git`, [`init`], {

--- a/packages/plugin-init/sources/index.ts
+++ b/packages/plugin-init/sources/index.ts
@@ -1,8 +1,9 @@
 import {Plugin, SettingsType} from '@yarnpkg/core';
 
+import InitInitializerCommand from './commands/init-initializer';
 import InitCommand            from './commands/init';
 
-export {InitCommand};
+export {InitCommand, InitInitializerCommand};
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
@@ -38,6 +39,7 @@ const plugin: Plugin = {
   },
   commands: [
     InitCommand,
+    InitInitializerCommand,
   ],
 };
 


### PR DESCRIPTION
## What's the problem this PR addresses?

The `yarn init <package>` syntax works, but not `yarn init <package> [...options]`.

## How did you fix it?

I split the `init` command in two, with the second one having a proxy option to consume whatever follows the first required positional argument.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
