### PR TITLE
fix(workspace-tools): resolve catalog workspace deps in foreach

### DIFF
--- a/.yarn/versions/7129-catalog-workspace.yml
+++ b/.yarn/versions/7129-catalog-workspace.yml
@@ -1,0 +1,26 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -4,6 +4,7 @@ const {
   exec: {execFile},
   fs: {writeJson, writeFile},
   tests: {testIf, FEATURE_CHECKS},
+  yarn,
 } = require(`pkg-tests-core`);
 
 const forEachVerboseDone = FEATURE_CHECKS.forEachVerboseDone
@@ -766,6 +767,54 @@ describe(`Commands`, () => {
               `Test Workspace C\n`,
               `Test Workspace B\n`,
               `Test Workspace G\n`,
+              ...forEachVerboseDone,
+            ].join(``),
+          });
+        },
+      ),
+    );
+
+    test(
+      `should include workspace dependencies resolved through catalogs if using --from and --recursive`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await writeJson(`${path}/packages/my-dep/package.json`, {
+            name: `my-dep`,
+            version: `1.0.0`,
+            scripts: {
+              print: `echo Test My Dep`,
+            },
+          });
+
+          await writeJson(`${path}/packages/my-package/package.json`, {
+            name: `my-package`,
+            version: `1.0.0`,
+            scripts: {
+              print: `echo Test My Package`,
+            },
+            dependencies: {
+              [`my-dep`]: `catalog:`,
+            },
+          });
+
+          await yarn.writeConfiguration(path, {
+            enableTransparentWorkspaces: false,
+            catalog: {
+              [`my-dep`]: `workspace:*`,
+            },
+          });
+
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--recursive`, `--topological-dev`, `--from`, `my-package`, `--exclude`, `my-package`, `run`, `print`, {cwd: path})).resolves.toEqual({
+            code: 0,
+            stderr: ``,
+            stdout: [
+              `Test My Dep\n`,
               ...forEachVerboseDone,
             ].join(``),
           });

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -1,14 +1,14 @@
-import {BaseCommand, WorkspaceRequiredError}                         from '@yarnpkg/cli';
-import {Configuration, LocatorHash, Project, scriptUtils, Workspace} from '@yarnpkg/core';
-import {DescriptorHash, MessageName, Report, StreamReport}           from '@yarnpkg/core';
-import {formatUtils, miscUtils, structUtils, nodeUtils}              from '@yarnpkg/core';
-import {gitUtils}                                                    from '@yarnpkg/plugin-git';
-import {Command, Option, Usage, UsageError}                          from 'clipanion';
-import micromatch                                                    from 'micromatch';
-import pLimit                                                        from 'p-limit';
-import {Writable}                                                    from 'stream';
-import {WriteStream}                                                 from 'tty';
-import * as t                                                        from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                                                from '@yarnpkg/cli';
+import {Configuration, LocatorHash, Manifest, Project, scriptUtils, ThrowReport, Workspace} from '@yarnpkg/core';
+import {Descriptor, DescriptorHash, HardDependencies, MessageName, Report, StreamReport}    from '@yarnpkg/core';
+import {formatUtils, miscUtils, structUtils, nodeUtils}                                     from '@yarnpkg/core';
+import {gitUtils}                                                                           from '@yarnpkg/plugin-git';
+import {Command, Option, Usage, UsageError}                                                 from 'clipanion';
+import micromatch                                                                           from 'micromatch';
+import pLimit                                                                               from 'p-limit';
+import {Writable}                                                                           from 'stream';
+import {WriteStream}                                                                        from 'tty';
+import * as t                                                                               from 'typanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesForeachCommand extends BaseCommand {
@@ -149,6 +149,90 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     if (command.path.length === 0)
       throw new UsageError(`Invalid subcommand name for iteration - use the 'run' keyword if you wish to execute a script`);
 
+    const resolver = configuration.makeResolver();
+    const resolveOptions = {
+      project,
+      resolver,
+      report: new ThrowReport(),
+    };
+
+    const resolvedWorkspaceDependencies = new Map<string, Promise<Workspace | null>>();
+    const tryWorkspaceByDescriptor = async (workspace: Workspace, descriptor: Descriptor) => {
+      const cacheKey = `${workspace.anchoredLocator.locatorHash}:${descriptor.descriptorHash}`;
+      let promise = resolvedWorkspaceDependencies.get(cacheKey);
+      if (typeof promise === `undefined`) {
+        promise = (async () => {
+          const dependency = await configuration.reduceHook(hooks => {
+            return hooks.reduceDependency;
+          }, descriptor, project, workspace.anchoredLocator, descriptor, {
+            resolver,
+            resolveOptions,
+          });
+
+          if (!structUtils.areIdentsEqual(descriptor, dependency))
+            throw new Error(`Assertion failed: The descriptor ident cannot be changed through aliases`);
+
+          return project.tryWorkspaceByDescriptor(dependency);
+        })();
+
+        resolvedWorkspaceDependencies.set(cacheKey, promise);
+      }
+
+      return await promise;
+    };
+
+    const getRecursiveWorkspaceDependencies = async (workspace: Workspace, {dependencies = Manifest.hardDependencies}: {dependencies?: Array<HardDependencies>} = {}) => {
+      const workspaceList = new Set<Workspace>();
+
+      const visitWorkspace = async (workspace: Workspace) => {
+        for (const dependencyType of dependencies) {
+          for (const descriptor of workspace.manifest[dependencyType].values()) {
+            const foundWorkspace = await tryWorkspaceByDescriptor(workspace, descriptor);
+            if (foundWorkspace === null || workspaceList.has(foundWorkspace))
+              continue;
+
+            workspaceList.add(foundWorkspace);
+            await visitWorkspace(foundWorkspace);
+          }
+        }
+      };
+
+      await visitWorkspace(workspace);
+      return workspaceList;
+    };
+
+    const getRecursiveWorkspaceDependents = async (workspace: Workspace, {dependencies = Manifest.hardDependencies}: {dependencies?: Array<HardDependencies>} = {}) => {
+      const workspaceList = new Set<Workspace>();
+
+      const visitWorkspace = async (workspace: Workspace) => {
+        for (const projectWorkspace of project.workspaces) {
+          let isDependent = false;
+
+          for (const dependencyType of dependencies) {
+            for (const descriptor of projectWorkspace.manifest[dependencyType].values()) {
+              const foundWorkspace = await tryWorkspaceByDescriptor(projectWorkspace, descriptor);
+              if (foundWorkspace !== null && structUtils.areLocatorsEqual(foundWorkspace.anchoredLocator, workspace.anchoredLocator)) {
+                isDependent = true;
+                break;
+              }
+            }
+
+            if (isDependent) {
+              break;
+            }
+          }
+
+          if (isDependent && !workspaceList.has(projectWorkspace)) {
+            workspaceList.add(projectWorkspace);
+            await visitWorkspace(projectWorkspace);
+          }
+        }
+      };
+
+      await visitWorkspace(workspace);
+      return workspaceList;
+    };
+
     const log = (msg: string) => {
       if (!this.dryRun)
         return;
@@ -200,10 +284,14 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     if (this.recursive) {
       if (this.since) {
         log(`Option --recursive --since is set; recursively selecting all dependent workspaces`);
-        extra = new Set(selection.map(workspace => [...workspace.getRecursiveWorkspaceDependents()]).flat());
+        extra = new Set((await Promise.all(selection.map(async workspace => {
+          return [...await getRecursiveWorkspaceDependents(workspace)];
+        }))).flat());
       } else {
         log(`Option --recursive is set; recursively selecting all transitive dependencies`);
-        extra = new Set(selection.map(workspace => [...workspace.getRecursiveWorkspaceDependencies()]).flat());
+        extra = new Set((await Promise.all(selection.map(async workspace => {
+          return [...await getRecursiveWorkspaceDependencies(workspace)];
+        }))).flat());
       }
     } else if (this.worktree) {
       log(`Option --worktree is set; recursively selecting all nested workspaces`);
@@ -387,8 +475,8 @@ export default class WorkspacesForeachCommand extends BaseCommand {
               : workspace.manifest.dependencies;
 
             for (const descriptor of resolvedSet.values()) {
-              const workspace = project.tryWorkspaceByDescriptor(descriptor);
-              isRunnable = workspace === null || !needsProcessing.has(workspace.anchoredLocator.locatorHash);
+              const dependencyWorkspace = await tryWorkspaceByDescriptor(workspace, descriptor);
+              isRunnable = dependencyWorkspace === null || !needsProcessing.has(dependencyWorkspace.anchoredLocator.locatorHash);
 
               if (!isRunnable) {
                 break;


### PR DESCRIPTION
## What's the problem this PR addresses?

Fixes #7129.

When a workspace dependency is declared through a catalog entry that resolves to `workspace:*`, `workspaces foreach --recursive --topological-dev --from ... --exclude ...` can miss that workspace dependency if transparent workspace matching is disabled. The foreach dependency graph was checking raw manifest descriptors such as `catalog:` instead of the descriptor after Yarn's dependency reduction hooks had resolved it.

## How did you fix it?

`workspaces foreach` now reduces dependency descriptors through the existing `reduceDependency` hook path before checking whether they point at a workspace. The same helper is used for recursive dependency selection, recursive dependent selection, and topological wait checks.

I also added an acceptance test that disables transparent workspaces, puts `workspace:*` behind a catalog entry, and verifies that `foreach --recursive --topological-dev --from my-package --exclude my-package` still runs the dependency workspace.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

## Testing

- `yarn build:cli`
- `yarn workspace acceptance-tests test:integration packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js -t 'should include workspace dependencies resolved through catalogs'`
- `yarn workspace acceptance-tests test:integration packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js -t 'should include dependencies|should include workspace dependencies|following the topological order'`
- `yarn typecheck:all`
- `yarn version check`
- `yarn constraints`
- `git diff --check`
