### PR TITLE
Fix invalid fallback in bench-run.sh

### DIFF
--- a/scripts/bench-run.sh
+++ b/scripts/bench-run.sh
@@ -156,6 +156,6 @@ case $PACKAGE_MANAGER in
       'pnpm add dummy-pkg@link:./dummy-pkg'
     ;;
   *)
-    echo "Invalid package manager ${$1}"
-    return 1;;
+    echo "Invalid package manager ${PACKAGE_MANAGER}"
+    exit 1;;
 esac


### PR DESCRIPTION
## Summary

Fix the fallback branch in `scripts/bench-run.sh` so unknown package managers report a normal error instead of crashing with a bad shell substitution.

## Root cause

The default `case` branch used `${$1}`, which triggers `bad substitution` in bash before the intended message can be printed. It also used `return 1` even though this branch runs at script top level.

## Fix

- use `${PACKAGE_MANAGER}` in the error message
- use `exit 1` for the script-level failure path

## Verification

- `bash -n scripts/bench-run.sh`
- `bash scripts/bench-run.sh bogus gatsby /tmp/berry-bench-check` now prints `Invalid package manager bogus` and exits non-zero
