### PR TITLE
Implements yarn pack --preserve-workspaces

### DIFF
--- a/.yarn/versions/f772082a.yml
+++ b/.yarn/versions/f772082a.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-pack": minor
+
+declined:
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/plugin-pack/sources/commands/pack.ts
+++ b/packages/plugin-pack/sources/commands/pack.ts
@@ -34,6 +34,10 @@ export default class PackCommand extends BaseCommand {
     description: `Run a preliminary \`yarn install\` if the package contains build scripts`,
   });
 
+  preserveWorkspaces = Option.Boolean(`--preserve-workspaces`, false, {
+    description: `Preserve the workspaces in the package manifest`,
+  });
+
   dryRun = Option.Boolean(`-n,--dry-run`, false, {
     description: `Print the file paths without actually generating the package archive`,
   });
@@ -89,7 +93,9 @@ export default class PackCommand extends BaseCommand {
         }
 
         if (!this.dryRun) {
-          const pack = await packUtils.genPackStream(workspace, files);
+          const pack = await packUtils.genPackStream(workspace, files, {
+            preserveWorkspaces: this.preserveWorkspaces,
+          });
 
           await xfs.mkdirPromise(ppath.dirname(target), {recursive: true});
           const write = xfs.createWriteStream(target);


### PR DESCRIPTION
## What's the problem this PR addresses?

I'm working on a way for projects to add dependencies on git repositories while still resolving workspaces properly. For that to work, `yarn pack` needs to keep the `workspace:` prefixes rather than turn them into their semver counterparts.

## How did you fix it?

Implements a `--preserve-workspaces` flag that instructs Yarn to keep the workspaces unchanged.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
