### PR TITLE
Try to add a little more helpful information about tgz file references

### DIFF
--- a/packages/docusaurus/docs/advanced/01-general-reference/protocols/file.mdx
+++ b/packages/docusaurus/docs/advanced/01-general-reference/protocols/file.mdx
@@ -28,3 +28,6 @@ file:./relative/path/to/package.tgz
 ## Tarball-based links
 
 When `file:` points to a `.tgz` file, Yarn will transparently let you require files from within the archive. For the `node_modules` linker, it means that the archive will be unpacked into the generated `node_modules` folder.
+
+The `.tgz` file should have all the project files under a single top-level folder, and that folder should have a `package.json` file describing the package and its version.  For example, a package called `foo` might be
+in a file named `foo-1.0.tgz`, the `tgz` could have files in it at `foo/package.json` and `foo/main.js`.  You would add it to your project with a command like `yarn add foo@file:./path/to/foo-1.0.tgz`.


### PR DESCRIPTION
I was quite confused about why yarn would not accept my `tgz` file.  It seems like I had to put the `package.json` and other files into a folder inside the `tgz` rather than have them bare at the top level.

It seems like if this is a requirement for using `tgz` file it should be mentioned on this page.
