### PR TITLE
CI: Select node version to run CI against automatically

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,7 +6,7 @@ inputs:
   node-version:
     description: 'The version of Node.js to use'
     required: false
-    default: '22'
+    default: 'current'
 
 runs:
   using: composite

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -209,12 +209,28 @@ jobs:
         name: vscode-zipfs
         path: ./packages/vscode-zipfs/vscode-zipfs-*.vsix
 
+  node-versions:
+    name: 'Acceptance test node versions'
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: versions
+      shell: bash
+      run: >
+        echo -n 'versions='
+        >> $GITHUB_OUTPUT
+
+        curl https://nodejs.org/dist/index.json |
+        jq -c '[.[0:1] + map(select(.lts)) | .[].version | capture("^v(?<major>\\d+)") | .major | tonumber] | unique | map(select(. >= 18))'
+        >> $GITHUB_OUTPUT
+
   acceptance:
     strategy:
       fail-fast: false
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
-        node: [18, 19, 20, 21, 22]
+        node: ${{ fromJson(needs.node-versions.outputs.versions) }}
         platform: [[ubuntu, 22.04]]
         shard: ['1/2', '2/2']
         include:
@@ -239,7 +255,7 @@ jobs:
 
     name: '${{matrix.platform[0]}}-latest w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'
     runs-on: ${{matrix.platform[0]}}-${{matrix.platform[1]}}
-    needs: build
+    needs: [build, node-versions]
 
     # Permission required to produce a valid provenance statement during the tests
     # Only run inside the main repository; this may fail in master since it doesn't run in PRs from forks
@@ -249,10 +265,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: 'Use Node.js ${{matrix.node}}.x'
+    - name: 'Use Node.js ${{matrix.node}}'
       uses: actions/setup-node@v4
       with:
-        node-version: ${{matrix.node}}.x
+        node-version: ${{matrix.node}}
 
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
## What's the problem this PR addresses?

Our CI are running against node versions that are not supported like 19. The version list is manually managed, meaning we need to update it each time Node releases new majors.

Also, in #6575 we pinned node versions for most CI processes to Node 22 to avoid 23.0 shenanigans.

## How did you fix it?

Add a step to fetch available Node versions and filter them down to major versions that are even-numbered and >=18, or the latest major. This needs to be updated only when we change our own supported Node versions.

And essentially revert #6575 to use the current Node version

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
