### PR TITLE
Fix unitest to pass on Win32

### DIFF
--- a/packages/yarnpkg-libzip/tests/ZipOpenFS.test.ts
+++ b/packages/yarnpkg-libzip/tests/ZipOpenFS.test.ts
@@ -28,6 +28,8 @@ export const ZIP_FILE3 = ppath.join(ZIP_DIR3, `foo.txt`);
 export const ZIP_FILE4 = ppath.join(ZIP_DIR4, `foo.txt`);
 export const ZIP_FILE5 = ppath.join(ZIP_DIR5, `foo.txt`);
 
+const itSkipWin32 = process.platform !== `win32` ? it : it.skip;
+
 afterEach(() => {
   jest.useRealTimers();
 });
@@ -100,7 +102,8 @@ describe(`ZipOpenFS`, () => {
     fs.discardAndClose();
   });
 
-  it(`can read from a zip file that's a symlink`, () => {
+  // This test does not work on win32 because the checked in symlink is not properly materialized from git.
+  itSkipWin32(`can read from a zip file that's a symlink`, () => {
     const fs = new ZipOpenFS();
 
     expect(fs.readFileSync(ZIP_FILE4, `utf8`)).toEqual(`foo\n`);

--- a/packages/yarnpkg-shell/tests/shell.test.ts
+++ b/packages/yarnpkg-shell/tests/shell.test.ts
@@ -20,6 +20,10 @@ const expectResult = async (promise: Promise<any>, {exitCode = 0, stdout = ``, s
   return await expect(promise).resolves.toMatchObject({exitCode, stdout, stderr});
 };
 
+// Not all windows sku's ship cat on the path. findstr with "^" will match all the test cases here to map stdin to stdout
+// Should https://learn.microsoft.com/en-us/windows/core-utils/overview ship by default with windows, this can be removed and replaced with cat
+const catTool = isNotWin32 ? `cat` : `findstr "^"`;
+
 const bufferResult = async (command: string, args: Array<string> = [], options: Partial<UserOptions> & {tty?: boolean} = {}): Promise<Result> => {
   const stdout = new PassThrough();
   const stderr = new PassThrough();
@@ -778,7 +782,7 @@ describe(`Shell`, () => {
           await xfs.writeFilePromise(file, `hello world\n`);
 
           await expectResult(bufferResult(
-            `cat < "${file}"`,
+            `${catTool} < "${file}"`,
           ), {
             stdout: `hello world\n`,
           });
@@ -791,7 +795,7 @@ describe(`Shell`, () => {
           await xfs.writeFilePromise(file, `hello world\n`);
 
           await expectResult(bufferResult(
-            `cat 0< "${file}"`,
+            `${catTool} 0< "${file}"`,
           ), {
             stdout: `hello world\n`,
           });
@@ -807,7 +811,7 @@ describe(`Shell`, () => {
           await xfs.writeFilePromise(file2, `hello world\n`);
 
           await expectResult(bufferResult(
-            `cat < "${file1}" < "${file2}"`,
+            `${catTool} < "${file1}" < "${file2}"`,
           ), {
             stdout: `foo bar baz\nhello world\n`,
           });
@@ -820,15 +824,15 @@ describe(`Shell`, () => {
           await xfs.writeFilePromise(file, `hello world\n`);
 
           await expect(bufferResult(
-            `cat 1< "${file}"`,
+            `${catTool} 1< "${file}"`,
           )).rejects.toThrowError(`Unsupported file descriptor: "1"`);
 
           await expect(bufferResult(
-            `cat 2< "${file}"`,
+            `${catTool} 2< "${file}"`,
           )).rejects.toThrowError(`Unsupported file descriptor: "2"`);
 
           await expect(bufferResult(
-            `cat 3< "${file}"`,
+            `${catTool} 3< "${file}"`,
           )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
         });
       });
@@ -837,7 +841,7 @@ describe(`Shell`, () => {
     describe(`<<<`, () => {
       it(`should support input redirections (string)`, async () => {
         await expectResult(bufferResult(
-          `cat <<< "hello world"`,
+          `${catTool} <<< "hello world"`,
         ), {
           stdout: `hello world\n`,
         });
@@ -845,7 +849,7 @@ describe(`Shell`, () => {
 
       it(`should support input redirections to fd (string)`, async () => {
         await expectResult(bufferResult(
-          `cat 0<<< "hello world"`,
+          `${catTool} 0<<< "hello world"`,
         ), {
           stdout: `hello world\n`,
         });
@@ -854,15 +858,15 @@ describe(`Shell`, () => {
       it(`should throw on input redirections to unsupported file descriptors`, async () => {
         await xfs.mktempPromise(async tmpDir => {
           await expect(bufferResult(
-            `cat 1<<< "hello world"`,
+            `${catTool} 1<<< "hello world"`,
           )).rejects.toThrowError(`Unsupported file descriptor: "1"`);
 
           await expect(bufferResult(
-            `cat 2<<< "hello world"`,
+            `${catTool} 2<<< "hello world"`,
           )).rejects.toThrowError(`Unsupported file descriptor: "2"`);
 
           await expect(bufferResult(
-            `cat 3<<< "hello world"`,
+            `${catTool} 3<<< "hello world"`,
           )).rejects.toThrowError(`Unsupported file descriptor: "3"`);
         });
       });


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

UnitTests had failures when running on Windows.
...

## How did you fix it?

I updated Shell tests to use an alternative of `cat` in the tests that matches the stdin/stdout semantics on windows. Non-Windows keeps using `cat`

I skipped the unzip symlinked zip file on Windows systems. Git does not restore the symlink properly on windows and just leaves a text file with the symlink contents.

...

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
