### PR TITLE
docs: fix typo in enableScripts JSON schema key name

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -216,7 +216,7 @@
     },
     "enableScripts": {
       "_package": "@yarnpkg/core",
-      "titke": "Define whether to run postinstall scripts or not.",
+      "title": "Define whether to run postinstall scripts or not.",
       "description": "If false, Yarn will not execute the `postinstall` scripts from third-party packages when installing the project (workspaces will still see their postinstall scripts evaluated, as they're assumed to be safe if you're running an install within them).\n\nNote that you also have the ability to disable scripts on a per-package basis using `dependenciesMeta`, or to re-enable a specific script by combining `enableScripts` and `dependenciesMeta`.",
       "type": "boolean",
       "default": true


### PR DESCRIPTION
## What's the problem this PR addresses?

In the JSON schema for Yarn configuration, the `enableScripts` property contained a typo: the key `"title"` was misspelled as `"titke"`. This caused the documentation generator to not correctly display the title for this setting.

## How did you fix it?

I corrected the typo by changing the key from `"titke"` to `"title"` in the `enableScripts` schema entry. This ensures that documentation tools recognize and display the title properly.

| Before | After |
|:------:|:-----:|
|  <img width="1188" height="237" alt="스크린샷 2025-08-31 오후 7 50 58" src="https://github.com/user-attachments/assets/c22d0b80-b9d6-416d-95a2-01112abe9a08" /> |   <img width="1190" height="294" alt="스크린샷 2025-08-31 오후 7 50 49" src="https://github.com/user-attachments/assets/9441ccdc-071e-4f07-a8a6-a442c8659869" />|


## Checklist

- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective.
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
