### PR TITLE
Add configuration option to configure .store folder in pnpm mode

### DIFF
--- a/.yarn/versions/81e42c15.yml
+++ b/.yarn/versions/81e42c15.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-pnpm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpmStoreLocation.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpmStoreLocation.test.ts
@@ -17,6 +17,7 @@ describe(`Features`, () => {
         {
           nodeLinker: `pnpm`,
           pnpmStoreFolder: customStoreFolderName,
+          winLinkType: `symlinks`,
         },
         async ({path, run, source}) => {
           await run(`install`);
@@ -26,8 +27,7 @@ describe(`Features`, () => {
           expect(xfs.existsSync(absolutePnpmStorePath)).toEqual(true);
 
           // Ensure that the default node_modules/.store folder is not created
-          const defaultStorePath = ppath.join(path, `node_modules`, `.store`);
-          expect(xfs.existsSync(defaultStorePath)).toEqual(false);
+          expect(xfs.existsSync(ppath.join(path, `node_modules`, `.store`))).toEqual(false);
 
           // Ensure that the installed package is a symbolic link
           const installedPackagePath = ppath.join(path, `node_modules`, `no-deps`);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpmStoreLocation.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/pnpmStoreLocation.test.ts
@@ -1,0 +1,47 @@
+import {xfs, ppath} from '@yarnpkg/fslib';
+
+const {
+  fs: {FsLinkType, determineLinkType},
+} = require(`pkg-tests-core`);
+
+const customStoreFolderName = `.customStore`;
+
+describe(`Features`, () => {
+  describe(`pnpmStoreLocation`, () => {
+    test(
+      `it should create the store at custom path and symlink all files to the custom store location`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps`]: `1.0.0`},
+        },
+        {
+          nodeLinker: `pnpm`,
+          pnpmStoreFolder: customStoreFolderName,
+        },
+        async ({path, run, source}) => {
+          await run(`install`);
+
+          // Ensure that the customized folder is created
+          const absolutePnpmStorePath = ppath.join(path, customStoreFolderName);
+          expect(xfs.existsSync(absolutePnpmStorePath)).toEqual(true);
+
+          // Ensure that the default node_modules/.store folder is not created
+          const defaultStorePath = ppath.join(path, `node_modules`, `.store`);
+          expect(xfs.existsSync(defaultStorePath)).toEqual(false);
+
+          // Ensure that the installed package is a symbolic link
+          const installedPackagePath = ppath.join(path, `node_modules`, `no-deps`);
+          expect(await determineLinkType(installedPackagePath)).toEqual(FsLinkType.SYMBOLIC);
+
+          // Ensure that the link target is a relative path
+          const installedPackageLinkTarget = await xfs.readlinkPromise(installedPackagePath);
+          expect(ppath.isAbsolute(installedPackageLinkTarget)).toBeFalsy();
+
+          // Ensure that the resolved link target is within the customized pnpmStoreFolder.
+          const resolvedPackageLinkTarget = ppath.join(ppath.dirname(installedPackagePath), installedPackageLinkTarget);
+          expect(ppath.contains(absolutePnpmStorePath, resolvedPackageLinkTarget)).toBeTruthy();
+        },
+      ),
+    );
+  });
+});

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -481,6 +481,14 @@
       "type": "string",
       "default": "pnp"
     },
+    "pnpmStoreFolder": {
+      "_package": "@yarnpkg/plugin-pnpm",
+      "title": "Path where the pnpm store will be stored",
+      "description": "By default, the store is stored in the `node_modules/.store` of the project. Sometimes in CI scenario's it is convenient to store this in a different location so it can be cached and reused.",
+      "type": "string",
+      "format": "uri-reference",
+      "examples": [".cache/.store"]
+    },
     "winLinkType": {
       "_package": "@yarnpkg/core",
       "title": "Define whether to use junctions or symlinks when creating links on Windows.",

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -309,7 +309,7 @@ function getNodeModulesLocation(project: Project) {
 }
 
 function getStoreLocation(project: Project) {
-  return ppath.join(getNodeModulesLocation(project), `.store`);
+  return project.configuration.get(`pnpmStoreFolder`);
 }
 
 function getPackagePaths(locator: Locator, {project}: {project: Project}) {

--- a/packages/plugin-pnpm/sources/index.ts
+++ b/packages/plugin-pnpm/sources/index.ts
@@ -1,10 +1,24 @@
-import {Plugin}     from '@yarnpkg/core';
+import {Plugin, SettingsType} from '@yarnpkg/core';
+import {PortablePath}         from '@yarnpkg/fslib';
 
-import {PnpmLinker} from './PnpmLinker';
+import {PnpmLinker}           from './PnpmLinker';
 
 export {PnpmLinker};
 
+declare module '@yarnpkg/core' {
+  interface ConfigurationValueMap {
+    pnpmStoreFolder: PortablePath;
+  }
+}
+
 const plugin: Plugin = {
+  configuration: {
+    pnpmStoreFolder: {
+      description: `By default, the store is stored in the 'node_modules/.store' of the project. Sometimes in CI scenario's it is convenient to store this in a different location so it can be cached and reused.`,
+      type: SettingsType.ABSOLUTE_PATH,
+      default: `./node_modules/.store`,
+    },
+  },
   linkers: [
     PnpmLinker,
   ],


### PR DESCRIPTION
This changes adds a configuration option to configure `node_modules/.store` folder when using `nodeLinker: pnpm`.
It adds an option `pnpmStoreFolder` to .yarnrc.yml which will be used when installing with pnpm Mode.

## What's the problem this PR addresses?
In our CI system we run a few copies of js repos for different architectures in parralel. We want to share the .store folder between the multiple runs, so we have to hoist it outside of the sourceroot.
This adds an option to configure this.
```
nodeLinker: pnpm
pnpmStoreFolder: ../cache/.store
```

Resolves #6623

...

## How did you fix it?
* Added `configuration` field to `plugin-pnpm` that defines the new option `pnpmStoreFolder`
   I'm open to naming suggestions. 
   I just followed the pattern defined by `plugin-nm` of prefixing settings with the plugin name like `nmHoistingLimits`, `nmMode` & `nmSelfReferences`. As well as by `plugin-pnp` with setting `pnpUnpluggedFolder`
   I followed the Folder suffix to match `cacheFolder`, `patchFolder`, `globalFolder`,  `virtualFolder` & `pnpUnpluggedFolder`.
* Updated the function ` getStoreLocation(project: Project)` to get the setting from the configuration rather than a hardcoded default.
* Add type for configuration to match other built-in plugins
* Add documentation to docusaurus json file (local testing for this failed)
* Added a unittest that makes sure the links are correct

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
