### PR TITLE
docs: add `.gitignore` to migration instructions

### DIFF
--- a/packages/docusaurus/docs/getting-started/migrating/steps.mdx
+++ b/packages/docusaurus/docs/getting-started/migrating/steps.mdx
@@ -19,12 +19,13 @@ Note that those commands only need to be run once for the whole project and will
 ## Migration steps
 
 1. Make sure you're using Node 18+
-2. Run <CommandLineHighlight type={`inlineCode`} lines={[{type: `command`, command: {name: `corepack`, path: [`enable`], argv: [`enable`]}, split: false, tooltip: null, tokens: [{type: `path`, segmentIndex: 0, text: `enable`}]}]}/> to activate [Corepack](https://nodejs.org/api/corepack.html)
-2. Go into your project directory
-3. Run `yarn set version berry`
-4. Convert your `.npmrc` and `.yarnrc` files into [`.yarnrc.yml`](/configuration/yarnrc) (details [here](/migration/guide#update-your-configuration-to-the-new-settings))
-5. Run `yarn install` to migrate the lockfile
-6. Commit all changes
+1. Run <CommandLineHighlight type={`inlineCode`} lines={[{type: `command`, command: {name: `corepack`, path: [`enable`], argv: [`enable`]}, split: false, tooltip: null, tokens: [{type: `path`, segmentIndex: 0, text: `enable`}]}]}/> to activate [Corepack](https://nodejs.org/api/corepack.html)
+1. Go into your project directory
+1. Run `yarn set version berry`
+1. Convert your `.npmrc` and `.yarnrc` files into [`.yarnrc.yml`](/configuration/yarnrc) (details [here](/migration/guide#update-your-configuration-to-the-new-settings))
+1. Run `yarn install` to migrate the lockfile
+1. Update your project's `.gitignore` (details [here](/getting-started/qa#which-files-should-be-gitignored))
+1. Commit all changes
 
 Good, you should now have a working Yarn install! Some things might still require some adjustments in your CI scripts (for example the deprecation of [arbitrary `pre/post`-scripts](/advanced/lifecycle-scripts), or the renaming of `--frozen-lockfile` into `yarn install ! --immutable`), but at least we have a working project.
 


### PR DESCRIPTION
## What's the problem this PR addresses?

When following the step-by-step migration guide, I committed `.yarn/install-state.gz` into my repo. Turns out this is file isn't supposed to be committed, so here's a PR to add that to the migration steps.

## How did you fix it?

Added a link to the [`.gitignore` FAQ](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored).

The raw Markdown numbers were also inaccurate (there were two `2.` entries), so I also changed the list to just use `1.` for all entries. This change should render properly according to the Markdown spec, but adds more diff to the PR (in exchange for not needing to fiddle around with the numbers in the future). Let me know if that needs to be reverted.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
