### PR TITLE
feat(builder): support ESM bundle options

### DIFF
--- a/.yarn/versions/fe1b7347.yml
+++ b/.yarn/versions/fe1b7347.yml
@@ -1,2 +1,12 @@
 releases:
   "@yarnpkg/builder": minor
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/cli"

--- a/.yarn/versions/fe1b7347.yml
+++ b/.yarn/versions/fe1b7347.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/builder": minor

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@hapi__joi-17.1.1/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@hapi__joi-17.1.1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@hapi/joi",
+  "version": "17.1.1"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/@types__hapi_joi-17.1.1/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/@types__hapi_joi-17.1.1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@types/hapi__joi",
+  "version": "17.1.1"
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/plugins/plugin-typescript.test.ts
@@ -167,14 +167,14 @@ describe(`Plugins`, () => {
         makeTemporaryEnv({}, {
           tsEnableAutoTypes: true,
         }, async ({path, run, source}) => {
-          await run(`add`, `@babel/traverse@7.99.0`);
+          await run(`add`, `@hapi/joi@17.1.1`);
 
           await expect(readManifest(path)).resolves.toMatchObject({
             dependencies: {
-              [`@babel/traverse`]: `7.99.0`,
+              [`@hapi/joi`]: `17.1.1`,
             },
             devDependencies: {
-              [`@types/babel__traverse`]: `^7`,
+              [`@types/hapi__joi`]: `^17`,
             },
           });
         }),

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -19,6 +19,6 @@ A CLI tool designed for creating, building, and managing complex plugins.
 
 - [`builder new plugin`](https://yarnpkg.com/cli/builder/new/plugin) - Create a new plugin.
 
-- [`builder build plugin`](https://yarnpkg.com/cli/builder/build/plugin) - Build a local plugin. Supports opt-in `external` settings.
+- [`builder build plugin`](https://yarnpkg.com/cli/builder/build/plugin) - Build a local plugin. Supports opt-in `external` and `external-file` settings.
 
-- [`builder build bundle`](https://yarnpkg.com/cli/builder/build/bundle) - Build a yarn.js bundle from our repository **(internal)**. Supports opt-in bundle `format`, `target`, and `external` settings.
+- [`builder build bundle`](https://yarnpkg.com/cli/builder/build/bundle) - Build a yarn.js bundle from our repository **(internal)**. Supports opt-in bundle `format`, `target`, `external`, and `external-file` settings.

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -19,6 +19,6 @@ A CLI tool designed for creating, building, and managing complex plugins.
 
 - [`builder new plugin`](https://yarnpkg.com/cli/builder/new/plugin) - Create a new plugin.
 
-- [`builder build plugin`](https://yarnpkg.com/cli/builder/build/plugin) - Build a local plugin.
+- [`builder build plugin`](https://yarnpkg.com/cli/builder/build/plugin) - Build a local plugin. Supports opt-in `external` settings.
 
 - [`builder build bundle`](https://yarnpkg.com/cli/builder/build/bundle) - Build a yarn.js bundle from our repository **(internal)**. Supports opt-in bundle `format`, `target`, and `external` settings.

--- a/packages/yarnpkg-builder/README.md
+++ b/packages/yarnpkg-builder/README.md
@@ -21,4 +21,4 @@ A CLI tool designed for creating, building, and managing complex plugins.
 
 - [`builder build plugin`](https://yarnpkg.com/cli/builder/build/plugin) - Build a local plugin.
 
-- [`builder build bundle`](https://yarnpkg.com/cli/builder/build/bundle) - Build a yarn.js bundle from our repository **(internal)**.
+- [`builder build bundle`](https://yarnpkg.com/cli/builder/build/bundle) - Build a yarn.js bundle from our repository **(internal)**. Supports opt-in bundle `format`, `target`, and `external` settings.

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -12,6 +12,7 @@ import {promisify}                                                          from
 
 import pkg                                                                  from '../../../package.json';
 import {findPlugins}                                                        from '../../tools/findPlugins';
+import {getExternalDependencies}                                            from '../../tools/getExternalDependencies';
 
 const execFile = promisify(cp.execFile);
 
@@ -126,6 +127,10 @@ export default class BuildBundleCommand extends Command {
     description: `Dependencies that should remain external in the bundle`,
   });
 
+  externalFile = Option.String(`--external-file`, {
+    description: `Path to a JSON file listing dependencies that should remain external in the bundle`,
+  });
+
   async execute() {
     const basedir = process.cwd();
     const portableBaseDir = npath.toPortablePath(basedir);
@@ -200,7 +205,11 @@ export default class BuildBundleCommand extends Command {
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,
           target: this.target,
-          external: this.external,
+          external: getExternalDependencies({
+            cwd: basedir,
+            external: this.external,
+            externalFile: this.externalFile,
+          }),
         });
 
         for (const warning of res.warnings) {

--- a/packages/yarnpkg-builder/sources/commands/build/bundle.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/bundle.ts
@@ -3,7 +3,7 @@ import {StreamReport, MessageName, Configuration, formatUtils, structUtils} from
 import {npath, ppath, xfs}                                                  from '@yarnpkg/fslib';
 import chalk                                                                from 'chalk';
 import cp                                                                   from 'child_process';
-import {Command, Option, Usage}                                             from 'clipanion';
+import {Command, Option, Usage, UsageError}                                 from 'clipanion';
 import {build, Plugin}                                                      from 'esbuild';
 import {createRequire}                                                      from 'module';
 import path                                                                 from 'path';
@@ -14,6 +14,12 @@ import pkg                                                                  from
 import {findPlugins}                                                        from '../../tools/findPlugins';
 
 const execFile = promisify(cp.execFile);
+
+const BUNDLE_FORMATS = new Set([`iife`, `esm`]);
+
+type BundleFormat = `iife` | `esm`;
+
+const defaultBundleTarget = `node${semver.minVersion(pkg.engines.node)!.version}`;
 
 const pkgJsonVersion = (basedir: string): string => {
   return require(`${basedir}/package.json`).version;
@@ -26,6 +32,40 @@ const suggestHash = async (basedir: string) => {
   } catch {
     return null;
   }
+};
+
+const getBundleFormat = (format: string): BundleFormat => {
+  if (!BUNDLE_FORMATS.has(format))
+    throw new UsageError(`Invalid bundle format "${format}", expected one of ${[...BUNDLE_FORMATS].join(`, `)}`);
+
+  return format as BundleFormat;
+};
+
+const getBundleBanner = (format: BundleFormat) => {
+  const esmRequireShim = `
+await (async () => {
+  const {dirname} = await import("path");
+  const {fileURLToPath} = await import("url");
+
+  if (typeof globalThis.__filename === "undefined") {
+    globalThis.__filename = fileURLToPath(import.meta.url);
+  }
+  if (typeof globalThis.__dirname === "undefined") {
+    globalThis.__dirname = dirname(globalThis.__filename);
+  }
+  if (typeof globalThis.require === "undefined") {
+    const {default: module} = await import("module");
+    globalThis.require = module.createRequire(import.meta.url);
+  }
+})();
+`;
+
+  return [
+    `#!/usr/bin/env node`,
+    `/* eslint-disable */`,
+    `//prettier-ignore`,
+    format === `esm` ? esmRequireShim : null,
+  ].filter((line): line is string => line !== null).join(`\n`);
 };
 
 // eslint-disable-next-line arca/no-default-export
@@ -74,6 +114,18 @@ export default class BuildBundleCommand extends Command {
     description: `Emit a metafile next to the bundle`,
   });
 
+  format = Option.String(`--format`, `iife`, {
+    description: `Bundle output format`,
+  });
+
+  target = Option.String(`--target`, defaultBundleTarget, {
+    description: `Bundle compilation target`,
+  });
+
+  external = Option.Array(`--external`, [], {
+    description: `Dependencies that should remain external in the bundle`,
+  });
+
   async execute() {
     const basedir = process.cwd();
     const portableBaseDir = npath.toPortablePath(basedir);
@@ -84,6 +136,7 @@ export default class BuildBundleCommand extends Command {
     const modules = [...getDynamicLibs().keys()].concat(plugins);
     const output = ppath.join(portableBaseDir, `bundles/yarn.js`);
     const metafile = this.metafile ? ppath.join(portableBaseDir, `bundles/yarn.meta.json`) : false;
+    const format = getBundleFormat(this.format);
 
     let version = pkgJsonVersion(basedir);
 
@@ -119,7 +172,7 @@ export default class BuildBundleCommand extends Command {
 
         const res = await build({
           banner: {
-            js: `#!/usr/bin/env node\n/* eslint-disable */\n//prettier-ignore`,
+            js: getBundleBanner(format),
           },
           entryPoints: [path.join(basedir, `sources/cli.ts`)],
           bundle: true,
@@ -141,12 +194,13 @@ export default class BuildBundleCommand extends Command {
           // Default extensions + .mjs
           resolveExtensions: [`.tsx`, `.ts`, `.jsx`, `.mjs`, `.js`, `.css`, `.json`],
           logLevel: `silent`,
-          format: `iife`,
+          format,
           platform: `node`,
           plugins: [valLoader],
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,
-          target: `node${semver.minVersion(pkg.engines.node)!.version}`,
+          target: this.target,
+          external: this.external,
         });
 
         for (const warning of res.warnings) {

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -6,6 +6,7 @@ import path                                                                 from
 import semver                                                               from 'semver';
 
 import pkg                                                                  from '../../../package.json';
+import {getExternalDependencies}                                            from '../../tools/getExternalDependencies';
 import {isDynamicLib}                                                       from '../../tools/isDynamicLib';
 
 const matchAll = /()/;
@@ -60,6 +61,10 @@ export default class BuildPluginCommand extends Command {
 
   external = Option.Array(`--external`, [], {
     description: `Dependencies that should remain external in the bundle`,
+  });
+
+  externalFile = Option.String(`--external-file`, {
+    description: `Path to a JSON file listing dependencies that should remain external in the bundle`,
   });
 
   async execute() {
@@ -132,7 +137,11 @@ export default class BuildPluginCommand extends Command {
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,
           target: `node${semver.minVersion(pkg.engines.node)!.version}`,
-          external: this.external,
+          external: getExternalDependencies({
+            cwd: basedir,
+            external: this.external,
+            externalFile: this.externalFile,
+          }),
           supported: {
             /*
             Yarn plugin-runtime did not support builtin modules prefixed with "node:".

--- a/packages/yarnpkg-builder/sources/commands/build/plugin.ts
+++ b/packages/yarnpkg-builder/sources/commands/build/plugin.ts
@@ -58,6 +58,10 @@ export default class BuildPluginCommand extends Command {
     description: `Emit a metafile next to the bundle`,
   });
 
+  external = Option.Array(`--external`, [], {
+    description: `Dependencies that should remain external in the bundle`,
+  });
+
   async execute() {
     const basedir = process.cwd();
     const portableBaseDir = npath.toPortablePath(basedir);
@@ -128,6 +132,7 @@ export default class BuildPluginCommand extends Command {
           minify: !this.noMinify,
           sourcemap: this.sourceMap ? `inline` : false,
           target: `node${semver.minVersion(pkg.engines.node)!.version}`,
+          external: this.external,
           supported: {
             /*
             Yarn plugin-runtime did not support builtin modules prefixed with "node:".

--- a/packages/yarnpkg-builder/sources/tools/getExternalDependencies.ts
+++ b/packages/yarnpkg-builder/sources/tools/getExternalDependencies.ts
@@ -1,0 +1,23 @@
+import {UsageError} from 'clipanion';
+import {readFileSync} from 'fs';
+import path from 'path';
+
+export const getExternalDependencies = ({cwd, external, externalFile}: {
+  cwd: string;
+  external: Array<string>;
+  externalFile?: string;
+}) => {
+  if (typeof externalFile === `undefined`)
+    return external;
+
+  const externalFilePath = path.isAbsolute(externalFile)
+    ? externalFile
+    : path.resolve(cwd, externalFile);
+
+  const parsed = JSON.parse(readFileSync(externalFilePath, `utf8`));
+
+  if (!Array.isArray(parsed) || !parsed.every(value => typeof value === `string`))
+    throw new UsageError(`External dependency file must contain a JSON array of strings`);
+
+  return [...external, ...parsed];
+};

--- a/packages/yarnpkg-builder/sources/tools/getExternalDependencies.ts
+++ b/packages/yarnpkg-builder/sources/tools/getExternalDependencies.ts
@@ -1,6 +1,6 @@
-import {UsageError} from 'clipanion';
+import {UsageError}   from 'clipanion';
 import {readFileSync} from 'fs';
-import path from 'path';
+import path           from 'path';
 
 export const getExternalDependencies = ({cwd, external, externalFile}: {
   cwd: string;


### PR DESCRIPTION
## What's the problem this PR addresses?

Closes #7200.

`builder build bundle` currently hardcodes an IIFE bundle format and a Node-engine-derived target. It also doesn't expose a way to keep selected dependencies external at bundle time.

This makes ESM-only Yarn-based runtimes patch `@yarnpkg/builder` globally instead of using the official builder surface.

## How did you fix it?

Added opt-in `build bundle` options for the bundle settings that downstream runtimes need:

- `--format`, defaulting to the existing `iife` behavior;
- `--target`, defaulting to the existing Node target;
- repeatable `--external` entries passed to esbuild.

When `--format esm` is selected, the bundle banner also installs the small Node compatibility setup needed by existing bundle code paths that expect `require`, `__filename`, and `__dirname`.

The default `builder build bundle` behavior remains unchanged.

Local checks run:

- `yarn workspace @yarnpkg/builder prepack`
- `yarn typecheck:all --pretty false`
- `yarn version check`
- `yarn node packages/yarnpkg-builder/sources/boot-cli-dev.js build bundle --help`

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [x] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
