### PR TITLE
fix: throw explicit error when all semver-matching versions are quarantined

### DIFF
--- a/.yarn/versions/b455c024.yml
+++ b/.yarn/versions/b455c024.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
@@ -19,7 +19,7 @@ describe(`Features`, () => {
         makeTemporaryEnv({}, {
           npmMinimalAgeGate: `1d`,
         }, async ({run}) => {
-          await expect(run(`add`, `release-date@1.1.1`)).rejects.toThrowError(`No candidates found`);
+          await expect(run(`add`, `release-date@1.1.1`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
         }),
       );
 
@@ -92,7 +92,7 @@ describe(`Features`, () => {
         makeTemporaryEnv({}, {
           npmMinimalAgeGate: `1d`,
         }, async ({run}) => {
-          await expect(run(`add`, `@scoped/release-date@1.1.1`)).rejects.toThrowError(`No candidates found`);
+          await expect(run(`add`, `@scoped/release-date@1.1.1`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
         }),
       );
 
@@ -149,7 +149,7 @@ describe(`Features`, () => {
         }, {
           npmMinimalAgeGate: `1d`,
         }, async ({run}) => {
-          await expect(run(`install`)).rejects.toThrowError(`No candidates found`);
+          await expect(run(`install`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
         }),
       );
 
@@ -243,7 +243,7 @@ describe(`Features`, () => {
         }, {
           npmMinimalAgeGate: `1d`,
         }, async ({run}) => {
-          await expect(run(`install`)).rejects.toThrowError(`No candidates found`);
+          await expect(run(`install`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
         }),
       );
 

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -54,19 +54,23 @@ export class NpmSemverResolver implements Resolver {
       version: semver.valid(range.raw) ? range.raw : undefined,
     });
 
-    const candidates = miscUtils.mapAndFilter(Object.keys(registryData.versions), version => {
+    const semverCandidates = miscUtils.mapAndFilter(Object.keys(registryData.versions), version => {
       try {
         const candidate = new semverUtils.SemVer(version);
         if (range.test(candidate)) {
-          if (!isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version, publishTimes: registryData.time}))
-            return miscUtils.mapAndFilter.skip;
-
           return candidate;
         }
       } catch { }
 
       return miscUtils.mapAndFilter.skip;
     });
+
+    const candidates = semverCandidates.filter(candidate => {
+      return isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version: candidate.raw, publishTimes: registryData.time});
+    });
+
+    if (semverCandidates.length > 0 && candidates.length === 0)
+      throw new ReportError(MessageName.REMOTE_NOT_FOUND, `All versions satisfying "${descriptor.range.slice(PROTOCOL.length)}" are quarantined`);
 
     const noDeprecatedCandidates = candidates.filter(version => {
       return !registryData.versions[version.raw].deprecated;


### PR DESCRIPTION
## What's the problem this PR addresses?

When using `npmMinimalAgeGate` or `npmPreapprovedPackages`, if a semver range matches existing versions but all of them are quarantined, Yarn would silently return no candidates and throw a generic "No candidates found" error.

Closes #7041.

## How did you fix it?

In `NpmSemverResolver.getCandidates`, split the filtering into two steps:

  1. First collect all versions that satisfy the semver range
  2. Then filter those by package approval

  If step 1 yields results but step 2 yields none, throw an explicit `ReportError` with the message `All versions satisfying "<range>" are quarantined`, similar to the existing behavior in `NpmTagResolver`.

  Updated the affected integration tests in `npmMinimalAgeGate.test.ts` to reflect the new error message.

## Checklist
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
