### PR TITLE
Updates to enableScripts docs

### DIFF
--- a/packages/docusaurus/config/remark/autoLink.ts
+++ b/packages/docusaurus/config/remark/autoLink.ts
@@ -49,10 +49,16 @@ export const plugin = (userSpecs: Array<AutoLinkSpec>) => () => {
 
         for (const segment of segments) {
           if (node.type === `object`) {
-            if (!Object.hasOwn(node.properties, segment))
+            const bareSegment = segment.replace(`[]`, ``);
+            if (node.properties == null || !Object.hasOwn(node.properties, bareSegment))
               return false;
 
-            node = node.properties[segment];
+            node = node.properties[bareSegment];
+
+            if (segment.endsWith(`[]`) && node.patternProperties != null) {
+              const key = Object.keys(node.patternProperties)[0];
+              node = node.patternProperties[key];
+            }
           }
         }
 
@@ -60,7 +66,7 @@ export const plugin = (userSpecs: Array<AutoLinkSpec>) => () => {
           return false;
 
         const url = !ancestors.find(ancestor => ancestor.type === `link`)
-          ? spec.urlGenerator(segments.join(`.`))
+          ? spec.urlGenerator(segments.map(i => i.replace(`[]`, ``)).join(`.`))
           : null;
 
         result = {

--- a/packages/docusaurus/src/css/custom.css
+++ b/packages/docusaurus/src/css/custom.css
@@ -256,6 +256,10 @@ html.search-page-wrapper .row {
   color: rgb(156, 220, 254);
 }
 
+.rjd-annotation a code {
+  cursor: pointer;
+}
+
 .terminal-code pre {
   --prism-background-color: #393A34 !important;
   --prism-color: #f6f8fa !important;

--- a/packages/docusaurus/static/configuration/manifest.json
+++ b/packages/docusaurus/static/configuration/manifest.json
@@ -219,7 +219,7 @@
           "properties": {
             "built": {
               "title": "Define whether to run the postinstall script or not.",
-              "description": "If false, the package will never be built (deny-list). This behavior is reversed when the `enableScripts` yarnrc setting is toggled off - when that happens, only packages with `built` explicitly set to `true` will be built (allow-list); as for those with `built` explicitly set to `false`, they will simply see their build script warnings downgraded into simple notices.",
+              "description": "If false, the package will never be built (deny-list). This behavior is reversed when the [`enableScripts` yarnrc setting](yarnrc#enableScripts) is toggled off - when that happens, only packages with `built` explicitly set to `true` will be built (allow-list); as for those with `built` explicitly set to `false`, they will simply see their build script warnings downgraded into simple notices.",
               "type": "boolean",
               "examples": [false]
             },

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -217,7 +217,7 @@
     "enableScripts": {
       "_package": "@yarnpkg/core",
       "title": "Define whether to run postinstall scripts or not.",
-      "description": "If false, Yarn will not execute the `postinstall` scripts from third-party packages when installing the project (workspaces will still see their postinstall scripts evaluated, as they're assumed to be safe if you're running an install within them).\n\nNote that you also have the ability to disable scripts on a per-package basis using `dependenciesMeta`, or to re-enable a specific script by combining `enableScripts` and `dependenciesMeta`.",
+      "description": "If false, Yarn will not execute the `postinstall` scripts from third-party packages when installing the project (workspaces will still see their postinstall scripts evaluated, as they're assumed to be safe if you're running an install within them).\n\nNote that you also have the ability to disable scripts on a per-package basis using [`dependenciesMeta[].built`](manifest#dependenciesMeta.built), or to re-enable a specific script by combining `enableScripts` and [`dependenciesMeta[].built`](manifest#dependenciesMeta.built).",
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
## What's the problem this PR addresses?

While reading up on the `enableScripts` option, I was confused by references to `dependenciesMeta` and didn't realize that that referred to package.json, not .yarnrc.yml.

## How did you fix it?

Add cross-links between dependenciesMeta[].built docs and enableScripts docs.

Add autolink support for keys such as `dependenciesMeta[].built` so that the error codes page's autolinks work.

Improve error handling: Previously, a reference to an invalid key such as `dependenciesMeta.built` caused building the docs site to fail with the following error:

```
Cause: Cannot convert undefined or null to object
Details:
TypeError: Cannot convert undefined or null to object
    at Function.hasOwn (<anonymous>)
    at Array.find (<anonymous>)
```

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [X] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
