### PR TITLE
feat(plugin-pnpm): make pnpm install concurrency configurable

### DIFF
--- a/.yarn/versions/284c7d66.yml
+++ b/.yarn/versions/284c7d66.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-pnpm": minor
+
+declined:
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -81,10 +81,11 @@ export class PnpmLinker implements Linker {
 }
 
 class PnpmInstaller implements Installer {
-  private readonly asyncActions = new miscUtils.AsyncActions(10);
+  private readonly asyncActions: miscUtils.AsyncActions;
   private readonly indexFolderPromise: Promise<PortablePath>;
 
   constructor(private opts: LinkOptions) {
+    this.asyncActions = new miscUtils.AsyncActions(opts.project.configuration.get(`pnpmInstallConcurrency`));
     this.indexFolderPromise = setupCopyIndex(xfs, {
       indexPath: ppath.join(opts.project.configuration.get(`globalFolder`), `index`),
     });

--- a/packages/plugin-pnpm/sources/index.ts
+++ b/packages/plugin-pnpm/sources/index.ts
@@ -8,6 +8,7 @@ export {PnpmLinker};
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     pnpmStoreFolder: PortablePath;
+    pnpmInstallConcurrency: number;
   }
 }
 
@@ -17,6 +18,11 @@ const plugin: Plugin = {
       description: `By default, the store is stored in the 'node_modules/.store' of the project. Sometimes in CI scenario's it is convenient to store this in a different location so it can be cached and reused.`,
       type: SettingsType.ABSOLUTE_PATH,
       default: `./node_modules/.store`,
+    },
+    pnpmInstallConcurrency: {
+      description: `Maximum number of packages the pnpm linker will install in parallel. Lower this on monorepos with very large caches if you hit "Couldn't allocate enough memory" from the bundled libzip WASM heap.`,
+      type: SettingsType.NUMBER,
+      default: 10,
     },
   },
   linkers: [


### PR DESCRIPTION
## What's the problem this PR addresses?

Ran into this trying to switch our monorepo to the pnpm linker. Install keeps dying during the link step with:

```
Error: Failed to open the cache entry for <pkg>: Couldn't allocate enough memory
    at ZipFS.allocateBuffer (...)
```

The package that trips it is random — sometimes a big one, sometimes a tiny 2 MB one. Cache is ~2.3 GB across ~3500 packages, with a handful of big zips in the 70–200 MB range (patched `next`, platform binaries, etc).

After poking around I'm pretty sure it's the hardcoded concurrency in `PnpmLinker.ts`:

```ts
private readonly asyncActions = new miscUtils.AsyncActions(10);
```

10 packages copy in parallel, each holds its `ZipFS` open until its turn in the queue runs, and every open `ZipFS` mallocs its whole zip into the libzip WASM heap. That heap is capped at 2 GB (32-bit WASM). Enough big zips overlap and malloc returns 0.

node-modules linker doesn't use `AsyncActions` which is probably why nobody hits this there.

Matches the symptoms in #6736 and #6990, and lines up with the analysis in #6722.

## How did you fix it?

Made the concurrency configurable via a new `pnpmInstallConcurrency` setting. Default is still `10` so existing projects are unaffected. Affected users can just drop this in `.yarnrc.yml`:

```yaml
pnpmInstallConcurrency: 1
```

With `1` it finishes the link step in 27s on our repo (vs instantly crashing before). `2` or `3` probably work too for smaller repos that just need a bit more headroom — haven't measured.

Not a root-cause fix — the real problem is that libzip mallocs the full archive instead of streaming it — but this at least gives people an escape hatch without touching the WASM stuff.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.