### PR TITLE
Fix vscode settings generated by @yarnpkg/sdks

### DIFF
--- a/.yarn/versions/d5fd6220.yml
+++ b/.yarn/versions/d5fd6220.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": minor

--- a/packages/yarnpkg-sdks/sources/sdkUtils.ts
+++ b/packages/yarnpkg-sdks/sources/sdkUtils.ts
@@ -2,6 +2,10 @@ import {miscUtils}                       from '@yarnpkg/core';
 import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
 import {PnpApi}                          from '@yarnpkg/pnp';
 import CJSON                             from 'comment-json';
+import {exec}                            from 'node:child_process';
+import {promisify}                       from 'node:util';
+
+export const execPromise = promisify(exec);
 
 export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeFileName: PortablePath, patch: any) => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
@@ -17,6 +21,28 @@ export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeF
   const patched = `${CJSON.stringify(miscUtils.mergeIntoTarget(data, patch), null, 2)}\n`;
 
   await xfs.mkdirPromise(ppath.dirname(filePath), {recursive: true});
+  await xfs.changeFilePromise(filePath, patched, {
+    automaticNewlines: true,
+  });
+};
+
+export const removeSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeFileName: PortablePath, keysToRemove: Array<string>) => {
+  const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
+  const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
+
+  const filePath = ppath.join(projectRoot, relativeFileName);
+
+  if (!await xfs.existsPromise(filePath))
+    return;
+
+  const content = await xfs.readFilePromise(filePath, `utf8`);
+  const data = CJSON.parse(content);
+
+  for (const key of keysToRemove)
+    delete data[key];
+
+  const patched = `${CJSON.stringify(data, null, 2)}\n`;
+
   await xfs.changeFilePromise(filePath, patched, {
     automaticNewlines: true,
   });

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -14,6 +14,11 @@ export const addVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCo
   await sdkUtils.addSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch);
 };
 
+export const removeVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCodeConfiguration, patch: any) => {
+  const relativeFilePath = `.vscode/${type}` as PortablePath;
+  await sdkUtils.removeSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch);
+};
+
 export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: PnpApi) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`search.exclude`]: {
@@ -94,16 +99,38 @@ export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (p
 };
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
-  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`js/ts.tsdk.path`]: npath.fromPortablePath(
-      ppath.dirname(
-        wrapper.getProjectPathTo(
-          `lib/tsserver.js` as PortablePath,
-        ),
-      ),
-    ),
-    [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
-  });
+  let patch = {};
+  const [major, minor] = await getVSCodeVersion();
+  const tsdkPath = npath.fromPortablePath(ppath.dirname(wrapper.getProjectPathTo(`lib/tsserver.js` as PortablePath)));
+
+  if (major === undefined || minor === undefined) {
+    // could not detect vscode version, use both for compatibility
+    patch = {
+      [`js/ts.tsdk.path`]: tsdkPath,
+      [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
+      [`typescript.tsdk`]: tsdkPath,
+      [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+    };
+  } else if (major === 1 && minor < 110) {
+    // use separate ts settings (old format)
+    patch = {
+      [`typescript.tsdk`]: tsdkPath,
+      [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+    };
+  } else {
+    // use unified js/ts settings (new format)
+    patch = {
+      [`js/ts.tsdk.path`]: tsdkPath,
+      [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
+    };
+    // Remove old TypeScript settings if present to prevent deprecation warnings from vscode
+    await removeVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, [
+      `typescript.tsdk`,
+      `typescript.enablePromptUseWorkspaceTsdk`,
+    ]);
+  }
+
+  await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, patch);
 };
 
 export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
@@ -150,3 +177,16 @@ export const VSCODE_SDKS: IntegrationSdks = [
   [`svelte-language-server`, generateSvelteLanguageServerWrapper],
   [`flow-bin`, generateFlowBinWrapper],
 ];
+
+async function getVSCodeVersion() {
+  try {
+    const command = `code${process.platform === `win32` && `.cmd`} --version`;
+    const {stdout} = await sdkUtils.execPromise(`${command} --version`, {encoding: `utf8`, shell: `cmd.exe`});
+    const version = stdout.split(`\n`)[0].trim();
+    console.log(`VSCode version: v${version}`);
+    return version.split(`.`).map(value => parseInt(value, 10));
+  } catch {
+    // VS Code CLI might not be in the PATH
+    return [void 0, void 0];
+  }
+}

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -111,7 +111,7 @@ export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpA
       [`typescript.tsdk`]: tsdkPath,
       [`typescript.enablePromptUseWorkspaceTsdk`]: true,
     };
-  } else if (major === 1 && minor < 110) {
+  } else if (major === 0 || (major === 1 && minor < 110)) {
     // use separate ts settings (old format)
     patch = {
       [`typescript.tsdk`]: tsdkPath,
@@ -183,7 +183,6 @@ async function getVSCodeVersion() {
     const command = `code${process.platform === `win32` && `.cmd`} --version`;
     const {stdout} = await sdkUtils.execPromise(`${command} --version`, {encoding: `utf8`, shell: `cmd.exe`});
     const version = stdout.split(`\n`)[0].trim();
-    console.log(`VSCode version: v${version}`);
     return version.split(`.`).map(value => parseInt(value, 10));
   } catch {
     // VS Code CLI might not be in the PATH

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -180,8 +180,8 @@ export const VSCODE_SDKS: IntegrationSdks = [
 
 async function getVSCodeVersion() {
   try {
-    const command = `code${process.platform === `win32` && `.cmd`} --version`;
-    const {stdout} = await sdkUtils.execPromise(`${command} --version`, {encoding: `utf8`, shell: `cmd.exe`});
+    const command = `code${process.platform === `win32` ? `.cmd` : ``} --version`;
+    const {stdout} = await sdkUtils.execPromise(command, {encoding: `utf8`});
     const version = stdout.split(`\n`)[0].trim();
     return version.split(`.`).map(value => parseInt(value, 10));
   } catch {

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -95,14 +95,14 @@ export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (p
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`typescript.tsdk`]: npath.fromPortablePath(
+    [`js/ts.tsdk.path`]: npath.fromPortablePath(
       ppath.dirname(
         wrapper.getProjectPathTo(
           `lib/tsserver.js` as PortablePath,
         ),
       ),
     ),
-    [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+    [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
   });
 };
 


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Adds VSCode version detection to `@yarnpkg/sdks` to ensure proper settings. See https://code.visualstudio.com/updates/v1_110#_unified-javascript-and-typescript-settings

Closes #7107 

## How did you fix it?

<!-- A detailed description of your implementation. -->

- I used the `code --version` command (or `code.cmd --version` on Windows) to check the version and parse it, just like we do for node in `@yarnpkg/pnp`.
- Then, if the version is compatible with the unified settings, use those and delete the old settings.
- If we can't figure out the VSCode version for some reason, we just add both sets of settings just to be sure it will work without modification.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
