### PR TITLE
Disables Prolog tests from new releases

### DIFF
--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/query.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/query.test.js
@@ -1,5 +1,6 @@
 const {
   fs: {writeFile},
+  tests: {testIf},
 } = require(`pkg-tests-core`);
 
 const {environments} = require(`./environments`);
@@ -24,7 +25,8 @@ custom_predicate(DependencyType):-
 
 describe(`Commands`, () => {
   describe(`constraints query`, () => {
-    test(
+    testIf(
+      `prologConstraints`,
       `test without trailing .`,
       makeTemporaryEnv({}, async({path, run, source}) => {
         await environments[`one regular dependency`](path);
@@ -43,7 +45,8 @@ describe(`Commands`, () => {
       }),
     );
 
-    test(
+    testIf(
+      `prologConstraints`,
       `test with a syntax error`,
       makeTemporaryEnv({}, async({path, run, source}) => {
         await environments[`one regular dependency`](path);
@@ -62,7 +65,8 @@ describe(`Commands`, () => {
       }),
     );
 
-    test(
+    testIf(
+      `prologConstraints`,
       `test with an unknown predicate`,
       makeTemporaryEnv({}, async({path, run, source}) => {
         await environments[`one regular dependency`](path);
@@ -81,7 +85,8 @@ describe(`Commands`, () => {
       }),
     );
 
-    test(
+    testIf(
+      `prologConstraints`,
       `test with an empty predicate`,
       makeTemporaryEnv({}, async({path, run, source}) => {
         await environments[`one regular dependency`](path);
@@ -102,7 +107,8 @@ describe(`Commands`, () => {
 
     for (const [environmentDescription, environment] of Object.entries(environments)) {
       for (const [queryDescription, query] of Object.entries(queries)) {
-        test(
+        testIf(
+          `prologConstraints`,
           `test (${environmentDescription} / ${queryDescription})`,
           makeTemporaryEnv({}, async ({path, run, source}) => {
             await environment(path);

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/source.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/constraints/source.test.js
@@ -1,5 +1,6 @@
 const {
   fs: {writeFile},
+  tests: {testIf},
 } = require(`pkg-tests-core`);
 
 const {environments} = require(`./environments`);
@@ -15,7 +16,8 @@ describe(`Commands`, () => {
   describe(`constraints source`, () => {
     for (const [environmentDescription, environment] of Object.entries(environments)) {
       for (const [scriptDescription, script] of Object.entries(constraints)) {
-        test(
+        testIf(
+          `prologConstraints`,
           `test (${environmentDescription} / ${scriptDescription})`,
           makeTemporaryEnv({}, async ({path, run, source}) => {
             await environment(path);


### PR DESCRIPTION
## What's the problem this PR addresses?

The prolog constraints are deprecated and will be removed from the next majors. They should be migrated to the JS interface.

## How did you fix it?

Prevent the tests from running on versions that don't support prolog constraints.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
