### PR TITLE
[extensions] Declare optional React type peer for next-themes

### DIFF
--- a/.yarn/versions/be27f475.yml
+++ b/.yarn/versions/be27f475.yml
@@ -1,0 +1,24 @@
+releases:
+  "@yarnpkg/cli": patch
+  "@yarnpkg/extensions": patch
+  "@yarnpkg/plugin-compat": patch
+
+declined:
+  - "@yarnpkg/plugin-constraints"
+  - "@yarnpkg/plugin-dlx"
+  - "@yarnpkg/plugin-essentials"
+  - "@yarnpkg/plugin-init"
+  - "@yarnpkg/plugin-interactive-tools"
+  - "@yarnpkg/plugin-nm"
+  - "@yarnpkg/plugin-npm-cli"
+  - "@yarnpkg/plugin-pack"
+  - "@yarnpkg/plugin-patch"
+  - "@yarnpkg/plugin-pnp"
+  - "@yarnpkg/plugin-pnpm"
+  - "@yarnpkg/plugin-stage"
+  - "@yarnpkg/plugin-typescript"
+  - "@yarnpkg/plugin-version"
+  - "@yarnpkg/plugin-workspace-tools"
+  - "@yarnpkg/builder"
+  - "@yarnpkg/core"
+  - "@yarnpkg/doctor"

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -1075,7 +1075,6 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
     },
   }],
   // https://github.com/pacocoursey/next-themes/pull/398
-  // https://github.com/pacocoursey/next-themes/pull/398
   [`next-themes@>=0.2.1 <=0.4.6`, {
     peerDependencies: {
       [`@types/react`]: `*`,

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -1074,6 +1074,8 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       typescript: optionalPeerDep,
     },
   }],
+  // https://github.com/pacocoursey/next-themes/pull/398
+  // https://github.com/pacocoursey/next-themes/pull/398
   [`next-themes@>=0.2.1 <=0.4.6`, {
     peerDependencies: {
       [`@types/react`]: `*`,

--- a/packages/yarnpkg-extensions/sources/index.ts
+++ b/packages/yarnpkg-extensions/sources/index.ts
@@ -1074,4 +1074,12 @@ export const packageExtensions: Array<[string, PackageExtensionData]> = [
       typescript: optionalPeerDep,
     },
   }],
+  [`next-themes@>=0.2.1 <=0.4.6`, {
+    peerDependencies: {
+      [`@types/react`]: `*`,
+    },
+    peerDependenciesMeta: {
+      [`@types/react`]: optionalPeerDep,
+    },
+  }],
 ];


### PR DESCRIPTION
## What's the problem this PR addresses?

`next-themes` publishes declarations that reference React types without declaring an `@types/react` peer. Yarn already infers optional type peers; this entry records the missing declaration for other consumers of the shared extensions database, including pnpm.

## How did you fix it?

Add an optional `@types/react` peer for `next-themes@>=0.2.1 <=0.4.6`. The matching [package-author draft](https://github.com/pacocoursey/next-themes/pull/398) fixes the manifest for future releases.

Verification with unmodified pnpm 11.19.0 and its global virtual store:

- Applying this entry restores `ThemeProvider` prop checking in 0.2.1 and `setTheme` callback typing in 0.4.6.
- The corrected 0.4.6 consumer passes a frozen offline reinstall and typecheck without changing its lockfile.

Yarn's six existing package-extension acceptance tests, focused ESLint, and `yarn version check` pass.

## Checklist

- [x] I have read the [Contributing Guide](https://yarnpkg.com/advanced/contributing).
- [x] I have set the packages that need to be released for my changes to be effective.
- [x] I will check that all automated PR checks pass before the PR gets reviewed.
