### PR TITLE
Fix Integration tests for Big endian on GA CI

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -286,10 +286,10 @@ jobs:
         name: yarn-artifacts
         path: packages
 
-    # https://github.com/multiarch/qemu-user-static
+    # https://github.com/tonistiigi/binfmt
     - name: 'Enable execution of multi-arch containers'
       run: |
-        docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes
+        docker run --rm --privileged tonistiigi/binfmt:latest --install all
       shell: bash
 
     # Apparently @babel/register is insanely slow inside the big-endian

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -27,7 +27,7 @@ const staticServer = serveStatic(npath.fromPortablePath(require(`pkg-tests-fixtu
 
 // Testing things inside a big-endian container takes forever
 export const TEST_TIMEOUT = os.endianness() === `BE`
-  ? 200000
+  ? 300000
   : 75000;
 
 export type PackageEntry = Map<string, {path: string, packageJson: Record<string, any>}>;


### PR DESCRIPTION
## What's the problem this PR addresses?

Fixes the GA CI Integration jobs failing for Big endian.


## How did you fix it?

1. Changed multiarch image to `tonistiigi/binfmt:latest` for running Big Endian tests as the tests failed in `multiarch/qemu-user-static` image. 
**Note:** All tests passed on s390x host VM, issues were seen in `multiarch/qemu-user-static` image. 
Tested running Integration tests using `tonistiigi/binfmt:latest` and all Big Endian Integration tests have passed.

2. Increased `TEST_TIMEOUT` for Big Endian to fix TC's failing due to timeout issue:

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
