### PR TITLE
docs: clarify yarn dlx version and bin resolution behavior

### DIFF
--- a/.yarn/versions/725295c4.yml
+++ b/.yarn/versions/725295c4.yml
@@ -1,0 +1,2 @@
+declined:
+  - "@yarnpkg/plugin-dlx"

--- a/packages/plugin-dlx/sources/commands/dlx.ts
+++ b/packages/plugin-dlx/sources/commands/dlx.ts
@@ -17,14 +17,24 @@ export default class DlxCommand extends BaseCommand {
 
       By default Yarn will download the package named \`command\`, but this can be changed through the use of the \`-p,--package\` flag which will instruct Yarn to still run the same command but from a different package.
 
+      The package name can include a version (e.g., \`create-vite@4\`), which will install that specific version.
+
       Using \`yarn dlx\` as a replacement of \`yarn add\` isn't recommended, as it makes your project non-deterministic (Yarn doesn't keep track of the packages installed through \`dlx\` - neither their name, nor their version).
+
+      If the specified command doesn't match any binary exposed by the installed package, but that package exposes exactly one binary, Yarn will automatically run that binary instead. This behavior only applies when installing a single package via the command argument (not when using \`-p,--package\`).
     `,
     examples: [[
       `Use create-vite to scaffold a new Vite project`,
       `yarn dlx create-vite`,
     ], [
+      `Install a specific version of a package`,
+      `yarn dlx create-vite@4 my-project`,
+    ], [
       `Install multiple packages for a single command`,
       `yarn dlx -p typescript -p ts-node ts-node --transpile-only -e "console.log('hello!')"`,
+    ], [
+      `Install a specific version using the -p flag`,
+      `yarn dlx -p typescript@5.0.4 tsc --version`,
     ]],
   });
 


### PR DESCRIPTION
## Summary
- document that `yarn dlx` accepts package versions in both the command and `-p,--package` forms
- clarify the single-package fallback behavior when the requested command does not match an exposed binary
- add focused examples for both cases

Closes #7083
Closes #7072

## Why
Issue #7072 appears partially addressed in code already, but the generated command documentation still omits a couple of practical behaviors that matter in real use: version-qualified packages and the single-package fallback to the sole exposed binary. This keeps the change docs-only and source-backed from the current command implementation.

## Testing
- docs-only change to command metadata and examples
- source-reviewed against `packages/plugin-dlx/sources/commands/dlx.ts` behavior