### PR TITLE
fix: update VS Code TypeScript SDK settings

### DIFF
--- a/.yarn/versions/2c8f7d3a.yml
+++ b/.yarn/versions/2c8f7d3a.yml
@@ -1,0 +1,2 @@
+releases:
+  "@yarnpkg/sdks": patch

--- a/packages/yarnpkg-sdks/sources/sdks/vscode.ts
+++ b/packages/yarnpkg-sdks/sources/sdks/vscode.ts
@@ -95,14 +95,14 @@ export const generateRelayCompilerWrapper: GenerateIntegrationWrapper = async (p
 
 export const generateTypescriptWrapper: GenerateIntegrationWrapper = async (pnpApi: PnpApi, target: PortablePath, wrapper: Wrapper) => {
   await addVSCodeWorkspaceConfiguration(pnpApi, VSCodeConfiguration.settings, {
-    [`typescript.tsdk`]: npath.fromPortablePath(
+    [`js/ts.tsdk.path`]: npath.fromPortablePath(
       ppath.dirname(
         wrapper.getProjectPathTo(
           `lib/tsserver.js` as PortablePath,
         ),
       ),
     ),
-    [`typescript.enablePromptUseWorkspaceTsdk`]: true,
+    [`js/ts.tsdk.promptToUseWorkspaceVersion`]: true,
   });
 };
 


### PR DESCRIPTION
## What changed

Update the VS Code TypeScript SDK settings generated by yarn sdks to the current js/ts.tsdk.* setting names.

## Testing

- TypeScript check passed with the repository bundled compiler
- git diff --check passed

Fixes #7107