### PR TITLE
fix(npm-audit): ensure message is a string before trimming for deprec…

### DIFF
--- a/.yarn/versions/e8aaefb7.yml
+++ b/.yarn/versions/e8aaefb7.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-npm-cli/sources/commands/npm/audit.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/audit.ts
@@ -161,7 +161,7 @@ export default class NpmAuditCommand extends BaseCommand {
         auditResult[packageName] ??= [];
         auditResult[packageName].push({
           id: `${packageName} (deprecation)`,
-          title: message.trim() || `This package has been deprecated.`,
+          title: (typeof message === `string` ? message : ``).trim() || `This package has been deprecated.`,
           severity: npmAuditTypes.Severity.Moderate,
           vulnerable_versions: version,
         });


### PR DESCRIPTION
Fix [Bug?]: TypeError: le.trim is not a function when running yarn npm audit -AR #6554

## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Closes #6554


## How did you fix it?

<!-- A detailed description of your implementation. -->

Ensure that message is a string, otherwise return the default message

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
