### PR TITLE
hoistingLimits - optimize hoisting when transitive dependency matches root one

### DIFF
--- a/.yarn/versions/3bda9cd7.yml
+++ b/.yarn/versions/3bda9cd7.yml
@@ -1,0 +1,25 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/pnpify"

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -797,8 +797,11 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
 
   const seenNodes = new Map<HoisterTree, HoisterWorkTree>([[tree, treeCopy]]);
 
-  const addNode = (node: HoisterTree, parentNode: HoisterWorkTree) => {
-    let workNode = seenNodes.get(node);
+  const addNode = (node: HoisterTree, parent: HoisterTree, parentNode: HoisterWorkTree) => {
+    const isHoistBorder = options.hoistingLimits.get(parentNode.locator)?.has(node.name) || false;
+
+    // for self-references, always use the parentNode reference, irrelevant of isHoistBorder value.
+    let workNode = parent === node ? parentNode : isHoistBorder ? undefined : seenNodes.get(node);
     const isSeen = !!workNode;
     if (!workNode) {
       const {name, identName, reference, peerNames, hoistPriority, dependencyKind} = node;
@@ -813,24 +816,24 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
         peerNames: new Set(peerNames),
         reasons: new Map(),
         decoupled: true,
-        isHoistBorder: false,
+        isHoistBorder,
         hoistPriority: hoistPriority || 0,
         dependencyKind: dependencyKind || HoisterDependencyKind.REGULAR,
         hoistedFrom: new Map(),
         hoistedTo: new Map(),
       };
-      seenNodes.set(node, workNode);
-    }
 
-    if (!workNode.isHoistBorder && options.hoistingLimits.get(parentNode.locator)?.has(node.name))
-      workNode.isHoistBorder = true;
+      if (!isHoistBorder) {
+        seenNodes.set(node, workNode);
+      }
+    }
 
     parentNode.dependencies.set(node.name, workNode);
     parentNode.originalDependencies.set(node.name, workNode);
 
     if (!isSeen) {
       for (const dep of node.dependencies) {
-        addNode(dep, workNode);
+        addNode(dep, node, workNode);
       }
     } else {
       const seenCoupledNodes = new Set();
@@ -853,7 +856,7 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
   };
 
   for (const dep of tree.dependencies)
-    addNode(dep, treeCopy);
+    addNode(dep, tree, treeCopy);
 
   return treeCopy;
 };

--- a/packages/yarnpkg-nm/sources/hoist.ts
+++ b/packages/yarnpkg-nm/sources/hoist.ts
@@ -802,7 +802,6 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
     const isSeen = !!workNode;
     if (!workNode) {
       const {name, identName, reference, peerNames, hoistPriority, dependencyKind} = node;
-      const dependenciesNmHoistingLimits = options.hoistingLimits.get(parentNode.locator);
       workNode = {
         name,
         references: new Set([reference]),
@@ -814,7 +813,7 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
         peerNames: new Set(peerNames),
         reasons: new Map(),
         decoupled: true,
-        isHoistBorder: dependenciesNmHoistingLimits ? dependenciesNmHoistingLimits.has(name) : false,
+        isHoistBorder: false,
         hoistPriority: hoistPriority || 0,
         dependencyKind: dependencyKind || HoisterDependencyKind.REGULAR,
         hoistedFrom: new Map(),
@@ -822,6 +821,9 @@ const cloneTree = (tree: HoisterTree, options: InternalHoistOptions): HoisterWor
       };
       seenNodes.set(node, workNode);
     }
+
+    if (!workNode.isHoistBorder && options.hoistingLimits.get(parentNode.locator)?.has(node.name))
+      workNode.isHoistBorder = true;
 
     parentNode.dependencies.set(node.name, workNode);
     parentNode.originalDependencies.set(node.name, workNode);

--- a/packages/yarnpkg-nm/tests/hoist.test.ts
+++ b/packages/yarnpkg-nm/tests/hoist.test.ts
@@ -419,7 +419,7 @@ describe(`hoist`, () => {
     };
     const hoistedTree = hoist(toTree(tree), {check: true});
     const [A] = Array.from(hoistedTree.dependencies).filter(x => x.name === `A`);
-    expect(Array.from(A.dependencies).filter(x => x.name === `B`)).toBeDefined();
+    expect(Array.from(A.dependencies).filter(x => x.name === `B`)).not.toEqual([]);
   });
 
   it(`should hoist cyclic peer dependencies`, () => {
@@ -667,7 +667,7 @@ describe(`hoist`, () => {
     expect(getTreeHeight(hoist(toTree(tree), {check: true}))).toEqual(4);
   });
 
-  it(`should hoistingLimits when top level dependency matches a transitive dependency`, () => {
+  it(`should respect hoistingLimits when top level dependency matches a transitive dependency`, () => {
     // . -> A -> B -> C
     //   -> B -> C
     // with hoistingLimits: dependencies, C should not be hoisted to the top
@@ -679,5 +679,48 @@ describe(`hoist`, () => {
     const hoistedTree = hoist(toTree(tree), {check: true, hoistingLimits: new Map([[`.@`, new Set([`A`, `B`])]])});
     const C = Array.from(hoistedTree.dependencies).filter(x => x.name === `C`);
     expect(C).toEqual([]);
+  });
+
+  it(`should optimize transitive dependency when it matches top level dependency with hoistingLimits`, () => {
+    // . -> [A] -> B -> C
+    // . -> [D] -> [B] -> C
+    // [x] marks hoisting border
+
+    // this test covers an implementation detail of hoisting algorithm when B node would be reused in the tree
+    // and marked as hoist border everywhere. It marks D->B as hoisting limit instead of putting B on root because
+    // of the possible optimization (see `should reuse existing dependency on parent even across hoist border` test).
+    const tree = {
+      '.': {dependencies: [`A`, `D`]},
+      A: {dependencies: [`B`]},
+      B: {dependencies: [`C`]},
+      D: {dependencies: [`B`]},
+    };
+
+    // expected:
+    // . -> A -> B
+    //        -> C
+    // . -> D -> B -> C
+
+    const hoistedTree = hoist(toTree(tree), {check: true, hoistingLimits: new Map([[`.@`, new Set([`A`, `D`])], [`D@`, new Set([`B`])]])});
+    const [A] = Array.from(hoistedTree.dependencies).filter(x => x.name === `A`);
+    expect(Array.from(A.dependencies).map(x => x.name)).toEqual([`B`, `C`]);
+    expect(getTreeHeight(A)).toEqual(2);
+    expect(getTreeHeight(hoistedTree)).toEqual(4);
+  });
+
+  it.skip(`should reuse existing dependency on parent even across hoist border`, () => {
+    // Test is disabled as the functionality is not yet implemented.
+
+    // . -> A -> B
+    // . -> B
+    // with hoistingLimits: dependencies, B can be deduplicated. Even though A is hoist border, this isn't hoisting B,
+    // but using the already existing B from the root.
+    const tree = {
+      '.': {dependencies: [`A`, `B`]},
+      A: {dependencies: [`B`]},
+    };
+
+    const hoistedTree = hoist(toTree(tree), {check: true, hoistingLimits: new Map([[`.@`, new Set([`A`, `B`])]])});
+    expect(getTreeHeight(hoistedTree)).toEqual(2);
   });
 });

--- a/packages/yarnpkg-nm/tests/hoist.test.ts
+++ b/packages/yarnpkg-nm/tests/hoist.test.ts
@@ -666,4 +666,18 @@ describe(`hoist`, () => {
     };
     expect(getTreeHeight(hoist(toTree(tree), {check: true}))).toEqual(4);
   });
+
+  it(`should hoistingLimits when top level dependency matches a transitive dependency`, () => {
+    // . -> A -> B -> C
+    //   -> B -> C
+    // with hoistingLimits: dependencies, C should not be hoisted to the top
+    const tree = {
+      '.': {dependencies: [`A`, `B`]},
+      A: {dependencies: [`B`]},
+      B: {dependencies: [`C`]},
+    };
+    const hoistedTree = hoist(toTree(tree), {check: true, hoistingLimits: new Map([[`.@`, new Set([`A`, `B`])]])});
+    const C = Array.from(hoistedTree.dependencies).filter(x => x.name === `C`);
+    expect(C).toEqual([]);
+  });
 });


### PR DESCRIPTION
This PR follows up on https://github.com/yarnpkg/berry/pull/7189 - this version makes sure that the transitive dependencies are still hoisted up to the hoist border.

It also adds a skipped unit test for potential future fix - when a transitive dependency matches the root one, it can be "hoisted" to root - it isn't hoisting since the dependency already exists. The PR does not include an implementation for this scenario.

Resolves #6662 