### PR TITLE
fix: set proper User-Agent header on outgoing HTTP requests

### DIFF
--- a/.yarn/versions/7162.yml
+++ b/.yarn/versions/7162.yml
@@ -1,0 +1,23 @@
+releases:
+  "@yarnpkg/core": minor
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/doctor"


### PR DESCRIPTION
## What

Set a meaningful `User-Agent` header on all outgoing HTTP requests, changing from the default `got (https://github.com/sindresorhus/got)` to `yarn/<version> node/<node_version>`.

## Why

As a sys admin, I want package managers to identify themselves with a meaningful User-Agent header, but Yarn 4 currently sends "got (https://github.com/sindresorhus/got)" instead of identifying itself as Yarn. This makes it impossible to distinguish Yarn traffic and determine its exact version, preventing us from enforcing package manager allow-lists across the organization.

This follows the convention already established by npm (`npm/x.x.x node/vx.x.x`) and pnpm (`pnpm/x.x.x`).

## How

- Imported `YarnVersion` from the YarnVersion module
- Set a default `user-agent` header on the `got` client, with caller-supplied headers taking precedence via spread ordering

Fixes #7146
