### PR TITLE
fix(plugin-npm): resolve "*" to prereleases when no stable version exists

### DIFF
--- a/.yarn/versions/54e66e35.yml
+++ b/.yarn/versions/54e66e35.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/.yarn/versions/54e66e35.yml
+++ b/.yarn/versions/54e66e35.yml
@@ -1,8 +1,8 @@
 releases:
   "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/cli": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
   - "@yarnpkg/plugin-npm-cli"
-  - "@yarnpkg/cli"
   - "@yarnpkg/core"

--- a/.yarn/versions/54e66e35.yml
+++ b/.yarn/versions/54e66e35.yml
@@ -1,8 +1,24 @@
 releases:
-  "@yarnpkg/plugin-npm": patch
   "@yarnpkg/cli": patch
+  "@yarnpkg/plugin-npm": patch
 
 declined:
   - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
   - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
   - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.1/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.1/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.1/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.1/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "prerelease-only",
+    "version": "1.0.0-rc.1"
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.2/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.2/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.2/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/prerelease-only-1.0.0-rc.2/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "prerelease-only",
+    "version": "1.0.0-rc.2"
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/protocols/npm.test.js
@@ -144,5 +144,52 @@ describe(`Protocols`, () => {
         },
       ),
     );
+
+    test(
+      `it should resolve a "*" range to a prerelease when the package only has prereleases`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`prerelease-only`]: `*`},
+        },
+        async ({run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('prerelease-only')`)).resolves.toMatchObject({
+            name: `prerelease-only`,
+            version: `1.0.0-rc.2`,
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should resolve a "*" range to the stable version when the package has one`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`no-deps-tags`]: `*`},
+        },
+        async ({run, source}) => {
+          await run(`install`);
+
+          await expect(source(`require('no-deps-tags')`)).resolves.toMatchObject({
+            name: `no-deps-tags`,
+            version: `1.0.0`,
+          });
+        },
+      ),
+    );
+
+    test(
+      `it should pass --check-resolutions for a "*" range that only has prereleases`,
+      makeTemporaryEnv(
+        {
+          dependencies: {[`prerelease-only`]: `*`},
+        },
+        async ({run}) => {
+          await run(`install`);
+          await run(`install`, `--check-resolutions`);
+        },
+      ),
+    );
   });
 });

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -15,15 +15,14 @@ const NODE_GYP_MATCH = /\b(node-gyp|prebuild-install)\b/;
 /**
  * Returns the versions from `versions` that satisfy the given range.
  *
- * The `rangeString` is the raw selector the user requested (for example `*`
- * or `^1.0.0`). When it's exactly `*` and nothing matched, every published
- * version is a prerelease (a stable `*` range never matches a prerelease by
- * default). In that specific case we retry while tolerating prereleases, so
- * the package can still be resolved until a stable release exists. This stays
- * deliberately scoped to `*` to avoid changing the semantics of other ranges.
+ * When `range.raw` is exactly `*` and nothing matched, every published version
+ * is a prerelease (a stable `*` range never matches a prerelease by default).
+ * In that specific case we retry while tolerating prereleases, so the package
+ * can still be resolved until a stable release exists. This stays deliberately
+ * scoped to `*` to avoid changing the semantics of other ranges.
  * See https://github.com/yarnpkg/berry/issues/6469.
  */
-export function selectMatchingVersions(rangeString: string, range: semver.Range, versions: Array<string>) {
+export function selectMatchingVersions(range: semver.Range, versions: Array<string>) {
   const match = (matchRange: semver.Range) => miscUtils.mapAndFilter(versions, version => {
     try {
       const candidate = new semverUtils.SemVer(version);
@@ -36,7 +35,7 @@ export function selectMatchingVersions(rangeString: string, range: semver.Range,
   });
 
   const matched = match(range);
-  if (matched.length > 0 || rangeString !== `*`)
+  if (matched.length > 0 || range.raw !== `*`)
     return matched;
 
   // eslint-disable-next-line no-restricted-properties
@@ -85,7 +84,7 @@ export class NpmSemverResolver implements Resolver {
       version: semver.valid(range.raw) ? range.raw : undefined,
     });
 
-    const semverCandidates = selectMatchingVersions(descriptor.range.slice(PROTOCOL.length), range, Object.keys(registryData.versions));
+    const semverCandidates = selectMatchingVersions(range, Object.keys(registryData.versions));
 
     const candidates = semverCandidates.filter(candidate => {
       return isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version: candidate.raw, publishTimes: registryData.time});

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -123,7 +123,7 @@ export class NpmSemverResolver implements Resolver {
     if (range === null)
       throw new Error(`Expected a valid range, got ${descriptor.range.slice(PROTOCOL.length)}`);
 
-    const results = miscUtils.mapAndFilter(locators, locator => {
+    const candidates = miscUtils.mapAndFilter(locators, locator => {
       if (locator.identHash !== descriptor.identHash)
         return miscUtils.mapAndFilter.skip;
 
@@ -131,14 +131,18 @@ export class NpmSemverResolver implements Resolver {
       if (!parsedRange)
         return miscUtils.mapAndFilter.skip;
 
-      const version = new semverUtils.SemVer(parsedRange.selector);
-      if (!range.test(version))
-        return miscUtils.mapAndFilter.skip;
-
-      return {locator, version};
+      return {locator, version: new semverUtils.SemVer(parsedRange.selector)};
     });
 
-    const sortedResults = results
+    // Route the candidate selection through the same helper as `getCandidates`
+    // so the `*`-only-prerelease case (see issue #6469) resolves consistently
+    // here, which is what `yarn install --check-resolutions` relies on.
+    const matchingVersions = new Set(
+      selectMatchingVersions(range, candidates.map(({version}) => version.raw)).map(version => version.raw),
+    );
+
+    const sortedResults = candidates
+      .filter(({version}) => matchingVersions.has(version.raw))
       .sort((a, b) => -a.version.compare(b.version))
       .map(({locator}) => locator);
 

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -12,6 +12,37 @@ import * as npmHttpUtils                                                        
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);
 const NODE_GYP_MATCH = /\b(node-gyp|prebuild-install)\b/;
 
+/**
+ * Returns the versions from `versions` that satisfy the given range.
+ *
+ * The `rangeString` is the raw selector the user requested (for example `*`
+ * or `^1.0.0`). When it's exactly `*` and nothing matched, every published
+ * version is a prerelease (a stable `*` range never matches a prerelease by
+ * default). In that specific case we retry while tolerating prereleases, so
+ * the package can still be resolved until a stable release exists. This stays
+ * deliberately scoped to `*` to avoid changing the semantics of other ranges.
+ * See https://github.com/yarnpkg/berry/issues/6469.
+ */
+export function selectMatchingVersions(rangeString: string, range: semver.Range, versions: Array<string>) {
+  const match = (matchRange: semver.Range) => miscUtils.mapAndFilter(versions, version => {
+    try {
+      const candidate = new semverUtils.SemVer(version);
+      if (matchRange.test(candidate)) {
+        return candidate;
+      }
+    } catch { }
+
+    return miscUtils.mapAndFilter.skip;
+  });
+
+  const matched = match(range);
+  if (matched.length > 0 || rangeString !== `*`)
+    return matched;
+
+  // eslint-disable-next-line no-restricted-properties
+  return match(new semver.Range(`*`, {includePrerelease: true}));
+}
+
 export class NpmSemverResolver implements Resolver {
   supportsDescriptor(descriptor: Descriptor, opts: MinimalResolveOptions) {
     if (!descriptor.range.startsWith(PROTOCOL))
@@ -54,16 +85,7 @@ export class NpmSemverResolver implements Resolver {
       version: semver.valid(range.raw) ? range.raw : undefined,
     });
 
-    const semverCandidates = miscUtils.mapAndFilter(Object.keys(registryData.versions), version => {
-      try {
-        const candidate = new semverUtils.SemVer(version);
-        if (range.test(candidate)) {
-          return candidate;
-        }
-      } catch { }
-
-      return miscUtils.mapAndFilter.skip;
-    });
+    const semverCandidates = selectMatchingVersions(descriptor.range.slice(PROTOCOL.length), range, Object.keys(registryData.versions));
 
     const candidates = semverCandidates.filter(candidate => {
       return isPackageApproved({configuration: opts.project.configuration, ident: descriptor, version: candidate.raw, publishTimes: registryData.time});

--- a/packages/plugin-npm/tests/NpmSemverResolver.test.ts
+++ b/packages/plugin-npm/tests/NpmSemverResolver.test.ts
@@ -7,7 +7,7 @@ const select = (rangeString: string, versions: Array<string>) => {
   if (range === null)
     throw new Error(`Invalid range: ${rangeString}`);
 
-  return selectMatchingVersions(rangeString, range, versions).map(version => version.raw);
+  return selectMatchingVersions(range, versions).map(version => version.raw);
 };
 
 describe(`NpmSemverResolver`, () => {

--- a/packages/plugin-npm/tests/NpmSemverResolver.test.ts
+++ b/packages/plugin-npm/tests/NpmSemverResolver.test.ts
@@ -1,6 +1,14 @@
-import {structUtils}       from '@yarnpkg/core';
+import {semverUtils, structUtils}                  from '@yarnpkg/core';
 
-import {NpmSemverResolver} from '../sources/NpmSemverResolver';
+import {NpmSemverResolver, selectMatchingVersions} from '../sources/NpmSemverResolver';
+
+const select = (rangeString: string, versions: Array<string>) => {
+  const range = semverUtils.validRange(rangeString);
+  if (range === null)
+    throw new Error(`Invalid range: ${rangeString}`);
+
+  return selectMatchingVersions(rangeString, range, versions).map(version => version.raw);
+};
 
 describe(`NpmSemverResolver`, () => {
   describe(`getSatisfying`, () => {
@@ -20,6 +28,24 @@ describe(`NpmSemverResolver`, () => {
 
       expect(results.locators.length).toEqual(1);
       expect(results.locators[0].locatorHash).toEqual(locator.locatorHash);
+    });
+  });
+
+  describe(`selectMatchingVersions`, () => {
+    it(`should match stable versions for "*" as usual`, () => {
+      expect(select(`*`, [`1.0.0`, `1.1.0`, `2.0.0-rc.1`])).toEqual([`1.0.0`, `1.1.0`]);
+    });
+
+    it(`should fall back to prereleases for "*" when every version is a prerelease`, () => {
+      expect(select(`*`, [`1.0.0-rc.1`, `1.0.0-rc.2`])).toEqual([`1.0.0-rc.1`, `1.0.0-rc.2`]);
+    });
+
+    it(`should not tolerate prereleases for ranges other than "*"`, () => {
+      expect(select(`^1.0.0`, [`1.0.0-rc.1`, `1.0.0-rc.2`])).toEqual([]);
+    });
+
+    it(`should return nothing when there are no versions to match`, () => {
+      expect(select(`*`, [])).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## What's the problem this PR addresses?

Installing a package whose only published versions are prereleases fails with `YN0082: No candidates found` when the range is `*`. The reported case is `@microsoft/kiota-abstractions@npm:*`, where every registry version is a prerelease. A stable `*` never matching a prerelease is correct semver, but it leaves these packages uninstallable until a stable release exists.

In #6469 @arcanis agreed with retrying using `includePrerelease` when the range is `*` and nothing matched, rather than treating `*` as `latest`:

> I think it'd make sense to tolerate the prerelease versions until at least one stable is released. We can't make `*` tolerate all prerelease everytime though, it wouldn't match semver (and would break backward compatibility).

Closes #6469.

## How did you fix it?

Pulled the version matching out of `NpmSemverResolver.getCandidates` into a `selectMatchingVersions` helper. It matches as before, and only when the range is exactly `*` and the normal match is empty does it retry with `new semver.Range('*', {includePrerelease: true})`. Any other range (say `^1.0.0`) keeps its current behavior and still won't pick up prereleases.

Tests in `NpmSemverResolver.test.ts`: with the fix removed the prerelease-only `*` case returns `[]`, and with it the prereleases come back; `^1.0.0` against a prerelease-only set stays `[]`, and a `*` against a set with stable versions still ignores prereleases. `yarn jest packages/plugin-npm/tests/NpmSemverResolver.test.ts` passes.

One thing left out on purpose: `getSatisfying` uses the same default-range filter, so a prerelease locked this way could fail to re-satisfy `*` on a later resolution. That felt like a separate change from the install path here, so I held off, but happy to follow up if you want it covered too.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.