### PR TITLE
Fixes the `/<name>/<version>` format

### DIFF
--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -479,16 +479,14 @@ export const startPackageServer = ({type}: {type: keyof typeof packageServerUrls
       const packageVersionEntry = packageEntry.get(version);
       invariant(packageVersionEntry, `This can only exist`);
 
-      const data = JSON.stringify({
-        [version as string]: Object.assign({}, packageVersionEntry!.packageJson, {
-          dist: {
-            shasum: await getPackageArchiveHash(name, version),
-            tarball: (localName === `unconventional-tarball` || localName === `private-unconventional-tarball`)
-              ? (await getPackageHttpArchivePath(name, version)).replace(`/-/`, `/tralala/`)
-              : await getPackageHttpArchivePath(name, version),
-          },
-        }),
-      });
+      const data = JSON.stringify(Object.assign({}, packageVersionEntry!.packageJson, {
+        dist: {
+          shasum: await getPackageArchiveHash(name, version),
+          tarball: (localName === `unconventional-tarball` || localName === `private-unconventional-tarball`)
+            ? (await getPackageHttpArchivePath(name, version)).replace(`/-/`, `/tralala/`)
+            : await getPackageHttpArchivePath(name, version),
+        },
+      }));
 
       response.writeHead(200, {[`Content-Type`]: `application/json`});
       response.end(data);


### PR DESCRIPTION
## What's the problem this PR addresses?

The test framework was using the wrong format for the `/<name>/<version>` endpoint from the npm registry:
https://registry.npmjs.org/lodash/1.0.0

The value shouldn't be wrapped in a dictionary.

## How did you fix it?

Remove the extra wrapper.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
