### PR TITLE
fix(sdks): update deprecated VSCode TypeScript settings to new keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.tabSize": 2,
   "files.eol": "\n",
-  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "js/ts.tsdk.path": ".yarn/sdks/typescript/lib",
   "typescript.tsserver.watchOptions": {
     "watchFile": "useFsEventsOnParentDirectory",
     "watchDirectory": "useFsEvents"
@@ -21,7 +21,7 @@
   "pasteImage.basePath": "${projectRoot}/packages/gatsby/static",
   "pasteImage.forceUnixStyleSeparator": true,
   "pasteImage.prefix": "/",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "search.exclude": {
     "**/.pnp.*": true,
     "**/.yarn": true,

--- a/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
+++ b/packages/yarnpkg-sdks/sources/commands/SdkCommand.ts
@@ -27,7 +27,7 @@ export default class SdkCommand extends Command {
 
       - When \`base\` is used, only the base SDKs will be generated. This is useful for when an editor is not yet supported and you plan to manage the settings yourself.
 
-      - When a set of integrations is used (e.g. \`vscode\`, \`vim\`, ...), the base SDKs will be installed plus all the settings relevant to the corresponding environments (for example on VSCode it would set \`typescript.tsdk\`).
+      - When a set of integrations is used (e.g. \`vscode\`, \`vim\`, ...), the base SDKs will be installed plus all the settings relevant to the corresponding environments (for example on VSCode it would set \`js/ts.tsdk.path\`).
 
       The supported integrations at this time are: ${[...SUPPORTED_INTEGRATIONS.keys()].map(integration => `\`${integration}\``).join(`, `)}.
 

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -95,14 +95,14 @@ export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (p
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`typescript.tsdk`]: npath.fromPortablePath(
+    [`js/ts.tsdk.path`]: npath.fromPortablePath(
       ppath.dirname(
         wrapper.getProjectPathTo(
           `lib/tsserver.js` as PortablePath,
         ),
       ),
     ),
-    [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+    [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
   });
 };
 


### PR DESCRIPTION
## Summary

Updates the deprecated VSCode settings generated by `@yarnpkg/sdks` for TypeScript SDK:

- `typescript.tsdk` -> `js/ts.tsdk.path`
- `typescript.enablePromptUseWorkspaceTsdk` -> `js/ts.tsdk.promptToUseWorkspaceVersion`

## Changes

- **`packages/yarnpkg-sdks/sources/sdks/vscode.ts`**: Update `generateTypescriptWrapper` to use new VSCode settings keys
- **`packages/yarnpkg-sdks/sources/commands/SdkCommand.ts`**: Update help text to reference the new setting key
- **`.vscode/settings.json`**: Update project VSCode settings for consistency

## Related

Closes #7107