### PR TITLE
Fix Next.JS e2e test

### DIFF
--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         echo 'import text from "raw-loader!./text.txt"; export default () => <div>{text}</div>;' | tee pages/index.js
         echo 'hello world!' | tee pages/text.txt
 
-        yarn next build
+        yarn next build --webpack
 
     - name: 'Running the integration test, with TypeScript'
       run: |
@@ -53,6 +53,6 @@ jobs:
         echo 'const text = require("raw-loader!./text.txt").default; export default () => <div>{text}</div>;' | tee pages/home.tsx
         echo 'hello world!' | tee pages/text.txt
 
-        yarn next build
+        yarn next build --webpack
       if: |
         success() || failure()

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: 'Running the integration test, without TypeScript'
       run: |
-        source scripts/e2e-setup-ci.sh
+        source scripts/e2e-setup-ci.sh nm
         yarn init
 
         # Required
@@ -36,14 +36,11 @@ jobs:
         echo 'import text from "raw-loader!./text.txt"; export default () => <div>{text}</div>;' | tee pages/index.js
         echo 'hello world!' | tee pages/text.txt
 
-        # Configure Next.js for isolated environment
-        echo 'module.exports = { turbopack: { root: "." } }' > next.config.js
-
         yarn next build
 
     - name: 'Running the integration test, with TypeScript'
       run: |
-        source scripts/e2e-setup-ci.sh
+        source scripts/e2e-setup-ci.sh nm
         yarn init
 
         # Required
@@ -55,9 +52,6 @@ jobs:
         mkdir pages
         echo 'const text = require("raw-loader!./text.txt").default; export default () => <div>{text}</div>;' | tee pages/home.tsx
         echo 'hello world!' | tee pages/text.txt
-
-        # Configure Next.js for isolated environment
-        echo 'export default { turbopack: { root: "." } }' > next.config.ts
 
         yarn next build
       if: |

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - test
   pull_request:
     paths:
     - .github/actions/prepare/action.yml

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -36,6 +36,9 @@ jobs:
         echo 'import text from "raw-loader!./text.txt"; export default () => <div>{text}</div>;' | tee pages/index.js
         echo 'hello world!' | tee pages/text.txt
 
+        # Configure Next.js for isolated environment
+        echo 'module.exports = { turbopack: { root: "." } }' > next.config.js
+
         yarn next build
 
     - name: 'Running the integration test, with TypeScript'
@@ -52,6 +55,9 @@ jobs:
         mkdir pages
         echo 'const text = require("raw-loader!./text.txt").default; export default () => <div>{text}</div>;' | tee pages/home.tsx
         echo 'hello world!' | tee pages/text.txt
+
+        # Configure Next.js for isolated environment
+        echo 'export default { turbopack: { root: "." } }' > next.config.ts
 
         yarn next build
       if: |

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: 'Running the integration test, without TypeScript'
       run: |
-        source scripts/e2e-setup-ci.sh nm
+        source scripts/e2e-setup-ci.sh
         yarn init
 
         # Required
@@ -40,7 +40,7 @@ jobs:
 
     - name: 'Running the integration test, with TypeScript'
       run: |
-        source scripts/e2e-setup-ci.sh nm
+        source scripts/e2e-setup-ci.sh
         yarn init
 
         # Required

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - test
   pull_request:
     paths:
     - .github/actions/prepare/action.yml


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Previously, the turbopack build failed because `"We couldn't find the Next.js package (next/package.json) from the project directory: /tmp/tmp.mgDFNvbv3k."`

After fixing this issue, a new error arises:

```
./pages/home.tsx:1:14
Module not found: Can't resolve 'raw-loader!./text.txt'
```

## How did you fix it?

<!-- A detailed description of your implementation. -->

Switching the linker to node-modules fixes the original issue, but then the new error occurs.
To fix this, we just force next.js to use webpack (`--webpack`) instead of turbopack to make it work well with raw-loader.
As it turns out, we just needed to use webpack and can leave the linker as pnp.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
