### PR TITLE
Tweak workspaces run doc to clarify gotcha with global scripts

### DIFF
--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -44,7 +44,7 @@ export default class WorkspacesForeachCommand extends BaseCommand {
 
       The \`-v,--verbose\` flag can be passed up to twice: once to prefix output lines with the originating workspace's name, and again to include start/finish/timing log lines. Maximum verbosity is enabled by default in terminal environments.
 
-      If the command is \`run\` and the script being run does not exist the child workspace will be skipped without error.
+      If the command is \`run\` and the script being run does not exist the child workspace will be skipped without error.  Note that [global scripts](https://yarnpkg.com/features/workspaces#global-scripts) are considered to exist on all workspaces.
     `,
     examples: [[
       `Publish all packages`,


### PR DESCRIPTION
## What's the problem this PR addresses?

I was very confused when `yarn workspaces foreach run xxx:yyy` was running in every workspace, even ones that do not define a script with that name.  I imagine others may be similarly confused as the docs currently are a bit ambiguous about this point.  Also many users are likely not even aware of the concept of "global scripts" using ":".

## How did you fix it?

I added a bit more to the docs to clarify that `yarn workspaces foreach run xxx:yyy` will run in every workspace, even ones that do not define a script by that name.
