### PR TITLE
docs: remove peerDependencies from catalog supported fields

### DIFF
--- a/packages/docusaurus/docs/features/catalogs.mdx
+++ b/packages/docusaurus/docs/features/catalogs.mdx
@@ -86,4 +86,4 @@ When publishing packages, the `catalog:` protocol is automatically replaced with
 
 ## Supported fields
 
-The `catalog:` protocol works in `dependencies`, `devDependencies`, `peerDependencies`.
+The `catalog:` protocol works in `dependencies` and `devDependencies`.


### PR DESCRIPTION
The docs list `peerDependencies` as supported for `catalog:`, but it isn't yet: it resolves to `*` (see #6925, fix proposed in #6926). Removing it from the list until that lands.