### PR TITLE
feat(publish): Add `--dry-run` and `--json` flag to `yarn npm publish`

### DIFF
--- a/.yarn/versions/4c28a2b4.yml
+++ b/.yarn/versions/4c28a2b4.yml
@@ -1,0 +1,13 @@
+releases:
+  "@yarnpkg/plugin-npm-cli": minor
+
+undecided:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/core"
+  - "@yarnpkg/sdks"

--- a/.yarn/versions/4c28a2b4.yml
+++ b/.yarn/versions/4c28a2b4.yml
@@ -1,14 +1,23 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-npm-cli": minor
 
-undecided:
+declined:
+  - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
   - "@yarnpkg/plugin-essentials"
-  - "@yarnpkg/plugin-git"
-  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
   - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
-  - "@yarnpkg/cli"
+  - "@yarnpkg/builder"
   - "@yarnpkg/core"
-  - "@yarnpkg/sdks"
+  - "@yarnpkg/doctor"

--- a/.yarn/versions/4c28a2b4.yml
+++ b/.yarn/versions/4c28a2b4.yml
@@ -9,5 +9,6 @@ undecided:
   - "@yarnpkg/plugin-pnpm"
   - "@yarnpkg/plugin-version"
   - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"
   - "@yarnpkg/core"
   - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -1,4 +1,4 @@
-import {npath, xfs} from '@yarnpkg/fslib';
+import {npath, ppath, xfs} from '@yarnpkg/fslib';
 
 const {
   tests: {testIf},
@@ -129,8 +129,8 @@ describe(`publish`, () =>   {
   }, async ({path, run, source}) => {
     await run(`install`);
 
-    const {code} = await run(`npm`, `publish`, path, `--dry-run`, `--tolerate-republish`, {
-      cwd: npath.dirname(path),
+    const {code} = await run(`npm`, `publish`, `--directory`, npath.fromPortablePath(path), `--dry-run`, `--tolerate-republish`, {
+      cwd: ppath.dirname(path),
     });
     expect(code).toBe(0);
   }));

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -1,4 +1,4 @@
-import {npath, ppath, xfs} from '@yarnpkg/fslib';
+import {npath, xfs} from '@yarnpkg/fslib';
 
 const {
   tests: {testIf},
@@ -110,29 +110,6 @@ describe(`publish`, () =>   {
     expect(result).toHaveProperty(`name`, `json-test`);
     expect(result).toHaveProperty(`version`, `1.0.0`);
     expect(result).toHaveProperty(`dryRun`, true);
-  }));
-
-  test(`should support --registry flag`, makeTemporaryEnv({
-    name: `registry-test`,
-    version: `1.0.0`,
-  }, async ({path, run, source}) => {
-    await run(`install`);
-
-    const {stdout} = await run(`npm`, `publish`, `--json`, `--dry-run`, `--registry`, `https://registry.npmjs.org`, `--tolerate-republish`);
-    const result = JSON.parse(stdout);
-    expect(result).toHaveProperty(`registry`, `https://registry.npmjs.org`);
-  }));
-
-  test(`should support directory argument`, makeTemporaryEnv({
-    name: `directory-test`,
-    version: `1.0.0`,
-  }, async ({path, run, source}) => {
-    await run(`install`);
-
-    const {code} = await run(`npm`, `publish`, `--directory`, npath.fromPortablePath(path), `--dry-run`, `--tolerate-republish`, {
-      cwd: ppath.dirname(path),
-    });
-    expect(code).toBe(0);
   }));
 
   testIf(

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -89,6 +89,52 @@ describe(`publish`, () =>   {
     });
   }));
 
+  test(`should support --dry-run flag`, makeTemporaryEnv({
+    name: `dry-run-test`,
+    version: `1.0.0`,
+  }, async ({path, run, source}) => {
+    await run(`install`);
+
+    const {stdout} = await run(`npm`, `publish`, `--dry-run`, `--tolerate-republish`);
+    expect(stdout).toContain(`[DRY RUN]`);
+  }));
+
+  test(`should support --json flag`, makeTemporaryEnv({
+    name: `json-test`,
+    version: `1.0.0`,
+  }, async ({path, run, source}) => {
+    await run(`install`);
+
+    const {stdout} = await run(`npm`, `publish`, `--json`, `--dry-run`, `--tolerate-republish`);
+    const result = JSON.parse(stdout);
+    expect(result).toHaveProperty(`name`, `json-test`);
+    expect(result).toHaveProperty(`version`, `1.0.0`);
+    expect(result).toHaveProperty(`dryRun`, true);
+  }));
+
+  test(`should support --registry flag`, makeTemporaryEnv({
+    name: `registry-test`,
+    version: `1.0.0`,
+  }, async ({path, run, source}) => {
+    await run(`install`);
+
+    const {stdout} = await run(`npm`, `publish`, `--json`, `--dry-run`, `--registry`, `https://registry.npmjs.org`, `--tolerate-republish`);
+    const result = JSON.parse(stdout);
+    expect(result).toHaveProperty(`registry`, `https://registry.npmjs.org`);
+  }));
+
+  test(`should support directory argument`, makeTemporaryEnv({
+    name: `directory-test`,
+    version: `1.0.0`,
+  }, async ({path, run, source}) => {
+    await run(`install`);
+
+    const {code} = await run(`npm`, `publish`, path, `--dry-run`, `--tolerate-republish`, {
+      cwd: npath.dirname(path),
+    });
+    expect(code).toBe(0);
+  }));
+
   testIf(
     () => !!process.env.ACTIONS_ID_TOKEN_REQUEST_URL,
     `should publish a package with a valid provenance statement`,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -122,11 +122,9 @@ describe(`publish`, () =>   {
     expect(result).toHaveProperty(`provenance`);
     expect(result).toHaveProperty(`gitHead`);
 
-    const filesObject = jsonObjects.find((obj: any) => obj.type === `files`);
+    expect(result).toHaveProperty(`gitHead`);
 
-    expect(filesObject).toBeDefined();
-    expect(filesObject).toHaveProperty(`files`);
-    expect(Array.isArray(filesObject.files)).toBe(true);
+    expect(Array.isArray(result.files)).toBe(true);
   }));
 
   testIf(

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -2,6 +2,7 @@ import {npath, xfs} from '@yarnpkg/fslib';
 
 const {
   tests: {testIf},
+  misc,
 } = require(`pkg-tests-core`);
 
 const {
@@ -106,10 +107,26 @@ describe(`publish`, () =>   {
     await run(`install`);
 
     const {stdout} = await run(`npm`, `publish`, `--json`, `--dry-run`, `--tolerate-republish`);
-    const result = JSON.parse(stdout);
+    const jsonObjects = misc.parseJsonStream(stdout);
+    const result = jsonObjects.find((obj: any) => obj.name && obj.version);
+
+    expect(result).toBeDefined();
     expect(result).toHaveProperty(`name`, `json-test`);
     expect(result).toHaveProperty(`version`, `1.0.0`);
     expect(result).toHaveProperty(`dryRun`, true);
+    expect(result).toHaveProperty(`registry`);
+    expect(result).toHaveProperty(`published`, false);
+    expect(result).toHaveProperty(`message`);
+
+    expect(result).toHaveProperty(`tag`);
+    expect(result).toHaveProperty(`provenance`);
+    expect(result).toHaveProperty(`gitHead`);
+
+    const filesObject = jsonObjects.find((obj: any) => obj.type === `files`);
+
+    expect(filesObject).toBeDefined();
+    expect(filesObject).toHaveProperty(`files`);
+    expect(Array.isArray(filesObject.files)).toBe(true);
   }));
 
   testIf(

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts
@@ -120,10 +120,8 @@ describe(`publish`, () =>   {
 
     expect(result).toHaveProperty(`tag`);
     expect(result).toHaveProperty(`provenance`);
-    expect(result).toHaveProperty(`gitHead`);
 
-    expect(result).toHaveProperty(`gitHead`);
-
+    expect(result).toHaveProperty(`files`);
     expect(Array.isArray(result.files)).toBe(true);
   }));
 

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -193,6 +193,10 @@ export default class NpmPublishCommand extends BaseCommand {
     }
   }
 
+  private isStreamingReport(report: any): boolean {
+    return report.reportInfo && typeof report.reportInfo === `function`;
+  }
+
   private determineProvenance(workspace: any, configuration: any): boolean {
     if (workspace.manifest.publishConfig && `provenance` in workspace.manifest.publishConfig)
       return Boolean(workspace.manifest.publishConfig.provenance);
@@ -220,7 +224,7 @@ export default class NpmPublishCommand extends BaseCommand {
     const files = await packUtils.genPackList(workspace);
 
     // Report files if this is a streaming report
-    if (report.reportInfo && typeof report.reportInfo === `function`) {
+    if (this.isStreamingReport(report)) {
       for (const file of files) {
         report.reportInfo(null, file);
       }
@@ -232,7 +236,7 @@ export default class NpmPublishCommand extends BaseCommand {
     const provenance = this.determineProvenance(workspace, configuration);
 
     // Report provenance decision if this is a streaming report
-    if (report.reportInfo && typeof report.reportInfo === `function`)
+    if (this.isStreamingReport(report))
       this.reportProvenanceDecision(provenance, workspace, report);
 
     const body = await npmPublishUtils.makePublishBody(workspace, buffer, {
@@ -251,7 +255,7 @@ export default class NpmPublishCommand extends BaseCommand {
         otp: this.otp,
         jsonResponse: true,
       });
-    } else if (report.reportInfo && typeof report.reportInfo === `function`) {
+    } else if (this.isStreamingReport(report)) {
       report.reportInfo(MessageName.UNNAMED, `[DRY RUN] Package would be published to ${registry}`);
     }
 

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -92,6 +92,10 @@ export default class NpmPublishCommand extends BaseCommand {
       return 0;
     }
 
+    return await this.executeWithReportStream(workspace, registry, configuration, ident, version);
+  }
+
+  private async executeWithReportStream(workspace: any, registry: string, configuration: any, ident: any, version: string): Promise<number> {
     const report = await StreamReport.start({
       configuration,
       stdout: this.context.stdout,

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -47,7 +47,7 @@ export default class NpmPublishCommand extends BaseCommand {
     description: `Generate provenance for the package. Only available in GitHub Actions and GitLab CI. Can be set globally through the \`npmPublishProvenance\` setting or the \`YARN_NPM_CONFIG_PROVENANCE\` environment variable, or per-package through the \`publishConfig.provenance\` field in package.json.`,
   });
 
-  dryRun = Option.Boolean(`--dry-run`, false, {
+  dryRun = Option.Boolean(`-n,--dry-run`, false, {
     description: `Show what would be published without actually publishing`,
   });
 

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -189,7 +189,6 @@ export default class NpmPublishCommand extends BaseCommand {
           published: !this.dryRun,
           message: finalMessage,
           provenance: Boolean(provenance),
-          gitHead: gitHead || null,
         });
       });
     });

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -157,16 +157,8 @@ export default class NpmPublishCommand extends BaseCommand {
         else if (provenance)
           message = `Generating provenance statement because \`npmPublishProvenance\` setting is set.`;
 
-        if (message) {
-          if (this.json) {
-            report.reportJson({
-              type: `info`,
-              message,
-            });
-          } else {
-            report.reportInfo(null, message);
-          }
-        }
+        if (message)
+          report.reportInfo(null, message);
 
         const body = await npmPublishUtils.makePublishBody(workspace, buffer, {
           access: this.access,
@@ -186,14 +178,7 @@ export default class NpmPublishCommand extends BaseCommand {
           });
         } else {
           const dryRunMessage = `[DRY RUN] Package would be published to ${registry}`;
-          if (this.json) {
-            report.reportJson({
-              type: `info`,
-              message: dryRunMessage,
-            });
-          } else {
-            report.reportInfo(MessageName.UNNAMED, dryRunMessage);
-          }
+          report.reportInfo(MessageName.UNNAMED, dryRunMessage);
         }
       });
 

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -165,14 +165,11 @@ export default class NpmPublishCommand extends BaseCommand {
             otp: this.otp,
             jsonResponse: true,
           });
-        } else {
-          const dryRunMessage = `[DRY RUN] Package would be published to ${registry}`;
-          report.reportInfo(MessageName.UNNAMED, dryRunMessage);
         }
       });
 
       const finalMessage = this.dryRun
-        ? `[DRY RUN] Package publication completed`
+        ? `[DRY RUN] Package would be published to ${registry} with tag ${this.tag}`
         : `Package archive published`;
 
       if (this.json) {

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -124,34 +124,30 @@ export default class NpmPublishCommand extends BaseCommand {
 
         const pack = await packUtils.genPackStream(workspace, files);
         const buffer = await miscUtils.bufferStream(pack);
+
         const gitHead = await npmPublishUtils.getGitHead(workspace.cwd);
 
-        // Determine provenance
         let provenance = false;
-        if (workspace.manifest.publishConfig && `provenance` in workspace.manifest.publishConfig)
+        let provenanceMessage = ``;
+        if (workspace.manifest.publishConfig && `provenance` in workspace.manifest.publishConfig) {
           provenance = Boolean(workspace.manifest.publishConfig.provenance);
-        else if (this.provenance)
-          provenance = true;
-        else if (configuration.get(`npmPublishProvenance`))
-          provenance = true;
-
-        // Report provenance decision
-        let message = ``;
-        if (workspace.manifest.publishConfig && `provenance` in workspace.manifest.publishConfig)
-          message = provenance
+          provenanceMessage = provenance
             ? `Generating provenance statement because \`publishConfig.provenance\` field is set.`
             : `Skipping provenance statement because \`publishConfig.provenance\` field is set to false.`;
-        else if (this.provenance)
-          message = `Generating provenance statement because \`--provenance\` flag is set.`;
-        else if (provenance)
-          message = `Generating provenance statement because \`npmPublishProvenance\` setting is set.`;
+        } else if (this.provenance) {
+          provenance = true;
+          provenanceMessage = `Generating provenance statement because \`--provenance\` flag is set.`;
+        } else if (configuration.get(`npmPublishProvenance`)) {
+          provenance = true;
+          provenanceMessage = `Generating provenance statement because \`npmPublishProvenance\` setting is set.`;
+        }
 
-        if (message) {
-          report.reportInfo(null, message);
+        if (provenanceMessage) {
+          report.reportInfo(null, provenanceMessage);
           report.reportJson({
             type: `provenance`,
             enabled: provenance,
-            message,
+            provenanceMessage,
           });
         }
 

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -55,22 +55,12 @@ export default class NpmPublishCommand extends BaseCommand {
     description: `Output the result in JSON format`,
   });
 
-  registry = Option.String(`--registry`, {
-    description: `The registry to publish to`,
-  });
-
-  directory = Option.String(`--directory`, {
-    description: `The directory to publish (defaults to current directory)`,
-    required: false,
-  });
-
   async execute() {
-    const cwd = this.directory ? ppath.resolve(this.context.cwd, this.directory) : this.context.cwd;
-    const configuration = await Configuration.find(cwd, this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, cwd);
+    const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+    const {project, workspace} = await Project.find(configuration, this.context.cwd);
 
     if (!workspace)
-      throw new WorkspaceRequiredError(project.cwd, cwd);
+      throw new WorkspaceRequiredError(project.cwd, this.context.cwd);
 
     if (workspace.manifest.private)
       throw new UsageError(`Private workspaces cannot be published`);
@@ -83,7 +73,7 @@ export default class NpmPublishCommand extends BaseCommand {
     const ident = workspace.manifest.name;
     const version = workspace.manifest.version;
 
-    const registry = this.registry || npmConfigUtils.getPublishRegistry(workspace.manifest, {configuration});
+    const registry = npmConfigUtils.getPublishRegistry(workspace.manifest, {configuration});
 
     const report = await StreamReport.start({
       configuration,

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -1,6 +1,5 @@
 import {BaseCommand, WorkspaceRequiredError}                                                    from '@yarnpkg/cli';
 import {Configuration, MessageName, Project, ReportError, StreamReport, scriptUtils, miscUtils} from '@yarnpkg/core';
-import {ppath}                                                                                  from '@yarnpkg/fslib';
 import {npmConfigUtils, npmHttpUtils, npmPublishUtils}                                          from '@yarnpkg/plugin-npm';
 import {packUtils}                                                                              from '@yarnpkg/plugin-pack';
 import {Command, Option, Usage, UsageError}                                                     from 'clipanion';

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -59,7 +59,7 @@ export default class NpmPublishCommand extends BaseCommand {
     description: `The registry to publish to`,
   });
 
-  directory = Option.String({
+  directory = Option.String(`--directory`, {
     description: `The directory to publish (defaults to current directory)`,
     required: false,
   });


### PR DESCRIPTION
## What's the problem this PR addresses?

Addresses #6849 

## How did you fix it?

Full disclosure, used Github Copilot Agent Mode to generate most of this PR here --> https://github.com/Saadnajmi/berry/pull/2
Since then, lots more manual edits on my side. I took some spirit from https://github.com/yarnpkg/berry/pull/3404/ and `pack.ts` to determine how to print paths and when to call `report.reportInfo` vs `report.reportJson`.

This adds a couple of flags to `yarn npm publish`, so that it matches other package managers like `pnpm` and `bun`, and is thus easier for tools like `nx release` to use (see https://github.com/nrwl/nx/issues/29242 ). We add

 - `--dry-run` (Bails out right before the final publish to NPM)
 - `--json` (This takes advantage of StreamReports JSON config)
 
 Using both flags together looks something like this:
 
 ```shell
sanajmi@Mac foo % yarn npm publish --dry-run       
➤ YN0000: README.md
➤ YN0000: bar.js
➤ YN0000: package.json
➤ YN0000: xyz.js
➤ YN0000: [DRY RUN] Package would be published to https://registry.yarnpkg.com with tag latest
➤ YN0000: Done in 0s 13ms

sanajmi@Mac foo % yarn npm publish --dry-run --json
{"file":"README.md"}
{"file":"bar.js"}
{"file":"package.json"}
{"file":"xyz.js"}
{"name":"foo","version":"1.0.0","registry":"https://registry.yarnpkg.com","tag":"latest","files":["README.md","bar.js","package.json","xyz.js"],"access":null,"dryRun":true,"published":false,"message":"[DRY RUN] Package would be published to https://registry.yarnpkg.com with tag latest","provenance":false,"gitHead":"d4f82af6fdb7f2f81c5910535900c5ad8a70a019"}
 ```

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

(TODO)

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
