### PR TITLE
fix: explain peer-default dependencies in why

### DIFF
--- a/.yarn/versions/02e7cbb8.yml
+++ b/.yarn/versions/02e7cbb8.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/plugin-essentials": patch
+
+declined:
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/cli"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/why.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/why.test.ts
@@ -36,6 +36,52 @@ describe(`Commands`, () => {
     );
 
     test(
+      `it should list dependencies that are also declared as peers`,
+      makeTemporaryEnv({
+        workspaces: [`packages/*`],
+      }, async ({path, run, source}) => {
+        await fs.writeJson(ppath.join(path, `packages/a/package.json`), {
+          name: `a`,
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+          peerDependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        });
+
+        await run(`install`);
+
+        const {stdout} = await run(`why`, `no-deps`, `--json`);
+
+        expect(misc.parseJsonStream(stdout)).toEqual([{
+          value: `a@workspace:packages/a`,
+          children: {
+            [`no-deps@npm:1.0.0`]: {
+              descriptor: `no-deps@npm:1.0.0`,
+              locator: `no-deps@npm:1.0.0`,
+            },
+          },
+        }]);
+
+        const {stdout: recursiveStdout} = await run(`why`, `-R`, `no-deps`, `--json`);
+
+        expect(misc.parseJsonStream(recursiveStdout)).toEqual([{
+          value: `a@workspace:packages/a`,
+          children: {
+            [`no-deps@npm:1.0.0`]: {
+              value: {
+                descriptor: `no-deps@npm:1.0.0`,
+                locator: `no-deps@npm:1.0.0`,
+              },
+              children: {},
+            },
+          },
+        }]);
+      }),
+    );
+
+    test(
       `it should list the packages using a specific dependency`,
       makeTemporaryEnv({
         workspaces: [`packages/*`],

--- a/packages/plugin-essentials/sources/commands/why.ts
+++ b/packages/plugin-essentials/sources/commands/why.ts
@@ -81,7 +81,7 @@ function whySimple(project: Project, targetPkg: Descriptor, {configuration, peer
     const node: treeUtils.TreeNode | null = null;
 
     for (const dependency of pkg.dependencies.values()) {
-      if (!peers && pkg.peerDependencies.has(dependency.identHash))
+      if (!peers && isVirtualPeerDependency(pkg, dependency))
         continue;
 
       const resolution = project.storedResolutions.get(dependency.descriptorHash);
@@ -137,7 +137,7 @@ function whyRecursive(project: Project, targetPkg: Descriptor, {configuration, p
     let depends = false;
 
     for (const dependency of pkg.dependencies.values()) {
-      if (!peers && pkg.peerDependencies.has(dependency.identHash))
+      if (!peers && isVirtualPeerDependency(pkg, dependency))
         continue;
 
       const resolution = project.storedResolutions.get(dependency.descriptorHash);
@@ -197,7 +197,7 @@ function whyRecursive(project: Project, targetPkg: Descriptor, {configuration, p
     printed.add(pkg.locatorHash);
 
     for (const dependency of pkg.dependencies.values()) {
-      if (!peers && pkg.peerDependencies.has(dependency.identHash))
+      if (!peers && isVirtualPeerDependency(pkg, dependency))
         continue;
 
       const resolution = project.storedResolutions.get(dependency.descriptorHash);
@@ -216,4 +216,8 @@ function whyRecursive(project: Project, targetPkg: Descriptor, {configuration, p
     printAllDependents(workspace.anchoredPackage, rootChildren, null);
 
   return root;
+}
+
+function isVirtualPeerDependency(pkg: Package, dependency: Descriptor) {
+  return structUtils.isVirtualLocator(pkg) && pkg.peerDependencies.has(dependency.identHash);
 }


### PR DESCRIPTION
Closes #7159.

`yarn why` currently skips any dependency whose ident is also listed in `peerDependencies`, which hides real peer-with-default dependency edges. In the issue reproduction, `@siteimprove/alfa-cypress` declares `cypress` in both `dependencies` and `peerDependencies`, so `yarn why cypress` reports nothing unless `--peers` is set.

This keeps the default behavior of hiding injected virtual peer provisions, but no longer hides regular dependency edges just because the package also has a peer declaration for the same ident.

Verification:

- `TEST_BINARY=scripts/run-yarn.js node scripts/run-yarn.js workspace acceptance-tests test:integration packages/acceptance-tests/pkg-tests-specs/sources/commands/why.test.ts --runInBand`
- `YARN_IGNORE_PATH=1 node scripts/run-yarn.js why cypress` in a clone of `Siteimprove/alfa-integrations` now prints `@siteimprove/alfa-cypress -> cypress`
- `YARN_IGNORE_PATH=1 node scripts/run-yarn.js why -R yauzl` in the same clone now includes the Cypress branch
- `node scripts/run-yarn.js test:lint`
- `node scripts/run-yarn.js typecheck:all`
- `node scripts/run-yarn.js version check`
- `git diff --check`
