### PR TITLE
up: Add example for undocumented no-argument usage

### DIFF
--- a/packages/plugin-essentials/sources/commands/up.ts
+++ b/packages/plugin-essentials/sources/commands/up.ts
@@ -40,6 +40,9 @@ export default class UpCommand extends BaseCommand {
       **Note:** The ranges have to be static, only the package scopes and names can contain glob patterns.
     `,
     examples: [[
+      `Upgrade all packages`,
+      `$0 up`,
+    ], [
       `Upgrade all instances of lodash to the latest release`,
       `$0 up lodash`,
     ], [


### PR DESCRIPTION
## What's the problem this PR addresses?

Currently, the `yarn up` specifies that it may be run without arguments (i.e. `yarn up ...`).

However this zero-argument form has no behavior document. Does it update no packages? All packages?

## How did you fix it?

I added an example of the zero-argument invocation to the examples section and specified that it shall update all packages.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
