### PR TITLE
Add documentation for opts.conditions of resolveRequest from pnpapi

### DIFF
--- a/packages/docusaurus/docs/advanced/03-pnp/pnp-api.mdx
+++ b/packages/docusaurus/docs/advanced/03-pnp/pnp-api.mdx
@@ -223,6 +223,10 @@ Note that in some cases you may just have a folder to work with as `issuer` para
 
 This function will return `null` if the request is a builtin module, unless `considerBuiltins` is set to `false`.
 
+Options:
+
+- `considerBuiltins`: Whether to consider builtins during resolution, such as `node:fs` or `node:path`.
+
 ### `resolveUnqualified(...)`
 
 ```ts
@@ -245,10 +249,14 @@ Might very well be resolved into:
 /my/cache/lodash/1.0.0/node_modules/lodash/uniq/index.js
 ```
 
+Options:
+
+- `extensions`: A list of file extensions to try and resolve, such as [".js", ".ts"].
+
 ### `resolveRequest(...)`
 
 ```ts
-export function resolveRequest(request: string, issuer: string | null, opts?: {considerBuiltins?: boolean, extensions?: string[]]}): string | null;
+export function resolveRequest(request: string, issuer: string | null, opts?: {considerBuiltins?: boolean, extensions?: string[]], conditions: Set<string>}): string | null;
 ```
 
 The `resolveRequest` function is a wrapper around both `resolveToUnqualified` and `resolveUnqualified`. In essence, it's a bit like calling `resolveUnqualified(resolveToUnqualified(...))`, but shorter.
@@ -268,6 +276,12 @@ Might very well be resolved into:
 ```
 
 This function will return `null` if the request is a builtin module, unless `considerBuiltins` is set to `false`.
+
+Options:
+
+- `considerBuiltins`: Whether to consider builtins during resolution, such as `node:fs` or `node:path`.
+- `extensions`: A list of file extensions to try and resolve, such as [".js", ".ts"].
+- `conditions`: Export conditions to consider, when the `package.json` contains an `exports` field. Defaults to `["node", "require"]`.
 
 ### `resolveVirtual(...)`
 


### PR DESCRIPTION
Add documentation for `opts.conditions` of the `resolveRequest` function from `pnpapi`


## What's the problem this PR addresses?

Is the `conditions` option for the `resolveRequest` function from the pnpapi public? It's currently not documented anywhere.

I came across this as part of visjs/vis-timeline#1898. `resolveRequest` would not resolve the request properly, complaining that it's not defined in the `exports` conditions of the `package.json`.

Then I looked through the .pnpapi.cjs code and found that `resolveRequest` has a `conditions` option that defaults to `node, require`. After setting it to `import`, it could resolve it successfully.

## How did you fix it?

Added documentation.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [x] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
