### PR TITLE
docs: align corepack installation instructions

### DIFF
--- a/packages/docusaurus/docs/getting-started/extra/corepack.mdx
+++ b/packages/docusaurus/docs/getting-started/extra/corepack.mdx
@@ -18,12 +18,18 @@ Corepack is marked experimental so we can iterate on its CLI faster, but it's al
 
 ## Installation
 
-Corepack is included with all official Node.js releases starting from Node.js 14.19 / 16.9. It's however opt-in for the duration of the experimental stage, so you'll need to run `corepack enable` before it's active.
+To install and enable Corepack use:
 
-You can quickly check whether Corepack is enabled by running `yarn exec env | grep COREPACK_ROOT`: if you get a path as output, Corepack is properly installed. If not, something may be messing with how the shims are installed. In that case check the [Troubleshooting](/corepack#troubleshooting) section for advices.
+```
+npm install -g corepack
+```
+
+Alternatively, Corepack is included in supported Node.js versions lower than Node.js 25.0.0. Run `corepack enable` to activate it.
+
+You can quickly check whether Corepack is enabled by running `yarn exec env | grep COREPACK_ROOT`: if you get a path as output, Corepack is properly installed. If not, something may be messing with how the shims are installed. In that case check the [Troubleshooting](/corepack#troubleshooting) section for advice.
 
 :::danger
-Some third-party distributors may not include Corepack by default, in particular if you install Node.js from your system package manager. If that happens, running `npm install -g corepack` before `corepack enable` should do the trick.
+Some third-party distributors may not include Corepack by default, in particular if you install Node.js from your operating system package manager. If that happens, running `npm install -g corepack` should do the trick.
 :::
 
 ## Troubleshooting


### PR DESCRIPTION
- supersedes https://github.com/yarnpkg/berry/pull/6924

## What's the problem this PR addresses?

The [Installation](https://yarnpkg.com/getting-started/install) page says to install Corepack with:

```shell
npm install -g corepack
```

The [Corepack](https://yarnpkg.com/corepack) page gives different information, which is partially outdated:

> Corepack is included with all official Node.js releases starting from Node.js 14.19 / 16.9. It's however opt-in for the duration of the experimental stage, so you'll need to run `corepack enable` before it's active.

As described in the [Node.js Distribution Policy](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md)

> [corepack](https://github.com/nodejs/corepack) was added in Node.js 14.9.0 and 16.9.0. It is no longer distributed as of Node.js 25.0.0.

Also, according to https://github.com/nodejs/corepack/issues/686, installing with `npm install -g corepack` automatically enables Corepack.

## How did you fix it?

Make documentation changes to [packages/docusaurus/docs/getting-started/extra/corepack.mdx](https://github.com/yarnpkg/berry/blob/master/packages/docusaurus/docs/getting-started/extra/corepack.mdx) to be published to the [Corepack](https://yarnpkg.com/corepack) page.

## Checklist

- [X] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [X] I have set the packages that need to be released for my changes to be effective.
- [X] I will check that all automated PR checks pass before the PR gets reviewed.
