### PR TITLE
Add peer dependency for react-csv

### DIFF
--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -134,7 +134,7 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
   // https://github.com/react-csv/react-csv/pull/387
   [`react-csv@*`, {
     peerDependencies: {
-      'prop-types': '*'
+      `prop-types`: `*`,
     },
   }],
   // https://github.com/angeloocana/gatsby-plugin-i18n/pull/145


### PR DESCRIPTION
react-csv uses propTypes in its runtime code

## What's the problem this PR addresses?

this makes it so consumers of react-csv don't have to add this to their package.json
```json
    "packageExtensions": {
      "react-csv": {
        "dependencies": {
          "prop-types": "*"
        }
      }
    },
```
    

...

## How did you fix it?

by sending a PR upstream and contributing your extension to the @yarnpkg/extensions database, like [this](https://pnpm.io/settings#:~:text=sending%20a%20PR%20upstream%20and%20contributing%20your%20extension%20to%20the%20%40yarnpkg/extensions%20database) recommends

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
