### PR TITLE
Fixes npmMinimalAgeGate with tags and prereleases

### DIFF
--- a/.yarn/versions/bbd0ef35.yml
+++ b/.yarn/versions/bbd0ef35.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -181,6 +181,7 @@ const RELEASE_DATE_PACKAGES: Record<string, Record<string, number | string>> = {
   "release-date": {
     "1.0.0": new Date(new Date().getTime() - /* 10 days */ 1000 * 60 * 60 * 24 * 10).toISOString(),
     "1.1.0": new Date(new Date().getTime() - /* 5 days */ 1000 * 60 * 60 * 24 * 5).toISOString(),
+    "1.1.1-beta": new Date(new Date().getTime() - /* 3 days */ 1000 * 60 * 60 * 24 * 3).toISOString(),
     "1.1.1": new Date().toISOString(),
   },
   "release-date-transitive": {

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/release-date-1.1.1-beta/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/release-date-1.1.1-beta/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/release-date-1.1.1-beta/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/release-date-1.1.1-beta/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "release-date",
+    "version": "1.1.1-beta",
+    "dependencies": {
+        "release-date-transitive": "^1.0.0"
+    }
+}

--- a/packages/plugin-npm/sources/NpmTagResolver.ts
+++ b/packages/plugin-npm/sources/NpmTagResolver.ts
@@ -59,8 +59,10 @@ export class NpmTagResolver implements Resolver {
     let version = distTags[tag];
 
     if (tag === `latest` && !isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version, publishTimes: times})) {
+      const toleratePrereleases = version.includes(`-`);
+
       const nextVersion = semver.rsort(versions).find(candidateVersion => {
-        return semver.lt(candidateVersion, version) && isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version: candidateVersion, publishTimes: times});
+        return semver.lt(candidateVersion, version) && (toleratePrereleases || !candidateVersion.includes(`-`)) && isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version: candidateVersion, publishTimes: times});
       });
 
       if (!nextVersion)


### PR DESCRIPTION
## What's the problem this PR addresses?

The `npmMinimalAgeGate` feature was favouring prerelease installs when running `yarn add`; it should instead remain on stable tracks until the final release passes the gate.

Fixes #6914 

## How did you fix it?

Added a check to only allow prereleases to be used if the initial tag version is also a prerelease.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
