### PR TITLE
Detect `.cts` and `.mts` files in loader utils

### DIFF
--- a/.yarn/versions/17ee2f94.yml
+++ b/.yarn/versions/17ee2f94.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/pnp": minor

--- a/packages/yarnpkg-pnp/sources/esm-loader/loaderUtils.ts
+++ b/packages/yarnpkg-pnp/sources/esm-loader/loaderUtils.ts
@@ -33,10 +33,12 @@ export function getFileFormat(filepath: string): string | null {
   const ext = path.extname(filepath);
 
   switch (ext) {
-    case `.mjs`: {
+    case `.mjs`:
+    case `.mts`: {
       return `module`;
     }
-    case `.cjs`: {
+    case `.cjs`:
+    case `.cts`: {
       return `commonjs`;
     }
     case `.wasm`: {


### PR DESCRIPTION


## What's the problem this PR addresses?

Fixes #6595.

This change lets Yarn's ESM loader correctly detect TypeScript files that use `.mts` or `.cts` extensions. 

## How did you fix it?

I updated `getFileFormat()` in loaderUtils.ts to treat `.mts` as having a "module" format and `.cts` as having a "commonjs" format.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
