### PR TITLE
Docs: fix npmMinimalAgeGate default

### DIFF
--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -503,7 +503,7 @@
         { "type": "number" },
         { "type": "string", "pattern": "^(\\d*\\.?\\d+)(ms|s|m|h|d|w)?$" }
       ],
-      "default": "0m",
+      "default": "1d",
       "examples": ["1w", "1d", "3h", "30m"]
     },
     "npmPreapprovedPackages": {


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

The default value for `npmMinimalAgeGate` is incorrect in the docs

## How did you fix it?

Changed the documented default value

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
