### PR TITLE
ci: use react with vite in storybook E2E

### DIFF
--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -16,7 +16,7 @@ env:
   STORYBOOK_DISABLE_TELEMETRY: 1
 jobs:
   chore:
-    name: 'Validating Storybook (with a React app)'
+    name: 'Validating Storybook (React with Vite app)'
     runs-on: ubuntu-latest
 
     steps:
@@ -27,9 +27,7 @@ jobs:
     - name: 'Running the integration test'
       run: |
         source scripts/e2e-setup-ci.sh
-        yarn create react-app my-cra && cd my-cra
-
-        yarn add @babel/preset-env
+        yarn create vite react --template react && cd react
 
         yarn dlx storybook@latest init --yes --no-dev
         yarn build-storybook


### PR DESCRIPTION
## What's the problem this PR addresses?

- closes https://github.com/yarnpkg/berry/issues/6696

The workflow [.github/workflows/e2e-storybook-workflow.yml](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-storybook-workflow.yml) fails with

```text
create-react-app is deprecated.

You can find a list of up-to-date React frameworks on react.dev
For more info see:https://react.dev/link/cra

This error message will only be shown once per install.
/tmp/xfs-1a340a15/dlx-2010/.pnp.cjs:5738
      throw EROFS(`open '${p}'`);
```

It was last successful on Dec 28, 2024.

## How did you fix it?

In the workflow [.github/workflows/e2e-storybook-workflow.yml](https://github.com/yarnpkg/berry/blob/master/.github/workflows/e2e-storybook-workflow.yml)

replace

```yaml
yarn create react-app my-cra && cd my-cra
```

using

```yaml
yarn create vite react --template react && cd react
```

## Checklist

- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [X] I have set the packages that need to be released for my changes to be effective.

- [X] I will check that all automated PR checks pass before the PR gets reviewed.
