### PR TITLE
fix: resolve catalog workspace deps in foreach

### DIFF
--- a/.yarn/versions/df418b4a.yml
+++ b/.yarn/versions/df418b4a.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-workspace-tools": patch
+
+declined:
+  - "@yarnpkg/cli"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
@@ -4,6 +4,7 @@ const {
   exec: {execFile},
   fs: {writeJson, writeFile},
   tests: {testIf, FEATURE_CHECKS},
+  yarn,
 } = require(`pkg-tests-core`);
 
 const forEachVerboseDone = FEATURE_CHECKS.forEachVerboseDone
@@ -246,6 +247,55 @@ describe(`Commands`, () => {
           ]);
 
           expect({code, stderr}).toEqual({code: 0, stderr: ``});
+        },
+      ),
+    );
+
+    test(
+      `should follow workspace dependencies resolved through catalogs when using --recursive --topological-dev`,
+      makeTemporaryEnv(
+        {
+          private: true,
+          workspaces: [`packages/*`],
+        },
+        async ({path, run}) => {
+          await writeJson(`${path}/packages/workspace-a/package.json`, {
+            name: `workspace-a`,
+            version: `1.0.0`,
+            scripts: {
+              build: `echo build a`,
+            },
+          });
+
+          await writeJson(`${path}/packages/workspace-b/package.json`, {
+            name: `workspace-b`,
+            version: `1.0.0`,
+            scripts: {
+              build: `echo build b`,
+            },
+            dependencies: {
+              [`workspace-a`]: `catalog:local`,
+            },
+          });
+
+          await yarn.writeConfiguration(path, {
+            catalogs: {
+              local: {
+                [`workspace-a`]: `workspace:*`,
+              },
+            },
+          });
+
+          await run(`install`);
+
+          await expect(run(`workspaces`, `foreach`, `--recursive`, `--topological-dev`, `--from`, `workspace-b`, `--exclude`, `workspace-b`, `run`, `build`)).resolves.toEqual({
+            code: 0,
+            stderr: ``,
+            stdout: [
+              `build a\n`,
+              ...forEachVerboseDone,
+            ].join(``),
+          });
         },
       ),
     );

--- a/packages/plugin-workspace-tools/sources/commands/foreach.ts
+++ b/packages/plugin-workspace-tools/sources/commands/foreach.ts
@@ -1,14 +1,14 @@
-import {BaseCommand, WorkspaceRequiredError}                         from '@yarnpkg/cli';
-import {Configuration, LocatorHash, Project, scriptUtils, Workspace} from '@yarnpkg/core';
-import {DescriptorHash, MessageName, Report, StreamReport}           from '@yarnpkg/core';
-import {formatUtils, miscUtils, structUtils, nodeUtils}              from '@yarnpkg/core';
-import {gitUtils}                                                    from '@yarnpkg/plugin-git';
-import {Command, Option, Usage, UsageError}                          from 'clipanion';
-import micromatch                                                    from 'micromatch';
-import pLimit                                                        from 'p-limit';
-import {Writable}                                                    from 'stream';
-import {WriteStream}                                                 from 'tty';
-import * as t                                                        from 'typanion';
+import {BaseCommand, WorkspaceRequiredError}                                                    from '@yarnpkg/cli';
+import {Configuration, LocatorHash, Manifest, Project, scriptUtils, ThrowReport, Workspace}     from '@yarnpkg/core';
+import {Descriptor, DescriptorHash, Locator, MessageName, Report, ResolveOptions, StreamReport} from '@yarnpkg/core';
+import {formatUtils, miscUtils, structUtils, nodeUtils}                                         from '@yarnpkg/core';
+import {gitUtils}                                                                               from '@yarnpkg/plugin-git';
+import {Command, Option, Usage, UsageError}                                                     from 'clipanion';
+import micromatch                                                                               from 'micromatch';
+import pLimit                                                                                   from 'p-limit';
+import {Writable}                                                                               from 'stream';
+import {WriteStream}                                                                            from 'tty';
+import * as t                                                                                   from 'typanion';
 
 // eslint-disable-next-line arca/no-default-export
 export default class WorkspacesForeachCommand extends BaseCommand {
@@ -156,6 +156,90 @@ export default class WorkspacesForeachCommand extends BaseCommand {
       this.context.stdout.write(`${msg}\n`);
     };
 
+    const resolver = configuration.makeResolver();
+    const resolveOptions: ResolveOptions = {
+      project,
+      resolver,
+      report: new ThrowReport(),
+    };
+    const workspaceDependencyCache = new Map<string, Workspace | null>();
+
+    const getWorkspaceByDependency = async (descriptor: Descriptor, fromLocator: Locator) => {
+      const cacheKey = `${fromLocator.locatorHash}:${descriptor.descriptorHash}`;
+      const cachedWorkspace = workspaceDependencyCache.get(cacheKey);
+      if (typeof cachedWorkspace !== `undefined`)
+        return cachedWorkspace;
+
+      const dependency = await configuration.reduceHook(hooks => {
+        return hooks.reduceDependency;
+      }, descriptor, project, fromLocator, descriptor, {
+        resolver,
+        resolveOptions,
+      });
+
+      if (!structUtils.areIdentsEqual(descriptor, dependency))
+        throw new Error(`Assertion failed: The descriptor ident cannot be changed through aliases`);
+
+      const bound = resolver.bindDescriptor(dependency, fromLocator, resolveOptions);
+
+      const workspace = project.tryWorkspaceByDescriptor(bound);
+      workspaceDependencyCache.set(cacheKey, workspace);
+
+      return workspace;
+    };
+
+    const getRecursiveWorkspaceDependencies = async (workspace: Workspace, {dependencies = Manifest.hardDependencies}: {dependencies?: typeof Manifest.hardDependencies} = {}) => {
+      const workspaceList = new Set<Workspace>();
+
+      const visitWorkspace = async (workspace: Workspace) => {
+        for (const dependencyType of dependencies) {
+          for (const descriptor of workspace.manifest[dependencyType].values()) {
+            const foundWorkspace = await getWorkspaceByDependency(descriptor, workspace.anchoredLocator);
+            if (foundWorkspace === null || workspaceList.has(foundWorkspace))
+              continue;
+
+            workspaceList.add(foundWorkspace);
+            await visitWorkspace(foundWorkspace);
+          }
+        }
+      };
+
+      await visitWorkspace(workspace);
+      return workspaceList;
+    };
+
+    const getRecursiveWorkspaceDependents = async (workspace: Workspace, {dependencies = Manifest.hardDependencies}: {dependencies?: typeof Manifest.hardDependencies} = {}) => {
+      const workspaceList = new Set<Workspace>();
+
+      const visitWorkspace = async (workspace: Workspace) => {
+        for (const projectWorkspace of project.workspaces) {
+          let isDependent = false;
+
+          for (const dependencyType of dependencies) {
+            for (const descriptor of projectWorkspace.manifest[dependencyType].values()) {
+              const foundWorkspace = await getWorkspaceByDependency(descriptor, projectWorkspace.anchoredLocator);
+              if (foundWorkspace !== null && structUtils.areLocatorsEqual(foundWorkspace.anchoredLocator, workspace.anchoredLocator)) {
+                isDependent = true;
+                break;
+              }
+            }
+
+            if (isDependent) {
+              break;
+            }
+          }
+
+          if (isDependent && !workspaceList.has(projectWorkspace)) {
+            workspaceList.add(projectWorkspace);
+            await visitWorkspace(projectWorkspace);
+          }
+        }
+      };
+
+      await visitWorkspace(workspace);
+      return workspaceList;
+    };
+
     const getFromWorkspaces = () => {
       const matchers = this.from!.map(pattern => micromatch.matcher(pattern));
 
@@ -200,10 +284,10 @@ export default class WorkspacesForeachCommand extends BaseCommand {
     if (this.recursive) {
       if (this.since) {
         log(`Option --recursive --since is set; recursively selecting all dependent workspaces`);
-        extra = new Set(selection.map(workspace => [...workspace.getRecursiveWorkspaceDependents()]).flat());
+        extra = new Set((await Promise.all(selection.map(workspace => getRecursiveWorkspaceDependents(workspace)))).flatMap(workspaces => [...workspaces]));
       } else {
         log(`Option --recursive is set; recursively selecting all transitive dependencies`);
-        extra = new Set(selection.map(workspace => [...workspace.getRecursiveWorkspaceDependencies()]).flat());
+        extra = new Set((await Promise.all(selection.map(workspace => getRecursiveWorkspaceDependencies(workspace)))).flatMap(workspaces => [...workspaces]));
       }
     } else if (this.worktree) {
       log(`Option --worktree is set; recursively selecting all nested workspaces`);
@@ -382,13 +466,19 @@ export default class WorkspacesForeachCommand extends BaseCommand {
           let isRunnable = true;
 
           if (this.topological || this.topologicalDev) {
-            const resolvedSet = this.topologicalDev
-              ? new Map([...workspace.manifest.dependencies, ...workspace.manifest.devDependencies])
-              : workspace.manifest.dependencies;
+            const dependencyTypes = this.topologicalDev
+              ? Manifest.hardDependencies
+              : [`dependencies`] as const;
 
-            for (const descriptor of resolvedSet.values()) {
-              const workspace = project.tryWorkspaceByDescriptor(descriptor);
-              isRunnable = workspace === null || !needsProcessing.has(workspace.anchoredLocator.locatorHash);
+            for (const dependencyType of dependencyTypes) {
+              for (const descriptor of workspace.manifest[dependencyType].values()) {
+                const dependencyWorkspace = await getWorkspaceByDependency(descriptor, workspace.anchoredLocator);
+                isRunnable = dependencyWorkspace === null || !needsProcessing.has(dependencyWorkspace.anchoredLocator.locatorHash);
+
+                if (!isRunnable) {
+                  break;
+                }
+              }
 
               if (!isRunnable) {
                 break;


### PR DESCRIPTION
## What changed

- Resolves `workspaces foreach` dependency graph checks through the normal dependency-reduction hooks before testing whether a dependency points at a workspace.
- Applies that to recursive workspace selection and topological wait points, so named catalog entries that resolve to `workspace:*` are treated as workspace edges.
- Adds acceptance coverage for `catalog:local` resolving to `workspace:*` with `--recursive --topological-dev --from ... --exclude ...`.

Fixes #7129.

## Verification

```console
TEST_BINARY=$PWD/scripts/run-yarn.js node scripts/run-yarn.js jest --runTestsByPath packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js --runInBand
node scripts/run-yarn.js eslint --max-warnings 0 packages/plugin-workspace-tools/sources/commands/foreach.ts packages/acceptance-tests/pkg-tests-specs/sources/commands/workspaces/foreach.test.js
node scripts/run-yarn.js typecheck:all
node scripts/run-yarn.js test:lint
node scripts/run-yarn.js version check
git diff --check
```