### PR TITLE
fix(extensions): Add peer dependency for vitepress-plugin-pagefind, vue-command-palette

### DIFF
--- a/.yarn/versions/86dbe846.yml
+++ b/.yarn/versions/86dbe846.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -1012,4 +1012,16 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       fastify: `^4.0.0`,
     },
   }],
+  // https://github.com/ATQQ/sugar-blog/issues/429
+  [`vitepress-plugin-pagefind@*`, {
+    peerDependencies: {
+      vue: `^3.0.0`,
+    },
+  }],
+  // https://github.com/xiaoluoboding/vue-command-palette/issues/29
+  [`vue-command-palette@*`, {
+    peerDependencies: {
+      vue: `^3.0.0`,
+    },
+  }],
 ];


### PR DESCRIPTION
## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

https://github.com/ATQQ/sugar-blog/issues/429
https://github.com/xiaoluoboding/vue-command-palette/issues/29

## How did you fix it?

<!-- A detailed description of your implementation. -->

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
