### PR TITLE
feat: `yarn set version` - support resolving from a private npm registry

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -12368,12 +12368,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12387,9 +12389,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12401,12 +12405,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12420,9 +12426,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12434,12 +12442,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12453,9 +12463,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12467,12 +12479,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12486,9 +12500,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12500,12 +12516,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12519,6 +12537,7 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core"\
         ],\
@@ -12532,12 +12551,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12551,9 +12572,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12565,12 +12588,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12584,9 +12609,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12598,12 +12625,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:35104c47575f2fe378d8d20383ae667f19d4dd801df8cc4c76848603aa6b4a2234a00142ff12fd557f6f48bd2810880e31c40c767010ea61a31fca302c2cc5e0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12617,9 +12646,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12631,12 +12662,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12650,9 +12683,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12664,12 +12699,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12683,9 +12720,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12697,12 +12736,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:8bb72793b532d34e63bbc26264dcbcfc4dc4faa0a42627635e997081722bf229d67b7a677d86a568dad949d756630e45b9d4da97ee14b1b4c506494f8a58ea91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:7b82ac5a3734606065dc76f117982c681b5b5076260acfcac869c687f06db0b8c08eae0998f419d64b9e59f6c816bcc70e067c87fa32ffe9cb979faf85cd80b4#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:8bb72793b532d34e63bbc26264dcbcfc4dc4faa0a42627635e997081722bf229d67b7a677d86a568dad949d756630e45b9d4da97ee14b1b4c506494f8a58ea91#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12716,9 +12757,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12730,12 +12773,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12749,9 +12794,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12763,12 +12810,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12782,6 +12831,7 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core"\
         ],\
@@ -12795,12 +12845,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12814,9 +12866,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12828,12 +12882,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12847,9 +12903,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12861,12 +12919,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12880,9 +12940,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12894,12 +12956,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:b63ad861025672af62aed0e7c80dca4cfce3194ca046161e54fc14c498c39e3b82004ea844489c7a58d2f1a31867f388bf25b8128f5ccce46f35305e1f91e9ab#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:b63ad861025672af62aed0e7c80dca4cfce3194ca046161e54fc14c498c39e3b82004ea844489c7a58d2f1a31867f388bf25b8128f5ccce46f35305e1f91e9ab#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12913,9 +12977,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12927,12 +12993,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:e3ce0ce4b7f0796ca44011528cb9cdc133fc62a76363fea6de68497bae04bdbe5a6dd47e6b9f23c282eb8e4533d75e96cf378c943d07a4e78aae0b715f06a450#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12946,9 +13014,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12960,12 +13030,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:86c95fabbcd56c56f5f2d2e080e64a1095e3fe233877aa9f7958f317f88a95627e0be2765e89c0cff02c9f08f27b64b7cbc9d5c3960c1df509d5e6ea98cca4f4#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -12979,9 +13051,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -12993,12 +13067,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -13012,9 +13088,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -13026,12 +13104,14 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__cli", null],\
           ["@types/yarnpkg__core", null],\
           ["@types/yarnpkg__plugin-git", null],\
+          ["@types/yarnpkg__plugin-npm", null],\
           ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\
@@ -13045,9 +13125,11 @@ const RAW_RUNTIME_STATE =
           "@types/yarnpkg__cli",\
           "@types/yarnpkg__core",\
           "@types/yarnpkg__plugin-git",\
+          "@types/yarnpkg__plugin-npm",\
           "@yarnpkg/cli",\
           "@yarnpkg/core",\
-          "@yarnpkg/plugin-git"\
+          "@yarnpkg/plugin-git",\
+          "@yarnpkg/plugin-npm"\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -13062,6 +13144,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/parsers", "workspace:packages/yarnpkg-parsers"],\
           ["@yarnpkg/plugin-essentials", "workspace:packages/plugin-essentials"],\
           ["@yarnpkg/plugin-git", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-git"],\
+          ["@yarnpkg/plugin-npm", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/plugin-npm"],\
           ["ci-info", "npm:4.0.0"],\
           ["clipanion", "virtual:576bf3e379b293160348e4cadfbd6541796e6f78477b0875c4437065090cec6f78b6ec2281b8e15d1c870d61578dc7dee16a5ae49a65701fec83e592ce2ebdeb#npm:4.0.0-rc.2"],\
           ["enquirer", "npm:2.3.6"],\

--- a/.yarn/versions/89963a91.yml
+++ b/.yarn/versions/89963a91.yml
@@ -1,3 +1,34 @@
 releases:
-  "@yarnpkg/cli": minor
+  "@yarnpkg/builder": patch
+  "@yarnpkg/cli": minor 
+  "@yarnpkg/core": patch
+  "@yarnpkg/doctor": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-catalog": patch
+  "@yarnpkg/plugin-compat": patch
+  "@yarnpkg/plugin-constraints": patch
+  "@yarnpkg/plugin-dlx": patch
   "@yarnpkg/plugin-essentials": minor
+  "@yarnpkg/plugin-exec": patch
+  "@yarnpkg/plugin-file": patch
+  "@yarnpkg/plugin-git": patch
+  "@yarnpkg/plugin-github": patch
+  "@yarnpkg/plugin-http": patch
+  "@yarnpkg/plugin-init": patch
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-jsr": patch
+  "@yarnpkg/plugin-link": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": patch
+  "@yarnpkg/plugin-pack": patch
+  "@yarnpkg/plugin-patch": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+  "@yarnpkg/plugin-stage": patch
+  "@yarnpkg/plugin-typescript": patch
+  "@yarnpkg/plugin-version": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+  "@yarnpkg/pnpify": patch
+  "@yarnpkg/sdks": patch

--- a/.yarn/versions/89963a91.yml
+++ b/.yarn/versions/89963a91.yml
@@ -1,0 +1,3 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/plugin-essentials": minor

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/makeTemporaryEnv.ts
@@ -70,6 +70,8 @@ const mte = generatePkgDriver({
         [`NODE_SKIP_PLATFORM_CHECK`]: `1`,
         // We don't want the PnP runtime to be accidentally injected
         [`NODE_OPTIONS`]: ``,
+        // Pass through TLS certificates for local testing
+        [`NODE_EXTRA_CA_CERTS`]: process.env.NODE_EXTRA_CA_CERTS,
         ...rcEnv,
         ...env,
       },

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-2.0.0-bad-bin/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-2.0.0-bad-bin/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@yarnpkg/cli-dist",
+  "version": "2.0.0-bad-bin",
+  "bin": {
+    "yarn": "bin/yarn.js"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-2.0.0-malformed/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-2.0.0-malformed/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@yarnpkg/cli-dist",
+  "version": "2.0.0-malformed"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-3.0.0/bin/yarn.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-3.0.0/bin/yarn.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+if (process.argv.includes(`--version`))
+  process.stdout.write(`3.0.0\n`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-3.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-3.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@yarnpkg/cli-dist",
+  "version": "3.0.0",
+  "bin": {
+    "yarn": "bin/yarn.js"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.0.0/bin/yarn.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.0.0/bin/yarn.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+if (process.argv.includes(`--version`))
+  process.stdout.write(`4.0.0\n`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@yarnpkg/cli-dist",
+  "version": "4.0.0",
+  "bin": {
+    "yarn": "bin/yarn.js"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.1.0/bin/yarn.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.1.0/bin/yarn.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+if (process.argv.includes(`--version`))
+  process.stdout.write(`4.1.0\n`);

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.1.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@yarnpkg__cli-dist-4.1.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@yarnpkg/cli-dist",
+  "version": "4.1.0",
+  "bin": {
+    "yarn": "bin/yarn.js"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/set/version.test.ts
@@ -1,4 +1,5 @@
 import {xfs, ppath, PortablePath, Filename} from '@yarnpkg/fslib';
+import {tests}                              from 'pkg-tests-core';
 
 const yarnrcRegexp = /^yarnPath:/;
 
@@ -139,6 +140,189 @@ describe(`Commands`, () => {
         await check(projectDir, {corepackVersion: /[0-9]+\./, usePath: true});
       }),
     );
+
+    describe(`--from-registry`, () => {
+      test(
+        `it should fetch an exact version from a custom registry via --from-registry`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          const {stdout} = await run(`set`, `version`, `4.0.0`, `--from-registry`, registryUrl);
+          expect(stdout).toContain(`Downloading @yarnpkg/cli-dist@4.0.0 from`);
+          expect(stdout).toContain(`registry.example.org`);
+          expect(stdout).not.toContain(`repo.yarnpkg.com`);
+          await check(path, {corepackVersion: `4.0.0`, usePath: true});
+        }),
+      );
+
+      test(
+        `it should fetch an exact version from a custom registry via config`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          const {stdout} = await run(`set`, `version`, `4.0.0`, {
+            env: {YARN_VERSION_NPM_REGISTRY_SERVER: registryUrl},
+          });
+          expect(stdout).toContain(`Downloading @yarnpkg/cli-dist@4.0.0 from`);
+          expect(stdout).toContain(`registry.example.org`);
+          expect(stdout).not.toContain(`repo.yarnpkg.com`);
+          await check(path, {corepackVersion: `4.0.0`, usePath: true});
+        }),
+      );
+
+      test(
+        `it should resolve a semver range from the custom registry`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          const {stdout} = await run(`set`, `version`, `4.x`, `--from-registry`, registryUrl);
+          expect(stdout).toContain(`Downloading @yarnpkg/cli-dist@4.1.0 from`);
+          expect(stdout).toContain(`registry.example.org`);
+          expect(stdout).not.toContain(`repo.yarnpkg.com`);
+          await check(path, {corepackVersion: `4.1.0`, usePath: true});
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with tag specifiers`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `stable`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with classic`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `classic`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with Yarn 1.x versions`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `1.22.1`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with URL specifiers`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `https://example.com/yarn.js`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with file path specifiers`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `./yarn.cjs`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with self`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `self`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should silently ignore versionNpmRegistryServer for incompatible specifiers`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          await run(`set`, `version`, `self`, {
+            env: {YARN_VERSION_NPM_REGISTRY_SERVER: `https://bogus.invalid`},
+          });
+          await check(path, {corepackVersion: /[0-9]+\./, usePath: true});
+        }),
+      );
+
+      test(
+        `it should use --from-registry flag over versionNpmRegistryServer config`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          const {stdout} = await run(`set`, `version`, `4.0.0`, `--from-registry`, registryUrl, {
+            env: {YARN_VERSION_NPM_REGISTRY_SERVER: `https://bogus.invalid`},
+          });
+          expect(stdout).toContain(`registry.example.org`);
+          expect(stdout).not.toContain(`bogus.invalid`);
+          await check(path, {corepackVersion: `4.0.0`, usePath: true});
+        }),
+      );
+
+      test(
+        `it should error when using --from-registry with a 1.x range`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `1.x`, `--from-registry`, registryUrl)).rejects.toThrow(/--from-registry flag can only be used with Yarn 2\+ semver versions or ranges/);
+        }),
+      );
+
+      test(
+        `it should error when no versions match the range on the registry`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `99.x`, `--from-registry`, registryUrl)).rejects.toThrow(/No matching version of @yarnpkg\/cli-dist found for range/);
+        }),
+      );
+
+      test(
+        `it should error when the exact version does not exist on the registry`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `4.99.0`, `--from-registry`, registryUrl)).rejects.toThrow();
+        }),
+      );
+
+      test(
+        `it should error when the tarball has no bin.yarn entry in package.json`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `2.0.0-malformed`, `--from-registry`, registryUrl)).rejects.toThrow(/Could not find a 'bin\.yarn' entry in the @yarnpkg\/cli-dist package\.json/);
+        }),
+      );
+
+      test(
+        `it should error when bin.yarn points to a missing file in the tarball`,
+        makeTemporaryEnv({}, {
+          env: {COREPACK_ROOT: undefined},
+        }, async ({path, run, source}) => {
+          const registryUrl = await tests.startPackageServer();
+          await expect(run(`set`, `version`, `2.0.0-bad-bin`, `--from-registry`, registryUrl)).rejects.toThrow(/The 'bin\.yarn' entry in @yarnpkg\/cli-dist points to '.*', but this file does not exist in the tarball/);
+        }),
+      );
+    });
   });
 });
 

--- a/packages/plugin-essentials/package.json
+++ b/packages/plugin-essentials/package.json
@@ -22,14 +22,16 @@
   "peerDependencies": {
     "@yarnpkg/cli": "workspace:^",
     "@yarnpkg/core": "workspace:^",
-    "@yarnpkg/plugin-git": "workspace:^"
+    "@yarnpkg/plugin-git": "workspace:^",
+    "@yarnpkg/plugin-npm": "workspace:^"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.1",
     "@types/semver": "^7.1.0",
     "@yarnpkg/cli": "workspace:^",
     "@yarnpkg/core": "workspace:^",
-    "@yarnpkg/plugin-git": "workspace:^"
+    "@yarnpkg/plugin-git": "workspace:^",
+    "@yarnpkg/plugin-npm": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -2,7 +2,7 @@ import {BaseCommand}                                                            
 import {Configuration, StreamReport, MessageName, Report, Manifest, YarnVersion, ReportError} from '@yarnpkg/core';
 import {execUtils, formatUtils, httpUtils, miscUtils, semverUtils, structUtils, tgzUtils}     from '@yarnpkg/core';
 import {CwdFS, PortablePath, ppath, xfs, npath}                                               from '@yarnpkg/fslib';
-import {npmHttpUtils}                                                                         from '@yarnpkg/plugin-npm';
+import {npmHttpUtils, NpmSemverFetcher}                                                       from '@yarnpkg/plugin-npm';
 import {Command, Option, Usage, UsageError}                                                   from 'clipanion';
 import semver                                                                                 from 'semver';
 
@@ -123,10 +123,9 @@ export default class SetVersionCommand extends BaseCommand {
     const registryConfig = configuration.get(`versionNpmRegistryServer`);
     const effectiveRegistry = registryFlag ?? registryConfig;
 
-    const isRegistryCompatible = (
-      semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`)
-      || (semverUtils.validRange(this.version) !== null && semver.intersects(this.version, `>=2.0.0`))
-    );
+    const isExactBerryVersion = semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`);
+    const isBerryRange = !isExactBerryVersion && semverUtils.validRange(this.version) !== null && semver.intersects(this.version, `>=2.0.0`);
+    const isRegistryCompatible = isExactBerryVersion || isBerryRange;
 
     if (typeof registryFlag !== `undefined` && !isRegistryCompatible)
       throw new UsageError(`The --from-registry flag can only be used with Yarn 2+ semver versions or ranges`);
@@ -138,7 +137,7 @@ export default class SetVersionCommand extends BaseCommand {
     if (useRegistry) {
       const registry = effectiveRegistry!;
 
-      if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`)) {
+      if (isExactBerryVersion) {
         registryFetchInfo = {registry, version: this.version};
       } else {
         const resolved = await resolveVersionFromRegistry(configuration, registry, this.version);
@@ -241,8 +240,8 @@ async function resolveVersionFromRegistry(configuration: Configuration, registry
 
 async function fetchBundleFromRegistry(configuration: Configuration, registry: string, version: string): Promise<Buffer> {
   const ident = structUtils.makeIdent(`yarnpkg`, `cli-dist`);
-  const identUrl = npmHttpUtils.getIdentUrl(ident);
-  const tarballPath = `${identUrl}/-/cli-dist-${version}.tgz`;
+  const locator = structUtils.makeLocator(ident, `npm:${version}`);
+  const tarballPath = NpmSemverFetcher.getLocatorUrl(locator);
 
   let tgzBuffer: Buffer;
   try {

--- a/packages/plugin-essentials/sources/commands/set/version.ts
+++ b/packages/plugin-essentials/sources/commands/set/version.ts
@@ -1,7 +1,8 @@
 import {BaseCommand}                                                                          from '@yarnpkg/cli';
 import {Configuration, StreamReport, MessageName, Report, Manifest, YarnVersion, ReportError} from '@yarnpkg/core';
-import {execUtils, formatUtils, httpUtils, miscUtils, semverUtils}                            from '@yarnpkg/core';
-import {PortablePath, ppath, xfs, npath}                                                      from '@yarnpkg/fslib';
+import {execUtils, formatUtils, httpUtils, miscUtils, semverUtils, structUtils, tgzUtils}     from '@yarnpkg/core';
+import {CwdFS, PortablePath, ppath, xfs, npath}                                               from '@yarnpkg/fslib';
+import {npmHttpUtils}                                                                         from '@yarnpkg/plugin-npm';
 import {Command, Option, Usage, UsageError}                                                   from 'clipanion';
 import semver                                                                                 from 'semver';
 
@@ -39,6 +40,8 @@ export default class SetVersionCommand extends BaseCommand {
       - a local file referenced through either a relative or absolute path
 
       - \`self\` -> the version used to invoke the command
+
+      When the \`--from-registry\` flag is set, or when \`versionNpmRegistryServer\` is configured in your \`.yarnrc.yml\`, the release will be downloaded from the \`@yarnpkg/cli-dist\` package on the specified npm registry instead of from the default Yarn repository. Note that this only works with semver versions and ranges (Yarn 2+), not with tags like \`stable\` or \`canary\`.
     `,
     examples: [[
       `Download the latest release from the Yarn repository`,
@@ -67,6 +70,9 @@ export default class SetVersionCommand extends BaseCommand {
     ], [
       `Download the version used to invoke the command`,
       `$0 set version self`,
+    ], [
+      `Download a specific version from a specified npm registry`,
+      `$0 set version 4.0.0 --from-registry https://registry.internal.com`,
     ]],
   });
 
@@ -76,6 +82,10 @@ export default class SetVersionCommand extends BaseCommand {
 
   onlyIfNeeded = Option.Boolean(`--only-if-needed`, false, {
     description: `Only lock the Yarn version if it isn't already locked`,
+  });
+
+  fromRegistry = Option.String(`--from-registry`, {
+    description: `Fetch the Yarn release from the specified npm registry instead of the default Yarn repository`,
   });
 
   version = Option.String();
@@ -109,26 +119,54 @@ export default class SetVersionCommand extends BaseCommand {
       return {version, url: url.replace(/\{\}/g, version)};
     };
 
-    if (this.version === `self`)
+    const registryFlag = this.fromRegistry;
+    const registryConfig = configuration.get(`versionNpmRegistryServer`);
+    const effectiveRegistry = registryFlag ?? registryConfig;
+
+    const isRegistryCompatible = (
+      semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`)
+      || (semverUtils.validRange(this.version) !== null && semver.intersects(this.version, `>=2.0.0`))
+    );
+
+    if (typeof registryFlag !== `undefined` && !isRegistryCompatible)
+      throw new UsageError(`The --from-registry flag can only be used with Yarn 2+ semver versions or ranges`);
+
+    const useRegistry = typeof effectiveRegistry === `string` && isRegistryCompatible;
+
+    let registryFetchInfo: {registry: string, version: string} | null = null;
+
+    if (useRegistry) {
+      const registry = effectiveRegistry!;
+
+      if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`)) {
+        registryFetchInfo = {registry, version: this.version};
+      } else {
+        const resolved = await resolveVersionFromRegistry(configuration, registry, this.version);
+        registryFetchInfo = {registry, version: resolved};
+      }
+
+      bundleRef = {version: registryFetchInfo.version, url: `${registry}/@yarnpkg/cli-dist/-/cli-dist-${registryFetchInfo.version}.tgz`};
+    } else if (this.version === `self`) {
       bundleRef = {url: getBundlePath(), version: YarnVersion ?? `self`};
-    else if (this.version === `latest` || this.version === `berry` || this.version === `stable`)
+    } else if (this.version === `latest` || this.version === `berry` || this.version === `stable`) {
       bundleRef = getRef(`https://repo.yarnpkg.com/{}/packages/yarnpkg-cli/bin/yarn.js`, await resolveTag(configuration, `stable`));
-    else if (this.version === `canary`)
+    } else if (this.version === `canary`) {
       bundleRef = getRef(`https://repo.yarnpkg.com/{}/packages/yarnpkg-cli/bin/yarn.js`, await resolveTag(configuration, `canary`));
-    else if (this.version === `classic`)
+    } else if (this.version === `classic`) {
       bundleRef = {url: `https://classic.yarnpkg.com/latest.js`, version: `classic`};
-    else if (this.version.match(/^https?:/))
+    } else if (this.version.match(/^https?:/)) {
       bundleRef = {url: this.version, version: `remote`};
-    else if (this.version.match(/^\.{0,2}[\\/]/) || npath.isAbsolute(this.version))
+    } else if (this.version.match(/^\.{0,2}[\\/]/) || npath.isAbsolute(this.version)) {
       bundleRef = {url: `file://${ppath.resolve(npath.toPortablePath(this.version))}`, version: `file`};
-    else if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`))
+    } else if (semverUtils.satisfiesWithPrereleases(this.version, `>=2.0.0`)) {
       bundleRef = getRef(`https://repo.yarnpkg.com/{}/packages/yarnpkg-cli/bin/yarn.js`, this.version);
-    else if (semverUtils.satisfiesWithPrereleases(this.version, `^0.x || ^1.x`))
+    } else if (semverUtils.satisfiesWithPrereleases(this.version, `^0.x || ^1.x`)) {
       bundleRef = getRef(`https://github.com/yarnpkg/yarn/releases/download/v{}/yarn-{}.js`, this.version);
-    else if (semverUtils.validRange(this.version))
+    } else if (semverUtils.validRange(this.version)) {
       bundleRef = getRef(`https://repo.yarnpkg.com/{}/packages/yarnpkg-cli/bin/yarn.js`, await resolveRange(configuration, this.version));
-    else
+    } else {
       throw new UsageError(`Invalid version descriptor "${this.version}"`);
+    }
 
     const report = await StreamReport.start({
       configuration,
@@ -136,6 +174,12 @@ export default class SetVersionCommand extends BaseCommand {
       includeLogs: !this.context.quiet,
     }, async (report: StreamReport) => {
       const fetchBuffer = async () => {
+        if (registryFetchInfo) {
+          const {registry, version} = registryFetchInfo;
+          report.reportInfo(MessageName.UNNAMED, `Downloading @yarnpkg/cli-dist@${version} from ${formatUtils.pretty(configuration, registry, formatUtils.Type.URL)}`);
+          return await fetchBundleFromRegistry(configuration, registry, version);
+        }
+
         const filePrefix = `file://`;
 
         if (bundleRef.url.startsWith(filePrefix)) {
@@ -171,6 +215,77 @@ export async function resolveTag(configuration: Configuration, request: `stable`
     throw new UsageError(`Tag ${formatUtils.pretty(configuration, request, formatUtils.Type.RANGE)} not found`);
 
   return data.latest[request];
+}
+
+async function resolveVersionFromRegistry(configuration: Configuration, registry: string, range: string): Promise<string> {
+  const ident = structUtils.makeIdent(`yarnpkg`, `cli-dist`);
+  const identUrl = npmHttpUtils.getIdentUrl(ident);
+
+  const metadata: any = await npmHttpUtils.get(identUrl, {
+    configuration,
+    registry,
+    ident,
+    jsonResponse: true,
+    authType: npmHttpUtils.AuthType.BEST_EFFORT,
+  });
+
+  const versions = Object.keys(metadata.versions ?? {});
+  const candidates = versions.filter(v => semverUtils.satisfiesWithPrereleases(v, range));
+
+  if (candidates.length === 0)
+    throw new UsageError(`No matching version of @yarnpkg/cli-dist found for range ${formatUtils.pretty(configuration, range, formatUtils.Type.RANGE)} on the configured registry`);
+
+  candidates.sort(semver.rcompare);
+  return candidates[0];
+}
+
+async function fetchBundleFromRegistry(configuration: Configuration, registry: string, version: string): Promise<Buffer> {
+  const ident = structUtils.makeIdent(`yarnpkg`, `cli-dist`);
+  const identUrl = npmHttpUtils.getIdentUrl(ident);
+  const tarballPath = `${identUrl}/-/cli-dist-${version}.tgz`;
+
+  let tgzBuffer: Buffer;
+  try {
+    tgzBuffer = await npmHttpUtils.get(tarballPath, {
+      configuration,
+      registry,
+      ident,
+      authType: npmHttpUtils.AuthType.BEST_EFFORT,
+    });
+  } catch {
+    // Fallback for registries that don't support %2f encoding
+    tgzBuffer = await npmHttpUtils.get(tarballPath.replace(/%2f/g, `/`), {
+      configuration,
+      registry,
+      ident,
+      authType: npmHttpUtils.AuthType.BEST_EFFORT,
+    });
+  }
+
+  return await extractBundleFromTarball(tgzBuffer);
+}
+
+async function extractBundleFromTarball(tgzBuffer: Buffer): Promise<Buffer> {
+  return await xfs.mktempPromise(async tmpDir => {
+    const extractTarget = new CwdFS(tmpDir);
+
+    await tgzUtils.extractArchiveTo(tgzBuffer, extractTarget, {
+      stripComponents: 1,
+    });
+
+    const manifestPath = ppath.join(tmpDir, `package.json` as PortablePath);
+    const manifest = await xfs.readJsonPromise(manifestPath);
+
+    const binPath = manifest?.bin?.yarn;
+    if (typeof binPath !== `string`)
+      throw new Error(`Could not find a 'bin.yarn' entry in the @yarnpkg/cli-dist package.json`);
+
+    const bundlePath = ppath.join(tmpDir, binPath as PortablePath);
+    if (!await xfs.existsPromise(bundlePath))
+      throw new Error(`The 'bin.yarn' entry in @yarnpkg/cli-dist points to '${binPath}', but this file does not exist in the tarball`);
+
+    return await xfs.readFilePromise(bundlePath);
+  });
 }
 
 export async function setVersion(configuration: Configuration, bundleVersion: string | null, fetchBuffer: () => Promise<Buffer>, {report, useYarnPath}: {report: Report, useYarnPath?: boolean}) {

--- a/packages/plugin-essentials/sources/index.ts
+++ b/packages/plugin-essentials/sources/index.ts
@@ -145,6 +145,7 @@ declare module '@yarnpkg/core' {
     // Defining this property with two different enum instances leads to a compiler error.
     defaultSemverRangePrefix: `^` | `~` | ``;
     preferReuse: boolean;
+    versionNpmRegistryServer: string | null;
   }
 }
 
@@ -167,6 +168,12 @@ const plugin: Plugin = {
       description: `If true, \`yarn add\` will attempt to reuse the most common dependency range in other workspaces.`,
       type: SettingsType.BOOLEAN,
       default: false,
+    },
+
+    versionNpmRegistryServer: {
+      description: `Registry to use when fetching Yarn releases via \`yarn set version\`. When set, the release will be downloaded from the \`@yarnpkg/cli-dist\` package on this registry instead of from the default Yarn repository`,
+      type: SettingsType.STRING,
+      default: null,
     },
   },
   commands: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6234,6 +6234,7 @@ __metadata:
     "@yarnpkg/fslib": "workspace:^"
     "@yarnpkg/parsers": "workspace:^"
     "@yarnpkg/plugin-git": "workspace:^"
+    "@yarnpkg/plugin-npm": "workspace:^"
     ci-info: "npm:^4.0.0"
     clipanion: "npm:^4.0.0-rc.2"
     enquirer: "npm:^2.3.6"
@@ -6246,6 +6247,7 @@ __metadata:
     "@yarnpkg/cli": "workspace:^"
     "@yarnpkg/core": "workspace:^"
     "@yarnpkg/plugin-git": "workspace:^"
+    "@yarnpkg/plugin-npm": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What's the problem this PR addresses?

In restricted corporate environments (e.g. behind firewalls that block `repo.yarnpkg.com`), `yarn set version` cannot fetch Yarn releases. Tools like Renovate rely on this command to update Yarn, leaving renovate users with no automated way to upgrade. Resolves #7114.

I'd love to contribute to the 5.x and 6.x branches as well if this contribution is accepted!

## How did you fix it?

Added support for resolving Yarn releases from a private npm registry via the `@yarnpkg/cli-dist` package:

- New `--from-registry <url>` flag for one-off use
- New `versionNpmRegistryServer` configuration setting in `.yarnrc.yml` for permanent configuration
- When either is set and the version is a Yarn 2+ semver version/range, the command fetches `@yarnpkg/cli-dist` from the specified registry, extracts the tarball, and installs the bundle from `bin.yarn`
- Auth is handled through existing `npmRegistries`/`npmAuthToken` configuration
- Added `plugin-npm` as a direct dependency of `plugin-essentials`
- Added integration tests covering exact versions, ranges, invalid packages, and Yarn 1.x rejection

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
