### PR TITLE
ci: properly mint a provenance token in workflows

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -18,6 +18,10 @@ jobs:
     env:
       NODE_OPTIONS: --max_old_space_size=8192
 
+    # Mint a token to produce the provenance statement
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -18,6 +18,10 @@ jobs:
     env:
       NODE_OPTIONS: --max_old_space_size=8192
 
+    # Mint a token to produce the provenance statement
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## What's the problem this PR addresses?

Follow-up #6750: enable provenance statements for Yarn

## How did you fix it?

<!-- A detailed description of your implementation. -->

Added `permissions: id-token: write` to publication workflows

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
