### PR TITLE
Fix stale script names in release wrapper

### DIFF
--- a/scripts/release/00-release.sh
+++ b/scripts/release/00-release.sh
@@ -10,5 +10,5 @@ if ! [[ -z $(git status --porcelain) ]]; then
   exit 1
 fi
 
-"$THIS_DIR"/release-tags.sh
-"$THIS_DIR"/release-builds.sh
+"$THIS_DIR"/01-release-tags.sh
+"$THIS_DIR"/02-release-builds.sh


### PR DESCRIPTION
## Summary

Fix `scripts/release/00-release.sh` so it calls the numbered release scripts that exist in `scripts/release/`.

## Root cause

The release wrapper still referenced the old unnumbered names (`release-tags.sh` and `release-builds.sh`), but the repository now ships `01-release-tags.sh` and `02-release-builds.sh` instead.

## Fix

- call `01-release-tags.sh` from `00-release.sh`
- call `02-release-builds.sh` from `00-release.sh`

## Verification

- `bash -n scripts/release/00-release.sh`
- confirmed `scripts/release/` contains `01-release-tags.sh` and `02-release-builds.sh` and not the old unnumbered files
