### PR TITLE
Adds GIT_AUTHOR_NAME to the test env

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -56,6 +56,11 @@ const mte = generatePkgDriver({
         [`YARN_PNP_FALLBACK_MODE`]: `none`,
         // Otherwise tests fail on systems where this is globally set to true
         [`YARN_ENABLE_GLOBAL_CACHE`]: `false`,
+        // To make sure we can call Git commands
+        [`GIT_AUTHOR_NAME`]: `John Doe`,
+        [`GIT_AUTHOR_EMAIL`]: `john.doe@example.org`,
+        [`GIT_COMMITTER_NAME`]: `John Doe`,
+        [`GIT_COMMITTER_EMAIL`]: `john.doe@example.org`,
         // Older versions of Windows need this set to not have node throw an error
         [`NODE_SKIP_PLATFORM_CHECK`]: `1`,
         // We don't want the PnP runtime to be accidentally injected


### PR DESCRIPTION
## What's the problem this PR addresses?

The test env doesn't automatically setup the git committer name / email. I noticed it when working on `yarn init`, as the test was passing but I didn't understand why until I dig deeper (turns out we don't pass the `strict` flag when calling the `git` commands; I don't remember whether it's an oversight or not).

## How did you fix it?

Automatically setup the git committer name / email. Should a test want to avoid that (for example to explicitly test that a command works without), they should override it manually.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
