### PR TITLE
Enables postinstall scripts for pnpm

### DIFF
--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -60,6 +60,8 @@ setup-yarn2-pnpm() {
 setup-pnpm() {
   >> "$BENCH_DIR/.npmrc" echo \
     "strict-peer-dependencies=false"
+  >> "$BENCH_DIR/pnpm-workspace.yaml" echo \
+    "dangerouslyAllowAllBuilds: true"
 }
 
 case $PACKAGE_MANAGER in


### PR DESCRIPTION
## What's the problem this PR addresses?

It came to me that since pnpm no longer runs postinstall scripts by default, the benchmark was a little skewed since Yarn (and npm) do. The benchmarks are intended to compare apples to apples, so either postinstalls should be disabled in Yarn / npm as well, or they should be enabled in pnpm.

## How did you fix it?

Enabled the postinstall scripts in the package manager benchmarks.

To be fair it doesn't change much - the full cold Gatsby benchmark shows around 2 seconds of removed install time around Feb 3rd 2025 which I think is caused by the lack of postinstall, although I'm not certain, but that's about it. Pnpm remains really fast, kudos!

<img width="145" height="93" alt="Screenshot 2025-09-18 at 10 43 02" src="https://github.com/user-attachments/assets/3f9a362a-5c71-41c1-99b2-b2bc930ca796" />

Curiously the same change occurs in the "Recurrent calls" benchmark which probably shouldn't need to run postinstall scripts. Does pnpm have a bug causing it to rebuild postinstall scripts when they aren't needed?

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
