### PR TITLE
updated globalFolder documentation

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -252,7 +252,7 @@
     "globalFolder": {
       "_package": "@yarnpkg/core",
       "title": "Path where all files global to the system will be stored.",
-      "description": "Various files we be stored there: global cache, metadata cache, ...",
+      "description": "The folder where all system-global files (cache, metadata, etc.) are stored. The location depends on the operating system; for example `$HOME/.yarn/berry` on Linux/macOS or `%LOCALAPPDATA%\\Yarn\\Berry` on Windows. This path can be overridden by the `YARN_GLOBAL_FOLDER` environment variable.",
       "type": "string",
       "format": "uri-reference",
       "examples": ["${HOME}/.yarn/berry"]


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
The `globalFolder` config in the Yarn settings documentation is shown with a value that appears to represent the default, but it's actually just an example. This may lead to confusion, where on platforms like Windows the actual default is different (%LOCALAPPDATA%\Yarn\Berry) - just to make things clear.

<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->
Closes #6814 

## How did you fix it?
Clarified in the documentation that the value shown for globalFolder is only an example and not the acutal platform-specific default.

<!-- A detailed description of your implementation. -->
I updated the `Settings (packages/docusaurus/static/configuration/yarnrc.json)` documentation file to clarify that the value shown for settings like globalFolder are example values adn not necessarily platform defaults. This helps revent confusion, especially for Windows users, where the default global folder is different than the one shown.
- I edited the respective JSON file in the `packages/docusaurus/static/configuration` directory
- I followed contribution guidelines and verified the changes using yarn start to preview the updated documentation.

![image](https://github.com/user-attachments/assets/4a46aa34-d204-46f6-bd61-315bb413b46e)

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.