### PR TITLE
fix(plugin-version): align suggestStrategy base with stableVersion-aware applyStrategy

### DIFF
--- a/.yarn/versions/85173f62.yml
+++ b/.yarn/versions/85173f62.yml
@@ -1,0 +1,28 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-version": patch
+
+declined:
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-workspace-tools"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts
@@ -294,5 +294,21 @@ describe(`Commands`, () => {
         });
       }),
     );
+
+    test(
+      `it should apply a literal semver bump against the stableVersion base when version is a prerelease (#7025)`,
+      makeTemporaryEnv({
+        version: `1.3.1-alpha`,
+        stableVersion: `1.2.1`,
+      }, async ({path, run, source}) => {
+        await expect(run(`version`, `1.3.1`)).resolves.toMatchObject({
+          code: 0,
+        });
+
+        await expect(xfs.readJsonPromise(`${path}/package.json` as PortablePath)).resolves.toMatchObject({
+          version: `1.3.1`,
+        });
+      }),
+    );
   });
 });

--- a/packages/plugin-version/sources/commands/version.ts
+++ b/packages/plugin-version/sources/commands/version.ts
@@ -66,7 +66,13 @@ export default class VersionCommand extends BaseCommand {
     let releaseStrategy: string | null;
     if (isSemver) {
       if (workspace.manifest.version !== null) {
-        const suggestedStrategy = versionUtils.suggestStrategy(workspace.manifest.version, this.strategy);
+        // `resolveVersionFiles` (used during `version apply`) bases the bump on
+        // `stableVersion ?? version` when `stableVersion` is set. The strategy
+        // suggested here must be expressed against the same base, otherwise a
+        // strategy like `patch` that fits `version` (`1.3.1-alpha` → `1.3.1`)
+        // would later be applied to `stableVersion` (`1.2.1` → `1.2.2`).
+        const baseVersion = workspace.manifest.raw.stableVersion ?? workspace.manifest.version;
+        const suggestedStrategy = versionUtils.suggestStrategy(baseVersion, this.strategy);
 
         if (suggestedStrategy !== null) {
           releaseStrategy = suggestedStrategy;


### PR DESCRIPTION
## What's the problem this PR addresses?

Closes #7025.

When a workspace has a prerelease `version` shadowed by a `stableVersion`, running `yarn version <semver>` against a literal target bumps the wrong way. Exact repro from the issue:

\`\`\`json
{
  "name": "test-version",
  "version": "1.3.1-alpha",
  "stableVersion": "1.2.1"
}
\`\`\`

\`\`\`
$ yarn version 1.3.1
➤ YN0000: test-version@workspace:.: Bumped to 1.2.2   ← wrong; should be 1.3.1
\`\`\`

Root cause is a base-version divergence between two internal paths:

- `packages/plugin-version/sources/commands/version.ts` picked a release strategy by calling `suggestStrategy(workspace.manifest.version, this.strategy)`. With `version="1.3.1-alpha"` and arg `"1.3.1"`, `semver.inc("1.3.1-alpha", "patch") === "1.3.1"` matched, so the suggestion came back as `patch`.
- `packages/plugin-version/sources/versionUtils.ts` (inside `resolveVersionFiles`) deliberately bases the bump on `workspace.manifest.raw.stableVersion ?? workspace.manifest.version`, per the existing comment "_If there's a `stableVersion` field, then we assume that `version` contains a prerelease version and that we need to base the version bump relative to the latest stable instead._" With `stableVersion="1.2.1"`, `semver.inc("1.2.1", "patch") === "1.2.2"` — hence the wrong bump.

The two paths disagreed on which version to treat as the base.

## How did you fix it?

Mirror the `stableVersion`-aware base in the suggest step so both paths agree on the baseline:

\`\`\`ts
// packages/plugin-version/sources/commands/version.ts
const baseVersion = workspace.manifest.raw.stableVersion ?? workspace.manifest.version;
const suggestedStrategy = versionUtils.suggestStrategy(baseVersion, this.strategy);
\`\`\`

When no pre-defined strategy matches the stable base (as in the #7025 case), the literal semver argument is preserved — `applyStrategy` already short-circuits on `semver.valid(strategy)` and returns it verbatim.

For the #7025 scenario this restores the expected flow:

- `baseVersion = "1.2.1"`, no strategy fits → `releaseStrategy = "1.3.1"` (literal).
- `applyStrategy(..., "1.3.1")` → `"1.3.1"`. Post-bump `applyReleases` removes the now-obsolete `stableVersion` field because `semver.prerelease("1.3.1") === null`.

A regression test is added under `packages/acceptance-tests/pkg-tests-specs/sources/commands/version.test.ts` covering the exact repro. All existing tests in that file (20 pre-existing + the new one) pass. Changeset shape follows #6879 (the most recent `plugin-version`-scoped PR): `@yarnpkg/cli: patch` + `@yarnpkg/plugin-version: patch`.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.