### PR TITLE
fix(plugin-interactive-tools): add --no-time-gate support to upgrade-interactive (#7207)

### DIFF
--- a/.yarn/versions/fix-yarn-issue-7207.yml
+++ b/.yarn/versions/fix-yarn-issue-7207.yml
@@ -1,0 +1,7 @@
+releases:
+  "@yarnpkg/cli": decline
+  "@yarnpkg/core": decline
+  "@yarnpkg/plugin-compat": decline
+  "@yarnpkg/plugin-interactive-tools": patch
+  "@yarnpkg/plugin-npm": patch
+  "@yarnpkg/plugin-npm-cli": decline

--- a/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
+++ b/packages/acceptance-tests/pkg-tests-core/sources/utils/tests.ts
@@ -486,9 +486,11 @@ export const startPackageServer = ({type}: {type: keyof typeof packageServerUrls
             }),
           )),
         ),
-        time: name in RELEASE_DATE_PACKAGES
-          ? RELEASE_DATE_PACKAGES[name]
-          : Object.fromEntries(versions.map(version => [version, OLD_RELEASE_DATE])),
+        ...(!name.startsWith(`no-time-`) ? {
+          time: name in RELEASE_DATE_PACKAGES
+            ? RELEASE_DATE_PACKAGES[name]
+            : Object.fromEntries(versions.map(version => [version, OLD_RELEASE_DATE])),
+        } : {}),
         [`dist-tags`]: {
           latest: semver.maxSatisfying(versions, `*`),
           ...distTags,

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-time-deps-1.0.0/index.js
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-time-deps-1.0.0/index.js
@@ -1,0 +1,7 @@
+module.exports = require(`./package.json`);
+
+for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  for (const dep of Object.keys(module.exports[key] || {})) {
+    module.exports[key][dep] = require(dep);
+  }
+}

--- a/packages/acceptance-tests/pkg-tests-fixtures/packages/no-time-deps-1.0.0/package.json
+++ b/packages/acceptance-tests/pkg-tests-fixtures/packages/no-time-deps-1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "no-time-deps",
+    "version": "1.0.0"
+}

--- a/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
+++ b/packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts
@@ -573,5 +573,21 @@ describe(`Features`, () => {
         }),
       );
     });
+
+    describe(`packages with no release time metadata (e.g. GitHub Packages)`, () => {
+      test(
+        `it should install a package with no release time even if npmMinimalAgeGate is set`,
+        makeTemporaryEnv({}, {
+          npmMinimalAgeGate: `1d`,
+        }, async ({run, source}) => {
+          await run(`add`, `no-time-deps`);
+
+          await expect(source(`require('no-time-deps/package.json')`)).resolves.toMatchObject({
+            name: `no-time-deps`,
+            version: `1.0.0`,
+          });
+        }),
+      );
+    });
   });
 });

--- a/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
+++ b/packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx
@@ -49,6 +49,10 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     validator: t.isEnum(InstallMode),
   });
 
+  noTimeGate = Option.Boolean(`--no-time-gate`, false, {
+    description: `Disable the minimum release age check for this command`,
+  });
+
   async execute() {
     libuiUtils.checkRequirements(this.context);
 
@@ -62,6 +66,9 @@ export default class UpgradeInteractiveCommand extends BaseCommand {
     const {default: React, useCallback, useEffect, useRef, useState} = await import(`react`);
 
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+
+    if (this.noTimeGate)
+      suggestUtils.disableTimeGate(configuration);
     const {project, workspace} = await Project.find(configuration, this.context.cwd);
     const cache = await Cache.find(configuration);
 

--- a/packages/plugin-npm/sources/npmConfigUtils.ts
+++ b/packages/plugin-npm/sources/npmConfigUtils.ts
@@ -111,8 +111,8 @@ export function getMinimalAgeGate(ident: Ident | null, {configuration}: {configu
 function shouldBeQuarantined({configuration, ident, version, publishTimes}: IsPackageApprovedOptions) {
   const minimalAgeGate = getMinimalAgeGate(ident, {configuration});
 
-  if (minimalAgeGate) {
-    const versionTime = publishTimes?.[version];
+  if (minimalAgeGate && publishTimes) {
+    const versionTime = publishTimes[version];
     if (typeof versionTime === `undefined`)
       return true;
 


### PR DESCRIPTION
<!--
  IMPORTANT: While Yarn 4.x is still actively developed we're now
  focusing work on our next major releases (5.x and 6.x).

  These sister releases use the same pattern as TypeScript-Go:
  
  - 5.x will only contain a handful of breaking changes to provide a safe
  migration path.

  - 6.x will be the "true" release, notable for being implemented in Rust
  and including a significantly improved core.
  
  While PRs can still be opened against 4.x, we recommend power users
  to try Yarn 6.x now and help us get it over the finish line. It uses
  the same testsuite as Berry, so compatibility should be at its best.

  To check out the working trunk for Yarn 6.x, please refer to this
  repository: https://github.com/yarnpkg/zpm
-->

## What's the problem this PR addresses?

In Yarn 4.17.0, `npmMinimalAgeGate` default was set to `1d`. While commands like `yarn add` and `yarn up` received `--no-time-gate` support to bypass age gate restrictions during package resolution, `yarn upgrade-interactive` did not support `--no-time-gate` or disable time gates during candidate version lookups.

As a result:
1. `yarn upgrade-interactive` failed to resolve and display available package upgrades when candidate versions fell within the age gate period or when registries/scope configs lacked publish timestamp metadata.
2. Because `upgrade-interactive` filters out packages when no newer candidate version is found (`suggestions.length <= 1`), out-of-date packages were hidden completely from the interactive menu.

Closes #7207

## How did you fix it?

1. **Added `--no-time-gate` flag to `yarn upgrade-interactive`:**
   Updated `UpgradeInteractiveCommand` in `packages/plugin-interactive-tools/sources/commands/upgrade-interactive.tsx` to accept the `--no-time-gate` option and invoke `suggestUtils.disableTimeGate(configuration)` when specified.

2. **Bypassed age gate when `publishTimes` metadata is absent:**
   Updated `shouldBeQuarantined` in `packages/plugin-npm/sources/npmConfigUtils.ts` to ensure `npmMinimalAgeGate` is bypassed if `publishTimes` metadata is missing (e.g. custom or scope registries like GitHub Packages/Artifactory).

3. **Added Acceptance Tests:**
   Added test coverage in `packages/acceptance-tests/pkg-tests-specs/sources/features/npmMinimalAgeGate.test.ts` for packages without release time metadata.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.