### PR TITLE
Fix usage metadata in hello plugin examples

### DIFF
--- a/scripts/plugin-hello-universe.js
+++ b/scripts/plugin-hello-universe.js
@@ -9,7 +9,7 @@ module.exports = {
         [`hello`, `universe`],
       ];
 
-      static usageusage = Command.Usage({
+      static usage = Command.Usage({
         description: `hello world!`,
         details: `
           This command will print a nice message.

--- a/scripts/plugin-hello-world.js
+++ b/scripts/plugin-hello-world.js
@@ -9,7 +9,7 @@ module.exports = {
         [`hello`],
       ];
 
-      static usageusage = Command.Usage({
+      static usage = Command.Usage({
         description: `hello world!`,
         details: `
           This command will print a nice message.


### PR DESCRIPTION
## Summary

Fix the example hello-world plugins so their Clipanion usage metadata is attached to the expected static field.

## Root cause

Both example commands used `static usageusage = Command.Usage(...)` instead of `static usage = Command.Usage(...)`, so Clipanion never reads the intended help metadata.

## Fix

- rename `usageusage` to `usage` in `scripts/plugin-hello-world.js`
- rename `usageusage` to `usage` in `scripts/plugin-hello-universe.js`

## Verification

- confirmed the typo was present in both files and nowhere else in these examples
- confirmed the resulting diff is only the two field renames
