### PR TITLE
ci: update to Node.js 26 and current GitHub Actions

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,17 +6,17 @@ inputs:
   node-version:
     description: 'The version of Node.js to use'
     required: false
-    default: '25.6'
+    default: '26.x'
 
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}
 
     #region Build the standard bundle
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       id: cache-build
       with:
         path: packages/yarnpkg-cli/bundles/yarn.js
@@ -35,7 +35,7 @@ runs:
       run: echo "globalFolder=$(YARN_IGNORE_PATH=1 node packages/yarnpkg-cli/bundles/yarn.js config get globalFolder)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: |
           ${{ steps.global-path.outputs.globalFolder }}/cache

--- a/.github/workflows/benchmark-workflow.yml
+++ b/.github/workflows/benchmark-workflow.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
       with:

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Setup upterm session
       uses: lhotari/action-upterm@d23c2722bdab893785c9fbeae314cbf080645bd7
       with:

--- a/.github/workflows/e2e-create-vue-workflow.yml
+++ b/.github/workflows/e2e-create-vue-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-docusaurus-workflow.yml
+++ b/.github/workflows/e2e-docusaurus-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-esbuild-workflow.yml
+++ b/.github/workflows/e2e-esbuild-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-eslint-workflow.yml
+++ b/.github/workflows/e2e-eslint-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-fsevents-workflow.yml
+++ b/.github/workflows/e2e-fsevents-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-gatsby-workflow.yml
+++ b/.github/workflows/e2e-gatsby-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-gulp-workflow.yml
+++ b/.github/workflows/e2e-gulp-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-husky-workflow.yml
+++ b/.github/workflows/e2e-husky-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-jest-workflow.yml
+++ b/.github/workflows/e2e-jest-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-mocha-workflow.yml
+++ b/.github/workflows/e2e-mocha-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-next-workflow.yml
+++ b/.github/workflows/e2e-next-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nm-angular-workflow.yml
+++ b/.github/workflows/e2e-nm-angular-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Enable git longpaths
       run: git config --global core.longpaths true
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nm-babel-workflow.yml
+++ b/.github/workflows/e2e-nm-babel-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Enable git longpaths
       run: git config --global core.longpaths true
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nm-berry-workflow.yml
+++ b/.github/workflows/e2e-nm-berry-workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-nyc-workflow.yml
+++ b/.github/workflows/e2e-nyc-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-parcel-workflow.yml
+++ b/.github/workflows/e2e-parcel-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-pnp-angular-workflow.yml
+++ b/.github/workflows/e2e-pnp-angular-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-prettier-workflow.yml
+++ b/.github/workflows/e2e-prettier-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-rollup-workflow.yml
+++ b/.github/workflows/e2e-rollup-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-storybook-workflow.yml
+++ b/.github/workflows/e2e-storybook-workflow.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-svelte-kit-workflow.yml
+++ b/.github/workflows/e2e-svelte-kit-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-typescript-workflow.yml
+++ b/.github/workflows/e2e-typescript-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-vite-workflow.yml
+++ b/.github/workflows/e2e-vite-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-vitest-workflow.yml
+++ b/.github/workflows/e2e-vitest-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/e2e-webpack-workflow.yml
+++ b/.github/workflows/e2e-webpack-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/integration-workflow.yml
+++ b/.github/workflows/integration-workflow.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - run: |
         git fetch --no-tags --unshallow origin HEAD master
 
     - name: 'Use Node.js ${{ env.node-version }}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.node-version }}
 
@@ -173,10 +173,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: 'Use Node.js ${{ env.node-version }}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.node-version }}
 
@@ -190,7 +190,7 @@ jobs:
         node ./scripts/run-yarn.js build:cli --no-minify
       shell: bash
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: yarn-artifacts
         path: |
@@ -204,7 +204,7 @@ jobs:
       if: |
         success() || failure()
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: vscode-zipfs
         path: ./packages/vscode-zipfs/vscode-zipfs-*.vsix
@@ -279,14 +279,14 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: 'Use Node.js ${{matrix.node}}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{matrix.node}}
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: yarn-artifacts
         path: packages
@@ -316,9 +316,9 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: yarn-artifacts
         path: packages

--- a/.github/workflows/plugin-compat-workflow.yml
+++ b/.github/workflows/plugin-compat-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./.github/actions/prepare
 

--- a/.github/workflows/pr-smart-merge.yml
+++ b/.github/workflows/pr-smart-merge.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: 'Remove the label'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.removeLabel({
@@ -30,7 +30,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{github.event.pull_request.head.sha}}
         fetch-depth: 0
@@ -81,7 +81,7 @@ jobs:
         git diff > merge-conflict-resolution.patch
 
     - name: Store the merge conflict resolution
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: merge-conflict-resolution
         path: merge-conflict-resolution.patch
@@ -92,13 +92,13 @@ jobs:
     needs: generate
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{github.event.pull_request.head.sha}}
           fetch-depth: 0
 
       - name: Retrieve the merge conflict resolution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: merge-conflict-resolution
 

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{github.event.inputs.branch}}
         token: ${{secrets.YARNBOT_TOKEN}}
@@ -32,7 +32,7 @@ jobs:
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
     - name: 'Use Node.js ${{ env.node-version }}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.node-version }}
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: master
         token: ${{secrets.YARNBOT_TOKEN}}
@@ -32,7 +32,7 @@ jobs:
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
     - name: 'Use Node.js ${{ env.node-version }}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.node-version }}
 

--- a/.github/workflows/release-rerun.yml
+++ b/.github/workflows/release-rerun.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{github.event.inputs.commit_sha}}
         token: ${{secrets.YARNBOT_TOKEN}}
@@ -36,7 +36,7 @@ jobs:
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
     - name: 'Use Node.js ${{ env.node-version }}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.node-version }}
 

--- a/.github/workflows/sherlock-workflow.yml
+++ b/.github/workflows/sherlock-workflow.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: 'Use Node.js ${{ env.node-version }}'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ env.node-version }}
 

--- a/.github/workflows/stale-workflow.yml
+++ b/.github/workflows/stale-workflow.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v6
+    - uses: actions/stale@v11
       with:
         repo-token: ${{secrets.YARNBOT_TOKEN}}
 


### PR DESCRIPTION
## What's the problem this PR addresses?

CI runs on Node.js 25, which reached end-of-life on 2026-06-01, and the workflows pin GitHub Actions (`actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4`, etc.) that run on the deprecated `node20` runtime. GitHub now force-runs them on newer Node and emits deprecation annotations.

Closes #7235

## How did you fix it?

- Bumped the default Node.js used by CI from `25.6` to `26.x` in the `prepare` composite action.
- Updated the GitHub Actions to their current major versions: `checkout` v4→v7, `setup-node` v4→v7, `cache` v4→v6, `upload-artifact` v4→v7, `download-artifact` v4→v8, `github-script` v6→v9, `stale` v6→v11.

The minimum supported Node.js (`18.x`) and the integration test matrix are intentionally left unchanged.

## Checklist
- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.