### PR TITLE
fix(pnpm): allow EBUSY when deleting node_modules

### DIFF
--- a/.yarn/versions/5ccd3d41.yml
+++ b/.yarn/versions/5ccd3d41.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -399,7 +399,7 @@ async function removeIfEmpty(dir: PortablePath) {
   try {
     await xfs.rmdirPromise(dir);
   } catch (error) {
-    if (error.code !== `ENOENT` && error.code !== `ENOTEMPTY`) {
+    if (error.code !== `ENOENT` && error.code !== `ENOTEMPTY` && error.code !== `EBUSY`) {
       throw error;
     }
   }


### PR DESCRIPTION
## What's the problem this PR addresses?

EBUSY should be allowed, if `node_modules` is an active docker mountpoint where rmdir attempts to unmount it which fails because there are open files.

Closes #4373 #4974 #4259 #1184 #4172 

## How did you fix it?

Allow EBUSY to not block "clearing" node_modules.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
