### PR TITLE
Replace deprecated ESLint rules

### DIFF
--- a/.yarn/versions/caca25a0.yml
+++ b/.yarn/versions/caca25a0.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/eslint-config": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/fslib"
+  - "@yarnpkg/libzip"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/shell"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/logout.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/npm/logout.test.ts
@@ -48,7 +48,7 @@ describe(`Commands`, () => {
         let stderr: string;
 
         try {
-          // @ts-expect-error
+          // @ts-expect-error - reason TBS
           ({code, stdout, stderr} = await run(`npm`, `logout`, {
             env: {
               HOME: homePath,
@@ -107,7 +107,7 @@ describe(`Commands`, () => {
         let stderr: string;
 
         try {
-          // @ts-expect-error
+          // @ts-expect-error - reason TBS
           ({code, stdout, stderr} = await run(`npm`, `logout`, `--all`, {
             env: {
               HOME: homePath,
@@ -155,7 +155,7 @@ describe(`Commands`, () => {
         let stderr: string;
 
         try {
-          // @ts-expect-error
+          // @ts-expect-error - reason TBS
           ({code, stdout, stderr} = await run(`npm`, `logout`, `--publish`, {
             env: {
               HOME: homePath,
@@ -202,7 +202,7 @@ describe(`Commands`, () => {
         let stderr: string;
 
         try {
-          // @ts-expect-error
+          // @ts-expect-error - reason TBS
           ({code, stdout, stderr} = await run(`npm`, `logout`, `--scope`, FAKE_FIRST_SCOPE, {
             env: {
               HOME: homePath,

--- a/packages/docusaurus/config/typedoc/plugin.ts
+++ b/packages/docusaurus/config/typedoc/plugin.ts
@@ -1,5 +1,5 @@
 import {miscUtils}                                                                                           from '@yarnpkg/core';
-// @ts-expect-error
+// @ts-expect-error - reason TBS
 import pnpApi                                                                                                from 'pnpapi';
 import {Application, Converter, DeclarationReflection, ProjectReflection, SignatureReflection, type Context} from 'typedoc';
 

--- a/packages/docusaurus/src/lib/npmTools.ts
+++ b/packages/docusaurus/src/lib/npmTools.ts
@@ -1,7 +1,7 @@
 import {normalizeRepoUrl}          from '@yarnpkg/monorepo/packages/plugin-git/sources/utils/normalizeRepoUrl';
 import DOMPurify                   from 'dompurify';
 import gitUrlParse                 from 'git-url-parse';
-// @ts-expect-error
+// @ts-expect-error - reason TBS
 import {Marked}                    from 'marked';
 import {useQuery}                  from 'react-query';
 import {resolve as resolveExports} from 'resolve.exports';

--- a/packages/docusaurus/src/theme/DocRoot/Layout/index.tsx
+++ b/packages/docusaurus/src/theme/DocRoot/Layout/index.tsx
@@ -14,7 +14,7 @@ function getReactNodeFromDomNode(domNode: Element) {
   if (!fiberKey)
     throw new Error(`Assertion failed: Couldn't find the React node associated with the DOM node`);
 
-  // @ts-expect-error
+  // @ts-expect-error - reason TBS
   const {type: Type, memoizedProps} = domNode[fiberKey];
   return <Type {...memoizedProps}/>;
 }

--- a/packages/eslint-config/rules/best-practices.js
+++ b/packages/eslint-config/rules/best-practices.js
@@ -20,7 +20,7 @@ export default [
         ignoreRestSiblings: true,
       }],
 
-      '@typescript-eslint/prefer-ts-expect-error': 2,
+      '@typescript-eslint/ban-ts-comment': 2,
 
       'arca/no-default-export': 2,
 

--- a/packages/eslint-config/rules/errors.js
+++ b/packages/eslint-config/rules/errors.js
@@ -50,7 +50,7 @@ export default [
 
       'no-misleading-character-class': 2,
 
-      'no-new-symbol': 2,
+      'no-new-native-nonconstructor': 2,
 
       'no-redeclare': 2,
 

--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -31,7 +31,7 @@ export default [
       'no-const-assign': 0,
 
       // Checked by Typescript - ts(2588)
-      'no-new-symbol': 0,
+      'no-new-native-nonconstructor': 0,
 
       // Checked by Typescript - ts(2376)
       'no-this-before-super': 0,

--- a/packages/plugin-constraints/sources/Constraints.ts
+++ b/packages/plugin-constraints/sources/Constraints.ts
@@ -2,7 +2,7 @@
 import {Ident, MessageName, nodeUtils, Project, ReportError, Workspace} from '@yarnpkg/core';
 import {miscUtils, structUtils}                                         from '@yarnpkg/core';
 import {xfs, ppath, PortablePath}                                       from '@yarnpkg/fslib';
-// @ts-expect-error
+// @ts-expect-error - reason TBS
 import plLists                                                          from 'tau-prolog/modules/lists';
 import pl                                                               from 'tau-prolog';
 

--- a/packages/plugin-npm-cli/sources/commands/npm/info.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/info.ts
@@ -163,7 +163,7 @@ export default class NpmInfoCommand extends BaseCommand {
           serialized = {};
 
           for (const field of fields) {
-            // @ts-expect-error
+            // @ts-expect-error - reason TBS
             const value = packageInformation[field];
 
             if (typeof value !== `undefined`) {

--- a/packages/yarnpkg-core/sources/Configuration.ts
+++ b/packages/yarnpkg-core/sources/Configuration.ts
@@ -2045,7 +2045,7 @@ export class Configuration {
 
       const ret = await hook(...args);
       if (typeof ret !== `undefined`) {
-        // @ts-expect-error
+        // @ts-expect-error - reason TBS
         return ret;
       }
     }

--- a/packages/yarnpkg-core/sources/structUtils.ts
+++ b/packages/yarnpkg-core/sources/structUtils.ts
@@ -527,13 +527,13 @@ export function parseRange<Opts extends ParseRangeOptions>(range: string, opts?:
     : null;
 
   return {
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     protocol,
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     source,
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     selector,
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     params,
   };
 }

--- a/packages/yarnpkg-doctor/sources/cli.ts
+++ b/packages/yarnpkg-doctor/sources/cli.ts
@@ -195,7 +195,7 @@ async function buildJsonNode(p: PortablePath, accesses: Array<string>) {
     /*setParentNodes */ true,
   );
 
-  // @ts-expect-error
+  // @ts-expect-error - reason TBS
   let node: ts.Node = sourceFile.statements[0].expression;
   if (!node)
     throw new Error(`Invalid source tree`);

--- a/packages/yarnpkg-fslib/sources/MountFS.ts
+++ b/packages/yarnpkg-fslib/sources/MountFS.ts
@@ -924,14 +924,14 @@ export class MountFS<MountedFS extends MountableFS> extends BasePortableFakeFS {
     return this.makeCallSync(p, () => {
       return this.baseFs.watch(
         p,
-        // @ts-expect-error
+        // @ts-expect-error - reason TBS
         a,
         b,
       );
     }, (mountFs, {subPath}) => {
       return mountFs.watch(
         subPath,
-        // @ts-expect-error
+        // @ts-expect-error - reason TBS
         a,
         b,
       );
@@ -944,7 +944,7 @@ export class MountFS<MountedFS extends MountableFS> extends BasePortableFakeFS {
     return this.makeCallSync(p, () => {
       return this.baseFs.watchFile(
         p,
-        // @ts-expect-error
+        // @ts-expect-error - reason TBS
         a,
         b,
       );

--- a/packages/yarnpkg-fslib/sources/NodeFS.ts
+++ b/packages/yarnpkg-fslib/sources/NodeFS.ts
@@ -55,7 +55,7 @@ export class NodeFS extends BasePortableFakeFS {
         this.realFs.opendir(npath.fromPortablePath(p), this.makeCallback(resolve, reject) as any);
       }
     }).then(dir => {
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       //
       // We need a way to tell TS that the values returned by the `read`
       // methods are compatible with `Dir`, especially the `name` field.
@@ -81,7 +81,7 @@ export class NodeFS extends BasePortableFakeFS {
       ? this.realFs.opendirSync(npath.fromPortablePath(p), opts)
       : this.realFs.opendirSync(npath.fromPortablePath(p));
 
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     //
     // We need a way to tell TS that the values returned by the `read`
     // methods are compatible with `Dir`, especially the `name` field.
@@ -572,7 +572,7 @@ export class NodeFS extends BasePortableFakeFS {
   watch(p: PortablePath, a?: WatchOptions | WatchCallback, b?: WatchCallback) {
     return this.realFs.watch(
       npath.fromPortablePath(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b,
     );
@@ -583,7 +583,7 @@ export class NodeFS extends BasePortableFakeFS {
   watchFile(p: PortablePath, a: WatchFileOptions | WatchFileCallback, b?: WatchFileCallback) {
     return this.realFs.watchFile(
       npath.fromPortablePath(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b,
     ) as unknown as StatWatcher;

--- a/packages/yarnpkg-fslib/sources/ProxiedFS.ts
+++ b/packages/yarnpkg-fslib/sources/ProxiedFS.ts
@@ -381,7 +381,7 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
   watch(p: P, a?: WatchOptions | WatchCallback, b?: WatchCallback) {
     return this.baseFs.watch(
       this.mapToBase(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b,
     );
@@ -392,7 +392,7 @@ export abstract class ProxiedFS<P extends Path, IP extends Path> extends FakeFS<
   watchFile(p: P, a: WatchFileOptions | WatchFileCallback, b?: WatchFileCallback) {
     return this.baseFs.watchFile(
       this.mapToBase(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b,
     );

--- a/packages/yarnpkg-fslib/sources/patchFs/patchFs.ts
+++ b/packages/yarnpkg-fslib/sources/patchFs/patchFs.ts
@@ -327,7 +327,7 @@ export function patchFs(patchedFs: typeof fs, fakeFs: FakeFS<NativePath>): void 
     }
 
     setupFn(patchedFsPromises, `open`, async (...args: Array<any>) => {
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       const fd = await fakeFs.openPromise(...args);
       return new FileHandle(fd, fakeFs);
     });
@@ -344,12 +344,12 @@ export function patchFs(patchedFs: typeof fs, fakeFs: FakeFS<NativePath>): void 
     // https://github.com/nodejs/node/blob/dc79f3f37caf6f25b8efee4623bec31e2c20f595/lib/fs.js#L690-L691
     // and
     // https://github.com/nodejs/node/blob/ba684805b6c0eded76e5cd89ee00328ac7a59365/lib/internal/util.js#L293
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     patchedFs.read[promisify.custom] = async (fd: number, buffer: Buffer, ...args: Array<any>) => {
       const res = fakeFs.readPromise(fd, buffer, ...args);
       return {bytesRead: await res, buffer};
     };
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     patchedFs.write[promisify.custom] = async (fd: number, buffer: Buffer, ...args: Array<any>) => {
       const res = fakeFs.writePromise(fd, buffer, ...args);
       return {bytesWritten: await res, buffer};

--- a/packages/yarnpkg-fslib/tests/ProxiedFS.test.ts
+++ b/packages/yarnpkg-fslib/tests/ProxiedFS.test.ts
@@ -5,10 +5,10 @@ import {PortablePath, ppath} from '../sources/path';
 describe(`ProxiedFS`, () => {
   it(`should resolve relative symlinks after remapping`, async () => {
     class SpyFS extends NoFS {
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       symlinkPromise = jest.fn(async () => {});
 
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       symlinkSync = jest.fn(() => {});
     }
 

--- a/packages/yarnpkg-libzip/sources/ZipFS.ts
+++ b/packages/yarnpkg-libzip/sources/ZipFS.ts
@@ -1434,7 +1434,7 @@ export class ZipFS extends BasePortableFakeFS {
   async readFilePromise(p: FSPath<PortablePath>, encoding?: BufferEncoding | null) {
     // This is messed up regarding the TS signatures
     if (typeof encoding === `object`)
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       encoding = encoding ? encoding.encoding : undefined;
 
     const data = await this.readFileBuffer(p, {asyncDecompress: true});
@@ -1447,7 +1447,7 @@ export class ZipFS extends BasePortableFakeFS {
   readFileSync(p: FSPath<PortablePath>, encoding?: BufferEncoding | null) {
     // This is messed up regarding the TS signatures
     if (typeof encoding === `object`)
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       encoding = encoding ? encoding.encoding : undefined;
 
     const data = this.readFileBuffer(p);

--- a/packages/yarnpkg-pnp/sources/esm-loader/hooks/resolve.ts
+++ b/packages/yarnpkg-pnp/sources/esm-loader/hooks/resolve.ts
@@ -8,7 +8,7 @@ import * as loaderUtils                      from '../loaderUtils';
 
 let findPnpApi: any = (esmModule as any).findPnpApi;
 if (!findPnpApi) {
-  // @ts-expect-error
+  // @ts-expect-error - reason TBS
   const require = createRequire(import.meta.url);
 
   const pnpApi = require(`./.pnp.cjs`);

--- a/packages/yarnpkg-pnp/sources/loader/makeApi.ts
+++ b/packages/yarnpkg-pnp/sources/loader/makeApi.ts
@@ -336,7 +336,7 @@ export function makeApi(runtimeState: RuntimeState, opts: MakeApiOptions): PnpAp
    */
 
   function makeFakeModule(path: NativePath): NodeModule {
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     const fakeModule = new Module(path, null);
     fakeModule.filename = path;
     fakeModule.paths = Module._nodeModulePaths(path);

--- a/packages/yarnpkg-pnp/sources/loader/makeManager.ts
+++ b/packages/yarnpkg-pnp/sources/loader/makeManager.ts
@@ -31,9 +31,9 @@ export function makeManager(pnpapi: PnpApi, opts: MakeManagerOptions) {
   function loadApiInstance(pnpApiPath: PortablePath): PnpApi {
     const nativePath = npath.fromPortablePath(pnpApiPath);
 
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     const module = new Module(nativePath, null);
-    // @ts-expect-error
+    // @ts-expect-error - reason TBS
     module.load(nativePath);
 
     return module.exports;

--- a/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
+++ b/packages/yarnpkg-pnpify/sources/NodeModulesFS.ts
@@ -622,7 +622,7 @@ export class PortableNodeModulesFS extends FakeFS<PortablePath> {
     } else {
       return this.baseFs.watch(
         this.resolveDirOrFilePath(p),
-        // @ts-expect-error
+        // @ts-expect-error - reason TBS
         a,
         b,
       );
@@ -634,7 +634,7 @@ export class PortableNodeModulesFS extends FakeFS<PortablePath> {
   watchFile(p: PortablePath, a: WatchFileOptions | WatchFileCallback, b?: WatchFileCallback): StatWatcher {
     return this.baseFs.watchFile(
       this.resolveDirOrFilePath(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b,
     );

--- a/packages/yarnpkg-shell/sources/pipe.ts
+++ b/packages/yarnpkg-shell/sources/pipe.ts
@@ -83,7 +83,7 @@ export function makeProcess(name: string, args: Array<string>, opts: ShellOption
             process.off(`SIGTERM`, sigtermHandler);
           }
 
-          // @ts-expect-error
+          // @ts-expect-error - reason TBS
           switch (error.code) {
             case `ENOENT`: {
               stdio[2].write(`command not found: ${name}\n`);


### PR DESCRIPTION
## What's the problem this PR addresses?

- closes https://github.com/yarnpkg/berry/issues/6713

`@yarnpkg/eslint-config` makes use of two ESLint rules that are now deprecated:

| Linter                                                                  | Deprecated Rule                                                                                         |
| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [ESLint](https://eslint.org/docs/latest/rules/)                         | [no-new-symbol](https://eslint.org/docs/latest/rules/no-new-symbol)                                     |
| [@typescript-eslint/eslint-plugin](https://typescript-eslint.io/rules/) | [@typescript-eslint/prefer-ts-expect-error](https://typescript-eslint.io/rules/prefer-ts-expect-error/) |

## How did you fix it?

Replaced the two deprecated rules as follows:

| Deprecated Rule                                                                                         | Replacement Rule                                                                                  |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [no-new-symbol](https://eslint.org/docs/latest/rules/no-new-symbol)                                     | [no-new-native-nonconstructor](https://eslint.org/docs/latest/rules/no-new-native-nonconstructor) |
| [@typescript-eslint/prefer-ts-expect-error](https://typescript-eslint.io/rules/prefer-ts-expect-error/) | [@typescript-eslint/ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment)            |

Changed all instances of  `// @ts-expect-error` without comments to `// @ts-expect-error - reason TBS` to satisfy `@typescript-eslint/ban-ts-comment`. Comments may be replaced later as necessary. The rule will however encourage any new use of `// @ts-expect-error`  to include an explanation comment.

Executed 

```shell
yarn test:lint
yarn typecheck:all
```

to confirm no remaining linting / TypeScript issues.

## Checklist

- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [X] I have set the packages that need to be released for my changes to be effective. (`@yarnpkg/eslint-config`)
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
