### PR TITLE
fix: add catalog settings to yarnrc schema

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -35,6 +35,27 @@
       "enum": ["required-only", "match-spec", "always"],
       "default": "always"
     },
+    "catalog": {
+      "_package": "@yarnpkg/plugin-catalog",
+      "title": "The default catalog of packages.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "_exampleKeys": ["react"]
+    },
+    "catalogs": {
+      "_package": "@yarnpkg/plugin-catalog",
+      "title": "Named catalogs of packages.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "_exampleKeys": ["react18"]
+    },
     "changesetBaseRefs": {
       "_package": "@yarnpkg/plugin-git",
       "title": "List of git refs against which Yarn will compare your branch when it needs to detect changes.",


### PR DESCRIPTION
## What's the problem this PR addresses?

Resolves #7178.

The published `.yarnrc.yml` JSON schema doesn't include the `catalog` and `catalogs` settings from `@yarnpkg/plugin-catalog`, so editors cannot validate or autocomplete them.

## How did you fix it?

Added `catalog` and `catalogs` entries to `packages/docusaurus/static/configuration/yarnrc.json`, matching the map shapes defined by the catalog plugin.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [ ] I have set the packages that need to be released for my changes to be effective. (Not applicable: static schema/documentation metadata only.)
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

Validation:

- `python3` JSON parse + assertions for `catalog` / `catalogs` schema shapes
- `git diff --check`
