### PR TITLE
perf(nm): avoid redundant package map sorting

### DIFF
--- a/.yarn/versions/e378878b.yml
+++ b/.yarn/versions/e378878b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/nm": patch

--- a/.yarn/versions/e378878b.yml
+++ b/.yarn/versions/e378878b.yml
@@ -1,2 +1,36 @@
 releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/core": patch
   "@yarnpkg/nm": patch
+  "@yarnpkg/plugin-nm": patch
+  "@yarnpkg/plugin-pnp": patch
+  "@yarnpkg/plugin-pnpm": patch
+
+declined:
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-compat"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/extensions"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-nm/sources/buildPackageMap.ts
+++ b/packages/yarnpkg-nm/sources/buildPackageMap.ts
@@ -147,7 +147,7 @@ const buildPackageMapFromDependencyFilter = (nodeModulesTree: NodeModulesTree, {
       const packageLocations = packageLocationsByNodeModulesPath.get(nodeModulesPath);
 
       if (typeof packageLocations !== `undefined`) {
-        for (const [dependencyName, dependencyLocation] of Array.from(packageLocations).sort(([a], [b]) => compareStrings(a, b))) {
+        for (const [dependencyName, dependencyLocation] of packageLocations) {
           if (dependencyNames !== null && !dependencyNames.has(dependencyName))
             continue;
 


### PR DESCRIPTION
## What's the problem this PR addresses?

Our tools detected a significant perf regression after updating from 4.13 to 4.17 and I was able to narrow down the impact to #7184

This change removes likely redundant sorting operation, speeding up (in my case) linking step by 97%, from 50s to 2s

## How did you fix it?

First I've tried to cache sorting operation, but later challenged its very existence. Tests and snapshots are happy and see no difference.


...

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

- [x] I have set the packages that need to be released for my changes to be effective.

- [x] I will check that all automated PR checks pass before the PR gets reviewed.
