### PR TITLE
fix: make sure hoistingLimits are not bypassed

### DIFF
--- a/.yarn/versions/3bda9cd7.yml
+++ b/.yarn/versions/3bda9cd7.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -802,7 +802,6 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
     const isSeen = !!workNode;
     if (!workNode) {
       const {name, identName, reference, peerNames, hoistPriority, dependencyKind} = node;
-      const dependenciesNmHoistingLimits = options.hoistingLimits.get(parentNode.locator);
       workNode = {
         name,
         references: new Set([reference]),
@@ -814,7 +813,7 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
         peerNames: new Set(peerNames),
         reasons: new Map(),
         decoupled: true,
-        isHoistBorder: dependenciesNmHoistingLimits ? dependenciesNmHoistingLimits.has(name) : false,
+        isHoistBorder: false,
         hoistPriority: hoistPriority || 0,
         dependencyKind: dependencyKind || HoisterDependencyKind.REGULAR,
         hoistedFrom: new Map(),
@@ -822,6 +821,9 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
       };
       seenNodes.set(node, workNode);
     }
+
+    if (!workNode.isHoistBorder && options.hoistingLimits.get(parentNode.locator)?.has(node.name))
+      workNode.isHoistBorder = true;
 
     parentNode.dependencies.set(node.name, workNode);
     parentNode.originalDependencies.set(node.name, workNode);

--- a/packages/yarnpkg-nm/tests/hoist.test.ts
+++ b/packages/yarnpkg-nm/tests/hoist.test.ts
@@ -666,4 +666,18 @@ describe(`hoist`, () => {
     };
     expect(getTreeHeight(hoist(toTree(tree), {check: true}))).toEqual(4);
   });
+
+  it(`should hoistingLimits when top level dependency matches a transitive dependency`, () => {
+    // . -> A -> B -> C
+    //   -> B -> C
+    // with hoistingLimits: dependencies, C should not be hoisted to the top
+    const tree = {
+      '.': {dependencies: [`A`, `B`]},
+      A: {dependencies: [`B`]},
+      B: {dependencies: [`C`]},
+    };
+    const hoistedTree = hoist(toTree(tree), {check: true, hoistingLimits: new Map([[`.@`, new Set([`A`, `B`])]])});
+    const C = Array.from(hoistedTree.dependencies).filter(x => x.name === `C`);
+    expect(C).toEqual([]);
+  });
 });


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

Fixes issue when hoistingLimits: dependencies get broken due to the same dependency being both a direct one (thus isHoistBorder: true) and a transitive one (with isHoistBorder: false)

Resolves #6662 
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

## How did you fix it?

during `cloneTree()` mark the copied `workNode` as hoist border when it is such at any time in the tree, not just the first time it is encountered.

Consider tree:

- pkg1
  - pkg2
    - pkg3
- pkg2
  - pkg3

with `hoistingLimits: dependencies` both pkg1 and pkg2 on the root level must be hoist borders. but due to the depth-first approach of `cloneTree`, the first time pkg2 is encountered is was marked with isHoistBorder: false and that was applied even to the top level entry.

before the fix:
- pkg1 *hoist border*
  - pkg2
    - pkg3
- pkg2
  - pkg3

and this means that pkg3 gets hoisted to top level.

The fix makes sure that pkg2 is correctly marked as hoist border.

The fix is not ideal, it results in
- pkg1 *hoist border*
  - pkg2 *hoist border*
    - pkg3
- pkg2 *hoist border*
  - pkg3

While not ideal, the fix does ensure that pkg3 does not get hoisted to top level which is the main point of hoistingLimits: dependencies

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
