### PR TITLE
fix: use correct env var to detect gitlab CI for OIDC

### DIFF
--- a/.yarn/versions/c5da5cd9.yml
+++ b/.yarn/versions/c5da5cd9.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+
+declined:
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/plugin-npm-cli/sources/commands/npm/publish.ts
+++ b/packages/plugin-npm-cli/sources/commands/npm/publish.ts
@@ -166,7 +166,7 @@ export default class NpmPublishCommand extends BaseCommand {
             ident,
             otp: this.otp,
             jsonResponse: true,
-            allowOidc: Boolean(process.env.CI && (process.env.GITHUB_ACTIONS || process.env.GITLAB)),
+            allowOidc: Boolean(process.env.CI && (process.env.GITHUB_ACTIONS || process.env.GITLAB_CI)),
           });
         }
 

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -593,7 +593,7 @@ function getOtpHeaders(otp: string) {
 async function getOidcToken(registry: string, {configuration, ident}: {configuration: Configuration, ident: Ident}): Promise<string | null> {
   let idToken: string | null = null;
 
-  if (process.env.GITLAB) {
+  if (process.env.GITLAB_CI) {
     idToken = process.env.NPM_ID_TOKEN || null;
   } else if (process.env.GITHUB_ACTIONS) {
     if (!(process.env.ACTIONS_ID_TOKEN_REQUEST_URL && process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN))


### PR DESCRIPTION
## What's the problem this PR addresses?

When #6898 added support for OIDC publishing, it copied the getOidcToken function from npm's implementation. However, `ciInfo` was directly replaced with `process.env`, which coincidentally worked fine for GitHub Actions (both the `ciInfo` constant and the environment variable are named `GITHUB_ACTIONS`), but not for GitLab (the `ciInfo` constant is `GITLAB`, but the actual env var is `GITLAB_CI`).

## How did you fix it?

Replaced `process.env.GITLAB` with `process.env.GITLAB_CI`

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
