### PR TITLE
fix(plugin-npm): mark fetchFromNetwork private to fix TypeScript issue

### DIFF
--- a/.yarn/versions/3d022429.yml
+++ b/.yarn/versions/3d022429.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/packages/plugin-npm/sources/NpmHttpFetcher.ts
+++ b/packages/plugin-npm/sources/NpmHttpFetcher.ts
@@ -43,7 +43,7 @@ export class NpmHttpFetcher implements Fetcher {
     };
   }
 
-  async fetchFromNetwork(locator: Locator, opts: FetchOptions) {
+  private async fetchFromNetwork(locator: Locator, opts: FetchOptions) {
     const {params} = structUtils.parseRange(locator.reference);
     if (params === null || typeof params.__archiveUrl !== `string`)
       throw new Error(`Assertion failed: The archiveUrl querystring parameter should have been available`);


### PR DESCRIPTION
## What's the problem this PR addresses?

As part of developing a Yarn plugin for our project, we introduced `@yarnpkg/plugin-npm` as a dependency. However when running typescript, the package raises the following error:

```bash
node_modules/@yarnpkg/plugin-npm/lib/NpmHttpFetcher.d.ts:12:76 - error TS2307: Cannot find module '/home/runner/work/berry/berry/.yarn/__virtual__/@yarnpkg-libzip-virtual-4957b34c08/1/packages/yarnpkg-libzip' or its corresponding type declarations.

12     fetchFromNetwork(locator: Locator, opts: FetchOptions): Promise<import("/home/runner/work/berry/berry/.yarn/__virtual__/@yarnpkg-libzip-virtual-4957b34c08/1/packages/yarnpkg-libzip").ZipFS>;
```

I've looked at the generated `lib/NpmHttpFetcher.d.ts` file https://www.npmjs.com/package/@yarnpkg/plugin-npm?activeTab=code, I found that the issue was in the `fetchFromNetwork` signature which includes a path generated during CI (`/home/runner/work/berry/berry/...`), which cannot be resolved locally.

```ts
export declare class NpmHttpFetcher implements Fetcher {
    supports(locator: Locator, opts: MinimalFetchOptions): boolean;
    getLocalPath(locator: Locator, opts: FetchOptions): null;
    fetch(locator: Locator, opts: FetchOptions): Promise<{
        packageFs: import("@yarnpkg/fslib").FakeFS<import("@yarnpkg/fslib").PortablePath>;
        releaseFs: () => void;
        prefixPath: import("@yarnpkg/fslib").PortablePath;
        checksum: string | null;
    }>;
    fetchFromNetwork(locator: Locator, opts: FetchOptions): Promise<import("/home/runner/work/berry/berry/.yarn/__virtual__/@yarnpkg-libzip-virtual-4957b34c08/1/packages/yarnpkg-libzip").ZipFS>;
```

## How did you fix it?

As the `fetchFromNetwork` method seems to be intended for local use only, I've marked it as private so that TypeScript skips inferring the return type, marking the change as minor. But please let me know if you would prefer to keep the method public and explicitly define the return type.

I've spotted a similar error in:
- https://github.com/yarnpkg/berry/blob/1908ee79fdf80fc8397d8ff928f3bfe25f30e715/packages/plugin-github/sources/GithubFetcher.ts#L39
- https://github.com/yarnpkg/berry/blob/1908ee79fdf80fc8397d8ff928f3bfe25f30e715/packages/plugin-http/sources/TarballHttpFetcher.ts#L34

happy to fix those as well.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
