### PR TITLE
fix: Widen EBADF fstat version gate to include Node 24.15+

### DIFF
--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -1433,7 +1433,7 @@ const WATCH_MODE_MESSAGE_USES_ARRAYS = major > 19 || major === 19 && minor >= 2 
 const HAS_LAZY_LOADED_TRANSLATORS = major === 20 && minor < 6 || major === 19 && minor >= 3;
 const SUPPORTS_IMPORT_ATTRIBUTES = major >= 21 || major === 20 && minor >= 10 || major === 18 && minor >= 20;
 const SUPPORTS_IMPORT_ATTRIBUTES_ONLY = major >= 22;
-const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || major === 25 && minor >= 7;
+const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || major === 25 && minor >= 7 || major === 24 && minor >= 15;
 
 function readPackageScope(checkPath) {
   const rootSeparatorIndex = checkPath.indexOf(npath.sep);

--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -1433,7 +1433,7 @@ const WATCH_MODE_MESSAGE_USES_ARRAYS = major > 19 || major === 19 && minor >= 2 
 const HAS_LAZY_LOADED_TRANSLATORS = major === 20 && minor < 6 || major === 19 && minor >= 3;
 const SUPPORTS_IMPORT_ATTRIBUTES = major >= 21 || major === 20 && minor >= 10 || major === 18 && minor >= 20;
 const SUPPORTS_IMPORT_ATTRIBUTES_ONLY = major >= 22;
-const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || major === 25 && minor >= 7 || major === 24 && minor >= 15;
+const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || major === 25 && minor >= 7;
 
 function readPackageScope(checkPath) {
   const rootSeparatorIndex = checkPath.indexOf(npath.sep);

--- a/.yarn/versions/7103.yml
+++ b/.yarn/versions/7103.yml
@@ -1,0 +1,21 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/pnp": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"

--- a/.yarn/versions/7103.yml
+++ b/.yarn/versions/7103.yml
@@ -4,6 +4,12 @@ releases:
   "@yarnpkg/pnp": patch
 
 declined:
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-constraints"
   - "@yarnpkg/plugin-dlx"

--- a/packages/yarnpkg-pnp/sources/esm-loader/loaderFlags.ts
+++ b/packages/yarnpkg-pnp/sources/esm-loader/loaderFlags.ts
@@ -21,4 +21,5 @@ export const SUPPORTS_IMPORT_ATTRIBUTES = major >= 21 || (major === 20 && minor 
 // https://github.com/nodejs/node/pull/52104
 export const SUPPORTS_IMPORT_ATTRIBUTES_ONLY = major >= 22;
 
-export const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || (major === 25 && minor >= 7);
+// https://github.com/nodejs/node/pull/61769 — backported to v24.15.0
+export const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || (major === 25 && minor >= 7) || (major === 24 && minor >= 15);


### PR DESCRIPTION
## What's the problem this PR addresses?

#7103

The fix in #7070 added a version gate for the EBADF fstat error:

```js
export const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || (major === 25 && minor >= 7);
```

However, the breaking change from [nodejs/node#61769](https://github.com/nodejs/node/pull/61769) (`lib: reduce cycles in esm loader and load it in snapshot`) was backported to **Node v24.15.0**, causing the identical `EBADF: bad file descriptor, fstat` error on that version.

Works on v24.14.1, fails on v24.15.0.

## How did you fix it?

Widened the version gate to also cover Node 24.15+:

```js
export const HAS_BROKEN_FSTAT_FOR_ZIP_FDS = major > 25 || (major === 25 && minor >= 7) || (major === 24 && minor >= 15);
```

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.