### PR TITLE
test: Fix test failures by specifying initial branch name in git init

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/exec.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/exec.ts
@@ -62,7 +62,7 @@ export const execFile = (
 export const execGitInit = async (
   options: Options,
 ) => {
-  await execFile(`git`, [`init`], options);
+  await execFile(`git`, [`init`, `--initial-branch=master`], options);
   await execFile(`git`, [`config`, `user.email`, `you@example.com`], options);
   await execFile(`git`, [`config`, `user.name`, `Your Name`], options);
   await execFile(`git`, [`config`, `commit.gpgSign`, `false`], options);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/check.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version/check.test.js
@@ -173,7 +173,7 @@ function makeVersionCheckEnv(cb) {
 
     await run(`install`);
 
-    await git(`init`, `.`);
+    await git(`init`, `--initial-branch=master`);
 
     // Otherwise we can't always commit
     await git(`config`, `user.name`, `John Doe`);


### PR DESCRIPTION
## What's the problem this PR addresses?
This PR adds --initial-branch=master option to ensure consistent test behavior across different development environments. It lowers barrier to entry for new contributors!(like me 😀)

Example

```bash
 FAIL  pkg-tests-specs/sources/commands/version/check.test.js (13.598 s)
  ● Commands › version check › it shouldn't detect a change when pulling master

    Temporary fixture folder: /private/var/folders/y2/dwrgd4rx32n7phb939mny5p00000gn/T/xfs-46e897df/test

    Command failed: git checkout master
    error: pathspec 'master' did not match any file(s) known to git


    ===== stdout:

    ```
    ```

    ===== stderr:

    ```
    error: pathspec 'master' did not match any file(s) known to git
    ```
```
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

## How did you fix it?

Explicitly set initial branch to master  to ensure consistent test behavior.
<!-- A detailed description of your implementation. -->

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
