### PR TITLE
Support artifactory tarball URIs

### DIFF
--- a/.yarn/versions/ed298685.yml
+++ b/.yarn/versions/ed298685.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/packages/plugin-npm/sources/NpmSemverFetcher.ts
+++ b/packages/plugin-npm/sources/NpmSemverFetcher.ts
@@ -72,7 +72,10 @@ export class NpmSemverFetcher implements Fetcher {
 
   static isConventionalTarballUrl(locator: Locator, url: string, {configuration}: {configuration: Configuration}) {
     let registry = npmConfigUtils.getScopeRegistry(locator.scope, {configuration});
-    const path = NpmSemverFetcher.getLocatorUrl(locator);
+    const version = NpmSemverFetcher.getLocatorVersion(locator);
+    const encodedIdentUrl = npmHttpUtils.getIdentUrl(locator);
+    const decodedIdentUrl = encodedIdentUrl.replace(/%2f/gi, `/`);
+    const filename = `${encodeURIComponent(locator.name)}-${encodeURIComponent(version)}.tgz`;
 
     // From time to time the npm registry returns http urls instead of https 🤡
     url = url.replace(/^https?:(\/\/(?:[^/]+\.)?npmjs.org(?:$|\/))/, `https:$1`);
@@ -81,22 +84,34 @@ export class NpmSemverFetcher implements Fetcher {
     registry = registry.replace(/^https:\/\/registry\.npmjs\.org($|\/)/, `https://registry.yarnpkg.com$1`);
     url = url.replace(/^https:\/\/registry\.npmjs\.org($|\/)/, `https://registry.yarnpkg.com$1`);
 
-    if (url === registry + path)
+    if (url === `${registry}${encodedIdentUrl}/-/${filename}`)
       return true;
-    if (url === registry + path.replace(/%2f/g, `/`))
+    if (url === `${registry}${decodedIdentUrl}/-/${filename}`)
       return true;
+
+    if (locator.scope) {
+      const encodedScope = encodeURIComponent(locator.scope);
+
+      if (url === `${registry}${encodedIdentUrl}/-/@${encodedScope}/${filename}` || url === `${registry}${decodedIdentUrl}/-/@${encodedScope}/${filename}`) {
+        return true;
+      }
+    }
 
     return false;
   }
 
   static getLocatorUrl(locator: Locator) {
-    const version = semverUtils.clean(locator.reference.slice(PROTOCOL.length));
-    if (version === null)
-      throw new ReportError(MessageName.RESOLVER_NOT_FOUND, `The npm semver resolver got selected, but the version isn't semver`);
-
+    const version = NpmSemverFetcher.getLocatorVersion(locator);
     const encodedName = encodeURIComponent(locator.name);
     const encodedVersion = encodeURIComponent(version);
 
     return `${npmHttpUtils.getIdentUrl(locator)}/-/${encodedName}-${encodedVersion}.tgz`;
+  }
+  private static getLocatorVersion(locator: Locator) {
+    const version = semverUtils.clean(locator.reference.slice(PROTOCOL.length));
+    if (version === null)
+      throw new ReportError(MessageName.RESOLVER_NOT_FOUND, `The npm semver resolver got selected, but the version isn't semver`);
+
+    return version;
   }
 }

--- a/packages/plugin-npm/tests/NpmSemverFetcher.test.js
+++ b/packages/plugin-npm/tests/NpmSemverFetcher.test.js
@@ -33,6 +33,15 @@ describe(`NpmSemverFetcher`, () => {
       expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url, {configuration})).toEqual(true);
     });
 
+    it(`it should detect a conventional Artifactory-style path (@scope/foo)`, async () => {
+      const configuration = await makeConfiguration();
+
+      const locator = structUtils.makeLocator(structUtils.makeIdent(`scope`, `foo`), `npm:1.0.0`);
+      const url = `${configuration.get(`npmRegistryServer`)}/@scope/foo/-/@scope/foo-1.0.0.tgz`;
+
+      expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url, {configuration})).toEqual(true);
+    });
+
     it(`it should detect non-conventional path (different registry)`, async () => {
       const configuration = await makeConfiguration();
 
@@ -47,6 +56,15 @@ describe(`NpmSemverFetcher`, () => {
 
       const locator = structUtils.makeLocator(structUtils.makeIdent(null, `foo`), `npm:1.0.0`);
       const url = `${configuration.get(`npmRegistryServer`)}/archives/foo/foo-1.0.0.tgz`;
+
+      expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url, {configuration})).toEqual(false);
+    });
+
+    it(`it should detect non-conventional Artifactory-style path with a different package name`, async () => {
+      const configuration = await makeConfiguration();
+
+      const locator = structUtils.makeLocator(structUtils.makeIdent(`scope`, `foo`), `npm:1.0.0`);
+      const url = `${configuration.get(`npmRegistryServer`)}/@scope/foo/-/@scope/bar-1.0.0.tgz`;
 
       expect(NpmSemverFetcher.isConventionalTarballUrl(locator, url, {configuration})).toEqual(false);
     });


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

Projects using JFrog Artifactory for their NPM registry may get superfluous `__archiveUrl=` values in their resolved lockfile entries due to an inconsistency between the request URI and the response's tarball URI.

Assuming the registry server URLs match, there's an inconsistency for Artifactory related to package scopes.

Yarn is opinionated and expects `<registry>/<scope>/<name>/-/<name>-<version>.tgz` in tarball urls to decide whether to inject an archiveUrl suffix. Artifactory servers may return `<registry>/<scope>/<name>/-/<scope>/<name>-<version>.tgz`. The difference is the extra package scope after the `/-/` bit.

This causes a mismatch and always injects an `__archiveUrl` suffix for dependencies that use a package scope.

In large monorepos the extra characters from all those archive Urls can lead to extra hundreds of kilobytes unnecessarily.

...

## How did you fix it?

Expand yarn's expectation to support with or without the package scope after the `/-/` bit.

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ x ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ x ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ x ] I will check that all automated PR checks pass before the PR gets reviewed.
