### PR TITLE
Adds `approvedGitRepositories`

### DIFF
--- a/.yarn/versions/e1c54913.yml
+++ b/.yarn/versions/e1c54913.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-git": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -61,7 +61,7 @@ describe(`Commands`, () => {
     );
 
     test(
-      `it should migrate old lockfiles by setting enableScripts to true when unset`,
+      `it should migrate old lockfiles by setting enableScripts and approvedGitRepositories when unset`,
       makeTemporaryEnv({
         dependencies: {
           [`no-deps`]: `1.0.0`,
@@ -92,6 +92,7 @@ describe(`Commands`, () => {
         await run(`install`);
 
         await expect(xfs.readFilePromise(rcPath, `utf8`)).resolves.toContain(`enableScripts: true`);
+        await expect(xfs.readFilePromise(rcPath, `utf8`)).resolves.toMatch(/approvedGitRepositories:\r?\n\s*-\s*['"]?\*\*['"]?/);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/checkResolutions.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/checkResolutions.test.ts
@@ -22,6 +22,9 @@ describe(`Features`, () => {
         // We don't care about this flag; in an actual attack,
         // the hash would be correct
         checksumBehavior: `ignore`,
+        approvedGitRepositories: [
+          `https://github.com/yarnpkg/util-deprecate.git`,
+        ],
       }, async ({path, run, source}) => {
         await run(`add`, replacement);
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/git.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/git.test.ts
@@ -21,6 +21,14 @@ const TESTED_URLS = {
   [`https://github.com/yarnpkg/util-deprecate.git#b3562c2798507869edb767da869cd7b85487726d`]: {version: `1.0.0`, runOnCI: true},
 };
 
+const defaultGitConfiguration = {
+  approvedGitRepositories: [
+    `http://localhost:*/repositories/*.git`,
+    `https://github.com/yarnpkg/util-deprecate.git`,
+    `ssh://git@github.com/yarnpkg/util-deprecate.git`,
+  ],
+};
+
 describe(`Protocols`, () => {
   describe(`git:`, () => {
     for (const [url, {version, runOnCI}] of Object.entries(TESTED_URLS)) {
@@ -34,6 +42,7 @@ describe(`Protocols`, () => {
           {
             dependencies: {[`util-deprecate`]: url},
           },
+          defaultGitConfiguration,
           async ({path, run, source}) => {
             await run(`install`);
 
@@ -54,6 +63,7 @@ describe(`Protocols`, () => {
             [`has-prepack`]: tests.startPackageServer().then(url => `${url}/repositories/has-prepack.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await run(`install`);
 
@@ -70,6 +80,7 @@ describe(`Protocols`, () => {
             [`no-prepack`]: tests.startPackageServer().then(url => `${url}/repositories/no-prepack.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await run(`install`);
 
@@ -87,6 +98,7 @@ describe(`Protocols`, () => {
             [`pkg-b`]: tests.startPackageServer().then(url => `${url}/repositories/deep-projects.git#cwd=projects/pkg-b`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await run(`install`);
 
@@ -104,6 +116,25 @@ describe(`Protocols`, () => {
     );
 
     test(
+      `it should block git dependencies from repositories that aren't approved`,
+      makeTemporaryEnv(
+        {
+          dependencies: {
+            [`has-prepack`]: tests.startPackageServer().then(url => `${url}/repositories/has-prepack.git`),
+          },
+        },
+        {
+          approvedGitRepositories: [`https://github.com/yarnpkg/*`],
+        },
+        async ({run}) => {
+          await expect(run(`install`)).rejects.toThrow(
+            /doesn't match any of the patterns in 'approvedGitRepositories'/,
+          );
+        },
+      ),
+    );
+
+    test(
       `it should support installing workspace packages from projects in subfolders`,
       makeTemporaryEnv(
         {
@@ -112,6 +143,7 @@ describe(`Protocols`, () => {
             [`lib-b`]: tests.startPackageServer().then(url => `${url}/repositories/deep-projects.git#cwd=projects/pkg-b&workspace=lib`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await run(`install`);
 
@@ -140,6 +172,7 @@ describe(`Protocols`, () => {
             [`pkg-b`]: tests.startPackageServer().then(url => `${url}/repositories/workspaces.git#workspace=pkg-b`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await run(`install`);
 
@@ -164,6 +197,7 @@ describe(`Protocols`, () => {
             [`yarn-1-project`]: tests.startPackageServer().then(url => `${url}/repositories/yarn-1-project.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await expect(run(`install`, {
             env: {
@@ -188,6 +222,7 @@ describe(`Protocols`, () => {
             [`npm-project`]: tests.startPackageServer().then(url => `${url}/repositories/npm-project.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await run(`install`);
 
@@ -204,6 +239,7 @@ describe(`Protocols`, () => {
             [`npm-has-prepack`]: tests.startPackageServer().then(url => `${url}/repositories/npm-has-prepack.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await expect(run(`install`, {
             env: {
@@ -236,6 +272,7 @@ describe(`Protocols`, () => {
             [`pkg-b`]: tests.startPackageServer().then(url => `${url}/repositories/npm-workspaces.git#workspace=pkg-b`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           const {code, stdout, stderr} = await execUtils.execvp(`npm`, [`--version`], {cwd: path});
           if (code !== 0)
@@ -271,6 +308,7 @@ describe(`Protocols`, () => {
             [`yarn-1-project`]: tests.startPackageServer().then(url => `${url}/repositories/yarn-1-project.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           // This checks that the `set version classic` part of `scriptUtils.prepareExternalProject` doesn't use Corepack.
           // The rest of the install will fail though.
@@ -295,6 +333,7 @@ describe(`Protocols`, () => {
             [`no-lockfile-project`]: tests.startPackageServer().then(url => `${url}/repositories/no-lockfile-project.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await expect(run(`install`, {
             env: {
@@ -314,6 +353,7 @@ describe(`Protocols`, () => {
             [`yarn-1-project`]: tests.startPackageServer().then(url => `${url}/repositories/yarn-1-project.git`),
           },
         },
+        defaultGitConfiguration,
         async ({path, run, source}) => {
           await expect(run(`install`)).resolves.toBeTruthy();
 

--- a/packages/docusaurus/docs/advanced/01-general-reference/protocols/git.mdx
+++ b/packages/docusaurus/docs/advanced/01-general-reference/protocols/git.mdx
@@ -11,6 +11,16 @@ The `git:` protocol fetches packages directly from a git repository. This is use
 yarn add typanion@git@github.com/arcanis/typanion.git
 ```
 
+## Repository approval
+
+Git dependencies are restricted through the `approvedGitRepositories` setting. GitHub repositories must match at least one of its glob patterns, otherwise Yarn will refuse to fetch them.
+
+```yaml
+approvedGitRepositories:
+  - https://github.com/yarnpkg/*
+  - ssh://git@github.com/yarnpkg/*
+```
+
 ## Packing
 
 The target repository won't be used as-is - it will first be packed using [`pack`](/cli/pack).

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -71,6 +71,17 @@
       "type": "number",
       "default": 2
     },
+    "approvedGitRepositories": {
+      "_package": "@yarnpkg/plugin-git",
+      "title": "Array of git repository URL glob patterns that are allowed to be fetched.",
+      "description": "When set, Yarn will block any git dependency whose normalized repository URL doesn't match one of these patterns. GitHub repositories must be explicitly approved.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "_exampleItems": ["https://github.com/yarnpkg/*", "ssh://git@github.com/yarnpkg/*"]
+    },
     "compressionLevel": {
       "_package": "@yarnpkg/core",
       "type": ["number", "string"],

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -25,6 +25,10 @@ const LOCKFILE_MIGRATION_RULES: Array<{
   value: `mixed`,
 }, {
   selector: v => v < 9,
+  name: `approvedGitRepositories` as keyof ConfigurationValueMap,
+  value: [`**`],
+}, {
+  selector: v => v < 9,
   name: `enableScripts`,
   value: true,
 }];

--- a/packages/plugin-git/sources/gitUtils.ts
+++ b/packages/plugin-git/sources/gitUtils.ts
@@ -123,10 +123,20 @@ export function normalizeLocator(locator: Locator) {
 }
 
 export function validateRepoUrl(url: string, {configuration}: {configuration: Configuration}) {
-  const normalizedRepoUrl = normalizeRepoUrl(url, {git: true});
+  const {repo} = splitRepoUrl(url);
+  const normalizedRepoUrl = normalizeRepoUrl(repo, {git: true});
+
   const networkSettings = httpUtils.getNetworkSettings(`https://${GitUrlParse(normalizedRepoUrl).resource}`, {configuration});
   if (!networkSettings.enableNetwork)
     throw new ReportError(MessageName.NETWORK_DISABLED, `Request to '${normalizedRepoUrl}' has been blocked because of your configuration settings`);
+
+  const approvedGitRepositoriesPattern = miscUtils.buildIgnorePattern(configuration.get(`approvedGitRepositories`));
+  if (approvedGitRepositoriesPattern === null || !normalizedRepoUrl.match(approvedGitRepositoriesPattern)) {
+    throw new ReportError(
+      MessageName.NETWORK_DISABLED,
+      `Request to '${normalizedRepoUrl}' has been blocked because it doesn't match any of the patterns in 'approvedGitRepositories'`,
+    );
+  }
 
   return normalizedRepoUrl;
 }

--- a/packages/plugin-git/sources/index.ts
+++ b/packages/plugin-git/sources/index.ts
@@ -24,6 +24,7 @@ export interface Hooks {
 
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
+    approvedGitRepositories: Array<string>;
     changesetBaseRefs: Array<string>;
     changesetIgnorePatterns: Array<string>;
     cloneConcurrency: number;
@@ -32,6 +33,12 @@ declare module '@yarnpkg/core' {
 
 const plugin: Plugin = {
   configuration: {
+    approvedGitRepositories: {
+      description: `Array of git repository URL glob patterns that are allowed to be fetched`,
+      type: SettingsType.STRING,
+      default: [],
+      isArray: true,
+    },
     changesetBaseRefs: {
       description: `The base git refs that the current HEAD is compared against when detecting changes. Supports git branches, tags, and commits.`,
       type: SettingsType.STRING,


### PR DESCRIPTION
## What's the problem this PR addresses?

The `enableScripts` flag doesn't affect `git:` dependencies, which always runs the `pack` script for whatever package manager the project is using.

## How did you fix it?

To avoid running arbitrary code through the `git:` protocol we're introducing a new setting called `approvedGitRepositories`. This list of glob will validate the repository urls we clone.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
