### PR TITLE
Fix duplicate yarn init entry in CLI docs

### DIFF
--- a/packages/docusaurus/config/docusaurus/plugins/cli-docs.ts
+++ b/packages/docusaurus/config/docusaurus/plugins/cli-docs.ts
@@ -65,13 +65,24 @@ export type Options = {
 
 const plugin = async function(context: LoadContext, options: Options): Promise<Plugin<Record<string, Array<Definition>>>> {
   async function createBinaryPages(packageName: string, definitions: Array<Definition>, actions: PluginContentLoadedActions) {
+    // Clipanion may register multiple commands with the same path (e.g. yarn init
+    // and yarn init <initializer>). Keep one entry per path in the generated docs.
+    const uniqueDefinitions: Array<Definition> = [];
+    const seenPaths = new Set<string>();
+    for (const definition of definitions) {
+      if (seenPaths.has(definition.path))
+        continue;
+      seenPaths.add(definition.path);
+      uniqueDefinitions.push(definition);
+    }
+
     const pages = await Promise.all(
-      definitions
+      uniqueDefinitions
         .sort((a, b) => a.path.localeCompare(b.path))
         .map(definition => createCommandPage(packageName, definition, actions)),
     );
 
-    const index = await createBinaryIndexPage(packageName, definitions, actions);
+    const index = await createBinaryIndexPage(packageName, uniqueDefinitions, actions);
 
     return {
       sidebarItem: {


### PR DESCRIPTION
## What's the problem this PR addresses?

Fixes #7187

The CLI reference page listed `yarn init` twice under General commands. That happened because Clipanion registers both the plain `init` command and the `init <initializer>` overload under the same path, and the docs generator emitted one row per command definition.

## How did you fix it?

In the CLI docs plugin, keep a single definition per command path before building the index and sidebar pages.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.

