### PR TITLE
fix: support registries without publish times using `minimalAgeGate`

### DIFF
--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -100,8 +100,11 @@ function shouldBeQuarantined({configuration, version, publishTimes}: IsPackageAp
   const minimalAgeGate = configuration.get(`npmMinimalAgeGate`);
 
   if (minimalAgeGate) {
-    const versionTime = new Date(publishTimes[version]);
-    const ageMinutes = (new Date().getTime() - versionTime.getTime()) / 60 / 1000;
+    const versionTime = publishTimes?.[version] ?? 0;
+    if (!versionTime)
+      return true;
+
+    const ageMinutes = (new Date().getTime() - new Date(versionTime).getTime()) / 60 / 1000;
     if (ageMinutes < minimalAgeGate) {
       return true;
     }
@@ -135,7 +138,7 @@ export type IsPackageApprovedOptions = {
   configuration: Configuration;
   ident: Ident;
   version: string;
-  publishTimes: Record<string, string>;
+  publishTimes?: Record<string, string>;
 };
 
 function isPreapproved({configuration, ident, version}: IsPackageApprovedOptions) {

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -287,7 +287,7 @@ export type PackageMetadata = {
       tarball: string;
     };
   }>;
-  time: Record<string, string>;
+  time?: Record<string, string>;
 };
 
 function pickPackageMetadata(metadata: PackageMetadata): PackageMetadata {


### PR DESCRIPTION

## What's the problem this PR addresses?

When using registries that don't expose the publish time along with `minimalAgeGate` setting will result in an error of `No candidates found` as the filter will silently fail and simply exclude it without first checking if it's excepted.

Closes #6906

## How did you fix it?

To address this I changed types to optional and mark candidates without publish time as automatically needing quarantine when `minimalAgeGate` is set instead of silently failing. 

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
