### PR TITLE
Adds support for package map generation

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -245,13 +245,13 @@ jobs:
           - {node: 18, platform: [macos, latest], shard: 3/3}
           # We also run them on the maximum Node version we support, to catch potential regressions in Node.js.
           # Windows tests
-          - {node: 22, platform: [windows, latest], shard: 1/3}
-          - {node: 22, platform: [windows, latest], shard: 2/3}
-          - {node: 22, platform: [windows, latest], shard: 3/3}
+          - {node: 27-nightly, platform: [windows, latest], shard: 1/3}
+          - {node: 27-nightly, platform: [windows, latest], shard: 2/3}
+          - {node: 27-nightly, platform: [windows, latest], shard: 3/3}
           # macOS tests
-          - {node: 22, platform: [macos, latest], shard: 1/3}
-          - {node: 22, platform: [macos, latest], shard: 2/3}
-          - {node: 22, platform: [macos, latest], shard: 3/3}
+          - {node: 27-nightly, platform: [macos, latest], shard: 1/3}
+          - {node: 27-nightly, platform: [macos, latest], shard: 2/3}
+          - {node: 27-nightly, platform: [macos, latest], shard: 3/3}
 
     name: '${{matrix.platform[0]}}-latest w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'
     runs-on: ${{matrix.platform[0]}}-${{matrix.platform[1]}}

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -17624,6 +17624,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:a4e4e792796cefb4fb82f09187fa18bf4c97a9cb5b106da0eab6189e1895a4bb9bf068e5c91168fec85cee1392df48e4a120f3bae6cbbbde019ff2c21186a374#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:10635d85d43c1773f587c2d6565f7a30c3bff1c16e39550dcdd44b3745dd69317ced5e20de16484758df2d6dc9314da646bf356d1ef8485a0dcd939b71a3327c#workspace:packages/plugin-stage"],\
@@ -17647,6 +17648,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:f4e4f4a9a0213f122880195b39adaee7de5cb560c1d806ebc8bace6a3124e5b8f820bbb89ebecd4d535caeb6f527d343143210aa405689c118ff2813b78998a0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:16f564b30745199d7e07a913c371ce0c078051290c6e08b972f07b3f1bf057a6993fe67b7c6ee24931d0b1dd67e1274151612081733a79b961dd8336318fdfb9#workspace:packages/plugin-stage"],\
@@ -17670,6 +17672,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:14a22fb3831dfc762a1bb8a042d17886271c56698e1a83233f09eaacff5a5b83fe6f87adb9255774eab3586392c18ff98cf87aa6b374d572d9b72f88829f6d9e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:1c3d72c6b31a8950672985f8306a860ecc80c9a006aac95cf4a7ba13a6e7cc4e095e37186a53c9909e9efe97bc0f7f570a74b3879778e2a2356cdcf407120006#workspace:packages/plugin-stage"],\
@@ -17693,6 +17696,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:2351fd5ac4f83ad35b714d8af9fdeea561ada341d529d0dba50742dd5735dc3750df6c56bd680e14833d5b987026a1eab6618211ea0ef1b34b727372b3c77bc9#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:616a2ba0d005227805d037f4c8ec29f1dd09fdb3e3f49f7b5c4a07a62139a147d373d38bc5ebcb31bddab3956c3fc25d54edf8722741d9ebdbe9d36d21968f91#workspace:packages/plugin-stage"],\
@@ -17716,6 +17720,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:ef8e1544cc953676e27fe7445218564293b5a190d023e4610c14767688870b772297269e2848a1d8d72f54605aacc9da3b2b7dc56dca754d297b70b14e6a665e#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:45a6746f11cef24d8db9429cc5650999571e6bb77a8cfb3904a0e832f542be35246ec490516049308ca15b8678eb03bcf394199e514a8145ec32731af7235c91#workspace:packages/plugin-stage"],\
@@ -17739,6 +17744,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:4864d30fc563f2fd1b72a5e3869493c5f50bf38f98ed3886173d80c044d981c3f68220dbf17f2b5fc5b4c5fba7d0af2e003926efe3487086484049f41c449852#workspace:packages/plugin-stage"],\
@@ -17762,6 +17768,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:35104c47575f2fe378d8d20383ae667f19d4dd801df8cc4c76848603aa6b4a2234a00142ff12fd557f6f48bd2810880e31c40c767010ea61a31fca302c2cc5e0#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:4ff153bc11101851444cc464184bde5e42ffd55b3939421c30a4c2b69483c3267c1680de4a4c00a49c98cbbe35e70111bb3c26f5ce8836b703c15cd5b753451a#workspace:packages/plugin-stage"],\
@@ -17785,6 +17792,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:712d04b0098634bdb13868ff8f85b327022bd7d3880873ada8c0ae56847ed36cf9da1fd74a88519380129cec528fe2bd2201426bc28ac9d4a8cc6734ff25c538#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:54c8b951e743ea46368d98ac86d4c1ac7d1aa57c9d31cbf6424fa2d918257654f26f71d51dbfe63844c533e97635ff97de50fd37e6e4bf74f2603a98754d6d22#workspace:packages/plugin-stage"],\
@@ -17808,6 +17816,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:27ebb8cf1fa70157f710b4926b6d25c44192e74dbac3a766c8dc6505a59ebc433221bfb4b5aabc8cca814bbe95fcb6e1ecffcf94ba96ee6112a57c89364571ac#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:6fc63e4d1a1b8c6564cfaaeabf378b05cdf49336a90189d76df005175060690d597b069801c0c39b9c60573a6fba29e7646274224b3007bd7f72c95871114cf2#workspace:packages/plugin-stage"],\
@@ -17831,6 +17840,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:8bb72793b532d34e63bbc26264dcbcfc4dc4faa0a42627635e997081722bf229d67b7a677d86a568dad949d756630e45b9d4da97ee14b1b4c506494f8a58ea91#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:7b82ac5a3734606065dc76f117982c681b5b5076260acfcac869c687f06db0b8c08eae0998f419d64b9e59f6c816bcc70e067c87fa32ffe9cb979faf85cd80b4#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:7b82ac5a3734606065dc76f117982c681b5b5076260acfcac869c687f06db0b8c08eae0998f419d64b9e59f6c816bcc70e067c87fa32ffe9cb979faf85cd80b4#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:7b82ac5a3734606065dc76f117982c681b5b5076260acfcac869c687f06db0b8c08eae0998f419d64b9e59f6c816bcc70e067c87fa32ffe9cb979faf85cd80b4#workspace:packages/plugin-stage"],\
@@ -17854,6 +17864,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:142f2540721377707149f0b1d7ad0188d020f822e234abcdca162642d42824b344a1ac44bd6035644a0ca9babd62eb7d72923350ac75b876b51e87eb92b3e464#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:a4e201fc3c2d8b3ec5632082d407d554bbf8ea8b84182577dde1ce419148ae0981b382a0805280637d50e1132628fef8f78ee6a015164963130b1310a4cca910#workspace:packages/plugin-stage"],\
@@ -17877,6 +17888,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:a7c38e9a420fd3b408ea245831c2c9f0e880eac64b268fab3219f5f0b1d6015f44b1f92d23aabfc6e980bbbbda00a23e9faa983fb98544fab94119ccd31f2440#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:a027ddc7edcbf74025e90effce333897039d2c6f8e1ebe319fb72c52c5be1b885da91acc56476d19bb6ce2e31cbc2d5b11241940b82f833a2cac262496c0088f#workspace:packages/plugin-stage"],\
@@ -17900,6 +17912,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:cfce476fbcac37853570c2d41665757b5f868b1c2f089ee6edbc8bb5aa32141e156cae7d75350d1095258d90afbabe2b2bb142142b995d133c3ee535c89d459b#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:adaf1cec8728346f1bf6a263f1954625a52d60518b8d2084da8a926203282105d2b95fb9da84922062af8d4fc84b8a1c39f220238424024e56f55577bdbc7208#workspace:packages/plugin-stage"],\
@@ -17923,6 +17936,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:3f21a2572d1fa6d1ff8d16d86e25bcefcbff7d17161c440fdbddbd871d9d675c377d66a2cbd98ddb8f2c024060bc7bc6c01e8ae328fa1fef861c72a9b2c30755#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:b4c0e602e8ac4e01a7b08db41bb5808da767dd1f6802758faa5125fb2423614bb0a8806ee1b30c3a0769f86da15ad37377f5118d93cd93fa48df0008a448fb35#workspace:packages/plugin-stage"],\
@@ -17946,6 +17960,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:b63ad861025672af62aed0e7c80dca4cfce3194ca046161e54fc14c498c39e3b82004ea844489c7a58d2f1a31867f388bf25b8128f5ccce46f35305e1f91e9ab#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/plugin-stage"],\
@@ -17969,6 +17984,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:e3ce0ce4b7f0796ca44011528cb9cdc133fc62a76363fea6de68497bae04bdbe5a6dd47e6b9f23c282eb8e4533d75e96cf378c943d07a4e78aae0b715f06a450#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:c4bd2716e35986fb2e70f5fba6e9570c69eceabc69282df5bcff5d22c6b7d0e696d0cfb4bcbd9a20675fe3e2eb6192b59d41b97baa8b27e1d474b94eeda3f778#workspace:packages/plugin-stage"],\
@@ -17992,6 +18008,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:86c95fabbcd56c56f5f2d2e080e64a1095e3fe233877aa9f7958f317f88a95627e0be2765e89c0cff02c9f08f27b64b7cbc9d5c3960c1df509d5e6ea98cca4f4#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:ce4dc3135569e847b88addae1199f9468fb0b37867e1a86ba6725f71b9df587a8ae43356ae86c3bfe3b0cbbf07dcf8c1a4a95199810d9f20df387eec0a1e1965#workspace:packages/plugin-stage"],\
@@ -18015,6 +18032,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:743b60015fc887fe314a7ee01ea4843b516ac512d77939f47dc39d50bc7db742dc8994fe9bb2245ada0b3ce6f8aa58329d603fbc24093050cd499cb16a1a995f#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:d1d72d9e3903ca8b8d9c23a360395cc764db2689e5992ef9af91c79f03a839db10ec675af9e4c1c8f4842aff1a614eb5b115fcc0afe8256630151ef1252de94b#workspace:packages/plugin-stage"],\
@@ -18038,6 +18056,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:4a733c8d9614e2148392368219d98ec1a70b4e8ce99164edd551241b22f6c5233e9d0ccf9f6d83265c8a5aafc617cfd3c4100b3efef1e092a42053c23770ed9a#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:f8376ca2bc11738adced76b97627e7eff07ec08f93f5b76caf8d6bd4f78f5ae9c1911cb9d1a0bd256ef3e0601dedeba933acf0d2381588b6513ee81e25626459#workspace:packages/plugin-stage"],\
@@ -18059,6 +18078,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/cli", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/yarnpkg-cli"],\
           ["@yarnpkg/core", "workspace:packages/yarnpkg-core"],\
           ["@yarnpkg/fslib", "workspace:packages/yarnpkg-fslib"],\
+          ["@yarnpkg/nm", "workspace:packages/yarnpkg-nm"],\
           ["@yarnpkg/plugin-pnp", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/plugin-pnp"],\
           ["@yarnpkg/plugin-pnpm", "workspace:packages/plugin-pnpm"],\
           ["@yarnpkg/plugin-stage", "virtual:baf8bf095598663073ea5e8bd5af72409e894f8926160bf6fe0a24c693d417f91b536d9e3bbb0ea5f3d0ad8cd2f1ec38b71e964f9475ba719a1f5a8505cf10c3#workspace:packages/plugin-stage"],\

--- a/.yarn/versions/31b3a616.yml
+++ b/.yarn/versions/31b3a616.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": minor
+  "@yarnpkg/core": minor
+  "@yarnpkg/nm": minor
+  "@yarnpkg/plugin-nm": minor
+  "@yarnpkg/plugin-pnp": minor
+  "@yarnpkg/plugin-pnpm": minor
+
+declined:
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
@@ -11,21 +11,14 @@ const getPackageMapPath = (path: PortablePath) => {
   return ppath.join(path, Filename.nodeModules, PACKAGE_MAP);
 };
 
-type Source = (script: string, callDefinition?: {env?: Record<string, string>}) => Promise<unknown>;
-
-const sourceWithPackageMap = async (path: PortablePath, source: Source, script: string) => {
-  return await source(script, {
-    env: {
-      NODE_OPTIONS: `--experimental-package-map=${npath.fromPortablePath(getPackageMapPath(path))}`,
-    },
-  });
-};
-
 const requireFromPackage = (packageName: string, request: string) => {
   return `require('module').createRequire(process.cwd() + '/node_modules/${packageName}/index.js')(${JSON.stringify(request)})`;
 };
 
-describe(`Package maps`, () => {
+const supportsPackageMaps = Number(process.versions.node.split(`.`)[0]) >= 27;
+const describePackageMaps = supportsPackageMaps ? describe : describe.skip;
+
+describePackageMaps(`Package maps`, () => {
   it(`should allow packages to require their declared dependencies`,
     makeTemporaryEnv(
       {
@@ -35,11 +28,12 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
       },
       async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
           name: `one-fixed-dep`,
           version: `1.0.0`,
           dependencies: {
@@ -73,7 +67,9 @@ describe(`Package maps`, () => {
           version: `1.0.0`,
         });
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
+        await run(`config`, `set`, `nodeExperimentalPackageMap`, `true`);
+
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
           externalException: {
             code: `MODULE_NOT_FOUND`,
           },
@@ -92,12 +88,13 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
         nodePackageMapType: `loose`,
       },
       async ({path, run, source}) => {
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
           name: `no-deps`,
           version: `1.0.0`,
         });
@@ -116,12 +113,13 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `pnpm`,
+        nodeExperimentalPackageMap: true,
       },
       async ({path, run, source}) => {
         await run(`install`);
 
         await expect(xfs.existsPromise(getPackageMapPath(path))).resolves.toEqual(true);
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
           name: `one-fixed-dep`,
           version: `1.0.0`,
           dependencies: {
@@ -131,7 +129,7 @@ describe(`Package maps`, () => {
             },
           },
         });
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
           externalException: {
             code: `MODULE_NOT_FOUND`,
           },
@@ -150,13 +148,14 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `pnpm`,
+        nodeExperimentalPackageMap: true,
         nodePackageMapType: `loose`,
       },
       async ({path, run, source}) => {
         await run(`install`);
 
         await expect(xfs.existsPromise(getPackageMapPath(path))).resolves.toEqual(true);
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
           name: `no-deps`,
           version: `1.0.0`,
         });
@@ -173,6 +172,7 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
       },
       async ({path, run, source}) => {
         await yarn.writeConfiguration(path, {
@@ -187,7 +187,7 @@ describe(`Package maps`, () => {
 
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
           name: `no-deps`,
           version: `1.0.0`,
         });
@@ -204,6 +204,7 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
       },
       async ({path, run, source}) => {
         await writeJson(ppath.join(path, `requester/package.json` as PortablePath), {
@@ -217,12 +218,12 @@ describe(`Package maps`, () => {
 
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`requester`, `no-deps2`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`requester`, `no-deps2`))).resolves.toMatchObject({
           name: `no-deps`,
           version: `2.0.0`,
         });
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`requester`, `no-deps`))).rejects.toMatchObject({
+        await expect(source(requireFromPackage(`requester`, `no-deps`))).rejects.toMatchObject({
           externalException: {
             code: `MODULE_NOT_FOUND`,
           },
@@ -242,6 +243,7 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
         nmHoistingLimits: `workspaces`,
       },
       async ({path, run, source}) => {
@@ -256,7 +258,7 @@ describe(`Package maps`, () => {
 
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, `{
+        await expect(source(`{
           const path = require('path');
           const rootOneFixedDepRequire = require('module').createRequire(path.join(process.cwd(), 'node_modules/one-fixed-dep/index.js'));
           const workspaceOneFixedDepPath = path.join(process.cwd(), 'workspace/node_modules/one-fixed-dep');
@@ -301,6 +303,7 @@ describe(`Package maps`, () => {
       },
       {
         nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
       },
       async ({path, run, source}) => {
         await yarn.writeConfiguration(path, {
@@ -315,7 +318,7 @@ describe(`Package maps`, () => {
 
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
           name: `no-deps`,
           version: `1.0.0`,
         });
@@ -323,7 +326,7 @@ describe(`Package maps`, () => {
         await xfs.removePromise(ppath.join(path, `.yarnrc.yml` as Filename));
         await run(`install`);
 
-        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
           externalException: {
             code: `MODULE_NOT_FOUND`,
           },

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
@@ -30,7 +30,7 @@ describePackageMaps(`Package maps`, () => {
         nodeLinker: `node-modules`,
         nodeExperimentalPackageMap: true,
       },
-      async ({path, run, source}) => {
+      async ({run, source}) => {
         await run(`install`);
 
         await expect(source(requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
@@ -58,7 +58,7 @@ describePackageMaps(`Package maps`, () => {
       {
         nodeLinker: `node-modules`,
       },
-      async ({path, run, source}) => {
+      async ({run, source}) => {
         await run(`install`);
 
         // This should work because the package map isn't here to reject undeclared dependencies
@@ -91,13 +91,63 @@ describePackageMaps(`Package maps`, () => {
         nodeExperimentalPackageMap: true,
         nodePackageMapType: `loose`,
       },
-      async ({path, run, source}) => {
+      async ({run, source}) => {
         await run(`install`);
 
         await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
           name: `no-deps`,
           version: `1.0.0`,
         });
+      },
+    ),
+  );
+
+  it(`should allow scoped packages to be required in node-modules installs`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`@scoped/release-date`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
+      },
+      async ({run, source}) => {
+        await run(`install`);
+
+        await expect(source(requireFromPackage(`@scoped/release-date`, `./package.json`))).resolves.toMatchObject({
+          name: `@scoped/release-date`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  it(`should install scoped workspaces in node-modules installs`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        workspaces: [`workspace`],
+      },
+      {
+        nodeLinker: `node-modules`,
+        nodeExperimentalPackageMap: true,
+      },
+      async ({path, run}) => {
+        await writeJson(ppath.join(path, `workspace/package.json` as PortablePath), {
+          name: `@scope/workspace`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: `1.0.0`,
+          },
+        });
+        await writeFile(ppath.join(path, `workspace/index.js` as PortablePath), ``);
+
+        await run(`install`);
+
+        await expect(xfs.existsPromise(getPackageMapPath(path))).resolves.toEqual(true);
+        await expect(xfs.existsPromise(ppath.join(path, `node_modules/@scope/workspace` as PortablePath))).resolves.toEqual(true);
       },
     ),
   );

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
@@ -1,0 +1,252 @@
+import {Filename, PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
+import {yarn}                                      from 'pkg-tests-core';
+
+const {
+  fs: {writeFile, writeJson},
+} = require(`pkg-tests-core`);
+
+const PACKAGE_MAP = `.package-map.json` as Filename;
+
+const getPackageMapPath = (path: PortablePath) => {
+  return ppath.join(path, Filename.nodeModules, PACKAGE_MAP);
+};
+
+type Source = (script: string, callDefinition?: {env?: Record<string, string>}) => Promise<unknown>;
+
+const sourceWithPackageMap = async (path: PortablePath, source: Source, script: string) => {
+  return await source(script, {
+    env: {
+      NODE_OPTIONS: `--experimental-package-map=${npath.fromPortablePath(getPackageMapPath(path))}`,
+    },
+  });
+};
+
+const requireFromPackage = (packageName: string, request: string) => {
+  return `require('module').createRequire(process.cwd() + '/node_modules/${packageName}/index.js')(${JSON.stringify(request)})`;
+};
+
+describe(`Package maps`, () => {
+  it(`should allow packages to require their declared dependencies`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
+          name: `one-fixed-dep`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `1.0.0`,
+            },
+          },
+        });
+      },
+    ),
+  );
+
+  it(`should reject undeclared dependencies even when they are hoisted`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+          [`various-requires`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        // This should work because the package map isn't here to reject undeclared dependencies
+        await expect(source(requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+          },
+        });
+      },
+    ),
+  );
+
+  it(`should allow package extensions to declare additional dependencies`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`various-requires`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await yarn.writeConfiguration(path, {
+          packageExtensions: {
+            [`various-requires@*`]: {
+              dependencies: {
+                [`no-deps`]: `1.0.0`,
+              },
+            },
+          },
+        });
+
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  it(`should resolve aliases through their alias name`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`requester`]: `file:./requester`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await writeJson(ppath.join(path, `requester/package.json` as PortablePath), {
+          name: `requester`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps2`]: `npm:no-deps@2.0.0`,
+          },
+        });
+        await writeFile(ppath.join(path, `requester/index.js` as PortablePath), ``);
+
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`requester`, `no-deps2`))).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `2.0.0`,
+        });
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`requester`, `no-deps`))).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+          },
+        });
+      },
+    ),
+  );
+
+  it(`should resolve dependencies from the issuer package instance`,
+    makeTemporaryEnv(
+      {
+        private: true,
+        workspaces: [`workspace`],
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+        nmHoistingLimits: `workspaces`,
+      },
+      async ({path, run, source}) => {
+        await writeJson(ppath.join(path, `workspace/package.json` as PortablePath), {
+          name: `workspace`,
+          version: `1.0.0`,
+          dependencies: {
+            [`one-fixed-dep`]: `1.0.0`,
+          },
+        });
+        await writeFile(ppath.join(path, `workspace/index.js` as PortablePath), ``);
+
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, `{
+          const path = require('path');
+          const rootOneFixedDepRequire = require('module').createRequire(path.join(process.cwd(), 'node_modules/one-fixed-dep/index.js'));
+          const workspaceOneFixedDepPath = path.join(process.cwd(), 'workspace/node_modules/one-fixed-dep');
+          const workspaceOneFixedDepRequire = require('module').createRequire(path.join(workspaceOneFixedDepPath, 'index.js'));
+
+          return {
+            rootDependencyLocation: rootOneFixedDepRequire.resolve('.'),
+            rootDependency: rootOneFixedDepRequire('.'),
+            workspaceDependencyLocation: workspaceOneFixedDepRequire.resolve(workspaceOneFixedDepPath),
+            workspaceDependency: workspaceOneFixedDepRequire(workspaceOneFixedDepPath),
+          };
+        }`)).resolves.toMatchObject({
+          rootDependencyLocation: expect.stringContaining(`${npath.sep}node_modules${npath.sep}one-fixed-dep${npath.sep}index.js`),
+          rootDependency: {
+            dependencies: {
+              [`no-deps`]: {
+                name: `no-deps`,
+                version: `1.0.0`,
+              },
+            },
+          },
+          workspaceDependencyLocation: expect.stringContaining(`${npath.sep}workspace${npath.sep}node_modules${npath.sep}one-fixed-dep${npath.sep}index.js`),
+          workspaceDependency: {
+            dependencies: {
+              [`no-deps`]: {
+                name: `no-deps`,
+                version: `1.0.0`,
+              },
+            },
+          },
+        });
+      },
+    ),
+  );
+
+  it(`should refresh dependency access after package extensions are removed`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`various-requires`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run, source}) => {
+        await yarn.writeConfiguration(path, {
+          packageExtensions: {
+            [`various-requires@*`]: {
+              dependencies: {
+                [`no-deps`]: `1.0.0`,
+              },
+            },
+          },
+        });
+
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+
+        await xfs.removePromise(ppath.join(path, `.yarnrc.yml` as Filename));
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+          },
+        });
+      },
+    ),
+  );
+});

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
@@ -82,6 +82,88 @@ describe(`Package maps`, () => {
     ),
   );
 
+  it(`should allow node-modules installs to use a loose package map`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+          [`various-requires`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+        nodePackageMapType: `loose`,
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
+  it(`should enforce declared dependencies for pnpm standard package maps`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+          [`one-fixed-dep`]: `1.0.0`,
+          [`various-requires`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `pnpm`,
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(xfs.existsPromise(getPackageMapPath(path))).resolves.toEqual(true);
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`one-fixed-dep`, `.`))).resolves.toMatchObject({
+          name: `one-fixed-dep`,
+          version: `1.0.0`,
+          dependencies: {
+            [`no-deps`]: {
+              name: `no-deps`,
+              version: `1.0.0`,
+            },
+          },
+        });
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).rejects.toMatchObject({
+          externalException: {
+            code: `MODULE_NOT_FOUND`,
+          },
+        });
+      },
+    ),
+  );
+
+  it(`should allow pnpm installs to use a loose package map`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`no-deps`]: `1.0.0`,
+          [`various-requires`]: `1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `pnpm`,
+        nodePackageMapType: `loose`,
+      },
+      async ({path, run, source}) => {
+        await run(`install`);
+
+        await expect(xfs.existsPromise(getPackageMapPath(path))).resolves.toEqual(true);
+        await expect(sourceWithPackageMap(path, source, requireFromPackage(`various-requires`, `./invalid-require`))).resolves.toMatchObject({
+          name: `no-deps`,
+          version: `1.0.0`,
+        });
+      },
+    ),
+  );
+
   it(`should allow package extensions to declare additional dependencies`,
     makeTemporaryEnv(
       {

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/packageMaps.test.ts
@@ -12,7 +12,7 @@ const getPackageMapPath = (path: PortablePath) => {
 };
 
 const requireFromPackage = (packageName: string, request: string) => {
-  return `require('module').createRequire(process.cwd() + '/node_modules/${packageName}/index.js')(${JSON.stringify(request)})`;
+  return `require('module').createRequire(require('path').join(process.cwd(), 'node_modules', ${JSON.stringify(packageName)}, 'index.js'))(${JSON.stringify(request)})`;
 };
 
 const supportsPackageMaps = Number(process.versions.node.split(`.`)[0]) >= 27;

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1992,6 +1992,7 @@ describe(`Node_Modules`, () => {
         await run(`install`);
 
         await expect(xfs.readdirPromise(ppath.join(path, Filename.nodeModules))).resolves.toEqual([
+          `.package-map.json`,
           `.yarn-state.yml`,
           `native`,
           `native-foo-x64`,

--- a/packages/docusaurus/static/configuration/yarnrc.json
+++ b/packages/docusaurus/static/configuration/yarnrc.json
@@ -494,6 +494,21 @@
       "type": "string",
       "default": "pnp"
     },
+    "nodeExperimentalPackageMap": {
+      "_package": "@yarnpkg/plugin-pnp",
+      "title": "Define whether Yarn should enable Node.js package maps for installs that support them.",
+      "description": "If true, Yarn will inject Node.js' experimental `--experimental-package-map` option into `NODE_OPTIONS` when using `nodeLinker: node-modules` or `nodeLinker: pnpm` and a package map has been generated.",
+      "type": "boolean",
+      "default": false
+    },
+    "nodePackageMapType": {
+      "_package": "@yarnpkg/plugin-pnp",
+      "title": "Define how Yarn should generate Node.js package maps.",
+      "description": "Possible values are:\n\n- If `standard` (the default), package maps will reflect the dependency graph and reject undeclared dependencies.\n- If `loose`, package maps will reflect the hoisted `node_modules` layout and mimic Node.js resolution more closely.\n\nThis setting applies to both `nodeLinker: node-modules` and `nodeLinker: pnpm`.",
+      "type": "string",
+      "enum": ["standard", "loose"],
+      "default": "standard"
+    },
     "npmMinimalAgeGate": {
       "_package": "@yarnpkg/core",
       "title": "Minimum age of a package version according to the publish date on the npm registry to be considered for installation.",

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -6,7 +6,7 @@ import {MessageName, Project, FetchResult, Installer}                       from
 import {PortablePath, npath, ppath, Filename}                               from '@yarnpkg/fslib';
 import {VirtualFS, xfs, FakeFS, NativePath}                                 from '@yarnpkg/fslib';
 import {ZipOpenFS}                                                          from '@yarnpkg/libzip';
-import {buildNodeModulesTree}                                               from '@yarnpkg/nm';
+import {buildNodeModulesTree, buildPackageMap}                              from '@yarnpkg/nm';
 import {NodeModulesLocatorMap, buildLocatorMap, NodeModulesHoistingLimits}  from '@yarnpkg/nm';
 import {parseSyml}                                                          from '@yarnpkg/parsers';
 import {jsInstallUtils}                                                     from '@yarnpkg/plugin-pnp';
@@ -20,6 +20,7 @@ const STATE_FILE_VERSION = 1;
 const NODE_MODULES = `node_modules` as Filename;
 const DOT_BIN = `.bin` as Filename;
 const INSTALL_STATE_FILE = `.yarn-state.yml` as Filename;
+const PACKAGE_MAP_FILE = `.package-map.json` as Filename;
 const MTIME_ACCURANCY = 1000;
 
 type InstallState = {locatorMap: NodeModulesLocatorMap, locationTree: LocationTree, binSymlinks: BinSymlinkMap, nmMode: NodeModulesMode, mtimeMs: number};
@@ -338,7 +339,12 @@ class NodeModulesInstaller implements Installer {
     }
     const locatorMap = buildLocatorMap(tree);
 
-    await persistNodeModules(preinstallState, locatorMap, {
+    const packageMap = buildPackageMap(tree, {
+      basePath: ppath.join(this.opts.project.cwd, NODE_MODULES),
+      pnp: pnpApi,
+    });
+
+    await persistNodeModules(preinstallState, locatorMap, packageMap, {
       baseFs: defaultFsLayer,
       project: this.opts.project,
       report: this.opts.report,
@@ -1102,7 +1108,7 @@ function invalidateBinSymlinks(binSymlinks: BinSymlinkMap, changedLocations: Set
   }
 }
 
-async function persistNodeModules(preinstallState: InstallState, installState: NodeModulesLocatorMap, {baseFs, project, report, loadManifest, realLocatorChecksums}: {project: Project, baseFs: FakeFS<PortablePath>, report: Report, loadManifest: LoadManifest, realLocatorChecksums: Map<LocatorHash, string | null>}) {
+async function persistNodeModules(preinstallState: InstallState, installState: NodeModulesLocatorMap, packageMap: ReturnType<typeof buildPackageMap>, {baseFs, project, report, loadManifest, realLocatorChecksums}: {project: Project, baseFs: FakeFS<PortablePath>, report: Report, loadManifest: LoadManifest, realLocatorChecksums: Map<LocatorHash, string | null>}) {
   const rootNmDirPath = ppath.join(project.cwd, NODE_MODULES);
 
   const {
@@ -1370,6 +1376,9 @@ async function persistNodeModules(preinstallState: InstallState, installState: N
     await Promise.all(addQueue);
 
     await xfs.mkdirPromise(rootNmDirPath, {recursive: true});
+    await xfs.changeFilePromise(ppath.join(rootNmDirPath, PACKAGE_MAP_FILE), JSON.stringify(packageMap, null, 2), {
+      automaticNewlines: true,
+    });
 
     invalidateBinSymlinks(prevBinSymlinks, new Set(addList.map(l => l.dstDir)));
     const binSymlinks = await createBinSymlinkMap(installState, locationTree, project.cwd, {loadManifest});

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -9,7 +9,7 @@ import {ZipOpenFS}                                                          from
 import {buildNodeModulesTree, buildPackageMap}                              from '@yarnpkg/nm';
 import {NodeModulesLocatorMap, buildLocatorMap, NodeModulesHoistingLimits}  from '@yarnpkg/nm';
 import {parseSyml}                                                          from '@yarnpkg/parsers';
-import {jsInstallUtils}                                                     from '@yarnpkg/plugin-pnp';
+import {NodePackageMapType, jsInstallUtils}                                 from '@yarnpkg/plugin-pnp';
 import {PnpApi, PackageInformation}                                         from '@yarnpkg/pnp';
 import cmdShim                                                              from '@zkochan/cmd-shim';
 import {UsageError}                                                         from 'clipanion';
@@ -341,7 +341,9 @@ class NodeModulesInstaller implements Installer {
 
     const packageMap = buildPackageMap(tree, {
       basePath: ppath.join(this.opts.project.cwd, NODE_MODULES),
-      pnp: pnpApi,
+      pnp: this.opts.project.configuration.get(`nodePackageMapType`) === NodePackageMapType.STANDARD
+        ? pnpApi
+        : null,
     });
 
     await persistNodeModules(preinstallState, locatorMap, packageMap, {

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -13,6 +13,11 @@ export {UnplugCommand};
 export {jsInstallUtils};
 export {pnpUtils};
 
+export enum NodePackageMapType {
+  STANDARD = `standard`,
+  LOOSE = `loose`,
+}
+
 export const getPnpPath = (project: Project) => {
   return {
     cjs: ppath.join(project.cwd, Filename.pnpCjs),
@@ -69,6 +74,7 @@ async function populateYarnPaths(project: Project, definePath: (path: PortablePa
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     nodeLinker: string;
+    nodePackageMapType: string;
     winLinkType: string;
     pnpMode: string;
     minizip: boolean;
@@ -92,6 +98,15 @@ const plugin: Plugin<CoreHooks & StageHooks> = {
       description: `The linker used for installing Node packages, one of: "pnp", "pnpm", or "node-modules"`,
       type: SettingsType.STRING,
       default: `pnp`,
+    },
+    nodePackageMapType: {
+      description: `If 'standard', generates package maps from the dependency graph. If 'loose', generates them from the hoisted node_modules layout.`,
+      type: SettingsType.STRING,
+      values: [
+        NodePackageMapType.STANDARD,
+        NodePackageMapType.LOOSE,
+      ],
+      default: NodePackageMapType.STANDARD,
     },
     minizip: {
       description: `Whether Yarn should use minizip to extract archives`,

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -121,12 +121,12 @@ const plugin: Plugin<CoreHooks & StageHooks> = {
       default: `pnp`,
     },
     nodeExperimentalPackageMap: {
-      description: `If true, Yarn will inject the experimental package map into Node.js processes.`,
+      description: `If true, Yarn will inject the experimental package map into Node.js processes when using the node-modules or pnpm linkers.`,
       type: SettingsType.BOOLEAN,
       default: false,
     },
     nodePackageMapType: {
-      description: `If 'standard', generates package maps from the dependency graph. If 'loose', generates them from the hoisted node_modules layout.`,
+      description: `If 'standard', package maps will reflect the dependency graph. If 'loose', they will reflect the hoisted node_modules layout.`,
       type: SettingsType.STRING,
       values: [
         NodePackageMapType.STANDARD,

--- a/packages/plugin-pnp/sources/index.ts
+++ b/packages/plugin-pnp/sources/index.ts
@@ -26,6 +26,10 @@ export const getPnpPath = (project: Project) => {
   };
 };
 
+export const getPackageMapPath = (project: Project) => {
+  return ppath.join(project.cwd, Filename.nodeModules, `.package-map.json` as Filename);
+};
+
 export const quotePathIfNeeded = (path: string) => {
   return /\s/.test(path) ? JSON.stringify(path) : path;
 };
@@ -36,18 +40,33 @@ async function setupScriptEnvironment(project: Project, env: NodeJS.ProcessEnv, 
   // TODO: Support `-r` as an alias for `--require` (in all packages)
   const pnpRegularExpression = /\s*--require\s+\S*\.pnp\.c?js\s*/g;
   const esmLoaderExpression = /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/;
+  const packageMapExpression = /\s*--experimental-package-map(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)\s*/g;
 
   const nodeOptions = (env.NODE_OPTIONS ?? ``)
     .replace(pnpRegularExpression, ` `)
     .replace(esmLoaderExpression, ` `)
+    .replace(packageMapExpression, ` `)
     .trim();
+
+  const nodeLinker = project.configuration.get(`nodeLinker`);
+  const extraNodeOptions: Array<string> = [];
+  const packageMapPath = getPackageMapPath(project);
+
+  if (project.configuration.get(`nodeExperimentalPackageMap`) && nodeLinker !== `pnp` && xfs.existsSync(packageMapPath))
+    extraNodeOptions.push(`--experimental-package-map=${quotePathIfNeeded(npath.fromPortablePath(packageMapPath))}`);
+
+  const applyNodeOptions = () => {
+    const effectiveNodeOptions = [...extraNodeOptions, nodeOptions].filter(Boolean).join(` `);
+
+    // When set to an empty string, some tools consider it as explicitly set
+    // to the empty value, and do not set their own value.
+    env.NODE_OPTIONS = effectiveNodeOptions ? effectiveNodeOptions : undefined;
+  };
 
   // We remove the PnP hook from NODE_OPTIONS because the process can have
   // NODE_OPTIONS set while changing linkers, which affects build scripts.
-  if (project.configuration.get(`nodeLinker`) !== `pnp`) {
-    // When set to an empty string, some tools consider it as explicitly set
-    // to the empty value, and do not set their own value.
-    env.NODE_OPTIONS = nodeOptions ? nodeOptions : undefined;
+  if (nodeLinker !== `pnp`) {
+    applyNodeOptions();
     return;
   }
 
@@ -58,7 +77,8 @@ async function setupScriptEnvironment(project: Project, env: NodeJS.ProcessEnv, 
     pnpRequire = `${pnpRequire} --experimental-loader ${pathToFileURL(npath.fromPortablePath(pnpPath.esmLoader)).href}`;
 
   if (xfs.existsSync(pnpPath.cjs)) {
-    env.NODE_OPTIONS = nodeOptions ? `${pnpRequire} ${nodeOptions}` : pnpRequire;
+    extraNodeOptions.unshift(pnpRequire);
+    applyNodeOptions();
   }
 }
 
@@ -74,6 +94,7 @@ async function populateYarnPaths(project: Project, definePath: (path: PortablePa
 declare module '@yarnpkg/core' {
   interface ConfigurationValueMap {
     nodeLinker: string;
+    nodeExperimentalPackageMap: boolean;
     nodePackageMapType: string;
     winLinkType: string;
     pnpMode: string;
@@ -98,6 +119,11 @@ const plugin: Plugin<CoreHooks & StageHooks> = {
       description: `The linker used for installing Node packages, one of: "pnp", "pnpm", or "node-modules"`,
       type: SettingsType.STRING,
       default: `pnp`,
+    },
+    nodeExperimentalPackageMap: {
+      description: `If true, Yarn will inject the experimental package map into Node.js processes.`,
+      type: SettingsType.BOOLEAN,
+      default: false,
     },
     nodePackageMapType: {
       description: `If 'standard', generates package maps from the dependency graph. If 'loose', generates them from the hoisted node_modules layout.`,

--- a/packages/plugin-pnpm/package.json
+++ b/packages/plugin-pnpm/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "@yarnpkg/cli": "workspace:^",
-    "@yarnpkg/core": "workspace:^"
+    "@yarnpkg/core": "workspace:^",
+    "@yarnpkg/nm": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-pnpm/sources/PnpmLinker.ts
+++ b/packages/plugin-pnpm/sources/PnpmLinker.ts
@@ -1,15 +1,25 @@
 import {Descriptor, FetchResult, formatUtils, Installer, InstallPackageExtraApi, Linker, LinkOptions, LinkType, Locator, LocatorHash, Manifest, MessageName, MinimalLinkOptions, Package, Project, miscUtils, structUtils, WindowsLinkType} from '@yarnpkg/core';
 import {Filename, PortablePath, setupCopyIndex, ppath, xfs, DirentNoPath}                                                                                                                                                                   from '@yarnpkg/fslib';
-import {jsInstallUtils}                                                                                                                                                                                                                     from '@yarnpkg/plugin-pnp';
+import type {PackageMap}                                                                                                                                                                                                                    from '@yarnpkg/nm';
+import {NodePackageMapType, jsInstallUtils}                                                                                                                                                                                                 from '@yarnpkg/plugin-pnp';
 import {UsageError}                                                                                                                                                                                                                         from 'clipanion';
 
 export type PnpmCustomData = {
   locatorByPath: Map<PortablePath, string>;
-  pathsByLocator: Map<LocatorHash, {
-    packageLocation: PortablePath;
-    dependenciesLocation: PortablePath | null;
-  }>;
+  pathsByLocator: Map<LocatorHash, PnpmPackagePaths>;
 };
+
+export type PnpmPackagePaths = {
+  packageLocation: PortablePath;
+  dependenciesLocation: PortablePath | null;
+};
+
+type PnpmPackageMapNode = {
+  packageLocation: PortablePath;
+  dependencies: Map<string, LocatorHash>;
+};
+
+const PACKAGE_MAP_FILE = `.package-map.json` as Filename;
 
 export class PnpmLinker implements Linker {
   getCustomDataKey() {
@@ -96,9 +106,29 @@ class PnpmInstaller implements Installer {
     locatorByPath: new Map(),
   };
 
+  private packageMapNodesByLocator: Map<LocatorHash, PnpmPackageMapNode> = new Map();
+
   attachCustomData(customData: any) {
     // We don't want to attach the data because it's only used in the Linker and we'll recompute it anyways in the Installer,
     // it needs to be invalidated because otherwise we'll never prune the store or we might run into various issues.
+  }
+
+  private registerPackageMapNode(locatorHash: LocatorHash, {packageLocation}: PnpmPackagePaths) {
+    const normalizedPackageLocation = stripTrailingSeparators(packageLocation);
+
+    if (!this.packageMapNodesByLocator.has(locatorHash)) {
+      this.packageMapNodesByLocator.set(locatorHash, {
+        packageLocation: normalizedPackageLocation,
+        dependencies: new Map(),
+      });
+    }
+  }
+
+  private registerPackageMapDependency(packageMapNode: PnpmPackageMapNode, dependencyName: string, dependency: Locator) {
+    if (!this.packageMapNodesByLocator.has(dependency.locatorHash))
+      throw new Error(`Assertion failed: Expected the package to have been registered (${structUtils.stringifyLocator(dependency)})`);
+
+    packageMapNode.dependencies.set(dependencyName, dependency.locatorHash);
   }
 
   async installPackage(pkg: Package, fetchResult: FetchResult, api: InstallPackageExtraApi) {
@@ -117,10 +147,13 @@ class PnpmInstaller implements Installer {
       ? ppath.join(packageLocation, Filename.nodeModules)
       : null;
 
-    this.customData.pathsByLocator.set(pkg.locatorHash, {
+    const packagePaths = {
       packageLocation,
       dependenciesLocation,
-    });
+    };
+
+    this.customData.pathsByLocator.set(pkg.locatorHash, packagePaths);
+    this.registerPackageMapNode(pkg.locatorHash, packagePaths);
 
     return {
       packageLocation,
@@ -134,6 +167,7 @@ class PnpmInstaller implements Installer {
 
     this.customData.locatorByPath.set(packageLocation, structUtils.stringifyLocator(pkg));
     this.customData.pathsByLocator.set(pkg.locatorHash, packagePaths);
+    this.registerPackageMapNode(pkg.locatorHash, packagePaths);
 
     api.holdFetchResult(this.asyncActions.set(pkg.locatorHash, async () => {
       await xfs.mkdirPromise(packageLocation, {recursive: true});
@@ -189,6 +223,10 @@ class PnpmInstaller implements Installer {
     if (!dependenciesLocation)
       return;
 
+    const packageMapNode = this.packageMapNodesByLocator.get(locator.locatorHash);
+    if (typeof packageMapNode === `undefined`)
+      throw new Error(`Assertion failed: Expected the package to have been registered (${structUtils.stringifyLocator(locator)})`);
+
     this.asyncActions.reduce(locator.locatorHash, async action => {
       await xfs.mkdirPromise(dependenciesLocation, {recursive: true});
 
@@ -213,6 +251,8 @@ class PnpmInstaller implements Installer {
           throw new Error(`Assertion failed: Expected the package to have been registered (${structUtils.stringifyLocator(dependency)})`);
 
         const name = structUtils.stringifyIdent(descriptor) as PortablePath;
+        this.registerPackageMapDependency(packageMapNode, name, targetDependency);
+
         const depDstPath = ppath.join(dependenciesLocation, name);
 
         const depLinkPath = ppath.relative(ppath.dirname(depDstPath), depSrcPaths.packageLocation);
@@ -292,8 +332,25 @@ class PnpmInstaller implements Installer {
       }));
     }
 
-    // Wait for the package installs to catch up
     await this.asyncActions.wait();
+
+    const nodeLinker = this.opts.project.configuration.get(`nodeLinker`);
+
+    if (nodeLinker === `pnpm`) {
+      const packageMap = buildPackageMap({
+        basePath: getNodeModulesLocation(this.opts.project),
+        packageMapNodesByLocator: this.packageMapNodesByLocator,
+        topLevelLocatorHash: this.opts.project.topLevelWorkspace.anchoredLocator.locatorHash,
+        type: this.opts.project.configuration.get(`nodePackageMapType`),
+      });
+
+      await xfs.mkdirPromise(getNodeModulesLocation(this.opts.project), {recursive: true});
+      await xfs.changeFilePromise(ppath.join(getNodeModulesLocation(this.opts.project), PACKAGE_MAP_FILE), JSON.stringify(packageMap, null, 2), {
+        automaticNewlines: true,
+      });
+    } else if (nodeLinker !== `node-modules`) {
+      await xfs.removePromise(ppath.join(getNodeModulesLocation(this.opts.project), PACKAGE_MAP_FILE));
+    }
 
     await removeIfEmpty(storeLocation);
     if (this.opts.project.configuration.get(`nodeLinker`) !== `node-modules`)
@@ -321,6 +378,71 @@ function getPackagePaths(locator: Locator, {project}: {project: Project}) {
   const dependenciesLocation = ppath.join(storeLocation, pkgKey, Filename.nodeModules);
 
   return {packageLocation, dependenciesLocation};
+}
+
+function stripTrailingSeparators(path: PortablePath) {
+  while (path !== PortablePath.root && path.endsWith(ppath.sep))
+    path = path.slice(0, -1) as PortablePath;
+
+  return path;
+}
+
+function getRelativeUrl(from: PortablePath, to: PortablePath) {
+  let relativePath = ppath.relative(from, to) || PortablePath.dot;
+
+  if (!relativePath.startsWith(`.`))
+    relativePath = `./${relativePath}` as PortablePath;
+
+  return relativePath;
+}
+
+function getPackageId(basePath: PortablePath, location: PortablePath) {
+  const relativePath = ppath.relative(basePath, location) || PortablePath.dot;
+
+  return relativePath === `..` ? PortablePath.dot : relativePath;
+}
+
+function compareStrings(a: string, b: string) {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function buildPackageMap({basePath, packageMapNodesByLocator, topLevelLocatorHash, type}: {basePath: PortablePath, packageMapNodesByLocator: Map<LocatorHash, PnpmPackageMapNode>, topLevelLocatorHash: LocatorHash, type: string}): PackageMap {
+  basePath = stripTrailingSeparators(basePath);
+
+  const topLevelPackageMapNode = packageMapNodesByLocator.get(topLevelLocatorHash);
+  if (typeof topLevelPackageMapNode === `undefined`)
+    throw new Error(`Assertion failed: Expected the top-level package to have been registered`);
+
+  const packageIdsByLocator = new Map<LocatorHash, string>();
+  for (const [locatorHash, packageMapNode] of packageMapNodesByLocator)
+    packageIdsByLocator.set(locatorHash, getPackageId(basePath, packageMapNode.packageLocation));
+
+  const serializeDependencies = (dependencies: Map<string, LocatorHash>) => {
+    return Object.fromEntries(Array.from(dependencies).sort(([a], [b]) => compareStrings(a, b)).map(([dependencyName, dependencyLocatorHash]) => {
+      const dependencyPackageId = packageIdsByLocator.get(dependencyLocatorHash);
+      if (typeof dependencyPackageId === `undefined`)
+        throw new Error(`Assertion failed: Expected the package to have been registered (${dependencyLocatorHash})`);
+
+      return [dependencyName, dependencyPackageId];
+    }));
+  };
+
+  const packages: PackageMap[`packages`] = {};
+  for (const packageMapNode of Array.from(packageMapNodesByLocator.values()).sort((a, b) => compareStrings(getPackageId(basePath, a.packageLocation), getPackageId(basePath, b.packageLocation)))) {
+    const packageDependencies = type === NodePackageMapType.LOOSE
+      ? new Map([
+        ...topLevelPackageMapNode.dependencies,
+        ...packageMapNode.dependencies,
+      ])
+      : packageMapNode.dependencies;
+
+    packages[getPackageId(basePath, packageMapNode.packageLocation)] = {
+      url: getRelativeUrl(basePath, packageMapNode.packageLocation),
+      dependencies: serializeDependencies(packageDependencies),
+    };
+  }
+
+  return {packages};
 }
 
 function isPnpmVirtualCompatible(locator: Locator, {project}: {project: Project}) {

--- a/packages/yarnpkg-nm/sources/buildPackageMap.ts
+++ b/packages/yarnpkg-nm/sources/buildPackageMap.ts
@@ -5,6 +5,7 @@ import {PnpApi}                                                                 
 import {LinkType, NodeModulesBaseNode, NodeModulesPackageNode, NodeModulesTree} from './buildNodeModulesTree';
 
 const NODE_MODULES = `node_modules` as Filename;
+const WORKSPACE_NAME_SUFFIX = `$wsroot$`;
 
 export type PackageMap = {
   packages: Record<string, PackageMapPackage>;
@@ -88,8 +89,11 @@ const compareStrings = (a: string, b: string) => {
 };
 
 const getPackageDependencyNames = (pnp: PnpApi, node: NodeModulesPackageNode) => {
-  const locator = structUtils.parseLocator(node.locator);
-  const packageInformation = pnp.getPackageInformation(locator);
+  const locator = structUtils.parseLocator(node.locator.replace(WORKSPACE_NAME_SUFFIX, ``));
+  const packageInformation = pnp.getPackageInformation({
+    name: structUtils.stringifyIdent(locator),
+    reference: locator.reference,
+  });
 
   if (packageInformation === null)
     throw new Error(`Assertion failed: Expected ${node.locator} to have been registered`);

--- a/packages/yarnpkg-nm/sources/buildPackageMap.ts
+++ b/packages/yarnpkg-nm/sources/buildPackageMap.ts
@@ -1,0 +1,186 @@
+import {structUtils}                                                            from '@yarnpkg/core';
+import {Filename, PortablePath, ppath}                                          from '@yarnpkg/fslib';
+import {PnpApi}                                                                 from '@yarnpkg/pnp';
+
+import {LinkType, NodeModulesBaseNode, NodeModulesPackageNode, NodeModulesTree} from './buildNodeModulesTree';
+
+const NODE_MODULES = `node_modules` as Filename;
+
+export type PackageMap = {
+  packages: Record<string, PackageMapPackage>;
+};
+
+export type PackageMapPackage = {
+  url: string;
+  dependencies: Record<string, string>;
+};
+
+export type PackageMapOptions = {
+  basePath: PortablePath;
+  pnp?: PnpApi | null;
+};
+
+export type LoosePackageMapOptions = {
+  basePath: PortablePath;
+};
+
+type PackageMapNode = {
+  id: string;
+  packagePath: PortablePath;
+  dependencyNames: Set<string> | null;
+};
+
+const isPackageNode = (node: NodeModulesBaseNode | NodeModulesPackageNode): node is NodeModulesPackageNode => {
+  return !node.dirList;
+};
+
+const stripTrailingSeparators = (path: PortablePath) => {
+  while (path !== PortablePath.root && path.endsWith(ppath.sep))
+    path = path.slice(0, -1) as PortablePath;
+
+  return path;
+};
+
+const getPackagePath = (location: PortablePath, node: NodeModulesPackageNode) => {
+  return stripTrailingSeparators(node.linkType === LinkType.SOFT ? node.target : location);
+};
+
+const getRelativeUrl = (from: PortablePath, to: PortablePath) => {
+  let relativePath = ppath.relative(from, to) || PortablePath.dot;
+
+  if (!relativePath.startsWith(`.`))
+    relativePath = `./${relativePath}` as PortablePath;
+
+  return relativePath;
+};
+
+const getPackageId = (basePath: PortablePath, location: PortablePath) => {
+  const relativePath = ppath.relative(basePath, location) || PortablePath.dot;
+
+  return relativePath === `..` ? PortablePath.dot : relativePath;
+};
+
+const getPackageName = (location: PortablePath) => {
+  const segments = location.split(ppath.sep);
+  const nodeModulesIndex = segments.lastIndexOf(NODE_MODULES);
+
+  if (nodeModulesIndex === -1)
+    return null;
+
+  const scopeOrName = segments[nodeModulesIndex + 1];
+  if (typeof scopeOrName === `undefined`)
+    return null;
+
+  const nodeModulesPath = segments.slice(0, nodeModulesIndex + 1).join(ppath.sep) as PortablePath;
+
+  if (!scopeOrName.startsWith(`@`))
+    return {nodeModulesPath, packageName: scopeOrName};
+
+  const name = segments[nodeModulesIndex + 2];
+  if (typeof name === `undefined`)
+    return null;
+
+  return {nodeModulesPath, packageName: `${scopeOrName}/${name}`};
+};
+
+const compareStrings = (a: string, b: string) => {
+  return a < b ? -1 : a > b ? 1 : 0;
+};
+
+const getPackageDependencyNames = (pnp: PnpApi, node: NodeModulesPackageNode) => {
+  const locator = structUtils.parseLocator(node.locator);
+  const packageInformation = pnp.getPackageInformation(locator);
+
+  if (packageInformation === null)
+    throw new Error(`Assertion failed: Expected ${node.locator} to have been registered`);
+
+  const dependencyNames = new Set<string>();
+
+  for (const [dependencyName, dependencyReference] of packageInformation.packageDependencies)
+    if (dependencyReference !== null)
+      dependencyNames.add(dependencyName);
+
+  return dependencyNames;
+};
+
+const buildPackageMapFromDependencyFilter = (nodeModulesTree: NodeModulesTree, {basePath}: LoosePackageMapOptions, getDependencyNames: (node: NodeModulesPackageNode) => Set<string> | null): PackageMap => {
+  const packageMapNodes = new Map<PortablePath, PackageMapNode>();
+  const packageLocationsByNodeModulesPath = new Map<PortablePath, Map<string, PortablePath>>();
+
+  basePath = stripTrailingSeparators(basePath);
+
+  for (const [location, node] of nodeModulesTree) {
+    if (!isPackageNode(node))
+      continue;
+
+    const normalizedLocation = stripTrailingSeparators(location);
+    const packageMapNode: PackageMapNode = {
+      id: getPackageId(basePath, normalizedLocation),
+      packagePath: getPackagePath(normalizedLocation, node),
+      dependencyNames: getDependencyNames(node),
+    };
+
+    packageMapNodes.set(normalizedLocation, packageMapNode);
+
+    const packageName = getPackageName(normalizedLocation);
+    if (packageName !== null) {
+      let packageLocations = packageLocationsByNodeModulesPath.get(packageName.nodeModulesPath);
+      if (typeof packageLocations === `undefined`) {
+        packageLocations = new Map();
+        packageLocationsByNodeModulesPath.set(packageName.nodeModulesPath, packageLocations);
+      }
+
+      packageLocations.set(packageName.packageName, normalizedLocation);
+    }
+  }
+
+  const getPackageDependencies = (packagePath: PortablePath, dependencyNames: Set<string> | null) => {
+    const dependencies = new Map<string, string>();
+
+    let currentPath = packagePath;
+    while (true) {
+      const nodeModulesPath = ppath.join(currentPath, NODE_MODULES);
+      const packageLocations = packageLocationsByNodeModulesPath.get(nodeModulesPath);
+
+      if (typeof packageLocations !== `undefined`) {
+        for (const [dependencyName, dependencyLocation] of Array.from(packageLocations).sort(([a], [b]) => compareStrings(a, b))) {
+          if (dependencyNames !== null && !dependencyNames.has(dependencyName))
+            continue;
+
+          if (dependencies.has(dependencyName))
+            continue;
+
+          const dependency = packageMapNodes.get(dependencyLocation);
+          if (typeof dependency === `undefined`)
+            throw new Error(`Assertion failed: Expected ${dependencyLocation} to have been registered`);
+
+          dependencies.set(dependencyName, dependency.id);
+        }
+      }
+
+      const parentPath = ppath.dirname(currentPath);
+      if (parentPath === currentPath)
+        break;
+
+      currentPath = parentPath;
+    }
+
+    return Object.fromEntries(Array.from(dependencies).sort(([a], [b]) => compareStrings(a, b)));
+  };
+
+  const packages: PackageMap[`packages`] = {};
+  for (const packageMapNode of Array.from(packageMapNodes.values()).sort((a, b) => compareStrings(a.id, b.id))) {
+    packages[packageMapNode.id] = {
+      url: getRelativeUrl(basePath, packageMapNode.packagePath),
+      dependencies: getPackageDependencies(packageMapNode.packagePath, packageMapNode.dependencyNames),
+    };
+  }
+
+  return {packages};
+};
+
+export const buildPackageMap = (nodeModulesTree: NodeModulesTree, {basePath, pnp}: PackageMapOptions): PackageMap => {
+  return buildPackageMapFromDependencyFilter(nodeModulesTree, {basePath}, node => {
+    return pnp ? getPackageDependencyNames(pnp, node) : null;
+  });
+};

--- a/packages/yarnpkg-nm/sources/index.ts
+++ b/packages/yarnpkg-nm/sources/index.ts
@@ -1,5 +1,6 @@
 import {NodeModulesLocatorMap, getArchivePath} from './buildNodeModulesTree';
 import {buildNodeModulesTree, buildLocatorMap} from './buildNodeModulesTree';
+import {buildPackageMap}                       from './buildPackageMap';
 
 export type {
   NodeModulesBaseNode,
@@ -7,6 +8,13 @@ export type {
   NodeModulesTreeOptions,
   NodeModulesTree,
 } from './buildNodeModulesTree';
+
+export type {
+  PackageMap,
+  PackageMapPackage,
+  PackageMapOptions,
+  LoosePackageMapOptions,
+} from './buildPackageMap';
 
 export {
   NodeModulesHoistingLimits,
@@ -16,6 +24,7 @@ export {
   buildNodeModulesTree,
   buildLocatorMap,
   getArchivePath,
+  buildPackageMap,
 };
 
 export type {NodeModulesLocatorMap};

--- a/packages/yarnpkg-nm/tests/packageMap.test.ts
+++ b/packages/yarnpkg-nm/tests/packageMap.test.ts
@@ -1,0 +1,175 @@
+import {PortablePath}              from '@yarnpkg/fslib';
+import {PnpApi}                    from '@yarnpkg/pnp';
+
+import {LinkType, NodeModulesTree} from '../sources/buildNodeModulesTree';
+import {buildPackageMap}           from '../sources';
+
+describe(`buildPackageMap`, () => {
+  it(`should generate one package map entry for each node_modules package node`, () => {
+    const tree: NodeModulesTree = new Map([
+      [`/project` as PortablePath, {
+        locator: `root@workspace:.`,
+        target: `/project` as PortablePath,
+        linkType: LinkType.SOFT,
+        nodePath: ``,
+        aliases: [],
+      }],
+      [`/project/node_modules/foo` as PortablePath, {
+        locator: `foo@npm:1.0.0`,
+        target: `/cache/foo` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/foo`,
+        aliases: [],
+      }],
+      [`/project/node_modules/bar` as PortablePath, {
+        locator: `bar@npm:1.0.0`,
+        target: `/cache/bar` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/bar`,
+        aliases: [],
+      }],
+      [`/project/node_modules/foo/node_modules/baz` as PortablePath, {
+        locator: `baz@npm:1.0.0`,
+        target: `/cache/baz` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/foo/baz`,
+        aliases: [],
+      }],
+      [`/project/packages/workspace/node_modules/foo` as PortablePath, {
+        locator: `foo@npm:1.0.0`,
+        target: `/cache/foo` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/workspace/foo`,
+        aliases: [],
+      }],
+    ]);
+
+    const pnp = {
+      getPackageInformation: ({name, reference}: {name: string, reference: string}) => {
+        const packageDependencies = new Map<string, string | null>();
+
+        if (`${name}@${reference}` === `root@workspace:.`) {
+          packageDependencies.set(`bar`, `npm:1.0.0`);
+          packageDependencies.set(`foo`, `npm:1.0.0`);
+        }
+
+        if (`${name}@${reference}` === `foo@npm:1.0.0`)
+          packageDependencies.set(`baz`, `npm:1.0.0`);
+
+        return {packageDependencies};
+      },
+    } as unknown as PnpApi;
+
+    expect(buildPackageMap(tree, {basePath: `/project/node_modules` as PortablePath, pnp})).toEqual({
+      packages: {
+        '.': {
+          url: `..`,
+          dependencies: {
+            bar: `bar`,
+            foo: `foo`,
+          },
+        },
+        '../packages/workspace/node_modules/foo': {
+          url: `../packages/workspace/node_modules/foo`,
+          dependencies: {},
+        },
+        bar: {
+          url: `./bar`,
+          dependencies: {},
+        },
+        foo: {
+          url: `./foo`,
+          dependencies: {
+            baz: `foo/node_modules/baz`,
+          },
+        },
+        'foo/node_modules/baz': {
+          url: `./foo/node_modules/baz`,
+          dependencies: {},
+        },
+      },
+    });
+  });
+
+  it(`should generate loose package dependencies from node_modules hoisting`, () => {
+    const tree: NodeModulesTree = new Map([
+      [`/project` as PortablePath, {
+        locator: `root@workspace:.`,
+        target: `/project` as PortablePath,
+        linkType: LinkType.SOFT,
+        nodePath: ``,
+        aliases: [],
+      }],
+      [`/project/node_modules/foo` as PortablePath, {
+        locator: `foo@npm:1.0.0`,
+        target: `/cache/foo` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/foo`,
+        aliases: [],
+      }],
+      [`/project/node_modules/bar` as PortablePath, {
+        locator: `bar@npm:1.0.0`,
+        target: `/cache/bar` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/bar`,
+        aliases: [],
+      }],
+      [`/project/node_modules/foo/node_modules/baz` as PortablePath, {
+        locator: `baz@npm:1.0.0`,
+        target: `/cache/baz` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/foo/baz`,
+        aliases: [],
+      }],
+      [`/project/packages/workspace/node_modules/foo` as PortablePath, {
+        locator: `foo@npm:1.0.0`,
+        target: `/cache/foo` as PortablePath,
+        linkType: LinkType.HARD,
+        nodePath: `/workspace/foo`,
+        aliases: [],
+      }],
+    ]);
+
+    expect(buildPackageMap(tree, {basePath: `/project/node_modules` as PortablePath, pnp: null})).toEqual({
+      packages: {
+        '.': {
+          url: `..`,
+          dependencies: {
+            bar: `bar`,
+            foo: `foo`,
+          },
+        },
+        '../packages/workspace/node_modules/foo': {
+          url: `../packages/workspace/node_modules/foo`,
+          dependencies: {
+            bar: `bar`,
+            foo: `../packages/workspace/node_modules/foo`,
+          },
+        },
+        bar: {
+          url: `./bar`,
+          dependencies: {
+            bar: `bar`,
+            foo: `foo`,
+          },
+        },
+        foo: {
+          url: `./foo`,
+          dependencies: {
+            bar: `bar`,
+            baz: `foo/node_modules/baz`,
+            foo: `foo`,
+          },
+        },
+        'foo/node_modules/baz': {
+          url: `./foo/node_modules/baz`,
+          dependencies: {
+            bar: `bar`,
+            baz: `foo/node_modules/baz`,
+            foo: `foo`,
+          },
+        },
+      },
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6517,6 +6517,7 @@ __metadata:
     "@yarnpkg/cli": "workspace:^"
     "@yarnpkg/core": "workspace:^"
     "@yarnpkg/fslib": "workspace:^"
+    "@yarnpkg/nm": "workspace:^"
     "@yarnpkg/plugin-pnp": "workspace:^"
     "@yarnpkg/plugin-stage": "workspace:^"
     clipanion: "npm:^4.0.0-rc.2"


### PR DESCRIPTION
This PR implements support for generating [package maps](https://nodejs.org/download/nightly//v27.0.0-nightly202606134383f67279/docs/api/packages.html#package-maps).

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
