### PR TITLE
fix(extensions): declare the `typescript` peer for the Volar packages

### DIFF
--- a/.yarn/versions/8b3c17ad.yml
+++ b/.yarn/versions/8b3c17ad.yml
@@ -1,0 +1,36 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-catalog"
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-exec"
+  - "@yarnpkg/plugin-file"
+  - "@yarnpkg/plugin-git"
+  - "@yarnpkg/plugin-github"
+  - "@yarnpkg/plugin-http"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-jsr"
+  - "@yarnpkg/plugin-link"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"
+  - "@yarnpkg/nm"
+  - "@yarnpkg/pnpify"
+  - "@yarnpkg/sdks"

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -1012,4 +1012,49 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       fastify: `^4.0.0`,
     },
   }],
+  // https://github.com/volarjs/volar.js/issues/284
+  [`@volar/typescript@*`, {
+    peerDependencies: {
+      typescript: `*`,
+    },
+    peerDependenciesMeta: {
+      typescript: optionalPeerDep,
+    },
+  }],
+  // https://github.com/volarjs/volar.js/issues/284
+  [`@volar/language-server@*`, {
+    peerDependencies: {
+      typescript: `*`,
+    },
+    peerDependenciesMeta: {
+      typescript: optionalPeerDep,
+    },
+  }],
+  // https://github.com/volarjs/volar.js/issues/284
+  [`@volar/language-service@*`, {
+    peerDependencies: {
+      typescript: `*`,
+    },
+    peerDependenciesMeta: {
+      typescript: optionalPeerDep,
+    },
+  }],
+  // https://github.com/volarjs/services/issues/125
+  [`volar-service-typescript@*`, {
+    peerDependencies: {
+      typescript: `*`,
+    },
+    peerDependenciesMeta: {
+      typescript: optionalPeerDep,
+    },
+  }],
+  // https://github.com/volarjs/services/issues/125
+  [`volar-service-typescript-twoslash-queries@*`, {
+    peerDependencies: {
+      typescript: `*`,
+    },
+    peerDependenciesMeta: {
+      typescript: optionalPeerDep,
+    },
+  }],
 ];


### PR DESCRIPTION
**What's the problem this PR addresses?**

Five packages in the Volar ecosystem import `typescript` from their published type declarations without declaring it in `dependencies` or `peerDependencies`:

| package | latest | `.d.ts` files importing `typescript` | example |
|---|---|---|---|
| `@volar/typescript` | 2.4.28 | 15 | `index.d.ts:9` — `import type * as ts from 'typescript'` |
| `@volar/language-server` | 2.4.28 | 7 | `lib/project/typescriptProject.d.ts:2` |
| `@volar/language-service` | 2.4.28 | 2 | `lib/types.d.ts:2` |
| `volar-service-typescript` | 0.0.71 | 14 | `index.d.ts:4` — `create(ts: typeof import('typescript'), …)` |
| `volar-service-typescript-twoslash-queries` | 0.0.71 | 1 | `index.d.ts:2` |

With a hoisting installer this resolves by accident. Under an isolated layout it only resolves when the package's real path happens to sit beneath a `node_modules` that has `typescript` as an ancestor, so it works in some projects and silently breaks in others. When it breaks, `tsc` reports `TS2307: Cannot find module 'typescript'` from inside the published `.d.ts`, every `ts.*` type degrades to `any`, and downstream `declare module` augmentation stops applying — which surfaces as errors that look unrelated to a missing dependency, e.g. `Property 'typescript' does not exist on type 'ProjectContext'`.

This came out of triaging a pnpm report against Astro's language-tools packages: https://github.com/pnpm/pnpm/issues/13331.

**How did you fix it?**

Added the five packages to the compatibility database with an *optional* `typescript` peer dependency. Optional is deliberate: all five receive the `ts` instance from their caller and never `require('typescript')` themselves, so a required peer would pull TypeScript into projects that only consume the runtime.

Verified on a reduced project (`@volar/typescript` + `typescript`, installed so the package resolves outside the project tree): without the extension `tsc` reports the `TS2307`s above plus a downstream `TS7006`; with the equivalent extension applied it compiles clean, with no other change.

Two notes for reviewers:

- **Upstream state.** The upstream request for `@volar/typescript` is https://github.com/volarjs/volar.js/issues/284, open since 2025-08-07 with no maintainer response; I've added the reproduction and the two additional packages from that repo to it. The two `volar-service-*` packages live in a different repo and had no report at all, so I opened https://github.com/volarjs/services/issues/125. I know the convention here is to link an upstream **PR** rather than an issue — happy to send PRs to both Volar repos and update these comments with the URLs if you'd prefer that before merging.
- **Version ranges.** I used `*` rather than an upper bound because all five are still unfixed at their latest release. If they later declare the peer themselves the extension becomes a no-op. Happy to switch to `<=2.4.28` / `<=0.0.71` if you'd rather bound it.

The `.yarn/versions` entry was written by hand rather than via `yarn version check --interactive` (I didn't want to run a full install of this repo just for the bump file) — tell me if it needs regenerating.

---
Written by an agent (Claude Code, claude-opus-5), on behalf of the pnpm maintainers.
