### PR TITLE
Skip OTP prompts in non-TTY mode

### DIFF
--- a/.yarn/versions/bee77477.yml
+++ b/.yarn/versions/bee77477.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"

--- a/packages/plugin-npm/sources/npmHttpUtils.ts
+++ b/packages/plugin-npm/sources/npmHttpUtils.ts
@@ -525,7 +525,7 @@ async function askForOtp(error: any, {configuration}: {configuration: Configurat
     }, async report => {
       report.reportInfo(MessageName.UNNAMED, notice.replace(/(https?:\/\/\S+)/g, formatUtils.pretty(configuration, `$1`, formatUtils.Type.URL)));
 
-      if (!process.env.YARN_IS_TEST_ENV) {
+      if (!process.env.YARN_IS_TEST_ENV && process.stdin.isTTY) {
         const autoOpen = notice.match(/open (https?:\/\/\S+)/i);
         if (autoOpen && nodeUtils.openUrl) {
           const {openNow} = await prompt<{openNow: boolean}>({
@@ -552,6 +552,9 @@ async function askForOtp(error: any, {configuration}: {configuration: Configurat
 
   if (process.env.YARN_IS_TEST_ENV)
     return process.env.YARN_INJECT_NPM_2FA_TOKEN || ``;
+
+  if (!process.stdin.isTTY)
+    throw new ReportError(MessageName.AUTHENTICATION_NOT_FOUND, `The registry requires additional authentication, but Yarn is not running in an interactive terminal`);
 
   const {otp} = await prompt<{otp: string}>({
     type: `password`,

--- a/packages/plugin-npm/tests/npmHttpUtils.test.ts
+++ b/packages/plugin-npm/tests/npmHttpUtils.test.ts
@@ -26,3 +26,59 @@ describe(`npmHttpUtils.get`, () => {
     }
   }
 });
+
+describe(`npmHttpUtils.put`, () => {
+  it(`shouldn't ask for an OTP when stdin isn't a TTY`, async () => {
+    const configuration = await makeConfiguration();
+
+    const originalIsTestEnv = process.env.YARN_IS_TEST_ENV;
+    const originalIsTTY = process.stdin.isTTY;
+
+    process.env.YARN_IS_TEST_ENV = ``;
+    Object.defineProperty(process.stdin, `isTTY`, {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      let requestCount = 0;
+
+      await expect(npmHttpUtils.put(`/foo`, {}, {
+        configuration,
+        registry: `https://example.org`,
+        authType: npmHttpUtils.AuthType.NO_AUTH,
+        async wrapNetworkRequest() {
+          return async () => {
+            requestCount += 1;
+
+            const error: Error & {response?: any} = new Error(`OTP required`);
+            error.name = `HTTPError`;
+            error.response = {
+              body: {
+                error: `OTP required`,
+              },
+              headers: {
+                [`www-authenticate`]: `OTP`,
+              },
+              statusCode: 401,
+            };
+
+            throw error;
+          };
+        },
+      })).rejects.toThrow(/The registry requires additional authentication, but Yarn is not running in an interactive terminal/);
+
+      expect(requestCount).toBe(1);
+    } finally {
+      if (typeof originalIsTestEnv === `undefined`)
+        delete process.env.YARN_IS_TEST_ENV;
+      else
+        process.env.YARN_IS_TEST_ENV = originalIsTestEnv;
+
+      Object.defineProperty(process.stdin, `isTTY`, {
+        configurable: true,
+        value: originalIsTTY,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What's the problem this PR addresses?

Programmatic calls to `yarn` can *hang* because yarn asks for the otp when the user is not there to provide it. To workaround this one, can call yarn with `stdin: "000000\n"`

## How did you fix it?

non-tty mode throws an error now instead of prompting

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
