### PR TITLE
fix(plugin-nm): set binary permissions for partial installs

### DIFF
--- a/.yarn/versions/944c0a3d.yml
+++ b/.yarn/versions/944c0a3d.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-2.0.0/bin.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-2.0.0/bin.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log(require(`./package.json`).version);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-2.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@scoped__has-bin-entry-2.0.0/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@scoped/has-bin-entry",
+	"version": "2.0.0",
+	"bin": {
+		"@scoped/has-bin-entry": "./bin.js"
+	}
+}


### PR DESCRIPTION
Hi! :wave: 

## What's the problem this PR addresses?

Resolves #5344 #6551 

When using `nodeLinker: node-modules` there's an issue where bin files sometimes don't have the correct permissions (755) after installation. Some examples of scenarios where this can occur:
1. Deleting a package directory containing a bin file in `node_modules` and then running `yarn install`
2. Upgrading a package containing a bin file
3. Using a stale `node_modules` (e.g. when using a CI cache) and then running `yarn install`

I ran a bisect and at least scenario 1 above seems to have started in [3.2.1](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#321), I suspect it's [this](https://github.com/yarnpkg/berry/pull/3467) change specifically although previous to this change the deleted directory was not reinstalled *at all*.

Digging into the issue I found that the general issue stems from reliance on presence of symlinks inside `node_modules/.bin/` ([here](https://github.com/yarnpkg/berry/blob/master/packages/plugin-nm/sources/NodeModulesLinker.ts#L1361)) to check whether permissions should be re-applied. The flaw with this approach is that for stale installation the old symlink is *still there* e.g. if a new version of a package is installed.

## How did you fix it?

This changes the `prevBinSymlinks` to remove all symlinks that were related to added/changed packages during the installation. The comparison between previous and current symlinks inside `persistBinSymlinks` will now recreate the symlinks for these updated packages and also set the correct permissions.

I've added two tests which were previously failing to cover this behavior, and a third which was already succeeding since it seemed sensible to explicitly test for permissions in a basic test as well.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
