### PR TITLE
feat: add meaningful User-Agent header to outgoing HTTP requests

### DIFF
--- a/packages/yarnpkg-core/sources/httpUtils.ts
+++ b/packages/yarnpkg-core/sources/httpUtils.ts
@@ -9,6 +9,7 @@ import {ConfigurationValueMap, Configuration}     from './Configuration';
 import {MessageName}                              from './MessageName';
 import {WrapNetworkRequestInfo}                   from './Plugin';
 import {ReportError}                              from './Report';
+import {YarnVersion}                              from './YarnVersion';
 import * as formatUtils                           from './formatUtils';
 import {MapValue, MapValueToObjectValue}          from './miscUtils';
 import * as miscUtils                             from './miscUtils';
@@ -230,6 +231,8 @@ export async function del(target: string, {customErrorMessage, ...options}: Opti
 
 async function requestImpl(target: string | URL, body: Body, {configuration, headers, jsonRequest, jsonResponse, method = Method.GET}: Omit<Options, `customErrorMessage`>): Promise<Response> {
   const url = typeof target === `string` ? new URL(target) : target;
+  const yarnVersion = YarnVersion ?? `unknown`;
+  const user_agent = `yarn/${yarnVersion} node/${process.version}`;
 
   const networkConfig = getNetworkSettings(url, {configuration});
   if (networkConfig.enableNetwork === false)
@@ -238,7 +241,10 @@ async function requestImpl(target: string | URL, body: Body, {configuration, hea
   if (url.protocol === `http:` && !micromatch.isMatch(url.hostname, configuration.get(`unsafeHttpWhitelist`)))
     throw new ReportError(MessageName.NETWORK_UNSAFE_HTTP, `Unsafe http requests must be explicitly whitelisted in your configuration (${url.hostname})`);
 
-  const gotOptions: ExtendOptions = {headers, method};
+  const gotOptions: ExtendOptions = {headers: {
+    'user-agent': user_agent,
+    ...headers,
+  }, method};
   gotOptions.responseType = jsonResponse
     ? `json`
     : `buffer`;


### PR DESCRIPTION
## What's the problem this PR addresses?

Currently, Yarn 4 identifies itself with the default `got` user-agent string (`got (https://github.com/sindresorhus/got)`) instead of identifying itself as Yarn. This makes it impossible for sysadmins and DevOps engineers to distinguish Yarn traffic or enforce package manager allow-lists across an organization.

Closes #7149 

## How did you fix it?

Modified `packages/yarnpkg-core/sources/httpUtils.ts` inside the `requestImpl` function. 

- Imported `YarnVersion` from the core constants.
- Formulated a meaningful `User-Agent` string following the standard convention: `yarn/${yarnVersion} node/${process.version}`.
- Injected it into `gotOptions.headers` while utilizing the spread operator (`...headers`) to ensure any explicitly passed custom headers are preserved and not overwritten.

## Checklist

- [x] I have read the Contributing Guide.
- [ ] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.