### PR TITLE
feat(perf) improve hoist traverse logic and memory usage

### DIFF
--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -332,25 +332,26 @@ const getHoistIdentMap = (rootNode: HoisterWorkTree, preferenceMap: PreferenceMa
  */
 const getSortedRegularDependencies = (node: HoisterWorkTree): Set<HoisterWorkTree> => {
   const dependencies: Set<HoisterWorkTree> = new Set();
+  const seenDeps: Set<HoisterWorkTree> = new Set();
 
-  const addDep = (dep: HoisterWorkTree, seenDeps = new Set()) => {
-    if (seenDeps.has(dep))
+  const addDep = (dep: HoisterWorkTree) => {
+    if (seenDeps.has(dep)) 
       return;
     seenDeps.add(dep);
-
+    
     for (const peerName of dep.peerNames) {
       if (!node.peerNames.has(peerName)) {
         const peerDep = node.dependencies.get(peerName);
         if (peerDep && !dependencies.has(peerDep)) {
-          addDep(peerDep, seenDeps);
+          addDep(peerDep);
         }
       }
     }
     dependencies.add(dep);
   };
 
-  for (const dep of node.dependencies.values()) {
-    if (!node.peerNames.has(dep.name)) {
+  for (const [name, dep] of node.dependencies) {
+    if (!node.peerNames.has(name)) { 
       addDep(dep);
     }
   }

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -335,10 +335,10 @@ const getSortedRegularDependencies = (node: HoisterWorkTree): Set<HoisterWorkTre
   const seenDeps: Set<HoisterWorkTree> = new Set();
 
   const addDep = (dep: HoisterWorkTree) => {
-    if (seenDeps.has(dep)) 
+    if (seenDeps.has(dep))
       return;
     seenDeps.add(dep);
-    
+
     for (const peerName of dep.peerNames) {
       if (!node.peerNames.has(peerName)) {
         const peerDep = node.dependencies.get(peerName);
@@ -351,7 +351,7 @@ const getSortedRegularDependencies = (node: HoisterWorkTree): Set<HoisterWorkTre
   };
 
   for (const [name, dep] of node.dependencies) {
-    if (!node.peerNames.has(name)) { 
+    if (!node.peerNames.has(name)) {
       addDep(dep);
     }
   }


### PR DESCRIPTION
## What's the problem this PR addresses?

This PR improves the performance of getSortedRegularDependencies by reusing a single `seenDeps` Set across recursive calls instead of creating new ones, and using Map entries for direct key access.


## How did you fix it?
The previous code traversed nodes redundantly by recreating seenDeps for every dependency, causing repeated processing of already visited nodes. By declaring seenDeps at the function level, we eliminate unnecessary traversals and reduce memory allocations.
This optimization preserves identical behavior while improving performance on large dependency trees with many nested packages.

refers: https://github.com/yarnpkg/berry/pull/1717#issuecomment-684253941
> node_modules hoisting algorithm recipe
The children of root node are already "hoisted", so you need to start from the dependencies of these children. You take some child and sort its dependencies so that regular dependencies without peer dependencies will come first and then those dependencies that peer depend on them. This is needed to make algorithm more efficient and hoist nodes which are easier to hoist first and then handle peer dependent nodes.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
