### PR TITLE
feat(plugin-npm): allow npmMinimalAgeGate per npmScope

### DIFF
--- a/.yarn/versions/9a3c1be4.yml
+++ b/.yarn/versions/9a3c1be4.yml
@@ -1,0 +1,28 @@
+releases:
+  "@yarnpkg/plugin-npm": minor
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnp"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
@@ -1,3 +1,9 @@
+import {xfs, PortablePath} from '@yarnpkg/fslib';
+
+const {
+  tests: {startPackageServer},
+} = require(`pkg-tests-core`);
+
 describe(`Features`, () => {
   describe(`npmMinimalAgeGate and npmPreapprovedPackages`, () => {
     describe(`add`, () => {
@@ -365,6 +371,126 @@ describe(`Features`, () => {
           await expect(source(`require('@scoped/release-date/package.json')`)).resolves.toMatchObject({
             name: `@scoped/release-date`,
             version: `1.1.0`,
+          });
+        }),
+      );
+    });
+    describe(`npmScopes override`, () => {
+      test(
+        `scope override tightens the gate beyond the global value`,
+        makeTemporaryEnv({}, async ({path, run}) => {
+          const registryUrl = await startPackageServer();
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            npmMinimalAgeGate: `1m`,
+            npmScopes: {
+              scoped: {
+                npmRegistryServer: registryUrl,
+                npmMinimalAgeGate: `1d`,
+              },
+            },
+          });
+
+          await expect(run(`add`, `@scoped/release-date@1.1.1`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
+        }),
+      );
+
+      test(
+        `scope override loosens the gate below the global value`,
+        makeTemporaryEnv({}, async ({path, run, source}) => {
+          const registryUrl = await startPackageServer();
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            npmMinimalAgeGate: `1d`,
+            npmScopes: {
+              scoped: {
+                npmRegistryServer: registryUrl,
+                npmMinimalAgeGate: 0,
+              },
+            },
+          });
+
+          await run(`add`, `@scoped/release-date@^1.0.0`);
+
+          await expect(source(`require('@scoped/release-date/package.json')`)).resolves.toMatchObject({
+            name: `@scoped/release-date`,
+            version: `1.1.2`,
+          });
+        }),
+      );
+
+      test(
+        `scope override does not affect unscoped packages`,
+        makeTemporaryEnv({}, async ({path, run, source}) => {
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            npmMinimalAgeGate: `1d`,
+            npmScopes: {
+              scoped: {
+                npmMinimalAgeGate: 0,
+              },
+            },
+          });
+
+          await run(`add`, `release-date@^1.0.0`);
+
+          await expect(source(`require('release-date/package.json')`)).resolves.toMatchObject({
+            name: `release-date`,
+            version: `1.1.0`,
+          });
+        }),
+      );
+
+      test(
+        `override on a different scope does not leak`,
+        makeTemporaryEnv({}, async ({path, run}) => {
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            npmMinimalAgeGate: `1d`,
+            npmScopes: {
+              other: {
+                npmMinimalAgeGate: 0,
+              },
+            },
+          });
+
+          await expect(run(`add`, `@scoped/release-date@1.1.1`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
+        }),
+      );
+
+      test(
+        `scope override tightens the gate even when the global is disabled`,
+        makeTemporaryEnv({}, async ({path, run}) => {
+          const registryUrl = await startPackageServer();
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            npmMinimalAgeGate: 0,
+            npmScopes: {
+              scoped: {
+                npmRegistryServer: registryUrl,
+                npmMinimalAgeGate: `1d`,
+              },
+            },
+          });
+
+          await expect(run(`add`, `@scoped/release-date@1.1.1`)).rejects.toThrowError(`All versions satisfying "1.1.1" are quarantined`);
+        }),
+      );
+
+      test(
+        `--no-time-gate bypasses scope override`,
+        makeTemporaryEnv({}, async ({path, run, source}) => {
+          const registryUrl = await startPackageServer();
+          await xfs.writeJsonPromise(`${path}/.yarnrc.yml` as PortablePath, {
+            npmMinimalAgeGate: `1d`,
+            npmScopes: {
+              scoped: {
+                npmRegistryServer: registryUrl,
+                npmMinimalAgeGate: `7d`,
+              },
+            },
+          });
+
+          await run(`add`, `--no-time-gate`, `@scoped/release-date@1.1.2`);
+
+          await expect(source(`require('@scoped/release-date/package.json')`)).resolves.toMatchObject({
+            name: `@scoped/release-date`,
+            version: `1.1.2`,
           });
         }),
       );

--- a/packages/plugin-essentials/sources/commands/add.ts
+++ b/packages/plugin-essentials/sources/commands/add.ts
@@ -130,7 +130,7 @@ export default class AddCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
     if (this.noTimeGate)
-      configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+      suggestUtils.disableTimeGate(configuration);
 
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);

--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -111,7 +111,7 @@ export default class UpCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
     if (this.noTimeGate)
-      configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+      suggestUtils.disableTimeGate(configuration);
 
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
@@ -161,7 +161,7 @@ export default class UpCommand extends BaseCommand {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
 
     if (this.noTimeGate)
-      configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+      suggestUtils.disableTimeGate(configuration);
 
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);

--- a/packages/plugin-essentials/sources/suggestUtils.ts
+++ b/packages/plugin-essentials/sources/suggestUtils.ts
@@ -72,6 +72,15 @@ export enum Strategy {
   CACHE = `cache`,
 }
 
+export function disableTimeGate(configuration: Configuration) {
+  configuration.useWithSource(`<cli>`, {npmMinimalAgeGate: `0`}, configuration.startingCwd, {overwrite: true});
+
+  const npmScopes = configuration.get(`npmScopes`) as Map<string, Map<string, unknown>>;
+  for (const scopeConfiguration of npmScopes.values()) {
+    scopeConfiguration.delete(`npmMinimalAgeGate`);
+  }
+}
+
 export function getModifier(flags: {exact: boolean, caret: boolean, tilde: boolean}, project: Project): Modifier {
   if (flags.exact)
     return Modifier.EXACT;

--- a/packages/plugin-npm/sources/index.ts
+++ b/packages/plugin-npm/sources/index.ts
@@ -68,13 +68,16 @@ const registrySettings = {
   },
 } satisfies Record<string, SettingsDefinition>;
 
-const packageGateSettings = {
+const scopablePackageGateSettings = {
   npmMinimalAgeGate: {
     description: `Minimum age of a package version according to the publish date on the npm registry to be considered for installation`,
     type: SettingsType.DURATION,
     unit: DurationUnit.MINUTES,
     default: `1d`,
   },
+} satisfies Record<string, SettingsDefinition>;
+
+const globalOnlyPackageGateSettings = {
   npmPreapprovedPackages: {
     description: `Array of package descriptors or package name glob patterns to exclude from the minimum release age check`,
     type: SettingsType.STRING,
@@ -103,6 +106,8 @@ declare module '@yarnpkg/core' {
 
       npmPublishRegistry: string | null;
       npmRegistryServer: string;
+
+      npmMinimalAgeGate: number;
     }>>;
     npmRegistries: Map<string, miscUtils.ToMapValue<{
       npmAlwaysAuth: boolean;
@@ -116,7 +121,8 @@ const plugin: Plugin = {
   configuration: {
     ...authSettings,
     ...registrySettings,
-    ...packageGateSettings,
+    ...scopablePackageGateSettings,
+    ...globalOnlyPackageGateSettings,
 
     npmScopes: {
       description: `Settings per package scope`,
@@ -127,6 +133,7 @@ const plugin: Plugin = {
         properties: {
           ...authSettings,
           ...registrySettings,
+          ...scopablePackageGateSettings,
         },
       },
     },

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -96,8 +96,20 @@ export function getAuthConfiguration(registry: string, {configuration, ident}: {
   return registryConfiguration || configuration;
 }
 
-function shouldBeQuarantined({configuration, version, publishTimes}: IsPackageApprovedOptions) {
-  const minimalAgeGate = configuration.get(`npmMinimalAgeGate`);
+export function getMinimalAgeGate(ident: Ident | null, {configuration}: {configuration: Configuration}): number {
+  if (ident?.scope) {
+    const scopeConfiguration = getScopeConfiguration(ident.scope, {configuration});
+    const scopeGate = scopeConfiguration?.get(`npmMinimalAgeGate`);
+    if (typeof scopeGate === `number`) {
+      return scopeGate;
+    }
+  }
+
+  return configuration.get(`npmMinimalAgeGate`);
+}
+
+function shouldBeQuarantined({configuration, ident, version, publishTimes}: IsPackageApprovedOptions) {
+  const minimalAgeGate = getMinimalAgeGate(ident, {configuration});
 
   if (minimalAgeGate) {
     const versionTime = publishTimes?.[version];


### PR DESCRIPTION
## What's the problem this PR addresses?

Closes #6984.

`npmMinimalAgeGate` is currently a single global setting. In environments that mix a public registry (where the gate is desired for supply-chain protection) with one or more trusted private/internal registries (where freshly published packages must be installable immediately), there is no way to express different policies per scope. Disabling the gate globally is the only workaround, which removes the protection everywhere.

## How did you fix it?

Allow `npmMinimalAgeGate` inside an `npmScopes` entry, falling back to the global value when unset:

```yaml
npmMinimalAgeGate: 1d

npmScopes:
  my-corp:
    npmRegistryServer: https://npm.pkg.mycompany.com
    npmMinimalAgeGate: 0
```

Implementation:

- Added `npmMinimalAgeGate` to the `npmScopes` shape (and to `ConfigurationValueMap`) in `packages/plugin-npm/sources/index.ts`. `npmPreapprovedPackages` stays global only.
- Introduced `getMinimalAgeGate(ident, {configuration})` in `packages/plugin-npm/sources/npmConfigUtils.ts`. Resolution rule:
  1. If the ident has a scope and that scope sets `npmMinimalAgeGate` -> return the scope value.
  2. Else -> return the global value.

  There is no longer any global-specific short-circuit: the scope value always wins when present, including the case where the global is `0` but a scope tightens the gate.
- `shouldBeQuarantined` now consults the helper instead of reading the global directly. No public API or call-site signature changes (`ident` was already on `IsPackageApprovedOptions`).
- The JSR default scope object does not declare `npmMinimalAgeGate`, so JSR-scoped lookups fall through to the global; no regression.

### \`--no-time-gate\`

Previously the CLI flag relied on the \`global === 0\` short-circuit to disable the gate everywhere. With that short-circuit gone, setting the global to \`0\` alone is no longer enough, since each scope carries its own gate (explicit, or the inherited default). The flag now goes through a shared \`suggestUtils.disableTimeGate(configuration)\` helper (used by \`add\` and \`up\`) that:

1. Sets the global \`npmMinimalAgeGate\` to \`0\` via a \`<cli>\` override.
2. Strips \`npmMinimalAgeGate\` from every \`npmScopes\` entry, so the CLI override is the only remaining source of truth.

(\`npmMinimalAgeGate\` is not registry-scopable -- it lives on the global config and on \`npmScopes\` only -- so nothing needs to be stripped from \`npmRegistries\`.)

Tests (`packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts`) add a new `describe('npmScopes override')` block:

1. Scope override tightens the gate beyond the global value.
2. Scope override loosens the gate below the global value.
3. Scope override does not affect unscoped packages.
4. Override on a different scope does not leak into the queried scope.
5. Scope override tightens the gate even when the global is disabled (`0`).
6. `--no-time-gate` bypasses scope override.

All existing tests in the gate suite continue to pass.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective (`@yarnpkg/plugin-npm` minor, `@yarnpkg/plugin-essentials` patch; `.yarn/versions/9a3c1be4.yml`).
- [x] I will check that all automated PR checks pass before the PR gets reviewed.