### PR TITLE
fix(sdks): migrate VSCode TypeScript settings

### DIFF
--- a/.yarn/versions/067ab8a9.yml
+++ b/.yarn/versions/067ab8a9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
@@ -27,7 +27,7 @@ export default class SdkCommand extends Command {
 
       - When \`base\` is used, only the base SDKs will be generated. This is useful for when an editor is not yet supported and you plan to manage the settings yourself.
 
-      - When a set of integrations is used (e.g. \`vscode\`, \`vim\`, ...), the base SDKs will be installed plus all the settings relevant to the corresponding environments (for example on VSCode it would set \`typescript.tsdk\`).
+      - When a set of integrations is used (e.g. \`vscode\`, \`vim\`, ...), the base SDKs will be installed plus all the settings relevant to the corresponding environments (for example on VSCode it would set \`js/ts.tsdk.path\`).
 
       The supported integrations at this time are: ${[...SUPPORTED_INTEGRATIONS.keys()].map(integration => `\`${integration}\``).join(`, `)}.
 

--- a/packages/yarnpkg-sdks/sources/sdkUtils.ts
+++ b/packages/yarnpkg-sdks/sources/sdkUtils.ts
@@ -3,7 +3,7 @@ import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
 import {PnpApi}                          from '@yarnpkg/pnp';
 import CJSON                             from 'comment-json';
 
-export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeFileName: PortablePath, patch: any) => {
+export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeFileName: PortablePath, patch: any, keysToRemove: Array<string> = []) => {
   const topLevelInformation = pnpApi.getPackageInformation(pnpApi.topLevel)!;
   const projectRoot = npath.toPortablePath(topLevelInformation.packageLocation);
 
@@ -14,6 +14,10 @@ export const addSettingWorkspaceConfiguration = async (pnpApi: PnpApi, relativeF
     : `{}`;
 
   const data = CJSON.parse(content);
+
+  for (const key of keysToRemove)
+    delete data[key];
+
   const patched = `${CJSON.stringify(miscUtils.mergeIntoTarget(data, patch), null, 2)}\n`;
 
   await xfs.mkdirPromise(ppath.dirname(filePath), {recursive: true});

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -9,9 +9,9 @@ export enum VSCodeConfiguration {
   extensions = `extensions.json`,
 }
 
-export const addVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCodeConfiguration, patch: any) => {
+export const addVSCodeWorkspaceConfiguration = async (pnpApi: PnpApi, type: VSCodeConfiguration, patch: any, keysToRemove: Array<string> = []) => {
   const relativeFilePath = `.vscode/${type}` as PortablePath;
-  await sdkUtils.addSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch);
+  await sdkUtils.addSettingWorkspaceConfiguration(pnpApi, relativeFilePath, patch, keysToRemove);
 };
 
 export const generateDefaultWrapper: GenerateDefaultWrapper = async (pnpApi: PnpApi) => {
@@ -95,15 +95,20 @@ export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (p
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`typescript.tsdk`]: npath.fromPortablePath(
+    [`js/ts.tsdk.path`]: npath.fromPortablePath(
       ppath.dirname(
         wrapper.getProjectPathTo(
           `lib/tsserver.js` as PortablePath,
         ),
       ),
     ),
-    [`typescript.enablePromptUseWorkspaceTsdk`]: true,
-  });
+    [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
+  },
+  [
+    `typescript.tsdk`,
+    `typescript.enablePromptUseWorkspaceTsdk`,
+  ],
+  );
 };
 
 export const generateSvelteLanguageServerWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {

--- a/packages/yarnpkg-sdks/tests/vscode.test.ts
+++ b/packages/yarnpkg-sdks/tests/vscode.test.ts
@@ -1,0 +1,97 @@
+import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
+import {PnpApi}                          from '@yarnpkg/pnp';
+
+import {Wrapper} from '../sources/generateSdk';
+import {generateTypescriptWrapper} from '../sources/sdks/vscode';
+
+const makePnpApi = (projectRoot: PortablePath) => {
+  return {
+    topLevel: {
+      name: null,
+      reference: null,
+    },
+
+    getPackageInformation: () => ({
+      packageLocation: npath.fromPortablePath(projectRoot),
+    }),
+  } as unknown as PnpApi;
+};
+
+const makeTypescriptWrapper = () => {
+  return {
+    getProjectPathTo: () =>
+      `.yarn/sdks/typescript/lib/tsserver.js` as PortablePath,
+  } as unknown as Wrapper;
+};
+
+describe(`VSCode SDK settings`, () => {
+  it(`should generate the unified JavaScript and TypeScript settings`, async () => {
+    await xfs.mktempPromise(async projectRoot => {
+      const pnpApi = makePnpApi(projectRoot);
+      const wrapper = makeTypescriptWrapper();
+
+      await generateTypescriptWrapper(
+        pnpApi,
+        PortablePath.dot,
+        wrapper,
+      );
+
+      const settingsPath = ppath.join(
+        projectRoot,
+        `.vscode/settings.json` as PortablePath,
+      );
+
+      const settings = await xfs.readJsonPromise(settingsPath);
+
+      expect(settings).toEqual({
+        [`js/ts.tsdk.path`]: npath.fromPortablePath(
+          `.yarn/sdks/typescript/lib` as PortablePath,
+        ),
+        [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
+      });
+    });
+  });
+
+  it(`should remove deprecated TypeScript settings while preserving unrelated settings`, async () => {
+    await xfs.mktempPromise(async projectRoot => {
+      const settingsPath = ppath.join(
+        projectRoot,
+        `.vscode/settings.json` as PortablePath,
+      );
+
+      await xfs.mkdirPromise(ppath.dirname(settingsPath), {
+        recursive: true,
+      });
+
+      await xfs.writeJsonPromise(settingsPath, {
+        [`editor.formatOnSave`]: true,
+        [`typescript.tsdk`]: `.yarn/sdks/typescript/lib`,
+        [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+      });
+
+      const pnpApi = makePnpApi(projectRoot);
+      const wrapper = makeTypescriptWrapper();
+
+      await generateTypescriptWrapper(
+        pnpApi,
+        PortablePath.dot,
+        wrapper,
+      );
+
+      const settings = await xfs.readJsonPromise(settingsPath);
+
+      expect(settings).toEqual({
+        [`editor.formatOnSave`]: true,
+        [`js/ts.tsdk.path`]: npath.fromPortablePath(
+          `.yarn/sdks/typescript/lib` as PortablePath,
+        ),
+        [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
+      });
+
+      expect(settings).not.toHaveProperty(`typescript.tsdk`);
+      expect(settings).not.toHaveProperty(
+        `typescript.enablePromptUseWorkspaceTsdk`,
+      );
+    });
+  });
+});

--- a/packages/yarnpkg-sdks/tests/vscode.test.ts
+++ b/packages/yarnpkg-sdks/tests/vscode.test.ts
@@ -1,8 +1,8 @@
 import {PortablePath, npath, ppath, xfs} from '@yarnpkg/fslib';
 import {PnpApi}                          from '@yarnpkg/pnp';
 
-import {Wrapper} from '../sources/generateSdk';
-import {generateTypescriptWrapper} from '../sources/sdks/vscode';
+import {Wrapper}                         from '../sources/generateSdk';
+import {generateTypescriptWrapper}       from '../sources/sdks/vscode';
 
 const makePnpApi = (projectRoot: PortablePath) => {
   return {


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?
@yarnpkg/sdks currently generates the deprecated VS Code TypeScript settings:

{
  "typescript.tsdk": ".yarn/sdks/typescript/lib",
  "typescript.enablePromptUseWorkspaceTsdk": true
}

These settings have been replaced by the unified JavaScript and TypeScript settings:

{
  "js/ts.tsdk.path": ".yarn/sdks/typescript/lib",
  "js/ts.tsdk.promptToUseWorkspaceVersion": true
}

Simply adding the new settings isn't sufficient for existing projects, since the deprecated settings would remain in .vscode/settings.json.

Fixes #7107.
<!-- Describe the rationale of your PR. -->
<!-- Link all issues that it closes. (Closes/Resolves #xxxx.) -->

...

## How did you fix it?

<!-- A detailed description of your implementation. -->
Updated the VS Code TypeScript SDK generator to use the new js/ts.tsdk.* settings.
Extended the workspace configuration helper so obsolete settings can be removed before applying a patch.
Removed the deprecated typescript.tsdk and typescript.enablePromptUseWorkspaceTsdk settings during migration.
Preserved unrelated user-defined VS Code settings.
Updated the SDK command help text to reference the new setting name.
Added tests for both fresh settings generation and migration of an existing settings file.

The removal and replacement happen during the same settings-file update.

Tests

Added tests covering:

Generating the unified settings for a new project.
Removing deprecated settings from an existing project.
Preserving unrelated user settings during migration.
yarn test:unit packages/yarnpkg-sdks/tests/vscode.test.ts --runInBand

Result:

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Related work

I'm aware of #7116 and #7119, which also address #7107. This implementation focuses on performing the migration in a single configuration update and includes automated coverage for both fresh and existing projects.
...



The Netlify failure appears unrelated to this PR.

I reproduced the exact same failure from a clean detached worktree at the current `origin/master` commit (`0a230c14e`):

```text
Docusaurus static site generation failed for:
- /configuration/yarnrc

Using exampleKeys without patternProperties is not supported (in catalog)
```

This PR only changes `packages/yarnpkg-sdks` and its release metadata. `origin/master...HEAD` reports `0 3`, and none of the PR changes reference `catalog`, `exampleKeys`, `patternProperties`, or the Docusaurus configuration.

Could the Netlify check be waived/retried after the base documentation build is fixed?

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [ ] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [ ] I will check that all automated PR checks pass before the PR gets reviewed.
