### PR TITLE
fix(nm): prefer direct dependency binaries

### DIFF
--- a/.yarn/versions/a46c1d8d.yml
+++ b/.yarn/versions/a46c1d8d.yml
@@ -1,0 +1,5 @@
+releases:
+  "@yarnpkg/plugin-nm": patch
+
+declined:
+  - "@yarnpkg/cli"

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/one-dep-alias-bins-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/one-dep-alias-bins-1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "one-dep-alias-bins",
+  "version": "1.0.0",
+  "dependencies": {
+    "@fixture/old": "npm:has-bin-entries@1.0.0"
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts
@@ -1,5 +1,6 @@
 import {WindowsLinkType}                           from '@yarnpkg/core';
 import {xfs, npath, PortablePath, ppath, Filename} from '@yarnpkg/fslib';
+import {parseSyml}                                 from '@yarnpkg/parsers';
 
 
 const {
@@ -145,6 +146,34 @@ describe(`Node_Modules`, () => {
         if (process.platform !== `win32`) {
           // Check that destination has 0o700 - execute for all permissions set
           expect(stats.mode & 0o700).toEqual(0o700);
+        }
+      },
+    ),
+  );
+
+  test(`should prefer direct dependency bins over transitive dependency bins`,
+    makeTemporaryEnv(
+      {
+        dependencies: {
+          [`@fixture/native`]: `npm:has-bin-entries@2.0.0`,
+          [`has-bin-entries`]: `npm:one-dep-alias-bins@1.0.0`,
+        },
+      },
+      {
+        nodeLinker: `node-modules`,
+      },
+      async ({path, run}) => {
+        await run(`install`);
+
+        const installState = parseSyml(await xfs.readFilePromise(ppath.join(path, `node_modules/.yarn-state.yml` as PortablePath), `utf8`));
+        const rootState = Object.values<any>(installState).find(({locations}) => locations?.includes(``));
+
+        expect(rootState?.bin?.[`.`]?.[`has-bin-entries-with-relative-require`]).toEqual(`@fixture/native/bin-with-relative-require.js`);
+
+        if (process.platform !== `win32`) {
+          await expect(run(`node`, `${path}/node_modules/.bin/has-bin-entries-with-relative-require`)).resolves.toMatchObject({
+            stdout: `2.0.0\n`,
+          });
         }
       },
     ),

--- a/packages/plugin-nm/sources/NodeModulesLinker.ts
+++ b/packages/plugin-nm/sources/NodeModulesLinker.ts
@@ -1053,7 +1053,9 @@ async function createBinSymlinkMap(installState: NodeModulesLocatorMap, location
       for (const [childLocation, childNode] of node.children) {
         const childSymlinks = getBinSymlinks(ppath.join(location, childLocation), parentLocatorLocation, childNode);
         for (const [name, symlinkTarget] of childSymlinks) {
-          symlinks.set(name, symlinkTarget);
+          if (!symlinks.has(name)) {
+            symlinks.set(name, symlinkTarget);
+          }
         }
       }
     }


### PR DESCRIPTION
## What's the problem this PR addresses?

Closes #7215.

With the node-modules linker, packages that export the same binary currently overwrite each other in traversal order. A transitive alias can therefore replace a direct dependency binary, as in the TypeScript 6/7 setup where `.bin/tsc` points to `@typescript/old`.

## How did you fix it?

Bin collection now keeps the first target for a name, preserving the direct dependency encountered before its transitive dependency.

The regression uses aliased fixture packages and checks both the persisted root bin target and the generated `.bin` executable.

## Validation

- `corepack yarn build:cli`
- `corepack yarn workspace acceptance-tests test:integration --runTestsByPath "$PWD/packages/acceptance-tests/pkg-tests-specs/sources/node-modules.test.ts" --runInBand` (63 passed, 2 platform-specific skipped)
- `corepack yarn test:lint`
- `corepack yarn typecheck:all`
- `corepack yarn constraints`
- `corepack yarn version check`

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.