### PR TITLE
Fix @yarnpkg/sdks vscode settings major

### DIFF
--- a/.yarn/versions/c309a37a.yml
+++ b/.yarn/versions/c309a37a.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": major

--- a/packages/yarnpkg-sdks/sources/sdkUtils.ts
+++ b/packages/yarnpkg-sdks/sources/sdkUtils.ts
@@ -21,3 +21,25 @@ export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeF
     automaticNewlines: true,
   });
 };
+
+export const removeSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeFileName: PortablePath, keysToRemove: Array<string>) => {
+  const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
+  const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
+
+  const filePath = ppath.join(projectRoot, relativeFileName);
+
+  if (!await xfs.existsPromise(filePath))
+    return;
+
+  const content = await xfs.readFilePromise(filePath, `utf8`);
+  const data = CJSON.parse(content);
+
+  for (const key of keysToRemove)
+    delete data[key];
+
+  const patched = `${CJSON.stringify(data, null, 2)}\n`;
+
+  await xfs.changeFilePromise(filePath, patched, {
+    automaticNewlines: true,
+  });
+};

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -14,6 +14,11 @@ export const addVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCo
   await sdkUtils.addSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch);
 };
 
+export const removeVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCodeConfiguration, patch: any) => {
+  const relativeFilePath = `.vscode/${type}` as PortablePath;
+  await sdkUtils.removeSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch);
+};
+
 export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: PnpApi) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
     [`search.exclude`]: {
@@ -94,15 +99,21 @@ export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (p
 };
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
+  // Remove old TypeScript settings if present to prevent deprecation warnings from vscode
+  await removeVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, [
+    `typescript.tsdk`,
+    `typescript.enablePromptUseWorkspaceTsdk`,
+  ]);
+
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`typescript.tsdk`]: npath.fromPortablePath(
+    [`js/ts.tsdk.path`]: npath.fromPortablePath(
       ppath.dirname(
         wrapper.getProjectPathTo(
           `lib/tsserver.js` as PortablePath,
         ),
       ),
     ),
-    [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+    [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
   });
 };
 


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

Replaces old settings.json values deprecated in vscode v1.110 with the new ones.
closes #7107 

## How did you fix it?

<!-- A detailed description of your implementation. -->

Delete the olds keys from the settings.json, then add the new ones instead.

I think this would be a major release due to it breaking compatibility with vscode < v1.110

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
