### PR TITLE
docs: add a link to the `Hooks` interface

### DIFF
--- a/packages/docusaurus/docs/advanced/04-technical/plugin-tutorial.mdx
+++ b/packages/docusaurus/docs/advanced/04-technical/plugin-tutorial.mdx
@@ -193,6 +193,6 @@ The `YARN_PLUGINS` environment variable is a semicolon-separated list of plugin 
 
 Packages can use this mechanism to dynamically register plugins and query the Yarn API using commands without having to explicitly depend on the Yarn packages and deal with potential version mismatches.
 
-## Official hooks
+## Available hooks
 
-Our new website doesn't support generating the hook list yet; sorry :(
+For the list of the available hooks, see documentation of the [Hooks interface](https://yarnpkg.com/api/yarnpkg-core/interface/Hooks).


### PR DESCRIPTION
## What's the problem this PR addresses?

Currently the Plugins page states that the list of available plugins is not possible to be generated. 
 
## How did you fix it?

The list is available from the documentation of the `Hooks` interface. This PR provides a link to the available page instead.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
