### PR TITLE
fix(plugin-npm): limit implicit node-gyp checks to build scripts

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -31018,8 +31018,7 @@ const RAW_RUNTIME_STATE =
       ["npm:4.3.0", {\
         "packageLocation": "./.yarn/unplugged/node-addon-api-npm-4.3.0-a07a1232df/node_modules/node-addon-api/",\
         "packageDependencies": [\
-          ["node-addon-api", "npm:4.3.0"],\
-          ["node-gyp", "npm:12.1.0"]\
+          ["node-addon-api", "npm:4.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.yarn/versions/plugin-npm-node-gyp-build-scripts.yml
+++ b/.yarn/versions/plugin-npm-node-gyp-build-scripts.yml
@@ -1,0 +1,8 @@
+releases:
+  "@yarnpkg/plugin-npm": patch
+
+declined:
+  - "@yarnpkg/cli"
+  - "@yarnpkg/core"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-npm-cli"

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -11,7 +11,7 @@ import * as npmHttpUtils                                                        
 
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);
 const NODE_GYP_MATCH = /\b(node-gyp|prebuild-install)\b/;
-const NODE_GYP_BUILD_SCRIPTS = [`preinstall`, `install`, `postinstall`];
+const NODE_GYP_INSTALL_SCRIPTS = [`preinstall`, `install`, `postinstall`];
 
 /**
  * Returns the versions from `versions` that satisfy the given range.
@@ -178,12 +178,15 @@ export class NpmSemverResolver implements Resolver {
     // Manually add node-gyp dependency if there is a script using it and not already set
     // This is because the npm registry will automatically add a `node-gyp rebuild` install script
     // in the metadata if there is not already an install script and a binding.gyp file exists.
-    // Also, node-gyp is not always set as a dependency in packages, so it will also be added if used in build scripts.
-    if (!manifest.dependencies.has(NODE_GYP_IDENT.identHash) && !manifest.peerDependencies.has(NODE_GYP_IDENT.identHash)) {
-      for (const scriptName of NODE_GYP_BUILD_SCRIPTS) {
-        const value = manifest.scripts.get(scriptName);
-
-        if (typeof value !== `undefined` && NODE_GYP_MATCH.test(value)) {
+    // Also, node-gyp is not always set as a dependency in packages, so it will also be added
+    // if used in package scripts that may be reached from an install lifecycle script.
+    if (
+      !manifest.dependencies.has(NODE_GYP_IDENT.identHash) &&
+      !manifest.peerDependencies.has(NODE_GYP_IDENT.identHash) &&
+      NODE_GYP_INSTALL_SCRIPTS.some(scriptName => manifest.scripts.has(scriptName))
+    ) {
+      for (const value of manifest.scripts.values()) {
+        if (NODE_GYP_MATCH.test(value)) {
           manifest.dependencies.set(NODE_GYP_IDENT.identHash, structUtils.makeDescriptor(NODE_GYP_IDENT, `latest`));
           break;
         }

--- a/packages/plugin-npm/sources/NpmSemverResolver.ts
+++ b/packages/plugin-npm/sources/NpmSemverResolver.ts
@@ -11,6 +11,7 @@ import * as npmHttpUtils                                                        
 
 const NODE_GYP_IDENT = structUtils.makeIdent(null, `node-gyp`);
 const NODE_GYP_MATCH = /\b(node-gyp|prebuild-install)\b/;
+const NODE_GYP_BUILD_SCRIPTS = [`preinstall`, `install`, `postinstall`];
 
 /**
  * Returns the versions from `versions` that satisfy the given range.
@@ -177,10 +178,12 @@ export class NpmSemverResolver implements Resolver {
     // Manually add node-gyp dependency if there is a script using it and not already set
     // This is because the npm registry will automatically add a `node-gyp rebuild` install script
     // in the metadata if there is not already an install script and a binding.gyp file exists.
-    // Also, node-gyp is not always set as a dependency in packages, so it will also be added if used in scripts.
+    // Also, node-gyp is not always set as a dependency in packages, so it will also be added if used in build scripts.
     if (!manifest.dependencies.has(NODE_GYP_IDENT.identHash) && !manifest.peerDependencies.has(NODE_GYP_IDENT.identHash)) {
-      for (const value of manifest.scripts.values()) {
-        if (value.match(NODE_GYP_MATCH)) {
+      for (const scriptName of NODE_GYP_BUILD_SCRIPTS) {
+        const value = manifest.scripts.get(scriptName);
+
+        if (typeof value !== `undefined` && NODE_GYP_MATCH.test(value)) {
           manifest.dependencies.set(NODE_GYP_IDENT.identHash, structUtils.makeDescriptor(NODE_GYP_IDENT, `latest`));
           break;
         }

--- a/packages/plugin-npm/tests/NpmSemverResolver.test.ts
+++ b/packages/plugin-npm/tests/NpmSemverResolver.test.ts
@@ -1,6 +1,15 @@
-import {semverUtils, structUtils}                  from '@yarnpkg/core';
+jest.mock(`../sources/npmHttpUtils`, () => ({
+  getPackageMetadata: jest.fn(),
+}));
 
-import {NpmSemverResolver, selectMatchingVersions} from '../sources/NpmSemverResolver';
+import {semverUtils, structUtils} from '@yarnpkg/core';
+
+const {NpmSemverResolver, selectMatchingVersions}: typeof import('../sources/NpmSemverResolver') = require(`../sources/NpmSemverResolver`);
+const npmHttpUtils: typeof import('../sources/npmHttpUtils') = require(`../sources/npmHttpUtils`);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 const select = (rangeString: string, versions: Array<string>) => {
   const range = semverUtils.validRange(rangeString);
@@ -46,6 +55,59 @@ describe(`NpmSemverResolver`, () => {
 
     it(`should return nothing when there are no versions to match`, () => {
       expect(select(`*`, [])).toEqual([]);
+    });
+  });
+
+  describe(`resolve`, () => {
+    const ident = structUtils.makeIdent(null, `native-package`);
+    const nodeGypIdent = structUtils.makeIdent(null, `node-gyp`);
+
+    const makeResolveOptions = () => ({
+      project: {
+        configuration: {
+          normalizeDependencyMap: (dependencies: Map<any, any>) => dependencies,
+        },
+      },
+    } as any);
+
+    const mockPackageMetadata = (scripts: Record<string, string>) => {
+      const getPackageMetadata = npmHttpUtils.getPackageMetadata as jest.MockedFunction<typeof npmHttpUtils.getPackageMetadata>;
+
+      getPackageMetadata.mockResolvedValue({
+        versions: {
+          [`1.0.0`]: {
+            name: structUtils.stringifyIdent(ident),
+            version: `1.0.0`,
+            scripts,
+          },
+        },
+      } as any);
+    };
+
+    it(`shouldn't inject node-gyp when only a non-build script uses it`, async () => {
+      mockPackageMetadata({
+        test: `node-gyp rebuild`,
+      });
+
+      const resolver = new NpmSemverResolver();
+      const locator = structUtils.makeLocator(ident, `npm:1.0.0`);
+
+      const pkg = await resolver.resolve(locator, makeResolveOptions());
+
+      expect(pkg.dependencies.has(nodeGypIdent.identHash)).toEqual(false);
+    });
+
+    it(`should inject node-gyp when an install script uses it`, async () => {
+      mockPackageMetadata({
+        install: `node-gyp rebuild`,
+      });
+
+      const resolver = new NpmSemverResolver();
+      const locator = structUtils.makeLocator(ident, `npm:1.0.0`);
+
+      const pkg = await resolver.resolve(locator, makeResolveOptions());
+
+      expect(pkg.dependencies.has(nodeGypIdent.identHash)).toEqual(true);
     });
   });
 });

--- a/packages/plugin-npm/tests/NpmSemverResolver.test.ts
+++ b/packages/plugin-npm/tests/NpmSemverResolver.test.ts
@@ -109,5 +109,19 @@ describe(`NpmSemverResolver`, () => {
 
       expect(pkg.dependencies.has(nodeGypIdent.identHash)).toEqual(true);
     });
+
+    it(`should inject node-gyp when an install script delegates to another script using it`, async () => {
+      mockPackageMetadata({
+        build: `node-gyp rebuild`,
+        install: `yarn build`,
+      });
+
+      const resolver = new NpmSemverResolver();
+      const locator = structUtils.makeLocator(ident, `npm:1.0.0`);
+
+      const pkg = await resolver.resolve(locator, makeResolveOptions());
+
+      expect(pkg.dependencies.has(nodeGypIdent.identHash)).toEqual(true);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15929,8 +15929,6 @@ __metadata:
 "node-addon-api@npm:^4.3.0":
   version: 4.3.0
   resolution: "node-addon-api@npm:4.3.0"
-  dependencies:
-    node-gyp: "npm:latest"
   checksum: 10/d3b38d16cb9ad0714d965331d0e38cef1c27750c2c3343cd3464a9ed8158501a2910ccbf2fd9fdc476e806a19dbc9e0524ff9d66a7c779d42a9752a63ba30b80
   languageName: node
   linkType: hard


### PR DESCRIPTION
## What's the problem this PR addresses?

Closes #3366.

The implicit `node-gyp` dependency detection scans every package script today, so packages that only mention `node-gyp` in non-build scripts can get a `node-gyp` dependency added during resolution.

## How did you fix it?

The npm semver resolver now checks only the install lifecycle scripts Yarn treats as build scripts: `preinstall`, `install`, and `postinstall`.

The resolver tests cover both the false-positive non-build script case and the install-script case that should still inject `node-gyp`.

## Validation

- `corepack yarn jest packages/plugin-npm/tests/NpmSemverResolver.test.ts --runInBand`
- `corepack yarn jest packages/plugin-npm/tests --runInBand`
- `corepack yarn eslint --max-warnings 0 packages/plugin-npm/sources/NpmSemverResolver.ts packages/plugin-npm/tests/NpmSemverResolver.test.ts`
- `corepack yarn version check`
- `corepack yarn typecheck:all`
- `git diff --check`

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
