### PR TITLE
Fix: Names the Experimental ESM support warning

### DIFF
--- a/.yarn/versions/73a88def.yml
+++ b/.yarn/versions/73a88def.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
+  "@yarnpkg/plugin-pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/docusaurus/docs/advanced/01-general-reference/error-codes.mdx
+++ b/packages/docusaurus/docs/advanced/01-general-reference/error-codes.mdx
@@ -485,3 +485,9 @@ publish:
     - yarn config set npmAuthToken $NPM_TOKEN
     - yarn publish --provenance --tolerate-republish
 ```
+
+## YN0092 - `EXPERIMENTAL`
+
+A feature you're using depends on an experimental or unstable API provided by the underlying runtime (e.g. Node.js). While the feature works today, the API it relies on may change or be removed without notice in future runtime versions, which could lead to breakage.
+
+This is informational — everything should work correctly for now, but be aware that updates to your runtime may require corresponding updates to Yarn before the feature can continue to work as expected.

--- a/packages/plugin-pnp/sources/PnpLinker.ts
+++ b/packages/plugin-pnp/sources/PnpLinker.ts
@@ -349,7 +349,7 @@ export class PnpInstaller implements Installer {
     }
 
     if (this.isEsmEnabled()) {
-      this.opts.report.reportWarning(MessageName.UNNAMED, `ESM support for PnP uses the experimental loader API and is therefore experimental`);
+      this.opts.report.reportWarning(MessageName.EXPERIMENTAL, `ESM support for PnP uses the experimental loader API and is therefore experimental`);
       await xfs.changeFilePromise(pnpPath.esmLoader, getESMLoaderTemplate(), {
         automaticNewlines: true,
         mode: 0o644,

--- a/packages/yarnpkg-core/sources/MessageName.ts
+++ b/packages/yarnpkg-core/sources/MessageName.ts
@@ -103,6 +103,7 @@ export enum MessageName {
   TIPS_NOTICE = 89,
   OFFLINE_MODE_ENABLED = 90,
   INVALID_PROVENANCE_ENVIRONMENT = 91,
+  EXPERIMENTAL = 92,
 }
 
 export function stringifyMessageName(name: MessageName | number): string {


### PR DESCRIPTION
Names the ESM experimental loading warning

## What's the problem this PR addresses?

Simple justification: unnamed logs should be avoided

More complex justifiation:
Lots of workspaces now are esm by default. This warning will appear on all of them. While it is "true", there is a strong desire to filter it out so that it does not:
- cause others to ignore genuine warnings
- make identifying warnings in CI overly complex, (partially address #7066)

Unnamed logs cannot be filtered.

## How did you fix it?

I've added a new name for the warning, and made the warning use that name

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
