### PR TITLE
docs(constraints): add missing @typedef alias for `Context`

### DIFF
--- a/packages/docusaurus/docs/features/constraints.mdx
+++ b/packages/docusaurus/docs/features/constraints.mdx
@@ -134,6 +134,10 @@ This code ensures that no two workspaces in your project can list the same packa
 const {defineConfig} = require(`@yarnpkg/types`);
 
 /**
+ * @typedef {import('@yarnpkg/types').Yarn.Constraints.Context} Context
+ */
+
+/**
  * This rule will enforce that a workspace MUST depend on the same version of
  * a dependency as the one used by the other workspaces.
  *


### PR DESCRIPTION
## What's the problem this PR addresses?

Pasting the code as-is into my `yarn.config.cjs` gives a `ts-check` error because `Context` is undefined.

## How did you fix it?

There was an associate `@typedef` alias explanation a couple paragraphs higher. I just pasted in the missing alias into the final example.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
