### PR TITLE
chore: upgrade workflows to ubuntu 22 images

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -215,7 +215,7 @@ jobs:
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
         node: [18, 19, 20, 21, 22]
-        platform: [[ubuntu, 20.04]]
+        platform: [[ubuntu, 22.04]]
         shard: ['1/2', '2/2']
         include:
           # We run the rest of the tests on the minimum Node version we support with 3 shards.


### PR DESCRIPTION
## What's the problem this PR addresses?

[Ubuntu 20 images have been deprecated by Github.](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) [Workflows are failing because of it.](https://github.com/yarnpkg/berry/actions/runs/14700798041/job/41249908502?pr=6734)

## How did you fix it?

Changed version `20.04` to `22.04`

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
