### PR TITLE
chore(docs): quote variables

### DIFF
--- a/packages/docusaurus/docs/getting-started/extra/questions-and-answers.mdx
+++ b/packages/docusaurus/docs/getting-started/extra/questions-and-answers.mdx
@@ -142,7 +142,7 @@ Little-known Yarn feature: any script with a colon in its name (`build:foo`) can
     "typescript": "^3.8.0"
   },
   "scripts": {
-    "g:tsc": "cd $INIT_CWD && tsc"
+    "g:tsc": "cd \"$INIT_CWD\" && tsc"
   }
 }
 ```
@@ -172,7 +172,7 @@ Should you want to run a script in the base of your project:
 ```json
 {
   "scripts": {
-    "build": "node ${PROJECT_CWD}/scripts/update-contributors.js"
+    "build": "node \"$PROJECT_CWD/scripts/update-contributors.js\""
   }
 }
 ```


### PR DESCRIPTION
## What's the problem this PR addresses?

This adjusts the Q&A code examples.

The provided snippets do not allow (e.g.) spaces within the current path.

It might be rare that this happens, but technically it is allowed, so in case someone just copies the example, they will not run in any unexpected situation.

## How did you fix it?

By wrapping the variable in quotes.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
