### PR TITLE
CI: Fix diff checks for testing chores steps

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: 'Check that the cache files are consistent with their remote sources'
       run: |
-        if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- '.yarn/cache' 'packages/yarnpkg-libzip' | wc -l) -gt 0 ]]; then
+        if ! git diff --quiet --merge-base origin/"$TARGET_BRANCH" HEAD -- '.yarn/cache' 'packages/yarnpkg-libzip'; then
           node ./scripts/run-yarn.js --immutable --immutable-cache --check-cache
         fi
       shell: bash
@@ -67,9 +67,9 @@ jobs:
 
     - name: 'Check that libzip artifacts are consistent with a fresh build (fix w/ "git merge master && bash packages/yarnpkg-libzip/artifacts/build.sh")'
       run: |
-        if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- 'packages/yarnpkg-libzip/artifacts' 'packages/yarnpkg-libzip/sources/*.js' | wc -l) -gt 0 ]]; then
+        if ! git diff --quiet --merge-base origin/"$TARGET_BRANCH" HEAD -- 'packages/yarnpkg-libzip/artifacts' 'packages/yarnpkg-libzip/sources/*.js'; then
           bash packages/yarnpkg-libzip/artifacts/build.sh
-          [[ $(git diff --name-only 'packages/yarnpkg-libzip/artifacts' 'packages/yarnpkg-libzip/sources/*.js' | wc -l) -eq 0 ]]
+          git diff --exit-code 'packages/yarnpkg-libzip/artifacts' 'packages/yarnpkg-libzip/sources/*.js'
         fi
       shell: bash
       if: |
@@ -79,9 +79,9 @@ jobs:
 
     - name: 'Check that the PnP hooks are consistent with a fresh build (fix w/ "git merge master && yarn update:pnp:hook")'
       run: |
-        if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- 'packages/yarnpkg-{fslib,libzip,pnp}/sources/**/*' | wc -l) -gt 0 ]]; then
+        if ! git diff --quiet --merge-base origin/"$TARGET_BRANCH" HEAD -- 'packages/yarnpkg-fslib/sources' 'packages/yarnpkg-libzip/sources' 'packages/yarnpkg-pnp/sources'; then
           node ./scripts/run-yarn.js build:pnp:hook
-          [[ $(git diff --name-only packages/yarnpkg-pnp/sources/{hook.js,esm-loader/built-loader.js} | wc -l) -eq 0 ]]
+          git diff --exit-code -- 'packages/yarnpkg-pnp/sources/hook.js' 'packages/yarnpkg-pnp/sources/esm-loader/built-loader.js'
         fi
       shell: bash
       if: |
@@ -91,9 +91,9 @@ jobs:
 
     - name: 'Check that the Zip worker is consistent with a fresh build (fix w/ "git merge master && yarn update:zip:worker")'
       run: |
-        if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- 'packages/yarnpkg-{fslib,libzip,core}/sources/**/*' | wc -l) -gt 0 ]]; then
+        if ! git diff --quiet --merge-base origin/"$TARGET_BRANCH" HEAD -- 'packages/yarnpkg-fslib/sources' 'packages/yarnpkg-libzip/sources' 'packages/yarnpkg-core/sources'; then
           node ./scripts/run-yarn.js build:zip:worker
-          [[ $(git diff --name-only packages/yarnpkg-core/sources/worker-zip/index.js | wc -l) -eq 0 ]]
+          git diff --exit-code -- 'packages/yarnpkg-core/sources/worker-zip/index.js'
         fi
       shell: bash
       if: |
@@ -103,9 +103,9 @@ jobs:
 
     - name: 'Check that the pluginCommands file is consistent with a fresh build (fix w/ "yarn build:plugin-commands")'
       run: |
-        if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- packages/yarnpkg-cli/sources/pluginCommands.ts 'packages/*/sources/commands/**/*' | wc -l) -gt 0 ]]; then
+        if ! git diff --quiet --merge-base origin/"$TARGET_BRANCH" HEAD -- 'packages/yarnpkg-cli/sources/pluginCommands.ts' ':(glob)packages/*/sources/commands'; then
           node ./scripts/run-yarn.js build:plugin-commands
-          [[ $(git diff --name-only packages/yarnpkg-cli/sources/pluginCommands.ts | tee /dev/stderr | wc -l) -eq 0 ]]
+          git diff --exit-code -- 'packages/yarnpkg-cli/sources/pluginCommands.ts'
         fi
       shell: bash
       if: |
@@ -115,9 +115,9 @@ jobs:
 
     - name: 'Check that the grammars are consistent with fresh builds (fix w/ "yarn grammar:all")'
       run: |
-        if [[ $(git diff --name-only "$(git merge-base origin/"$TARGET_BRANCH" HEAD)" HEAD -- 'packages/yarnpkg-parsers/sources/grammars/*.{pegjs,js}' | wc -l) -gt 0 ]]; then
+        if ! git diff --quiet --merge-base origin/"$TARGET_BRANCH" HEAD -- 'packages/yarnpkg-parsers/sources/grammars/*.pegjs' 'packages/yarnpkg-parsers/sources/grammars/*.js'; then
           node ./scripts/run-yarn.js grammar:all
-          [[ $(git diff --name-only packages/yarnpkg-parsers/sources/grammars/*.js | tee /dev/stderr | wc -l) -eq 0 ]]
+          git diff --exit-code -- 'packages/yarnpkg-parsers/sources/grammars/*.js'
         fi
       shell: bash
       if: |


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

In the "Testing chores" job in our CI, there are a number of checks that regenerate artifacts from source and check whether the results match the committed artifacts. Most of these only run if the source files used in the generation are modified by the PR.

We run `git diff` to check for such modifications, using globs and bash expansion syntax to list the relevant source files, but the args given to `git diff` are [pathspecs](https://git-scm.com/docs/gitglossary/2.54.0#Documentation/gitglossary.txt-pathspec), which behave closer wildcards than globs. In particular, `*`s matches any string of characters (including `/` and `.`) and there are no brace expansions. See [this action run](https://github.com/yarnpkg/berry/actions/runs/25515078160/job/74883916321?pr=7131) for a PR that modified the PnP hooks without triggering the regeneration check

There are also a few more nice-to-*not*-haves:

- For each check we spawn 2 `git` commands and a `wc` command, when a single `git` suffices
- If we run the regeneration and find differences, the logs doesn't show what those differences are

## How did you fix it?

Use a single `git diff` command to check for source modifications, with correct pathspecs.

After running regeneration, the output of the final `git diff` is not shortened. The full diffs are recorded in the CI logs.

I left the check for `plugin-compat` patches unmodified, because that one works correctly and would be moved by #7009 anyway.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
