### PR TITLE
Fix JSON Schema

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -10336,6 +10336,7 @@ const RAW_RUNTIME_STATE =
           ["@tanstack/react-query", "virtual:efae73f2e9aa11493dde5182b5b7f0894b5c101cb3c916b74523dc0bde92d8579259d43c7f83a5363dbd8939dc3d1e6c45c5965b9191878533d9a2c19b046d70#npm:5.74.7"],\
           ["@types/dompurify", "npm:3.0.2"],\
           ["@types/git-url-parse", "npm:9.0.0"],\
+          ["@types/jest", "npm:28.1.6"],\
           ["@types/markdown-it", "npm:12.2.3"],\
           ["@types/marked", "npm:5.0.0"],\
           ["@types/mdast", "npm:4.0.3"],\
@@ -10362,6 +10363,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/pnpify", "workspace:packages/yarnpkg-pnpify"],\
           ["@yarnpkg/sdks", "workspace:packages/yarnpkg-sdks"],\
           ["@yarnpkg/shell", "workspace:packages/yarnpkg-shell"],\
+          ["ajv", "npm:8.17.1"],\
           ["algoliasearch", "npm:4.22.1"],\
           ["ansi-to-html", "npm:0.7.2"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -6,7 +6,8 @@
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve"
+    "serve": "docusaurus serve",
+    "test:schema": "run test:unit packages/docusaurus"
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",
@@ -79,6 +80,7 @@
     "@docusaurus/types": "^3.7.0",
     "@types/dompurify": "^3",
     "@types/git-url-parse": "^9.0.0",
+    "@types/jest": "^28.1.6",
     "@types/markdown-it": "^12.2.3",
     "@types/marked": "^5.0.0",
     "@types/mdast": "^4.0.3",
@@ -91,6 +93,7 @@
     "@types/resolve": "^1.20.0",
     "@types/semver": "^7.1.0",
     "@types/three": "^0.144.0",
+    "ajv": "^8.17.1",
     "clipanion": "^4.0.0-rc.2",
     "mdast-util-mdx-jsx": "^3.0.0",
     "unified": "^11.0.4"

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -273,7 +273,7 @@
     "httpTimeout": {
       "_package": "@yarnpkg/core",
       "title": "Amount of time to wait before cancelling pending HTTP requests.",
-      "type": "mixed",
+      "type": ["number", "string"],
       "oneOf": [
         { "type": "number" },
         { "type": "string", "pattern": "^(\\d*\\.?\\d+)(ms|s|m|h|d|w)?$" }
@@ -487,7 +487,7 @@
       "_package": "@yarnpkg/core",
       "title": "Minimum age of a package version according to the publish date on the npm registry to be considered for installation.",
       "description": "If a package version is newer than the minimal age gate, it will not be considered for installation. This can be used to reduce the likelihood of installing compromised packages, or to avoid relying on packages that could still be unpublished (e.g. the npm registry has specific rules for packages less than 3 days old).",
-      "type": "mixed",
+      "type": ["number", "string"],
       "oneOf": [
         { "type": "number" },
         { "type": "string", "pattern": "^(\\d*\\.?\\d+)(ms|s|m|h|d|w)?$" }
@@ -861,7 +861,7 @@
       "_package": "@yarnpkg/core",
       "title": "Define the minimal amount of time between two telemetry events.",
       "description": "By default we only send one request per week, making it impossible for us to track your usage with a lower granularity.",
-      "type": "mixed",
+      "type": ["number", "string"],
       "oneOf": [
         { "type": "number" },
         { "type": "string", "pattern": "^(\\d*\\.?\\d+)(ms|s|m|h|d|w)?$" }

--- a/packages/docusaurus/tests/schema.test.ts
+++ b/packages/docusaurus/tests/schema.test.ts
@@ -1,0 +1,24 @@
+import Ajv2019         from 'ajv/dist/2019';
+import draft2019Schema from 'ajv/dist/refs/json-schema-2019-09/schema.json';
+
+import manifestSchema  from '../static/configuration/manifest.json';
+import yarnRcSchema    from '../static/configuration/yarnrc.json';
+
+const ajv = new Ajv2019();
+const validate = ajv.compile(draft2019Schema);
+
+describe(`manifest.json`, () => {
+  it(`is a valid JSON Schema`, () => {
+    const result = validate(manifestSchema);
+    expect(validate.errors).toBeNull();
+    expect(result).toBe(true);
+  });
+});
+
+describe(`yarnrc.json`, () => {
+  it(`is a valid JSON Schema`, () => {
+    const result = validate(yarnRcSchema);
+    expect(validate.errors).toBeNull();
+    expect(result).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5957,6 +5957,7 @@ __metadata:
     "@tanstack/react-query": "npm:^5.74.7"
     "@types/dompurify": "npm:^3"
     "@types/git-url-parse": "npm:^9.0.0"
+    "@types/jest": "npm:^28.1.6"
     "@types/markdown-it": "npm:^12.2.3"
     "@types/marked": "npm:^5.0.0"
     "@types/mdast": "npm:^4.0.3"
@@ -5982,6 +5983,7 @@ __metadata:
     "@yarnpkg/pnpify": "workspace:^"
     "@yarnpkg/sdks": "workspace:^"
     "@yarnpkg/shell": "workspace:^"
+    ajv: "npm:^8.17.1"
     algoliasearch: "npm:^4.14.2"
     ansi-to-html: "npm:^0.7.2"
     clipanion: "npm:^4.0.0-rc.2"
@@ -6848,7 +6850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.9.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.17.1, ajv@npm:^8.9.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:


### PR DESCRIPTION
## What's the problem this PR addresses?

`"type": "mixed"` is not valid JSON Schema. This results in errors in features such as VS Code's automatic validation:

```
Schema 'Yarn Config (.yarnrc.yml) - Yarnrc configuration files (yarnrc.json)' is not valid:
/properties/httpTimeout/type : must be equal to one of the allowed values
/properties/httpTimeout/type : must be array
/properties/httpTimeout/type : must match a schema in anyOfYAML(768)
```

Resolves #6972

## How did you fix it?

`type` could be omitted completely (it's redundant with `oneOf`) but is required by the Docusaurus configuration (via
https://github.com/arcanis/react-json-doc?), so I added it as an array.

To prevent further regressions, I added validation of the JSON Schemas using [AJV](https://ajv.js.org/). If there's a better place for this test to reside, please let me know.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
