### PR TITLE
Makes `npmMinimalAgeGate: 1d` the default

### DIFF
--- a/.yarn/versions/dab519eb.yml
+++ b/.yarn/versions/dab519eb.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/plugin-essentials": minor
+  "@yarnpkg/plugin-npm": minor
+
+declined:
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
+catalog:
+  typescript: ^5.9.2
+
 changesetIgnorePatterns:
   - .github/**
   - .yarn/cache/**
@@ -15,33 +18,31 @@ immutablePatterns:
 
 initScope: yarnpkg
 
-pnpZipBackend: js
+npmMinimalAgeGate: 0
 
 npmPublishAccess: public
 
 npmPublishProvenance: true
 
-catalog:
-  typescript: "^5.9.2"
-
 packageExtensions:
+  "@docusaurus/preset-classic@3.7.0":
+    peerDependencies:
+      "@docusaurus/plugin-content-docs": 3.7.0
+  docusaurus-plugin-typedoc-api@^4:
+    dependencies:
+      "@docusaurus/mdx-loader": ^3
+      "@docusaurus/theme-common": ^3
+    peerDependencies:
+      "@docusaurus/plugin-content-docs": "*"
+      react-dom: "*"
+      typedoc: "*"
   markdown-it@*:
     dependencies:
       punycode: "*"
 
-  "@docusaurus/preset-classic@3.7.0":
-    peerDependencies:
-      "@docusaurus/plugin-content-docs": "3.7.0"
-  docusaurus-plugin-typedoc-api@^4:
-    dependencies:
-      "@docusaurus/mdx-loader": "^3"
-      "@docusaurus/theme-common": "^3"
-    peerDependencies:
-      react-dom: "*"
-      typedoc: "*"
-      "@docusaurus/plugin-content-docs": "*"
-
 pnpEnableEsmLoader: true
+
+pnpZipBackend: js
 
 preferInteractive: true
 

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -179,6 +179,11 @@ export const ADVISORIES = new Map<string, Array<npmAuditTypes.AuditMetadata>>([
   }]],
 ]);
 
+// Packages without an explicit publish date pretend to have been released long
+// ago, so that the `npmMinimalAgeGate` setting (defaulting to `1d`) doesn't
+// quarantine them when running tests.
+const OLD_RELEASE_DATE = new Date(0).toISOString();
+
 const RELEASE_DATE_PACKAGES: Record<string, Record<string, number | string>> = {
   "release-date": {
     "1.0.0": new Date(new Date().getTime() - /* 10 days */ 1000 * 60 * 60 * 24 * 10).toISOString(),
@@ -444,7 +449,9 @@ export const startPackageServer = ({type}: {type: keyof typeof packageServerUrls
             }),
           )),
         ),
-        time: name in RELEASE_DATE_PACKAGES ? RELEASE_DATE_PACKAGES[name] : undefined,
+        time: name in RELEASE_DATE_PACKAGES
+          ? RELEASE_DATE_PACKAGES[name]
+          : Object.fromEntries(versions.map(version => [version, OLD_RELEASE_DATE])),
         [`dist-tags`]: {
           latest: semver.maxSatisfying(versions, `*`),
           ...distTags,

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/install.test.ts
@@ -77,7 +77,7 @@ describe(`Commands`, () => {
 
         expect(match).not.toBeNull();
         const currentVersion = Number(match![1]);
-        const previousVersion = Math.max(0, currentVersion - 1);
+        const previousVersion = Math.max(0, currentVersion - 2);
 
         const downgraded = lockfile.replace(
           /^(__metadata:\r?\n {2}version: )\d+$/m,
@@ -93,6 +93,41 @@ describe(`Commands`, () => {
 
         await expect(xfs.readFilePromise(rcPath, `utf8`)).resolves.toContain(`enableScripts: true`);
         await expect(xfs.readFilePromise(rcPath, `utf8`)).resolves.toMatch(/approvedGitRepositories:\r?\n\s*-\s*['"]?\*\*['"]?/);
+      }),
+    );
+
+    test(
+      `it should migrate old lockfiles by disabling npmMinimalAgeGate when unset`,
+      makeTemporaryEnv({
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+        },
+      }, async ({path, run}) => {
+        const lockfilePath = ppath.join(path, Filename.lockfile);
+        const rcPath = ppath.join(path, Filename.rc);
+
+        await run(`install`);
+
+        const lockfile = await xfs.readFilePromise(lockfilePath, `utf8`);
+        const match = lockfile.match(/^__metadata:\r?\n {2}version: (\d+)$/m);
+
+        expect(match).not.toBeNull();
+        const currentVersion = Number(match![1]);
+        const previousVersion = Math.max(0, currentVersion - 1);
+
+        const downgraded = lockfile.replace(
+          /^(__metadata:\r?\n {2}version: )\d+$/m,
+          `$1${previousVersion}`,
+        );
+
+        expect(downgraded).not.toEqual(lockfile);
+        await xfs.writeFilePromise(lockfilePath, downgraded);
+
+        await expect(xfs.existsPromise(rcPath)).resolves.toBeFalsy();
+
+        await run(`install`);
+
+        await expect(xfs.readFilePromise(rcPath, `utf8`)).resolves.toMatch(/npmMinimalAgeGate:\s+['"]?0['"]?/);
       }),
     );
 

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
@@ -369,5 +369,83 @@ describe(`Features`, () => {
         }),
       );
     });
+    describe(`--no-time-gate`, () => {
+      test(
+        `yarn add should ignore the minimum release age when --no-time-gate is set`,
+        makeTemporaryEnv({}, {
+          npmMinimalAgeGate: `1d`,
+        }, async ({run, source}) => {
+          await run(`add`, `--no-time-gate`, `release-date@^1.0.0`);
+
+          await expect(source(`require('release-date/package.json')`)).resolves.toMatchObject({
+            name: `release-date`,
+            version: `1.1.1`,
+          });
+        }),
+      );
+
+      test(
+        `yarn add should ignore the minimum release age for exact versions when --no-time-gate is set`,
+        makeTemporaryEnv({}, {
+          npmMinimalAgeGate: `1d`,
+        }, async ({run, source}) => {
+          await run(`add`, `--no-time-gate`, `release-date@1.1.1`);
+
+          await expect(source(`require('release-date/package.json')`)).resolves.toMatchObject({
+            name: `release-date`,
+            version: `1.1.1`,
+          });
+        }),
+      );
+
+      test(
+        `yarn up should ignore the minimum release age when --no-time-gate is set`,
+        makeTemporaryEnv({
+          dependencies: {[`release-date`]: `^1.0.0`},
+        }, {
+          npmMinimalAgeGate: `1d`,
+        }, async ({run, source}) => {
+          await run(`install`);
+          await run(`set`, `resolution`, `release-date@npm:^1.0.0`, `npm:1.0.0`);
+
+          const preUpVersion = (await source(`require('release-date/package.json')`)).version;
+          if (preUpVersion !== `1.0.0`)
+            throw new Error(`Pre-up version is not 1.0.0`);
+
+          await run(`up`, `--no-time-gate`, `release-date`);
+
+          await expect(source(`require('release-date/package.json')`)).resolves.toMatchObject({
+            name: `release-date`,
+            version: `1.1.1`,
+          });
+        }),
+      );
+
+      test(
+        `yarn up -R should ignore the minimum release age when --no-time-gate is set`,
+        makeTemporaryEnv({
+          dependencies: {[`release-date`]: `^1.0.0`},
+        }, {
+          npmMinimalAgeGate: `1d`,
+          pnpFallbackMode: `all`,
+          pnpMode: `loose`,
+        }, async ({run, source}) => {
+          await run(`install`);
+          await run(`set`, `resolution`, `release-date@npm:^1.0.0`, `npm:1.0.0`);
+          await run(`set`, `resolution`, `release-date-transitive@npm:^1.0.0`, `npm:1.0.0`);
+
+          await run(`up`, `--no-time-gate`, `-R`, `*`);
+
+          await expect(source(`require('release-date/package.json')`)).resolves.toMatchObject({
+            name: `release-date`,
+            version: `1.1.1`,
+          });
+          await expect(source(`require('release-date-transitive/package.json')`)).resolves.toMatchObject({
+            name: `release-date-transitive`,
+            version: `1.1.1`,
+          });
+        }),
+      );
+    });
   });
 });

--- a/packages/docusaurus/docs/features/security.mdx
+++ b/packages/docusaurus/docs/features/security.mdx
@@ -23,7 +23,7 @@ Yarn doesn't run postinstalls by default ever since 4.14. You must either enable
 
 ## Age gate
 
-Yarn 4.12 introduced `npmMinimalAgeGate` to restrict packages installed on your machine to only packages that got published at least N days prior. The `npmPreapprovedPackages` setting also lets you bypass this check for specific packages.
+Yarn 4.12 introduced `npmMinimalAgeGate` to restrict packages installed on your machine to only packages that got published at least N days prior. The setting defaults to `1d`, so a brand new release won't be installed until it has had a chance to be reviewed by the community. The `npmPreapprovedPackages` setting also lets you bypass this check for specific packages, and the `--no-time-gate` flag on `yarn add` and `yarn up` lets you bypass it for a single command.
 
 ## Hardened mode
 

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -503,7 +503,7 @@
         { "type": "number" },
         { "type": "string", "pattern": "^(\\d*\\.?\\d+)(ms|s|m|h|d|w)?$" }
       ],
-      "default": "3d"
+      "default": "1d"
     },
     "npmPreapprovedPackages": {
       "_package": "@yarnpkg/core",

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -113,6 +113,10 @@ export default class AddCommand extends BaseCommand {
     description: `Reuse the highest version already used somewhere within the project`,
   });
 
+  noTimeGate = Option.Boolean(`--no-time-gate`, false, {
+    description: `Disable the minimum release age check for this command`,
+  });
+
   mode = Option.String(`--mode`, {
     description: `Change what artifacts installs generate`,
     validator: t.isEnum(InstallMode),
@@ -124,6 +128,10 @@ export default class AddCommand extends BaseCommand {
 
   async execute() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+
+    if (this.noTimeGate)
+      configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 

--- a/packages/plugin-essentials/sources/commands/install.ts
+++ b/packages/plugin-essentials/sources/commands/install.ts
@@ -31,6 +31,10 @@ const LOCKFILE_MIGRATION_RULES: Array<{
   selector: v => v < 9,
   name: `enableScripts`,
   value: true,
+}, {
+  selector: v => v < 10,
+  name: `npmMinimalAgeGate` as keyof ConfigurationValueMap,
+  value: `0`,
 }];
 
 // eslint-disable-next-line arca/no-default-export

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -84,6 +84,10 @@ export default class UpCommand extends BaseCommand {
     description: `Resolve again ALL resolutions for those packages`,
   });
 
+  noTimeGate = Option.Boolean(`--no-time-gate`, false, {
+    description: `Disable the minimum release age check for this command`,
+  });
+
   mode = Option.String(`--mode`, {
     description: `Change what artifacts installs generate`,
     validator: t.isEnum(InstallMode),
@@ -105,6 +109,10 @@ export default class UpCommand extends BaseCommand {
 
   async executeUpRecursive() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+
+    if (this.noTimeGate)
+      configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 
@@ -151,6 +159,10 @@ export default class UpCommand extends BaseCommand {
 
   async executeUpClassic() {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+
+    if (this.noTimeGate)
+      configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -73,7 +73,7 @@ const packageGateSettings = {
     description: `Minimum age of a package version according to the publish date on the npm registry to be considered for installation`,
     type: SettingsType.DURATION,
     unit: DurationUnit.MINUTES,
-    default: `0m`,
+    default: `1d`,
   },
   npmPreapprovedPackages: {
     description: `Array of package descriptors or package name glob patterns to exclude from the minimum release age check`,

--- a/packages/yarnpkg-core/sources/Project.ts
+++ b/packages/yarnpkg-core/sources/Project.ts
@@ -46,7 +46,7 @@ import {IdentHash, DescriptorHash, LocatorHash, PackageExtensionStatus} from './
 // the Package type; no more no less.
 export const LOCKFILE_VERSION = miscUtils.parseInt(
   process.env.YARN_LOCKFILE_VERSION_OVERRIDE ??
-  9,
+  10,
 );
 
 // Same thing but must be bumped when the members of the Project class changes (we

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10
 
 "@aashutoshrathi/word-wrap@npm:^1.2.3":


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

The rate at which supply chain attacks occur is growing, and given that we can't rely on the npm registry for good practices it means we need to become stricter to protect our users. 

## How did you fix it?

<!-- A detailed description of your implementation. -->

The `npmMinimalAgeGate` settings will now default to `1d`. Following the same pattern as in previous PRs (#7089, #7091) it will apply to all new projects, and the configuration of existing projects will be patched when upgrading their Yarn version to hardcode the previous defaults until users can ensure their projects are compatible with the new ones.

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
