### PR TITLE
feat: Add provenance to @yarnpkg/cli-dist

### DIFF
--- a/scripts/release/03-release-npm.sh
+++ b/scripts/release/03-release-npm.sh
@@ -28,4 +28,4 @@ cd "$TEMP_DIR"
 export YARN_ENABLE_IMMUTABLE_INSTALLS=0
 
 node "$TEMP_DIR"/bin/yarn.js
-node "$TEMP_DIR"/bin/yarn.js npm publish --tolerate-republish --access=public
+node "$TEMP_DIR"/bin/yarn.js npm publish --tolerate-republish --provenance --access=public


### PR DESCRIPTION
## What's the problem this PR addresses?

#6750 started publishing our packages with provenance via config, but `@yarnpkg/cli-dist` is published separately where the config does not take effect.

...

## How did you fix it?

Add the `--provenance` flag when publishing @yarnpkg/cli-dist`

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
