### PR TITLE
CI: Aggregate acceptance test matrix result

### DIFF
--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -348,7 +348,7 @@ jobs:
     name: 'Acceptance test results'
     runs-on: ubuntu-latest
     needs: [acceptance, big-endian]
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: "!cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group')"
     steps:
     - id: test-results
       shell: bash

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -219,6 +219,7 @@ jobs:
       shell: bash
       run: >
         # Get the latest and LTS major versions that we support
+
         echo -n 'versions='
         >> $GITHUB_OUTPUT
 
@@ -227,6 +228,7 @@ jobs:
         >> $GITHUB_OUTPUT
 
         # Get the latest nightly version that runs on both macOS and Windows
+
         echo -n 'nightly='
         >> $GITHUB_OUTPUT
 
@@ -235,6 +237,7 @@ jobs:
         >> $GITHUB_OUTPUT
 
         # Show output in logs
+
         cat $GITHUB_OUTPUT
 
   acceptance:

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -218,6 +218,7 @@ jobs:
     - id: versions
       shell: bash
       run: >
+        # Get the latest and LTS major versions that we support
         echo -n 'versions='
         >> $GITHUB_OUTPUT
 
@@ -225,36 +226,47 @@ jobs:
         jq -c '[.[0:1] + map(select(.lts)) | .[].version | capture("^v(?<major>\\d+)") | .major | tonumber] | unique | map(select(. >= 18))'
         >> $GITHUB_OUTPUT
 
+        # Get the latest nightly version that runs on both macOS and Windows
+        echo -n 'nightly='
+        >> $GITHUB_OUTPUT
+
+        curl https://nodejs.org/download/nightly/index.json |
+        jq -r 'map(select([("osx-arm64-tar", "win-x64-exe") as $FILE | .files | any(. == $FILE)] | all)) | first | .version'
+        >> $GITHUB_OUTPUT
+
+        # Show output in logs
+        cat $GITHUB_OUTPUT
+
   acceptance:
     strategy:
       fail-fast: false
       matrix:
         # We run the ubuntu tests on multiple Node versions with 2 shards since they're the fastest.
         node: ${{ fromJson(needs.node-versions.outputs.versions) }}
-        platform: [[ubuntu, 22.04]]
+        platform: [ubuntu-22.04]
         shard: ['1/2', '2/2']
         include:
           # We run the rest of the tests on the minimum Node version we support with 3 shards.
           # Windows tests
-          - {node: 18, platform: [windows, latest], shard: 1/3}
-          - {node: 18, platform: [windows, latest], shard: 2/3}
-          - {node: 18, platform: [windows, latest], shard: 3/3}
+          - {node: 18, platform: windows-latest, shard: 1/3}
+          - {node: 18, platform: windows-latest, shard: 2/3}
+          - {node: 18, platform: windows-latest, shard: 3/3}
           # macOS tests
-          - {node: 18, platform: [macos, latest], shard: 1/3}
-          - {node: 18, platform: [macos, latest], shard: 2/3}
-          - {node: 18, platform: [macos, latest], shard: 3/3}
+          - {node: 18, platform: macos-latest, shard: 1/3}
+          - {node: 18, platform: macos-latest, shard: 2/3}
+          - {node: 18, platform: macos-latest, shard: 3/3}
           # We also run them on the maximum Node version we support, to catch potential regressions in Node.js.
           # Windows tests
-          - {node: 27-nightly, platform: [windows, latest], shard: 1/3}
-          - {node: 27-nightly, platform: [windows, latest], shard: 2/3}
-          - {node: 27-nightly, platform: [windows, latest], shard: 3/3}
+          - {node: "${{ needs.node-versions.outputs.nightly }}", platform: windows-latest, shard: 1/3}
+          - {node: "${{ needs.node-versions.outputs.nightly }}", platform: windows-latest, shard: 2/3}
+          - {node: "${{ needs.node-versions.outputs.nightly }}", platform: windows-latest, shard: 3/3}
           # macOS tests
-          - {node: 27-nightly, platform: [macos, latest], shard: 1/3}
-          - {node: 27-nightly, platform: [macos, latest], shard: 2/3}
-          - {node: 27-nightly, platform: [macos, latest], shard: 3/3}
+          - {node: "${{ needs.node-versions.outputs.nightly }}", platform: macos-latest, shard: 1/3}
+          - {node: "${{ needs.node-versions.outputs.nightly }}", platform: macos-latest, shard: 2/3}
+          - {node: "${{ needs.node-versions.outputs.nightly }}", platform: macos-latest, shard: 3/3}
 
-    name: '${{matrix.platform[0]}}-latest w/ Node.js ${{matrix.node}}.x (${{matrix.shard}})'
-    runs-on: ${{matrix.platform[0]}}-${{matrix.platform[1]}}
+    name: '${{matrix.platform}} w/ Node.js ${{matrix.node}} (${{matrix.shard}})'
+    runs-on: ${{matrix.platform}}
     needs: [build, node-versions]
 
     # Permission required to produce a valid provenance statement during the tests
@@ -327,3 +339,18 @@ jobs:
       shell: bash
       if: |
         success() || failure()
+
+  test-results:
+    name: 'Acceptance test results'
+    runs-on: ubuntu-latest
+    needs: acceptance
+    if: github.event_name == "pull_request" || github.event_name == "merge_group"
+    steps:
+    - id: test-results
+      shell: bash
+      run: >
+        if [[ "${{ needs.acceptance.result }}" != "success" ]]; then
+          exit 1
+        elif [[ "${{ needs.big-endian.result }}" != "success" && "${{ needs.big-endian.result }}" != "skipped" ]]; then
+          exit 1
+        fi

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -343,8 +343,8 @@ jobs:
   test-results:
     name: 'Acceptance test results'
     runs-on: ubuntu-latest
-    needs: acceptance
-    if: github.event_name == "pull_request" || github.event_name == "merge_group"
+    needs: [acceptance, big-endian]
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
     - id: test-results
       shell: bash

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -213,6 +213,7 @@ jobs:
     name: 'Acceptance test node versions'
     outputs:
       versions: ${{ steps.versions.outputs.versions }}
+      nightly: ${{ steps.versions.outputs.nightly }}
     runs-on: ubuntu-latest
     steps:
     - id: versions


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

The acceptance test matrix on GitHub Actions is dynamically selected from available Node versions, but the required checks for GitHub branch protections uses exact job name match, causing it to drift out of sync over time with the actual test jobs.

## How did you fix it?

Added an additional job that check whether all of the test matrix succeeded, so that required checks have a stable job name to use.

Also made the nightly version tested against dynamic

## Checklist

<!--- Don't worry if you miss something, chores are automatically tested. -->
<!--- This checklist exists to help you remember doing the chores when you submit a PR. -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).

<!-- See https://yarnpkg.com/advanced/contributing#preparing-your-pr-to-be-released for more details. -->
<!-- Check with `yarn version check` and fix with `yarn version check -i` -->
- [x] I have set the packages that need to be released for my changes to be effective.

<!-- The "Testing chores" workflow validates that your PR follows our guidelines. -->
<!-- If it doesn't pass, click on it to see details as to what your PR might be missing. -->
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
