### PR TITLE
Sdks biomejs

### DIFF
--- a/.yarn/versions/af44cf1e.yml
+++ b/.yarn/versions/af44cf1e.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/yarnpkg-sdks/sources/generateSdk.ts
+++ b/packages/yarnpkg-sdks/sources/generateSdk.ts
@@ -198,6 +198,7 @@ export type SupportedSdk =
   | `@astrojs/language-server`
   | `eslint`
   | `prettier`
+  | `@biomejs/biome`
   | `relay-compiler`
   | `typescript-language-server`
   | `typescript`

--- a/packages/yarnpkg-sdks/sources/sdks/base.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/base.ts
@@ -27,6 +27,14 @@ export const generatePrettierBaseWrapper: GenerateBaseWrapper = async (pnpApi: P
   return wrapper;
 };
 
+export const generateBiomeBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
+  const wrapper = new Wrapper(`@biomejs/biome` as PortablePath, {pnpApi, target, manifestOverrides: {exports: undefined}});
+
+  await wrapper.writeDefaults();
+
+  return wrapper;
+};
+
 export const generateRelayCompilerBaseWrapper: GenerateBaseWrapper = async (pnpApi: PnpApi, target: PortablePath) => {
   const wrapper = new Wrapper(`relay-compiler` as PortablePath, {pnpApi, target});
 
@@ -289,6 +297,7 @@ export const BASE_SDKS: BaseSdks = [
   [`@astrojs/language-server`, generateAstroLanguageServerBaseWrapper],
   [`eslint`, generateEslintBaseWrapper],
   [`prettier`, generatePrettierBaseWrapper],
+  [`@biomejs/biome`, generateBiomeBaseWrapper],
   [`relay-compiler`, generateRelayCompilerBaseWrapper],
   [`typescript-language-server`, generateTypescriptLanguageServerBaseWrapper],
   [`typescript`, generateTypescriptBaseWrapper],

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -77,6 +77,22 @@ export const generatePrettierWrapper: GenerateIntegrationWrapper = async (pnpApi
   });
 };
 
+export const generateBiomeWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
+    [`biome.lsp.bin`]: npath.fromPortablePath(
+      wrapper.getProjectPathTo(
+        `bin/biome` as PortablePath,
+      ),
+    ),
+  });
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.extensions, {
+    [`recommendations`]: [
+      `biomejs.biome`,
+    ],
+  });
+};
+
 export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`relay.pathToRelay`]: npath.fromPortablePath(
@@ -144,6 +160,7 @@ export const VSCODE_SDKS: IntegrationSdks = [
   [`@astrojs/language-server`, generateAstroLanguageServerWrapper],
   [`eslint`, generateEslintWrapper],
   [`prettier`, generatePrettierWrapper],
+  [`@biomejs/biome`, generateBiomeWrapper],
   [`relay-compiler`, generateRelayCompilerWrapper],
   [`typescript-language-server`, null],
   [`typescript`, generateTypescriptWrapper],


### PR DESCRIPTION
## What's the problem this PR addresses?

Add support for `@biomejs/biome` package in sdks allowing IDEs to pick up the `biome` binary.

## How did you fix it?

I based my developments on other cli integrations and made some changes for biome.

I tested it by running the locally built sdks script (`packages/yarnpkg-sdks/sources/boot-cli-dev.js`) in a project that use `@biomejs/biome` and confirmed in vs code that `biome` was available. Before running the cli, `biome` was unavailable.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
