### PR TITLE
fix(plugin-essentials): fix hash validation pattern of explain peer-requirements

### DIFF
--- a/.yarn/versions/d432d26e.yml
+++ b/.yarn/versions/d432d26e.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/.yarn/versions/d432d26e.yml
+++ b/.yarn/versions/d432d26e.yml
@@ -1,7 +1,23 @@
 releases:
+  "@yarnpkg/cli": patch
   "@yarnpkg/plugin-essentials": patch
 
 declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
   - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
   - "@yarnpkg/plugin-typescript"
-  - "@yarnpkg/cli"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-essentials/sources/commands/explain/peerRequirements.ts
+++ b/packages/plugin-essentials/sources/commands/explain/peerRequirements.ts
@@ -20,7 +20,7 @@ export default class ExplainPeerRequirementsCommand extends BaseCommand {
 
       When used without arguments, this command lists all peer requirements and the corresponding hash that can be used to get detailed information about a given requirement.
 
-      **Note:** A hash is a six-letter p-prefixed code that can be obtained from peer dependency warnings or from the list of all peer requirements (\`yarn explain peer-requirements\`).
+      **Note:** A hash is a seven-letter code consisting of the letter 'p' followed by six characters that can be obtained from peer dependency warnings or from the list of all peer requirements(\`yarn explain peer-requirements\`).
     `,
     examples: [[
       `Explain the corresponding peer requirement for a hash`,
@@ -34,7 +34,7 @@ export default class ExplainPeerRequirementsCommand extends BaseCommand {
   hash = Option.String({
     required: false,
     validator: t.cascade(t.isString(), [
-      t.matchesRegExp(/^p[0-9a-f]{5}$/),
+      t.matchesRegExp(/^p[0-9a-f]{6}$/),
     ]),
   });
 


### PR DESCRIPTION
## What's the problem this PR addresses?

This fix of issue described here https://github.com/yarnpkg/berry/issues/6880

## How did you fix it?

Fix validation of hash at `explain peer-requirements` command

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
